### PR TITLE
NIP-34 Relay Supported Features

### DIFF
--- a/34.md
+++ b/34.md
@@ -1,0 +1,10 @@
+NIP-34
+======
+
+Relay Supported Features
+------------------------
+
+`draft` `optional` `author:Semisol`
+
+This NIP adds a field to the NIP-11 relay information document, `supported_features`, which is an array of strings containing a list of supported features.  
+Each supported feature must be a string that is named similar to Java packages (`com.example.ExampleFeature`) or `nip#.*` where `#` is replaced by a NIP number.  


### PR DESCRIPTION
Very simple NIP, adds `supported_features` to the relay information document that is an array of strings such as:
- `nip1.limit`
- `dev.semisol.search`
