### PR TITLE
NIP15: End of Stored Events Notice

### DIFF
--- a/15.md
+++ b/15.md
@@ -8,25 +8,12 @@ End of Stored Events Notice
 
 Relays may support notifying clients when all stored events have been sent.
 
-If a client sets `eose_notice` field to `true` in any of the filters in a `REQ` message and the relay supports this NIP, the relay MUST send the client a `EOSE` message in the format `["EOSE", <subscription_id>]` which indicates that all stored events matching the filters specified have been sent and all events from on are newly published events.
-
-Example Subscription Filter
----------------------------
-
-The following provides an example of a filter that requests the `set_metadata` (`0`) event(s) of a pubkey and requests the server to send an end of stored events message.
-
-```
-{
-  "kinds": [0],
-  "authors": ["52b4a076bcbbbdc3a1aefa3735816cf74993b1b8db202b01c883c58be7fad8bd"],
-  "eose_notice": true
-}
-```
+If a relay supports this NIP, the relay SHOULD send the client a `EOSE` message in the format `["EOSE", <subscription_id>]` after it has sent all the events it has persisted and all the events that come after this message are newly published.
 
 Client Behavior
 ---------------
 
-Clients SHOULD use the `supported_nips` field to learn if a relay supports end of stored events notices.  Clients MAY send filters with `eose_notice` to any relay, if they are prepared to not receive a message from relays that do not support this NIP.
+Clients SHOULD use the `supported_nips` field to learn if a relay supports end of stored events notices.
 
 Motivation
 ----------

--- a/15.md
+++ b/15.md
@@ -8,7 +8,7 @@ End of Stored Events Notice
 
 Relays may support notifying clients when all stored events have been sent.
 
-If a client sets `eose_notice` field to `true` in any of the filters in a `REQ` message and the relay supports this NIP, the relay MUST send the client a `EOSE` message in the format `["EN", <subscription_id>]` which indicates that all stored events matching the filters specified have been sent and all events from on are newly published events.
+If a client sets `eose_notice` field to `true` in any of the filters in a `REQ` message and the relay supports this NIP, the relay MUST send the client a `EOSE` message in the format `["EOSE", <subscription_id>]` which indicates that all stored events matching the filters specified have been sent and all events from on are newly published events.
 
 Example Subscription Filter
 ---------------------------

--- a/15.md
+++ b/15.md
@@ -1,0 +1,34 @@
+NIP-15
+======
+
+End of Stored Events Notice
+---------------------------
+
+`draft` `optional` `author:Semisol`
+
+Relays may support notifying clients when all stored events have been sent.
+
+If a client sets `eose_notice` field to `true` in any of the filters in a `REQ` message and the relay supports this NIP, the relay MUST send the client a `EOSE` message in the format `["EN", <subscription_id>]` which indicates that all stored events matching the filters specified have been sent and all events from on are newly published events.
+
+Example Subscription Filter
+---------------------------
+
+The following provides an example of a filter that requests the `set_metadata` (`0`) event(s) of a pubkey and requests the server to send an end of stored events message.
+
+```
+{
+  "kinds": [0],
+  "authors": ["52b4a076bcbbbdc3a1aefa3735816cf74993b1b8db202b01c883c58be7fad8bd"],
+  "eose_notice": true
+}
+```
+
+Client Behavior
+---------------
+
+Clients SHOULD use the `supported_nips` field to learn if a relay supports end of stored events notices.  Clients MAY send filters with `eose_notice` to any relay, if they are prepared to not receive a message from relays that do not support this NIP.
+
+Motivation
+----------
+
+The motivation for this proposal is to reduce uncertainty when all events have been sent by a relay to make client code possibly less complex.

--- a/15.md
+++ b/15.md
@@ -8,7 +8,7 @@ End of Stored Events Notice
 
 Relays may support notifying clients when all stored events have been sent.
 
-If a relay supports this NIP, the relay SHOULD send the client a `EOSE` message in the format `["EOSE", <subscription_id>]` after it has sent all the events it has persisted and all the events that come after this message are newly published.
+If a relay supports this NIP, the relay SHOULD send the client a `EOSE` message in the format `["EOSE", <subscription_id>]` after it has sent all the events it has persisted and it indicates all the events that come after this message are newly published.
 
 Client Behavior
 ---------------


### PR DESCRIPTION
This NIP specifies how relays may communicate to clients when all stored events have been sent. The motivation for this NIP is to reduce complexity (timeouts to make sure "we got all events").

This document was modified from NIP-12 heavily.