### PR TITLE
Add NIP-33 Parameterized replaceable events

### DIFF
--- a/16.md
+++ b/16.md
@@ -11,7 +11,7 @@ Relays may decide to allow replaceable and/or ephemeral events.
 Replaceable Events
 ------------------
 A *replaceable event* is defined as an event with a kind `10000 <= n < 20000`.
-Upon a replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind, the old event SHOULD be discarded and replaced with the newer event.
+Upon a replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind being received, the old event SHOULD be discarded and replaced with the newer event.
 
 Ephemeral Events
 ----------------

--- a/33.md
+++ b/33.md
@@ -1,0 +1,20 @@
+NIP-33
+======
+
+Parameterized Replaceable Events
+--------------------------------
+
+`draft` `optional` `author:Semisol`
+
+This NIP adds a new event range that allows for replacement of events that have the same `d` tag and kind unlike NIP-16 which only replaced by kind.
+
+Implementation
+--------------
+A *parameterized replaceable event* is defined as an event with a kind `30000 <= n < 40000`.
+Upon a parameterized replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind and `d` tag being received, the old event SHOULD be discarded and replaced with the newer event.  
+A missing `d` tag should be interpreted as an empty tag value and only the first tag's value should be accounted for.
+
+Client Behavior
+---------------
+
+Clients SHOULD use the `supported_nips` field to learn if a relay supports this NIP.  Clients MAY send parameterized replaceable events to relays that may not support this NIP, and clients querying SHOULD be prepared for the relay to send multiple events and should use the latest one and are recommended to send a `#d` tag filter.  

--- a/33.md
+++ b/33.md
@@ -4,7 +4,7 @@ NIP-33
 Parameterized Replaceable Events
 --------------------------------
 
-`draft` `optional` `author:Semisol`
+`draft` `optional` `author:Semisol` `author:Kukks` `author:Cameri` `author:fiatjaf`
 
 This NIP adds a new event range that allows for replacement of events that have the same `d` tag and kind unlike NIP-16 which only replaced by kind.
 

--- a/33.md
+++ b/33.md
@@ -11,8 +11,19 @@ This NIP adds a new event range that allows for replacement of events that have 
 Implementation
 --------------
 A *parameterized replaceable event* is defined as an event with a kind `30000 <= n < 40000`.
-Upon a parameterized replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind and `d` tag being received, the old event SHOULD be discarded and replaced with the newer event.  
-A missing `d` tag should be interpreted as an empty tag value and only the first tag's value should be accounted for.
+Upon a parameterized replaceable event with a newer timestamp than the currently known latest
+replaceable event with the same kind and first `d` tag value being received, the old event
+SHOULD be discarded and replaced with the newer event.  
+A missing or a `d` tag with no value should be interpreted equivalent to a `d` tag with the
+value as an empty string. Events from the same author with any of the following `tags`
+replace each other:
+
+* `"tags":[["d",""]]`
+* `"tags":[]`: implicit `d` tag with empty value
+* `"tags":[["d"]]`: implicit empty value `""`
+* `"tags":[["d",""],["d","not empty"]]`: only first `d` tag is considered
+* `"tags":[["d"],["d","some value"]]`: only first `d` tag is considered
+* `"tags":[["e"]]`: same as no tags
 
 Client Behavior
 ---------------

--- a/33.md
+++ b/33.md
@@ -17,4 +17,5 @@ A missing `d` tag should be interpreted as an empty tag value and only the first
 Client Behavior
 ---------------
 
-Clients SHOULD use the `supported_nips` field to learn if a relay supports this NIP.  Clients MAY send parameterized replaceable events to relays that may not support this NIP, and clients querying SHOULD be prepared for the relay to send multiple events and should use the latest one and are recommended to send a `#d` tag filter.  
+Clients SHOULD use the `supported_nips` field to learn if a relay supports this NIP.
+Clients MAY send parameterized replaceable events to relays that may not support this NIP, and clients querying SHOULD be prepared for the relay to send multiple events and should use the latest one and are recommended to send a `#d` tag filter. Clients should account for the fact that missing `d` tags or ones with no value are not returned in tag filters, and are recommended to always include a `d` tag with a value.  


### PR DESCRIPTION
NIP-33 allows for parameterized replaceable events which allow replacement by the `d` tag and the kind instead of just the kind.