### PR TITLE
NIP-32: Reputation

### DIFF
--- a/32.md
+++ b/32.md
@@ -10,3 +10,14 @@ Reputation
 This NIP defines a specification for key-based reputation.
 
 Any [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) keypair may assign reputation events to other keys based on user-defined schemas.
+
+## Kind 32: Assign Reputation
+
+**`tags`** MUST contain an entry identifying the recipient key, in the form `["p", "<pubkey, as a hex string>"]`.
+
+
+Additional Info
+---------------
+
+- [Reputation data-type conversation, Sept 2021](https://github.com/nostr-protocol/nostr/issues/20)
+- [Previous reputation NIP, not adopted](https://github.com/nostr-protocol/nostr/pull/72/files)

--- a/32.md
+++ b/32.md
@@ -8,3 +8,5 @@ Reputation
 `draft` `optional` `author:ChristopherDavid`
 
 This NIP defines a specification for key-based reputation.
+
+Users controlling keypairs may assign reputation events to other keys based on user-defined schemas.

--- a/32.md
+++ b/32.md
@@ -1,0 +1,10 @@
+
+NIP-32
+======
+
+Reputation
+-----------
+
+`draft` `optional` `author:ChristopherDavid`
+
+This NIP defines a specification for key-based reputation.

--- a/32.md
+++ b/32.md
@@ -9,4 +9,4 @@ Reputation
 
 This NIP defines a specification for key-based reputation.
 
-Users controlling keypairs may assign reputation events to other keys based on user-defined schemas.
+Any [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) keypair may assign reputation events to other keys based on user-defined schemas.

--- a/32.md
+++ b/32.md
@@ -15,6 +15,9 @@ Any [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) keypair m
 
 **`tags`** MUST contain an entry identifying the recipient key, in the form `["p", "<pubkey, as a hex string>"]`.
 
+**`tags`** MAY contain entries referencing previous events, in the form `["e", "<event_id, as a hex string>"]`.
+
+**`content`** MUST be a JSON object serialized as a string with [...]
 
 Additional Info
 ---------------


### PR DESCRIPTION
This NIP defines a specification for key-based reputation.

Any [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) keypair may assign reputation events to other keys based on user-defined schemas.

(wip - see latest version in [Files changed](https://github.com/nostr-protocol/nips/pull/46/files))