### PR TITLE
NIP-22: event created_at limits

### DIFF
--- a/22.md
+++ b/22.md
@@ -1,31 +1,38 @@
 NIP-22
 ======
 
-Unacceptable Event `created_at` time
+Event `created_at` Limits
 ---------------------------
 
 `draft` `optional` `author:jeffthibault`
 
-Relays may support notifying clients that the event they published has an unacceptable `created_at` time. A relay will consider the `created_at` time unacceptable if the `created_at` time is more than **[limit]** before the event was received by the relay (in the past) OR if the `created_at` time is later than the time the event was received by the relay (in the future). 
+Relays may define both upper and lower limits for which they will consider an event's `created_at` time to be acceptable if it is within those limits. Both the upper and lower limits MUST be unix timestamps to match the format of the event's `created_at` field. The upper limit restricts how far into the future an event's `created_at` time can be set to and the lower limit restricts how far into the past an event's `created_at` time can be set to.  
 
-If a relay supports this NIP, the relay SHOULD send the client a `NOTICE` message saying the event was not stored because the `created_at` time was unacceptable.
+If a relay supports this NIP, the relay SHOULD send the client a `NOTICE` message saying the event was not stored when the `created_at` time is not within the upper and lower limits.
 
 Client Behavior
 ---------------
 
-Clients SHOULD use the `supported_nips` field to learn if a relay supports event `created_at` time checks.
+Clients SHOULD use the `supported_nips` field to learn if a relay uses event `created_at` time limits as defined by this NIP.
 
 Motivation
 ----------
 
-The motivation for this NIP is to prevent clients from saying they published an event *significantly* earlier than they actually did or saying they published an event in the future.
+The motivation for this NIP is to formalize a way for relays to restrict event timestamps to times they deem to be acceptable and allow clients to be aware of relays that have these restrictions.
 
-The event `created_at` field is just a unix timestamp (integer) so one could set it to a time in the past or future. For example, the `created_at` field could be set to a time 10 years ago even though it was created today and it could still be a valid event. One could also set the `created_at` field to a time 10 years in the future and it could still be a valid event. This NIP aims to set a maximum amount of time elapsed between when an event was created and when it was *actually* published and prevent events from being from the future.
+The event `created_at` field is just a unix timestamp and can be set to a time in the past or future. For example, the `created_at` field can be set to a time 20 years ago even though it was created today and still be a valid event. It can also be set to a time 20 years in the future and still be a valid event. This NIP aims to define a way for relays that do not want to store events with *any* timestamp to set their own restrictions.
 
-Relay Logic
------------
+A wide adoption of this could create a better UX on clients as well because it would decrease the liklihood of the user seeing events from dates such as 1984 or 2084, which could be confusing.
 
