### PR TITLE
NIP-26: Delegated Event Signing

### DIFF
--- a/26.md
+++ b/26.md
@@ -4,57 +4,38 @@ NIP: 26
 Delegated Event Signing
 -----
 
-`draft` `mandatory` `author:markharding` `author:minds`
+`draft` `optional` `author:markharding` `author:minds`
 
-This NIP defines how events should be verified and signed to support generating events on behalf of someone else. It should be possible to sign Nostr events from other keypairs.
+This NIP defines how events can be delegated so that they can be signed by other keypairs.
 
 Another application of this proposal is to abstract away the use of the 'root' keypairs when interacting with clients. For example, a user could generate new keypairs for each client they wish to use and authorize those keypairs to generate events on behalf of their root pubkey, where the root keypair is stored in cold storage. 
 
-#### Introducing the 's' tag
+#### Introducing the 'delegation' tag
 
-This NIP introduces a new tag: `s` which is formatted as follows:
+This NIP introduces a new tag: `delegation` which is formatted as follows:
 
 ```json
 [
-  "s",
-  <signed pairing payload (base64 encoded)>,
-  <signed pairing signature (64-bytes shnnorr signature of the sha256 hash of the signed pairing payload>
+  "delegation",
+  <pubkey of the delegator>,
+  <conditions query string>,
+  <64-bytes schnorr signature of the sha256 hash of the delegation token>
 ]
 ```
 
-##### Signed Pairing Payload
+##### Delegation Token
 
-The Signed Pairing Payload should be a `base64` encoded JSON object as follows: 
+The **delegation token** should be a 64-bytes schnorr signature of the sha256 hash of the following string:
 
-```json
-{
-  "signerkey": <32-bytes hex-encoded public key of who is authorized to sign>,
-  "created_at": <unix timestamp of issued time>,
-  "expires_at": <optional, if present unix timestamp of invalidation time>
-}
+```
+nostr:delegation:<pubkey of publisher (delegatee)>:<conditions query string>
 ```
 
-For example, the Signed Pairing Payload `eyJzaWduZXJrZXkiOiI2MjkwM2IxZmY0MTU1OWRhZjllZTk4ZWYxYWU2N2NjNTJmMzAxYmI1Y2UyNmQxNGJhYmEzMDUyZjY0OWMzZjQ5IiwiY3JlYXRlZF9hdCI6MTY1OTQ0NjMxNX0=` consists of the payload:
+For example, the token `c33c88ba78ec3c760e49db591ac5f7b129e3887c8af7729795e85a0588007e5ac89b46549232d8f918eefd73e726cb450135314bfda419c030d0b6affe401ec1` is signed by `86f0689bd48dcd19c67a19d994f938ee34f251d8c39976290955ff585f2db42e` and consists of:
 
 ```json
-{
-  "signerkey": "62903b1ff41559daf9ee98ef1ae67cc52f301bb5ce26d14baba3052f649c3f49",
-  "created_at": 1659446315
-}
+nostr:delegation:62903b1ff41559daf9ee98ef1ae67cc52f301bb5ce26d14baba3052f649c3f49:kind=1&created_at>1640995200
 ```
-
-##### Signed Pairing Signature
-
-The Signed Pairing Signature is a schnorr signature of the sha256 hash of the Signed Pairing Payload. For example `2ed3e4b8470ce37b7e1946441a323d1d71c8a846fe49787ec406e14a44632cc96e48cabccc4a526eedd51aca33bf2a5cf7fb85462d23ad6d4de29c8b91abc41b` is a signature of the payload mentioned above.
-
-#### Modifying event verification
-
-When the `s` tag is provided, events **must** be signed and verified by the respective private key of the `signerkey`. Clients/relays **should** confirm that no revocation have been created with a greater `created_at` value. 
-
-Clients **must** verify the token is valid. The token **may** include the `expires_at` field if it wishes the delegated signing to be temporary (ie. sign events for 2 hours, 7 days, etc). 
-
-> TODO: How to revoke. This could be a future NIP.
-
 
 #### Example
 
@@ -62,19 +43,24 @@ Below is an example of an event published by `62903b1ff41559daf9ee98ef1ae67cc52f
 
 ```json
 {
-   "id":"23bf557814cd294d77a52e43d16903862c231857319f950ba40474fde1b9c393",
-   "pubkey":"86f0689bd48dcd19c67a19d994f938ee34f251d8c39976290955ff585f2db42e",
-   "created_at":1652969505,
-   "kind":1,
-   "tags":[
-      [
-         "s",
-         "eyJzaWduZXJrZXkiOiI2MjkwM2IxZmY0MTU1OWRhZjllZTk4ZWYxYWU2N2NjNTJmMzAxYmI1Y2UyNmQxNGJhYmEzMDUyZjY0OWMzZjQ5IiwiY3JlYXRlZF9hdCI6MTY1OTQ0NjMxNX0=",
-         "2ed3e4b8470ce37b7e1946441a323d1d71c8a846fe49787ec406e14a44632cc96e48cabccc4a526eedd51aca33bf2a5cf7fb85462d23ad6d4de29c8b91abc41b"
-      ]
-   ],
-   "content":"Hello Nostr. This is Minds calling.",
-   "sig":"30f0ebb907bd23416dd32a14b905abeb1db3fde97c74a151c51e5503e91ed25d58fbdcd95910ea4c11dc49d3fca8c616c0e7489e0f8da37b0938a7ce393285e7"
+  "id": "a080fd288b60ac2225ff2e2d815291bd730911e583e177302cc949a15dc2b2dc",
+  "pubkey": "62903b1ff41559daf9ee98ef1ae67cc52f301bb5ce26d14baba3052f649c3f49",
+  "created_at": 1660896109,
+  "kind": 1,
+  "tags": [
+    [
+      "delegation",
+      "86f0689bd48dcd19c67a19d994f938ee34f251d8c39976290955ff585f2db42e",
+      "kind=1&created_at>1640995200",
+      "c33c88ba78ec3c760e49db591ac5f7b129e3887c8af7729795e85a0588007e5ac89b46549232d8f918eefd73e726cb450135314bfda419c030d0b6affe401ec1"
+    ]
+  ],
+  "content": "Hello world",
+  "sig": "cd4a3cd20dc61dcbc98324de561a07fd23b3d9702115920c0814b5fb822cc5b7c5bcdaf3fa326d24ed50c5b9c8214d66c75bae34e3a84c25e4d122afccb66eb6"
 }
 ```
 
