### PR TITLE
add NIP-28 link and kinds in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-16: Event Treatment](16.md)
 - [NIP-22: Event created_at Limits](22.md)
 - [NIP-25: Reactions](25.md)
+- [NIP-28: Public Chat](28.md)
 
 ## Event Kinds
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 | 4    | Encrypted Direct Messages | 4    |
 | 5    | Event Deletion            | 9    |
 | 7    | Reaction                  | 25   |
+| 40   | Channel Creation          | 28   |
+| 41   | Channel Metadata          | 28   |
+| 42   | Channel Message           | 28   |
+| 43   | Channel Hide Message      | 28   |
+| 44   | Channel Mute User         | 28   |
+| 45-49 | Public Chat Reserved     | 28   |
+
 
 Please update this list when proposing NIPs introducing new event kinds.
 


### PR DESCRIPTION
Simply links to the now-merged NIP-28 (Public Chat) in the main README.