### PR TITLE
NIP-29 Bookmarks

### DIFF
--- a/29.md
+++ b/29.md
@@ -1,0 +1,53 @@
+NIP-29
+======
+
+Bookmarks & Pinned Events
+---------
+
+`draft` `optional` `author:plantimals`
+
+A bookmark is a stored event `ID`, allowing the user to keep track of events
+and indicate one of them as a pinned event.
+
+Bookmarks are indicated by `e` tags on a `kind 8` event containing the event
+`ID` being bookmarked along with a note.
+
+A pinned event is indicated by placing that event `ID` alone in the `content`
+field.
+
+Bookmarks: `["e", "<event-id>", "<note text>"]`
+
+Pinned Event: `"content": "<event-id>"`
+
+A bookmark event MUST contain at least one `e` tag and MAY contain one pinned
+event.
+
+Example kind 8 event:
+
+``` json
+{
+  "id": "168531d2858bf5ea34ea3fe9985e175eda0fe149b26695c34adca304c3857cca",
+  "pubkey": "dd81a8bacbab0b5c3007d1672fb8301383b4e9583d431835985057223eb298a5",
+  "created_at": 1661693844,
+  "kind": 8,
+  "tags": [
+    [
+      "e",
+      "40006e8a69380fbb49bdc3c4dca66ed2df13431f72a12bf547ebac13bff07def",
+      "first pinned events attempt"
+    ],
+    [
+      "e",
+      "23c3b0b30f018f1da2e2d63817f73d01df4cf0086e25eecf26250ba2c93928e8",
+      "balas' suggestion for bookmarking/pinned events"
+    ],
+    [
+      "e",
+      "c76166d9384355e8f55abfc071294fb815ac5f4050e2b9373b997b4bed66c669",
+      "dagon by hp lovecraft"
+    ]
+  ],
+  "content": "c76166d9384355e8f55abfc071294fb815ac5f4050e2b9373b997b4bed66c669",
+  "sig": "3c9247e3e33c0c7e24ce760646ef0f97c87509a5603e121f788cd3e4f0869dff031fdcc929df1c8295d478096b26ce44b53b57b339e8daeb127c8cfc3415093f"
+}
+```

--- a/29.md
+++ b/29.md
@@ -1,34 +1,27 @@
 NIP-29
 ======
 
-Bookmarks & Pinned Events
+Bookmarks
 ---------
 
 `draft` `optional` `author:plantimals`
 
-A bookmark is a stored event `ID`, allowing the user to keep track of events
-and indicate one of them as a pinned event.
+A bookmark is a stored event `ID`, allowing the user to keep track of events.
 
 Bookmarks are indicated by `e` tags on a `kind 8` event containing the event
 `ID` being bookmarked along with a note.
 
-A pinned event is indicated by placing that event `ID` alone in the `content`
-field.
-
 Bookmarks: `["e", "<event-id>", "<note text>"]`
 
-Pinned Event: `"content": "<event-id>"`
-
-A bookmark event MUST contain at least one `e` tag and MAY contain one pinned
-event.
+A bookmark event MUST contain at least one `e` tag.
 
 Example kind 8 event:
 
 ``` json
 {
-  "id": "168531d2858bf5ea34ea3fe9985e175eda0fe149b26695c34adca304c3857cca",
+  "id": "2d602d2d75c0ca4e87eae763bb67ba9022a0fc2aabb0e172cf2337602f689602",
   "pubkey": "dd81a8bacbab0b5c3007d1672fb8301383b4e9583d431835985057223eb298a5",
-  "created_at": 1661693844,
+  "created_at": 1661712710,
   "kind": 8,
   "tags": [
     [
@@ -47,7 +40,7 @@ Example kind 8 event:
       "dagon by hp lovecraft"
     ]
   ],
-  "content": "c76166d9384355e8f55abfc071294fb815ac5f4050e2b9373b997b4bed66c669",
-  "sig": "3c9247e3e33c0c7e24ce760646ef0f97c87509a5603e121f788cd3e4f0869dff031fdcc929df1c8295d478096b26ce44b53b57b339e8daeb127c8cfc3415093f"
+  "content": "",
+  "sig": "d996aefd542a036f796aef3c2878a17178bd9342efdc4c0061aa224eb7e2b39f0846ed8ccd2323e895c208dd134cfb38dd28c42f1cadd0205e2a231f124c12e8"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-16: Event Treatment](16.md)
 - [NIP-22: Event created_at Limits](22.md)
 - [NIP-25: Reactions](25.md)
+- [NIP-29: Bookmarks & Pinned Events](29.md)
 
 ## Event Kinds
 
@@ -32,6 +33,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 | 4    | Encrypted Direct Messages | 4    |
 | 5    | Event Deletion            | 9    |
 | 7    | Reaction                  | 25   |
+| 8    | Bookmarks                 | 29   |
 
 Please update this list when proposing NIPs introducing new event kinds.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-16: Event Treatment](16.md)
 - [NIP-22: Event created_at Limits](22.md)
 - [NIP-25: Reactions](25.md)
-- [NIP-29: Bookmarks & Pinned Events](29.md)
+- [NIP-29: Bookmarks](29.md)
 
 ## Event Kinds
 


### PR DESCRIPTION
This is a first pass at adding bookmarked events and pinned events. The specific form of this is largely inspired by balas ( `9ec7a778167afb1d30c4833de9322da0c08ba71a69e1911d5578d3144bb56437` ).

tl;dr:
* introduces `kind 8`
* bookmarks are `e` tags
* an event may be pinned by placing the event `ID` alone in the `content` field

A functioning prototype can be found implemented on profile view pages of nostr.io. 
* [example bookmark event in the wild](https://nostr.io/e/168531d2858bf5ea34ea3fe9985e175eda0fe149b26695c34adca304c3857cca)
* [example pinned event at the top of a profile page](https://nostr.io/p/dd81a8bacbab0b5c3007d1672fb8301383b4e9583d431835985057223eb298a5)