### PR TITLE
clarify that tags may contain `null` strings

### DIFF
--- a/01.md
+++ b/01.md
@@ -38,7 +38,7 @@ To obtain the `event.id`, we `sha256` the serialized event. The serialization is
   <pubkey, as a (lowercase) hex string>,
   <created_at, as a number>,
   <kind, as a number>,
-  <tags, as an array of arrays of strings>,
+  <tags, as an array of arrays of nullable strings>,
   <content, as a string>
 ]
 ```


### PR DESCRIPTION
From the nip-1 perspective, `tags` is not defined beyond being an array of arrays of strings.
nip-02 reveals that those strings also may be `null`, which apparently some relays currently do not like.