### PR TITLE
add NIP-19: bech32-encoding of stuff.

### DIFF
--- a/19.md
+++ b/19.md
@@ -4,21 +4,38 @@ NIP-19
 bech32-encoded entities
 -----------------------
 
-`draft` `optional` `author:jb55` `author:fiatjaf`
+`draft` `optional` `author:jb55` `author:fiatjaf` `author:Semisol`
+
+This NIP species all bech32-encoded entities.
+
+## Bare keys
 
 To prevent confusion and mixing between private keys, public keys and event ids, which are all 32 byte strings. bech32-(not-m) encoding with different prefixes can be used for each of these entities.
 
-For public keys, the prefix is `npub`, so, for example, `3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d` translates to `npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6`.
+These are the possible bech32 prefixes:
 
-For private keys, the prefix is `nsec`.
+  - `npub`: public keys
+  - `nsec`: private keys
+  - `note`: note ids
 
-For kind-1 notes, the prefix is `note`.
+Example: the hex public key `3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d` translates to `npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6`.
 
-## Optional extra metadata in bech32-encoded blobs
+## Shareable identifiers with extra metadata
 
-Parsers must expect to decode extra metadata that may exist after the initial 32 bytes. Any metadata must be added as a `TLV` (type-length-value) item, with `T` and `L` being 1 byte (`uint8`, range 0-255) each, and `V` being of the size indicated by `L`.
+When sharing a profile or an event, an app may decide to include relay information and other metadata such that other apps can locate and display these entities more easily.
 
-The possible standardized types are indicated here:
+For these events, the contents are a binary-encoded list of `TLV` (type-length-value), with `T` and `L` being 1 byte each (`uint8`, i.e. a number in the range of 0-255), and `V` being a sequence of bytes of the size indicated by `L`.
 
+These are the possible bech32 prefixes:
+
+  - `nprofile`: a nostr profile
+  - `nevent`: a nostr event
+
+These possible standardized `TLV` types are indicated here:
+
+- `0`: `special`
+  - depends on the bech32 prefix:
+    - for `nprofile` it will be the 32 bytes of the profile public key
+    - for `nevent` it will be the 32 bytes of the event id
 - `1`: `relay`
-  - in case the _npub_ writer wants to make sure its stuff will be found by the reader they can append this data so the reader will know where to look for basic metadata and events for that public key. This may be be included multiple times.
+  - A relay in which the entity (profile or event) is more likely to be found. This may be be included multiple times.

--- a/19.md
+++ b/19.md
@@ -6,7 +6,7 @@ bech32-encoded entities
 
 `draft` `optional` `author:jb55` `author:fiatjaf`
 
-To prevent confusion and mixing between private keys, public keys and event ids, which are all 32 byte strings. bech32-2 (not-m) encoding with different prefixes can be used for each of these entities.
+To prevent confusion and mixing between private keys, public keys and event ids, which are all 32 byte strings. bech32-(not-m) encoding with different prefixes can be used for each of these entities.
 
 For public keys, the prefix is `npub`, so, for example, `3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d` translates to `npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6`.
 
@@ -16,9 +16,9 @@ For kind-1 notes, the prefix is `note`.
 
 ## Optional extra metadata in bech32-encoded blobs
 
-Parsers must expect to decode extra metadata that may exist after the initial 32 bytes. Any metadata must be added as a `TLV` (type-length-value) item, with `T` and `L` being 2 bytes (`uint16` big-endian) each, and `V` being of the size indicated by `L`.
+Parsers must expect to decode extra metadata that may exist after the initial 32 bytes. Any metadata must be added as a `TLV` (type-length-value) item, with `T` and `L` being 1 byte (`uint8`, range 0-255) each, and `V` being of the size indicated by `L`.
 
 The possible standardized types are indicated here:
 
-- `1`: `master relay`
-  - in case the _npub_ writer wants to make sure its stuff will be found by the reader they can append this data so the reader will know where to look for basic metadata and events for that public key.
+- `1`: `relay`
+  - in case the _npub_ writer wants to make sure its stuff will be found by the reader they can append this data so the reader will know where to look for basic metadata and events for that public key. This may be be included multiple times.

