### PR TITLE
nip-01.md: kind: 0 - set_metadata conform to a standard event

### DIFF
--- a/01.md
+++ b/01.md
@@ -97,10 +97,65 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 
 ## Basic Event Kinds
 
-  - `0`: `set_metadata`: the `content` is set to a stringified JSON object `{name: <username>, about: <string>, picture: <url, string>}` describing the user who created the event. A relay may delete past `set_metadata` events once it gets a new one for the same pubkey.
-   * Where `<username>` is a string that matches the pattern: `[\w+\-]` (java regular epression).  Or, in other words, a sequence of the following
+  - `0`: `set_metadata`: Structure
+
+
+
+##### `[ "EVENT", {<event id>, <pubkey>, <created_at>, <kind>, ...`
+
+##### `"tags": [["name", "<regular_expression>"], ["about", "<string>"], ["picture", "<url>"], ... `
+
+##### `"content": "set_metadata", ...`
+
+##### `"sig": "<event_signature>" }]`
+
+describing the user who created the event.
+
+* A relay should delete past `set_metadata` events when it evaluates a `"kind": 0` EVENT with a newer `"created_at": <UTC_time_secs>,` tag for the same pubkey.
+
+* Where `<username>` is a string that matches the pattern: `[\w+\-]` (java regular epression).  Or, in other words, a sequence of the following
 	   characters: `[a-zA-Z_\-0-9]`.  <br>
 	   Thus `George-Washington-1776` is a valid `<username>`, but `George Washington` is not. Clients may reject metadata that does not comply.
+	   
+
+<details>
+<summary>Full Example: "kind": 0</summary>
+<p>
+
+```json
+[
+  "EVENT",
+  {
+    "id": "04f917a944830def000a8dbc2ecb64cd531572117101203d2ccd25f1aad9a669",
+    "pubkey": "edfa27d49d2af37ee331e1225bb6ed1912c6d999281b36d8018ad99bc3573c29",
+    "created_at": 1660142677,
+    "kind": 0,
+    "tags": [
+      [
+        "name",
+        "George-Washington-1776"
+      ],
+      [
+        "about",
+        "United States President"
+      ],
+      [
+        "picture",
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Gilbert_Stuart_Williamstown_Portrait_of_George_Washington.jpg/633px-Gilbert_Stuart_Williamstown_Portrait_of_George_Washington.jpg"
+      ]
+    ],
+    "content": "set_metadata",
+    "sig": "81bd5cc0d808f0ba1a6ebbc79f209a7665e10ae6364b2dda38bf44ab551029d2140080d090a2c4b5ff6ab6c0401b364d1f74f5c7c76290eeeb60a8d64f798743"
+  }
+]
+
+```
+
+</p>
+</details>
+
+---
+
   - `1`: `text_note`: the `content` is set to the text content of a note (anything the user wants to say).
   - `2`: `recommend_server`: the `content` is set to the URL (e.g., `https://somerelay.com`) of a relay the event creator wants to recommend to its followers.
 


### PR DESCRIPTION
added an example