### PR TITLE
NIP05: warn about CORS policies that may inhibit JS apps

### DIFF
--- a/05.md
+++ b/05.md
@@ -50,3 +50,16 @@ Clients may treat the identifier `_@domain` as the "root" identifier, and choose
 ### Reasoning for the `/.well-known/nostr.json?name=<local-part>` format
 
 By adding the `<local-part>` as a query string instead of as part of the path the protocol can support both dynamic servers that can generate JSON on-demand and static servers with a JSON file in it that may contain multiple names.
+
+### Allowing access from Javascript apps
+
+Javascript Nostr apps may be restricted by browser [CORS][] policies that prevent them from accesing `nostr.json` on the user's domain.  When CORS prevents JS from loading a resource, the JS program sees it as a network failure identical to the resource not existing, so it is not possible for a pure-JS app to tell the user for certain that the failure was caused by a CORS issue.  JS Nostr apps that see network failures requesting `nostr.json` files may want to recommend to users that they check the CORS policy of their servers, e.g.:
+
+```bash
+$ curl -sI https://example.com/.well-known/nostr.json?name=bob | grep ^Access-Control
+Access-Control-Allow-Origin: *
+```
+
+Users should ensure that their `nostr.json` is served with the HTTP header `Access-Control-Allow-Origin: *` to ensure it can be validated by pure JS apps running in modern browsers.
+
+[CORS]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS


### PR DESCRIPTION
JS Nostr apps such as Branle may not be able to load `nostr.json` files due to CORS policies.  Update NIP05 to warn about this and provide hints for troubleshooting and fixing the issue.

I think this is the best way to address a [confusion](https://branle.netlify.app/event/f0d79c9bd1795b9c2a7511313bd7ad6f96350aa3f4045a8a69829cc0ff042fd4) I had trying to add my NIP05 identifier to a Branle instance where I kept receiving an error.  It also implies that other Nostr apps may be able to load `nostr.json` files that Branle and other pure-JS apps won't be able to load, which may produce some user confusion.

Note: I'm not a webdev, I might not be describing CORS stuff accurately.