### PR TITLE
update to nip01 to specify syntax for usernames.

### DIFF
--- a/01.md
+++ b/01.md
@@ -97,7 +97,10 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 
 ## Basic Event Kinds
 
-  - `0`: `set_metadata`: the `content` is set to a stringified JSON object `{name: <string>, about: <string>, picture: <url, string>}` describing the user who created the event. A relay may delete past `set_metadata` events once it gets a new one for the same pubkey.
+  - `0`: `set_metadata`: the `content` is set to a stringified JSON object `{name: <username>, about: <string>, picture: <url, string>}` describing the user who created the event. A relay may delete past `set_metadata` events once it gets a new one for the same pubkey.
+   * Where `<username>` is a string that matches the pattern: `[\w+\-]` (java regular epression).  Or, in other words, a sequence of the following
+	   characters: `[a-zA-Z_\-0-9]`.  <br>
+	   Thus `George-Washington-1776` is a valid `<username>`, but `George Washington` is not. Clients may reject metadata that does not comply.
   - `1`: `text_note`: the `content` is set to the text content of a note (anything the user wants to say).
   - `2`: `recommend_server`: the `content` is set to the URL (e.g., `https://somerelay.com`) of a relay the event creator wants to recommend to its followers.
 


### PR DESCRIPTION
###Justification:  
In order for clients to make use of the `@username` syntax implied by NIP-08 we need some way to be able to reasonably parse those names.  This mechanisms is so standard that I don't think anyone will be surprised.  If we decide we need a better name field, we could add `formal_name` to the metadata.  

This is the pattern i've used in `more-speech`

Thoughts?