### PR TITLE
add nip22: unacceptable event created_at field

### DIFF
--- a/22.md
+++ b/22.md
@@ -6,18 +6,18 @@ Unacceptable Event `created_at` time
 
 `draft` `optional` `author:jeffthibault`
 
-Relays may support notifying clients that the event they published has an unacceptable `created_at` time. A relay will will consider the `created_at` time unacceptable if the `created_at` time is more than **[limit]** before the event was received by the relay. 
+Relays may support notifying clients that the event they published has an unacceptable `created_at` time. A relay will consider the `created_at` time unacceptable if the `created_at` time is more than **[limit]** before the event was received by the relay (in the past) OR if the `created_at` time is later than the time the event was received by the relay (in the future). 
 
-If a relay supports this NIP, the relay SHOULD send the client a `NOTICE` message saying the event was not stored because the timestamp was too old.
+If a relay supports this NIP, the relay SHOULD send the client a `NOTICE` message saying the event was not stored because the `created_at` time was unacceptable.
 
 Client Behavior
 ---------------
 
-Clients SHOULD use the `supported_nips` field to learn if a relay supports event `created_at` checks.
+Clients SHOULD use the `supported_nips` field to learn if a relay supports event `created_at` time checks.
 
 Motivation
 ----------
 
-The motivation for this NIP is to prevent clients from saying they published an event *significantly* earlier than they actually did.
+The motivation for this NIP is to prevent clients from saying they published an event *significantly* earlier than they actually did or saying they published an event in the future.
 
-The event `created_at` field is just a unix timestamp (integer) so one could set it to a time in the past. For example, the `created_at` field could be set to a time 10 years ago even though it was created today and it could still be a valid event. This NIP aims to set a maximum amount of time elapsed between when an event was created and when it was *actually* published.
+The event `created_at` field is just a unix timestamp (integer) so one could set it to a time in the past or future. For example, the `created_at` field could be set to a time 10 years ago even though it was created today and it could still be a valid event. One could also set the `created_at` field to a time 10 years in the future and it could still be a valid event. This NIP aims to set a maximum amount of time elapsed between when an event was created and when it was *actually* published and prevent events from being from the future.

--- a/22.md
+++ b/22.md
@@ -21,3 +21,11 @@ Motivation
 The motivation for this NIP is to prevent clients from saying they published an event *significantly* earlier than they actually did or saying they published an event in the future.
 
 The event `created_at` field is just a unix timestamp (integer) so one could set it to a time in the past or future. For example, the `created_at` field could be set to a time 10 years ago even though it was created today and it could still be a valid event. One could also set the `created_at` field to a time 10 years in the future and it could still be a valid event. This NIP aims to set a maximum amount of time elapsed between when an event was created and when it was *actually* published and prevent events from being from the future.
+
+Relay Logic
+-----------
+
+```
+if time.now - event.created_at > limit OR event.created_at > time.now:
+  send NOTICE
+```

--- a/22.md
+++ b/22.md
@@ -1,0 +1,23 @@
+NIP-22
+======
+
+Unacceptable Event `created_at` time
+---------------------------
+
+`draft` `optional` `author:jeffthibault`
+
+Relays may support notifying clients that the event they published has an unacceptable `created_at` time. A relay will will consider the `created_at` time unacceptable if the `created_at` time is more than **[limit]** before the event was received by the relay. 
+
+If a relay supports this NIP, the relay SHOULD send the client a `NOTICE` message saying the event was not stored because the timestamp was too old.
+
+Client Behavior
+---------------
+
+Clients SHOULD use the `supported_nips` field to learn if a relay supports event `created_at` checks.
+
+Motivation
+----------
+
+The motivation for this NIP is to prevent clients from saying they published an event *significantly* earlier than they actually did.
+
+The event `created_at` field is just a unix timestamp (integer) so one could set it to a time in the past. For example, the `created_at` field could be set to a time 10 years ago even though it was created today and it could still be a valid event. This NIP aims to set a maximum amount of time elapsed between when an event was created and when it was *actually* published.


### PR DESCRIPTION
Marked as draft because looking for input on the time limit. Should it be 1 minute, 10 minutes, 1 hour, etc...?