### PR TITLE
Fix regex for SetMetadata in NIP1

### DIFF
--- a/01.md
+++ b/01.md
@@ -98,8 +98,8 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 ## Basic Event Kinds
 
   - `0`: `set_metadata`: the `content` is set to a stringified JSON object `{name: <username>, about: <string>, picture: <url, string>}` describing the user who created the event. A relay may delete past `set_metadata` events once it gets a new one for the same pubkey.
-    * Where `<username>` is a string that matches the pattern: `[\w+\-]` (java regular expression).  Or, in other words, a sequence of the following
-	   characters: `[a-zA-Z_\-0-9]`.  <br>
+    * Where `<username>` is a string that matches the pattern: `\w[\w\-]+\w` (java regular expression).  Or, in other words, a sequence of the following
+	   characters: `[a-zA-Z_0-9][a-zA-Z_\-0-9]+[a-zA-Z_0-9]`.  <br>
 	   Thus `George-Washington-1776` is a valid `<username>`, but `George Washington` is not. Clients may reject metadata that does not comply.
   - `1`: `text_note`: the `content` is set to the text content of a note (anything the user wants to say).
   - `2`: `recommend_server`: the `content` is set to the URL (e.g., `https://somerelay.com`) of a relay the event creator wants to recommend to its followers.


### PR DESCRIPTION
It appears the regex given in NIP1 for setting the username in the setmetadata event was slightly off. I think the fix here is what was intended. Though I think what was meant here was pretty obvious, to make it easier on future developers, I updated the regex to something that should work with just copying and pasting.