### PR TITLE
NIP05: support for locating service using DNS SRV records

### DIFF
--- a/05.md
+++ b/05.md
@@ -12,6 +12,8 @@ Upon seeing that, the client splits the identifier into `<local-part>` and `<dom
 
 The result should be a JSON document object with a key `"names"` that should then be a mapping of names to public keys. If the public key for the given `<name>` matches the `pubkey` from the `set_metadata` event, the client then concludes that the given pubkey can indeed be referenced by its identifier.
 
+If the `/.well-known` request resulted in an error response, a server is found by resolving an SRV record for `_nip05._tcp.<domain>`. This may result in a hostname (to be resolved using AAAA or A records) and port. Requests are made to the resolved hostname and port, using 443 as a default port, with a Host header of `<domain>`. The target server must present a valid certificate for `<domain>` with the resolved hostname as an SAN.
+
 ### Example
 
 If a client sees an event like this:
@@ -26,6 +28,22 @@ If a client sees an event like this:
 ```
 
 It will make a GET request to `https://example.com/.well-known/nostr.json?name=bob` and get back a response that will look like
+
+```json
+{
+  "names": {
+    "bob": "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9"
+  }
+}
+```
+
+If the request returns an error, the client resolves an SRV record for `_nip05._tcp.example.com` and get back a record that will look like
+
+```dns
+_nip05._tcp.example.com 86400 IN SRV 0 0 443 nostr.example.com
+```
+
+It will make a GET request to `https://nostr.example.com:443/.well-known/nostr.json?name=bob` and get back a response that will look like
 
 ```json
 {
@@ -50,6 +68,10 @@ Clients may treat the identifier `_@domain` as the "root" identifier, and choose
 ### Reasoning for the `/.well-known/nostr.json?name=<local-part>` format
 
 By adding the `<local-part>` as a query string instead of as part of the path the protocol can support both dynamic servers that can generate JSON on-demand and static servers with a JSON file in it that may contain multiple names.
+
+### Using a subdomain
+
+An user owning a domain may not want to use their main domain to serve the NIP05 `/.well-known` for various reasons. They may want to use a subdomain to serve it, e.g. `nostr.example.com`, but may want their identifier to look like `bob@example.com` and thus not include the subdomain part (i.e. `bob@nostr.example.com`). In this case, the best way is to setup an SRV record on their domain DNS, to indicate the client where to make the request.
 
 ### Allowing access from JavaScript apps
 


### PR DESCRIPTION
An user owning a domain may not want to use their main domain to serve the NIP05 `/.well-known` for various reasons. They may want to use a subdomain to serve it, e.g. `nostr.example.com`, but may want their identifier to look like `bob@example.com` and thus not include the subdomain part (i.e. `bob@nostr.example.com`). In this case, the best way would be to setup an SRV record on their domain DNS, to indicate the client where to make the request.

If the used hostname is indeed `nostr.example.com`, the SRV record could look like this:
```dns
_nip05._tcp.example.com 86400 IN SRV 0 0 443 nostr.example.com
```

Draft and open to discussion.