### PR TITLE
Add specific replaceable events to nip16

### DIFF
--- a/16.md
+++ b/16.md
@@ -11,12 +11,17 @@ Relays may decide to allow replaceable and/or ephemeral events.
 Replaceable Events
 ------------------
 A *replaceable event* is defined as an event with a kind `10000 <= n < 20000`.
-Upon a replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind, the old event SHOULD be discarded and replaced with the newer event.
+Upon a replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind and author, the old event SHOULD be discarded and replaced with the newer event.
 
 Ephemeral Events
 ----------------
 An *ephemeral event* is defined as an event with a kind `20000 <= n < 30000`.
 Upon an ephemeral event being received, the relay SHOULD send it to all clients with a matching filter, and MUST NOT store it.
+
+Specifically Replaceable Events
+------------------
+A *specific replaceable event* is defined as an event with a kind `30000 <= n < 40000`.
+Upon a replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind, author, and the first tag (and its values), the old event SHOULD be discarded and replaced with the newer event.
 
 Client Behavior
 ---------------

--- a/16.md
+++ b/16.md
@@ -18,9 +18,9 @@ Ephemeral Events
 An *ephemeral event* is defined as an event with a kind `20000 <= n < 30000`.
 Upon an ephemeral event being received, the relay SHOULD send it to all clients with a matching filter, and MUST NOT store it.
 
-Specifically Replaceable Events
+Parameterized Replaceable Events
 ------------------
-A *specific replaceable event* is defined as an event with a kind `30000 <= n < 40000`.
+A *parameterized replaceable event* is defined as an event with a kind `30000 <= n < 40000`.
 Upon a replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind, author, and the first tag (and its values), the old event SHOULD be discarded and replaced with the newer event.
 
 Client Behavior

--- a/16.md
+++ b/16.md
@@ -21,7 +21,7 @@ Upon an ephemeral event being received, the relay SHOULD send it to all clients 
 Parameterized Replaceable Events
 ------------------
 A *parameterized replaceable event* is defined as an event with a kind `30000 <= n < 40000`.
-Upon a replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind, author, and the first tag (and its values), the old event SHOULD be discarded and replaced with the newer event.
+Upon a replaceable event being received with a newer timestamp than the currently known latest replaceable event with the same kind, author, and the value of the first `d` tag, the old event SHOULD be discarded and replaced with the newer event. If the `d` tag is missing, it is assumed that it is an empty string.
 
 Client Behavior
 ---------------


### PR DESCRIPTION
Adds specific replaceable events at a new range of kinds, where now it takes additional criteria to match and replace: the first tag and its values.

One use-case for this is if you are posting replaceable notes and need to anticipate a greater amount of notes to the allowed kind range for a single author. 