### PR TITLE
NIP16: Event Treatment

### DIFF
--- a/16.md
+++ b/16.md
@@ -10,20 +10,18 @@ Relays may decide to allow replaceable and/or ephemeral events.
 
 Replaceable Events
 ------------------
-A *replaceable event* is defined as an event with a `replaceable` tag with value `1`. Relays SHOULD treat unknown types as if the event is not replaceable.  
+A *replaceable event* is defined as an event with a kind `10000 <= n < 20000`.
 Upon a replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind, the old event SHOULD be discarded and replaced with the newer event.
 
 Ephemeral Events
 ----------------
-An *ephemeral event* is defined as an event with an `ephemeral` tag with value `1`. Relays are RECOMMENDED to reject unknown types for future extensions.  
+An *ephemeral event* is defined as an event with a kind `20000 <= n < 30000`.
 Upon an ephemeral event being received, the relay SHOULD send it to all clients with a matching filter, and MUST NOT store it.
 
 Client Behavior
 ---------------
 
-Clients SHOULD use the `supported_nips` field to learn if a relay supports generic tag queries.  Clients SHOULD NOT send ephemeral events to relays that do not support this NIP; they will be persisted.  Clients MAY send replaceable events to relays that may not support this NIP, and clients querying SHOULD be prepared for the relay to send multiple events and should use the latest one.  
-
-Clients are RECOMMENDED to ignore events without replaceability when requesting replaceable events.
+Clients SHOULD use the `supported_nips` field to learn if a relay supports generic tag queries.  Clients SHOULD NOT send ephemeral events to relays that do not support this NIP; they will most likely be persisted.  Clients MAY send replaceable events to relays that may not support this NIP, and clients querying SHOULD be prepared for the relay to send multiple events and should use the latest one.  
 
 Suggested Use Cases
 -------------------

--- a/16.md
+++ b/16.md
@@ -10,18 +10,18 @@ Relays may decide to allow replaceable and/or ephemeral events.
 
 Replaceable Events
 ------------------
-A *replaceable event* is defined as an event with a `replaceable` tag with value `1`. Relays SHOULD treat unknown types as if the event is not replaceable.
+A *replaceable event* is defined as an event with a `replaceable` tag with value `1`. Relays SHOULD treat unknown types as if the event is not replaceable.  
 Upon a replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind, the old event SHOULD be discarded and replaced with the newer event.
 
 Ephemeral Events
 ----------------
-An *ephemeral event* is defined as an event with an `ephemeral` tag with value `1`. Relays are RECOMMENDED to reject unknown types for future extensions.
+An *ephemeral event* is defined as an event with an `ephemeral` tag with value `1`. Relays are RECOMMENDED to reject unknown types for future extensions.  
 Upon an ephemeral event being received, the relay SHOULD send it to all clients with a matching filter, and MUST NOT store it.
 
 Client Behavior
 ---------------
 
-Clients SHOULD use the `supported_nips` field to learn if a relay supports generic tag queries.  Clients SHOULD NOT send ephemeral events to relays that do not support this NIP; they will be persisted.  Clients MAY send replaceable events to relays that may not support this NIP, and clients querying SHOULD be prepared for the relay to send multiple events and should use the latest one.
+Clients SHOULD use the `supported_nips` field to learn if a relay supports generic tag queries.  Clients SHOULD NOT send ephemeral events to relays that do not support this NIP; they will be persisted.  Clients MAY send replaceable events to relays that may not support this NIP, and clients querying SHOULD be prepared for the relay to send multiple events and should use the latest one.  
 
 Clients are RECOMMENDED to ignore events without replaceability when requesting replaceable events.
 

--- a/16.md
+++ b/16.md
@@ -1,0 +1,33 @@
+NIP-16
+======
+
+Event Treatment
+---------------
+
+`draft` `optional` `author:Semisol`
+
+Relays may decide to allow replaceable and/or ephemeral events.
+
+Replaceable Events
+------------------
+A *replaceable event* is defined as an event with a `replaceable` tag with value `1`. Relays SHOULD treat unknown types as if the event is not replaceable.
+Upon a replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind, the old event SHOULD be discarded and replaced with the newer event.
+
+Ephemeral Events
+----------------
+An *ephemeral event* is defined as an event with an `ephemeral` tag with value `1`. Relays are RECOMMENDED to reject unknown types for future extensions.
+Upon an ephemeral event being received, the relay SHOULD send it to all clients with a matching filter, and MUST NOT store it.
+
+Client Behavior
+---------------
+
+Clients SHOULD use the `supported_nips` field to learn if a relay supports generic tag queries.  Clients SHOULD NOT send ephemeral events to relays that do not support this NIP; they will be persisted.  Clients MAY send replaceable events to relays that may not support this NIP, and clients querying SHOULD be prepared for the relay to send multiple events and should use the latest one.
+
+Clients are RECOMMENDED to ignore events without replaceability when requesting replaceable events.
+
+Suggested Use Cases
+-------------------
+
+* States: An application may create a state event that is replaced every time a new state is set (such as statuses)
+* Typing indicators: A chat application may use ephemeral events as a typing indicator.
+* Messaging: Two pubkeys can message over nostr using ephemeral events.


### PR DESCRIPTION
This NIP allows events to be marked replaceable/ephemeral which allows building applications that may rely on a single latest state or that may want to only send events to currently subscribed clients without them being persisted, both which reduce load on relay storage.