-```
-if time.now - event.created_at > limit OR event.created_at > time.now:
-  send NOTICE
+Python Example
+--------------
+
+```python
+import time
+
+UPPER_LIMIT = int(time.now) + 900 # Define upper limit as 15 minutes into the future
+LOWER_LIMIT = int(time.now) - 86400 # Define lower limit as 1 day into the past
+
+if event.created_at < LOWER_LIMIT or event.created_at > UPPER_LIMIT:
+  ws.send('["NOTICE", "The event created_at field is out of the acceptable range for this relay and was not stored."]')
 ```

--- a/22.md
+++ b/22.md
@@ -22,7 +22,7 @@ The motivation for this NIP is to formalize a way for relays to restrict event t
 
 The event `created_at` field is just a unix timestamp and can be set to a time in the past or future. For example, the `created_at` field can be set to a time 20 years ago even though it was created today and still be a valid event. It can also be set to a time 20 years in the future and still be a valid event. This NIP aims to define a way for relays that do not want to store events with *any* timestamp to set their own restrictions.
 
-A wide adoption of this could create a better UX on clients as well because it would decrease the liklihood of the user seeing events from dates such as 1984 or 2084, which could be confusing.
+A wide adoption of this could create a better UX on clients as well because it would decrease the likelihood of the user seeing events from dates such as 1984 or 2084, which could be confusing.
 
 Python Example
 --------------

--- a/22.md
+++ b/22.md
@@ -6,18 +6,18 @@ Unacceptable Event `created_at` time
 
 `draft` `optional` `author:jeffthibault`
 
-Relays may support notifying clients that the event they published has an unacceptable `created_at` time. A relay will will consider the `created_at` time unacceptable if the `created_at` time is more than **[limit]** before the event was received by the relay. 
+Relays may support notifying clients that the event they published has an unacceptable `created_at` time. A relay will consider the `created_at` time unacceptable if the `created_at` time is more than **[limit]** before the event was received by the relay (in the past) OR if the `created_at` time is later than the time the event was received by the relay (in the future). 
 
-If a relay supports this NIP, the relay SHOULD send the client a `NOTICE` message saying the event was not stored because the timestamp was too old.
+If a relay supports this NIP, the relay SHOULD send the client a `NOTICE` message saying the event was not stored because the `created_at` time was unacceptable.
 
 Client Behavior
 ---------------
 
-Clients SHOULD use the `supported_nips` field to learn if a relay supports event `created_at` checks.
+Clients SHOULD use the `supported_nips` field to learn if a relay supports event `created_at` time checks.
 
 Motivation
 ----------
 
-The motivation for this NIP is to prevent clients from saying they published an event *significantly* earlier than they actually did.
+The motivation for this NIP is to prevent clients from saying they published an event *significantly* earlier than they actually did or saying they published an event in the future.
 
-The event `created_at` field is just a unix timestamp (integer) so one could set it to a time in the past. For example, the `created_at` field could be set to a time 10 years ago even though it was created today and it could still be a valid event. This NIP aims to set a maximum amount of time elapsed between when an event was created and when it was *actually* published.
+The event `created_at` field is just a unix timestamp (integer) so one could set it to a time in the past or future. For example, the `created_at` field could be set to a time 10 years ago even though it was created today and it could still be a valid event. One could also set the `created_at` field to a time 10 years in the future and it could still be a valid event. This NIP aims to set a maximum amount of time elapsed between when an event was created and when it was *actually* published and prevent events from being from the future.

--- a/22.md
+++ b/22.md
@@ -21,3 +21,11 @@ Motivation
 The motivation for this NIP is to prevent clients from saying they published an event *significantly* earlier than they actually did or saying they published an event in the future.
 
 The event `created_at` field is just a unix timestamp (integer) so one could set it to a time in the past or future. For example, the `created_at` field could be set to a time 10 years ago even though it was created today and it could still be a valid event. One could also set the `created_at` field to a time 10 years in the future and it could still be a valid event. This NIP aims to set a maximum amount of time elapsed between when an event was created and when it was *actually* published and prevent events from being from the future.
+
+Relay Logic
+-----------
+
+```
+if time.now - event.created_at > limit OR event.created_at > time.now:
+  send NOTICE
+```

--- a/22.md
+++ b/22.md
@@ -1,0 +1,23 @@
+NIP-22
+======
+
+Unacceptable Event `created_at` time
+---------------------------
+
+`draft` `optional` `author:jeffthibault`
+
+Relays may support notifying clients that the event they published has an unacceptable `created_at` time. A relay will will consider the `created_at` time unacceptable if the `created_at` time is more than **[limit]** before the event was received by the relay. 
+
+If a relay supports this NIP, the relay SHOULD send the client a `NOTICE` message saying the event was not stored because the timestamp was too old.
+
+Client Behavior
+---------------
+
+Clients SHOULD use the `supported_nips` field to learn if a relay supports event `created_at` checks.
+
+Motivation
+----------
+
+The motivation for this NIP is to prevent clients from saying they published an event *significantly* earlier than they actually did.
+
+The event `created_at` field is just a unix timestamp (integer) so one could set it to a time in the past. For example, the `created_at` field could be set to a time 10 years ago even though it was created today and it could still be a valid event. This NIP aims to set a maximum amount of time elapsed between when an event was created and when it was *actually* published.

--- a/22.md
+++ b/22.md
@@ -4,11 +4,11 @@ NIP-22
 Event `created_at` Limits
 ---------------------------
 
-`draft` `optional` `author:jeffthibault`
+`draft` `optional` `author:jeffthibault` `author:Giszmo`
 
 Relays may define both upper and lower limits within which they will consider an event's `created_at` to be acceptable. Both the upper and lower limits MUST be unix timestamps in seconds as defined in [NIP-01](01.md).
 
-If a relay supports this NIP, the relay SHOULD send the client a `NOTICE` message saying the event was not stored for the `created_at` not being within the permitted limits.
+If a relay supports this NIP, the relay SHOULD send the client a `NOTICE` message saying the event was not stored for the `created_at` timestamp not being within the permitted limits.
 
 Client Behavior
 ---------------
@@ -37,5 +37,6 @@ LOWER_LIMIT = TIME - (60 * 60 * 24) # Define lower limit as 1 day into the past
 UPPER_LIMIT = TIME + (60 * 15)      # Define upper limit as 15 minutes into the future
 
 if event.created_at not in range(LOWER_LIMIT, UPPER_LIMIT):
+  # NOTE: This is one example of a notice message. Relays can change this to notify clients however they like.
   ws.send('["NOTICE", "The event created_at field is out of the acceptable range (-24h, +15min) for this relay and was not stored."]')
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-14: Subject tag in text events.](14.md)
 - [NIP-15: End of Stored Events Notice](15.md)
 - [NIP-16: Event Treatment](16.md)
+- [NIP-22: Event created_at Limits](22.md)
 - [NIP-25: Reactions](25.md)
 
 ## Event Kinds

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 
 Please update this list when proposing NIPs introducing new event kinds.
 
+When experimenting with kinds, keep in mind the classification introduced by [NIP-16](16.md).
+
 ## Criteria for acceptance of NIPs
 
 1. They should be implemented somewhere at least as a prototype somewhere.


### PR DESCRIPTION
For relays to set limits on acceptable created_at times for events

Formatted: https://github.com/jeffthibault/nips/blob/nip22-unacceptable-event-time/22.md

Previous: #21  