### PR TITLE
NIP-31 Pinned Events

### DIFF
--- a/31.md
+++ b/31.md
@@ -1,0 +1,28 @@
+NIP-31
+======
+
+Pinned Events
+-------------
+
+`draft` `optional` `author:plantimals`
+
+NIP-31 amends the content metadata for `Kind 0` as described in [NIP-01](01.md).
+
+Each pubkey MAY indicate a pinned event by setting the field `"pinned_event"`
+in the json content of one's `Kind 0` metadata event to point to an
+event `ID`.
+
+Example json content from [this event](https://nostr.io/api/v1/events/71412d5cdb7e675b9806d23bda3d7c4878ca7f8e72ae3477c7179938e857cb9b):
+
+```json
+{
+    "name":"plantimals",
+    "picture":"https://plantimals.org/img/avatar.png","pinned_event":"c76166d9384355e8f55abfc071294fb815ac5f4050e2b9373b997b4bed66c669",
+    "about":"[plantimals](https://plantimals.org)",
+    "nip05":"_@plantimals.org"
+}
+```
+
+The `pinned_event` field is meant to provide a link to additional content for
+someone wishing to supplement their `about` text. Users SHOULD ONLY pin events
+that they have authored in order to avoid mistaken identity.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-16: Event Treatment](16.md)
 - [NIP-22: Event created_at Limits](22.md)
 - [NIP-25: Reactions](25.md)
+- [NIP-31: Pinned Events](31.md)
 
 ## Event Kinds
 


### PR DESCRIPTION
NIP-31 describes pinned events. It wasn't entirely clear whether to propose in-place edits to NIP-01 or create new NIP.

Put a field in your `kind 0` metadata content to indicate which event you want to pin. 


[This event](https://nostr.io/api/v1/events/71412d5cdb7e675b9806d23bda3d7c4878ca7f8e72ae3477c7179938e857cb9b) is an example of a `kind 0` metadata event with the `pinned_event` field specified. An implementation of a client that interprets the pinned event as an event that should appear at the top of a user's profile page, before other more recent events can be found [here](https://nostr.io/p/dd81a8bacbab0b5c3007d1672fb8301383b4e9583d431835985057223eb298a5).