+
+#### Relay & Client Querying Support
+
+Relays should answer requests such as `["REQ", "", {"authors": ["A"]}]` by querying both the `pubkey` and delegation tags `[1]` value.  

--- a/26.md
+++ b/26.md
@@ -1,0 +1,80 @@
+NIP: 26
+=======
+
+Delegated Event Signing
+-----
+
+`draft` `mandatory` `author:markharding` `author:minds`
+
+This NIP defines how events should be verified and signed to support generating events on behalf of someone else. It should be possible to sign Nostr events from other keypairs.
+
+Another application of this proposal is to abstract away the use of the 'root' keypairs when interacting with clients. For example, a user could generate new keypairs for each client they wish to use and authorize those keypairs to generate events on behalf of their root pubkey, where the root keypair is stored in cold storage. 
+
+#### Introducing the 's' tag
+
+This NIP introduces a new tag: `s` which is formatted as follows:
+
+```json
+[
+  "s",
+  <signed pairing payload (base64 encoded)>,
+  <signed pairing signature (64-bytes shnnorr signature of the sha256 hash of the signed pairing payload>
+]
+```
+
+##### Signed Pairing Payload
+
+The Signed Pairing Payload should be a `base64` encoded JSON object as follows: 
+
+```json
+{
+  "signerkey": <32-bytes hex-encoded public key of who is authorized to sign>,
+  "created_at": <unix timestamp of issued time>,
+  "expires_at": <optional, if present unix timestamp of invalidation time>
+}
+```
+
+For example, the Signed Pairing Payload `eyJzaWduZXJrZXkiOiI2MjkwM2IxZmY0MTU1OWRhZjllZTk4ZWYxYWU2N2NjNTJmMzAxYmI1Y2UyNmQxNGJhYmEzMDUyZjY0OWMzZjQ5IiwiY3JlYXRlZF9hdCI6MTY1OTQ0NjMxNX0=` consists of the payload:
+
+```json
+{
+  "signerkey": "62903b1ff41559daf9ee98ef1ae67cc52f301bb5ce26d14baba3052f649c3f49",
+  "created_at": 1659446315
+}
+```
+
+##### Signed Pairing Signature
+
+The Signed Pairing Signature is a schnorr signature of the sha256 hash of the Signed Pairing Payload. For example `2ed3e4b8470ce37b7e1946441a323d1d71c8a846fe49787ec406e14a44632cc96e48cabccc4a526eedd51aca33bf2a5cf7fb85462d23ad6d4de29c8b91abc41b` is a signature of the payload mentioned above.
+
+#### Modifying event verification
+
+When the `s` tag is provided, events **must** be signed and verified by the respective private key of the `signerkey`. Clients/relays **should** confirm that no revocation have been created with a greater `created_at` value. 
+
+Clients **must** verify the token is valid. The token **may** include the `expires_at` field if it wishes the delegated signing to be temporary (ie. sign events for 2 hours, 7 days, etc). 
+
+> TODO: How to revoke. This could be a future NIP.
+
+
+#### Example
+
+Below is an example of an event published by `62903b1ff41559daf9ee98ef1ae67cc52f301bb5ce26d14baba3052f649c3f49`, on behalf of `86f0689bd48dcd19c67a19d994f938ee34f251d8c39976290955ff585f2db42e`.
+
+```json
+{
+   "id":"23bf557814cd294d77a52e43d16903862c231857319f950ba40474fde1b9c393",
+   "pubkey":"86f0689bd48dcd19c67a19d994f938ee34f251d8c39976290955ff585f2db42e",
+   "created_at":1652969505,
+   "kind":1,
+   "tags":[
+      [
+         "s",
+         "eyJzaWduZXJrZXkiOiI2MjkwM2IxZmY0MTU1OWRhZjllZTk4ZWYxYWU2N2NjNTJmMzAxYmI1Y2UyNmQxNGJhYmEzMDUyZjY0OWMzZjQ5IiwiY3JlYXRlZF9hdCI6MTY1OTQ0NjMxNX0=",
+         "2ed3e4b8470ce37b7e1946441a323d1d71c8a846fe49787ec406e14a44632cc96e48cabccc4a526eedd51aca33bf2a5cf7fb85462d23ad6d4de29c8b91abc41b"
+      ]
+   ],
+   "content":"Hello Nostr. This is Minds calling.",
+   "sig":"30f0ebb907bd23416dd32a14b905abeb1db3fde97c74a151c51e5503e91ed25d58fbdcd95910ea4c11dc49d3fca8c616c0e7489e0f8da37b0938a7ce393285e7"
+}
+```
+


### PR DESCRIPTION
This NIP defines how events should be verified and signed to support generating events on behalf of someone else. It should be possible to sign Nostr events from other keypairs.

Another application of this proposal is to abstract away the use of the 'root' keypairs when interacting with clients. For example, a user could generate new keypairs for each client they wish to use and authorize those keypairs to generate events on behalf of their root pubkey, where the root keypair is stored in cold storage. 

I understand that this is a significant change to the protocol, so any feedback here is welcome.