--- a/19.md
+++ b/19.md
@@ -1,0 +1,22 @@
+NIP-19
+======
+
+bech32-encoded entities
+-----------------------
+
+`draft` `optional` `author:jb55` `author:fiatjaf`
+
+To prevent confusion and mixing between private keys, public keys and event ids, which are all 32 byte strings. bech32-2 (not-m) encoding with different prefixes can be used for each of these entities.
+
+For public keys, the prefix is `npub`, so, for example, `3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d` translates to `npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6`.
+
+For private keys, the prefix is `nsec`.
+
+## Optional extra metadata in bech32-encoded blobs
+
+Parsers must expect to decode extra metadata that may exist after the initial 32 bytes. Any metadata must be added as a `TLV` (type-length-value) item, with `T` and `L` being 2 bytes (`uint16`) each, and `V` being of the size indicated by `L`.
+
+The possible standardized types are indicated here:
+
+- `1`: `master relay`
+  - in case the _npub_ writer wants to make sure its stuff will be found by the reader they can append this data so the reader will know where to look for basic metadata and events for that public key.

--- a/19.md
+++ b/19.md
@@ -6,9 +6,9 @@ bech32-encoded entities
 
 `draft` `optional` `author:jb55` `author:fiatjaf` `author:Semisol`
 
-This NIP species all bech32-encoded entities.
+This NIP specifies all bech32-encoded entities.
 
-## Bare keys
+## Bare keys and ids
 
 To prevent confusion and mixing between private keys, public keys and event ids, which are all 32 byte strings. bech32-(not-m) encoding with different prefixes can be used for each of these entities.
 
@@ -20,13 +20,15 @@ These are the possible bech32 prefixes:
 
 Example: the hex public key `3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d` translates to `npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6`.
 
+The bech32 encodings of keys and ids are not meant to be used inside the standard NIP-01 event formats or inside the filters, they're meant for human-friendlier display and input only. Clients should still accept keys in both hex and npubformat for now, and convert internally.
+
 ## Shareable identifiers with extra metadata
 
 When sharing a profile or an event, an app may decide to include relay information and other metadata such that other apps can locate and display these entities more easily.
 
 For these events, the contents are a binary-encoded list of `TLV` (type-length-value), with `T` and `L` being 1 byte each (`uint8`, i.e. a number in the range of 0-255), and `V` being a sequence of bytes of the size indicated by `L`.
 
-These are the possible bech32 prefixes:
+These are the possible bech32 prefixes with `TLV`:
 
   - `nprofile`: a nostr profile
   - `nevent`: a nostr event
@@ -38,4 +40,4 @@ These possible standardized `TLV` types are indicated here:
     - for `nprofile` it will be the 32 bytes of the profile public key
     - for `nevent` it will be the 32 bytes of the event id
 - `1`: `relay`
-  - A relay in which the entity (profile or event) is more likely to be found. This may be be included multiple times.
+  - A relay in which the entity (profile or event) is more likely to be found, encoded as UTF-8. This may be included multiple times.

--- a/19.md
+++ b/19.md
@@ -16,7 +16,7 @@ For kind-1 notes, the prefix is `note`.
 
 ## Optional extra metadata in bech32-encoded blobs
 
-Parsers must expect to decode extra metadata that may exist after the initial 32 bytes. Any metadata must be added as a `TLV` (type-length-value) item, with `T` and `L` being 2 bytes (`uint16`) each, and `V` being of the size indicated by `L`.
+Parsers must expect to decode extra metadata that may exist after the initial 32 bytes. Any metadata must be added as a `TLV` (type-length-value) item, with `T` and `L` being 2 bytes (`uint16` big-endian) each, and `V` being of the size indicated by `L`.
 
 The possible standardized types are indicated here:
 

--- a/19.md
+++ b/19.md
@@ -12,6 +12,8 @@ For public keys, the prefix is `npub`, so, for example, `3bf0c63fcb93463407af97a
 
 For private keys, the prefix is `nsec`.
 
+For kind-1 notes, the prefix is `note`.
+
 ## Optional extra metadata in bech32-encoded blobs
 
 Parsers must expect to decode extra metadata that may exist after the initial 32 bytes. Any metadata must be added as a `TLV` (type-length-value) item, with `T` and `L` being 2 bytes (`uint16`) each, and `V` being of the size indicated by `L`.


### PR DESCRIPTION
With an extra section for TLV-encoded arbitrary metadata. Let me know what you think.

I think this will be very much necessary, for example, for Minds-like integrations through which some profiles and events will generally be only accessible from one master relay from each platform (e.g. the Minds relay). @ottman @harding what do you think?

And also when the network grows and we start to see more segregation of contents between relays, this makes it easier for people to share their profiles, without having to say: "my pubkey is X, and please make sure to add relay Z to your client".

https://github.com/nostr-protocol/nips/blob/ce4869b9404b9c588ef92353999cbe787cb679c3/19.md

Is this correct @jb55? What else are you bech32-encoding? Event ids?