### PR TITLE
NIP-30 Resources

### DIFF
--- a/30.md
+++ b/30.md
@@ -1,0 +1,50 @@
+NIP-30
+======
+
+Resources
+---------
+
+`draft` `optional` `author:plantimals`
+
+In order to allow events to transmit links to resources in a discoverable,
+semantically accessible way, there should be a `kind` that provides a URL
+and [media type](https://www.iana.org/assignments/media-types/media-types.xhtml) to allow clients to handle the associated content. An initial
+use case is in translating things like podcast feeds to nostr events. In that
+context, the `resource` would map to the [RSS enclosure](https://www.rssboard.org/rss-profile#element-channel-item-enclosure), which is how
+publishers indicate the URL to the audio content via RSS feed.
+
+Exposing the `resource` at the level of a tag allows for subscription filters
+to be added that return all events containing a certain media type. This
+allows content aggregation by various means, from "re-sharing" `kind 9` events
+that one encounters while browsing nostr feeds and later organizing those as
+personal media feeds, to dedicated distribution of content similar to how RSS
+feeds function for blogs, news, podcasts, etc.
+
+There are several favorable dynamics of this system of distribution to
+that of RSS.
+
+`kind 9` allows:
+
+* event-based distribution rather than polling a server
+* on the fly map/reduce semantics around feed creation
+* a broader distribution of the message content across many relays
+* replies that provide clips of the associated media as people find them
+* comments on the media to be syndicated along with the content itself
+
+Implementation
+--------------
+
+A resource is a `kind 9` event with one `resource` tag referencing a URL and
+its media type.
+
+A resource tag looks like `["resource", "https://anchor.fm/s/45563e80/podcast/play/56797105/https%3A%2F%2Fd3ctxlq1ktw2nl.cloudfront.net%2Fstaging%2F2022-7-29%2F2cc29ddf-c44f-b38c-ee2c-88e0e1634449.mp3", "audio/mpeg"]`
+
+The `content` field for `kind 9` MAY include text "about" the resource.
+
+A `kind 9` event MAY include `e` tags referencing other events.
+
+Notes
+-----
+
+media type: [https://www.iana.org/assignments/media-types/media-types.xhtml](https://www.iana.org/assignments/media-types/media-types.xhtml)
+RSS enclosure: [https://www.rssboard.org/rss-profile#element-channel-item-enclosure](https://www.rssboard.org/rss-profile#element-channel-item-enclosure)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-16: Event Treatment](16.md)
 - [NIP-22: Event created_at Limits](22.md)
 - [NIP-25: Reactions](25.md)
+- [NIP-30: Resources](30.md)
 
 ## Event Kinds
 
@@ -32,6 +33,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 | 4    | Encrypted Direct Messages | 4    |
 | 5    | Event Deletion            | 9    |
 | 7    | Reaction                  | 25   |
+| 9    | Resource                  | 30   |
 
 Please update this list when proposing NIPs introducing new event kinds.
 


### PR DESCRIPTION
[nip-30](https://github.com/plantimals/nips/blob/nip-30/30.md)

Looking for feedback.

I believe adding a `resource` kind will unlock a lot of immediately useful interactions in nostr, from being able to filter events based on their media content (find all images, links, audio, etc from a particular pubkey), to directly mapping podcasts and similar content to nostr events. I elaborate on the favorable dynamics in the NIP.  An important aspect is that the `URL` and `type` fields are in the tags so they can be filtered on without updating existing filter params.

I can also imagine the `resource` tag being added to `kind 1`, which would fit the form of `kind 9` perfectly. I went with a new `kind` in this draft because it seems the least disruptive. perhaps if the `kind 9` is approved and found to be productive it could eventually be merged into `kind 1`. 

The name `resource` seems best, but I can imagine it also being called an `attachment`, `URL`, `link`, `enclosure`, etc.