### PR TITLE
NIP-38 - Encrypted Group Chat using a single shared secret

### DIFF
--- a/38.md
+++ b/38.md
@@ -117,13 +117,23 @@ Clients that support this NIP will read that and know that they're invited to jo
 
 Other clients will decrypt this message, and ignore it, but the user can read that they have been invited to such a channel.
 
-
-
 ### Encryption
 
-All participants should ideally have the shared secret sent to them by the creator of the channel. If such a message is present, the client should get the shared secret from that messages, and then encrypt the 142 kind message using that.
+All participants should ideally have the shared secret sent to them by the creator of the channel. If such a message is present, the client should read the shared secret from that message, and then encrypt any 142 kind message they want to send using it.
 
 Only the given shared-secret private and public keys are used to encrypt or decrypt the messages. 
+
+## Adding and Removing Participants 
+
+### Adding Participants In Same Group
+
+To add participants to the group, the admin or creator of the group emits a kind 141 message with the updated p tags, which also include the pubkeys of new members. Along with this, the admin shall also communicate to the newly added members the group shared-secret, using the same mechanism as mentioned in section for kind 104 above. 
+
+### Removing Participants
+
+Once a group is created, all participants know the shared-secret, so to remove a participant, we need to change the shared-secret of the remaining or new group. The remaining group can now be considered a candidate for a new channel, and there will be established a logical relationship between the new channel and the old one. This is done by use of a tag in the creation event of the new channel. 
+
+The applications on looking at that tag can find out which was the precursor channel to this new channel, and display both the old and new channel seamlessly to the user, if that's needed.
 
 
 ## NIP-10 relay recommendations

--- a/38.md
+++ b/38.md
@@ -1,0 +1,142 @@
+
+NIP-38
+======
+
+Encrypted Group Chat
+--------------------
+
+`draft` `optional` `author:vishalxl` 
+
+This NIP defines new event kinds for encrypted group chat. 
+
+It works by creating a shared secret that is used to encrypt the group or channel messages. Only the participants know that secret, so only such members can read/write to this group chat.
+
+It reserves three event kinds (140-142) for immediate use and 7 event kinds (143-149) for future use.
+
+- `140 - create encrypted channel`
+- `141 - change channel metadata including participants`
+- `142 - send encrypted message`
+
+
+## Kind 140: Create Encrypted channel
+
+Create a Encrypted chat channel.
+
+In the channel creation `content` field, Client SHOULD include basic channel metadata (`name`, `about`, `picture` as specified in kind 41).
+
+```json
+{
+    "content": "{\"name\": \"Demo Channel\", \"about\": \"A test channel.\", \"picture\": \"https://placekitten.com/200/200\"}",
+    ...
+}
+```
+
+The members of the group ( people who are allowed to post there) should be added as p tags to this event.
+
+Further, the creator of the channel should send a Direct Message to each of the other participants, which will have the channel's shared-secret private/public keys. 
+
+The format of that message is:
+
+`App Encrypted Channels: inviting you to encrypted channel <channel id> encrypted using private public keys <shared private key> <corresponding shared public key>`
+
+The three id's mentioned should each be 64 byte long hex encoded strings. No quotes are used.
+
+Clients that support this NIP will read that and know that they're invited to join the given encrypted channel, and they can use the given secret key to send/read messages in that channel.
+Other clients will decrypt this message, and ignore it, but the user can read that they have been invited to such a channel.
+
+## Kind 141: Set Encrypted channel metadata
+
+Update an encrypted channel's public metadata including its particpants.
+
+Clients and relays SHOULD handle kind 141 events similar to kind 0 `metadata` events.
+
+Clients SHOULD ignore kind 141s from pubkeys other than the kind 140 pubkey.
+
+Clients SHOULD support basic metadata fields:
+
+- `name` - string - Channel name
+- `about` - string - Channel description
+- `picture` - string - URL of channel picture
+
+Clients MAY add additional metadata fields.
+
+Clients SHOULD use [NIP-10](10.md) marked "e" tags to recommend a relay.
+
+```json
+{
+    "content": "{\"name\": \"Updated Demo Channel\", \"about\": \"Updating a test channel.\", \"picture\": \"https://placekitten.com/201/201\"}",
+    "tags": [["e", <channel_create_event_id> <relay-url>]],
+    ...
+}
+```
+
+
+## Kind 142: Create encrypted channel message
+
+Send a text message to an encrypted channel.
+
+Clients SHOULD use [NIP-10](10.md) marked "e" tags to recommend a relay and specify whether it is a reply or root message.
+
+Clients SHOULD append [NIP-10](10.md) "p" tags to replies.
+
+### Format
+
+Root message:
+
+```json
+{
+    "content": <string>,
+    "tags": [["e", <kind_40_event_id> <relay-url> "root"]],
+    ...
+}
+```
+
+Reply to another message:
+
+```json
+{
+    "content": <string>,
+    "tags": [
+        ["e", <kind_42_event_id> <relay-url> "reply"],
+        ["p", <pubkey> <relay-url>],
+        ...
+    ],
+    ...
+}
+```
+
+### Encryption
+
+All participants should ideally have the shared secret sent to them by the creator of the channel. If such a message is present, the client should get the shared secret from that messages, and then encrypt the 142 kind message using that.
+
+Only the given shared-secret private and public keys are used to encrypt or decrypt the messages. 
+
+
+## NIP-10 relay recommendations
+
+For [NIP-10](10.md) relay recommendations, clients generally SHOULD use the relay URL of the original (oldest) kind 40 event.
+
+Clients MAY recommend any relay URL. For example, if a relay hosting the original kind 40 event for a channel goes offline, clients could instead fetch channel data from a backup relay, or a relay that clients trust more than the original relay.
+
+
+Future extensibility
+--------------------
+
+We reserve event kinds 143-149 for other events related to chat, to potentially include new types of media (photo/video), moderation, etc.
+
+
+Motivation
+----------
+This is one step to make some private channels. 
+
+Drawbacks
+---------
+The meta-data for any message is practically much public in nostr. So such group chat should not be considered private. Anybody can see who is sending message(s) to what channel, and when.
+
+Further, if any single participant of the group chat leaks the shared secret ( whether intentionally or by accident), all the messages (past or future) can then be decrypted by others.
+
+
+
+Additional info
+---------------
+

--- a/38.md
+++ b/38.md
@@ -33,7 +33,7 @@ In the channel creation `content` field, Client SHOULD include basic channel met
 
 The members of the group ( people who are allowed to post there) should be added as p tags to this event.
 
-Further, the creator of the channel should send a Direct Message to each of the other participants, which will have the channel's shared-secret private/public keys. 
+Further, the creator of the channel should send a Direct Message to each of the other participants, which will have the channel's shared-secret private/public keys. The Direct message should be sent by a kind other than 4; but presently kind 4 direct messages are used. 
 
 The format of that message is:
 

--- a/38.md
+++ b/38.md
@@ -11,8 +11,9 @@ This NIP defines new event kinds for encrypted group chat.
 
 It works by creating a shared secret that is used to encrypt the group or channel messages. Only the participants know that secret, so only such members can read/write to this group chat.
 
-It reserves three event kinds (140-142) for immediate use and 7 event kinds (143-149) for future use.
+It reserves 4 event kinds (104 and 140-142) for immediate use and 7 event kinds (143-149) for future use.
 
+- `104 - used to communicate the shared secret`
 - `140 - create encrypted channel`
 - `141 - change channel metadata including participants`
 - `142 - send encrypted message`
@@ -33,17 +34,7 @@ In the channel creation `content` field, Client SHOULD include basic channel met
 
 The members of the group ( people who are allowed to post there) should be added as p tags to this event. The creator should also add themselves as p tag, if they want to participate there too.
 
-Further, the creator of the channel should send a Direct Message to each of the other participants, which will have the channel's shared-secret private/public keys. The Direct message should be sent by a kind other than 4; but presently kind 4 direct messages are used. 
-
-The format of that message is:
-
-`App Encrypted Channels: inviting you to encrypted channel <channel id> encrypted using private public keys <shared private key> <corresponding shared public key>`
-
-The three id's mentioned should each be 64 byte long hex encoded strings. No quotes are used.
-
-Clients that support this NIP will read that and know that they're invited to join the given encrypted channel, and they can use the given secret key to send/read messages in that channel.
-
-Other clients will decrypt this message, and ignore it, but the user can read that they have been invited to such a channel.
+On creating a channel, the creator should also generate a unique/new private-public key pair which will serve as the `shared-secret` for a given channel. The creator of the channel should then communicate this secret to other members as described in section for `kind 104`.
 
 Note: Clients for a user may create a channel where the only participant is the creator of the channel. Then new members can be added by sending a kind 141 message, as discussed further. 
 
@@ -73,7 +64,7 @@ Clients SHOULD use [NIP-10](10.md) marked "e" tags to recommend a relay.
 }
 ```
 
-Further, the main use case of kind 141 event is to update the participants list. New p tags may be added, and old ones removed with the 141 event for an encrypted channel. Client will internally then manage participants. It should be noted that since the shared-secret is not changeable,  the 'removed' members can continue to read all channel messages. So effectively, it may be said that removal does not really work. However, addition of new members just shares the shared-secret with new members, and will prove useful when required.
+Further, the main use case of kind 141 event is to update the participants list. New p tags may be added, and old ones removed with the 141 event for an encrypted channel. Client will internally then manage participants. It should be noted that since the shared-secret is not changeable,  the 'removed' members can continue to read all channel messages.
 
 If new members are added, then its the responsibility of the creator's client to share the shared-secret with them as mentioned in kind 140 section. 
 
@@ -91,7 +82,7 @@ Root message:
 ```json
 {
     "content": <string>,
-    "tags": [["e", <kind_40_event_id> <relay-url> "root"]],
+    "tags": [["e", <kind_140_event_id>],
     ...
 }
 ```
@@ -102,13 +93,31 @@ Reply to another message:
 {
     "content": <string>,
     "tags": [
-        ["e", <kind_42_event_id> <relay-url> "reply"],
+        ["e", <kind_140_event_id>],
+        ["e", <kind_142_event_id_replied_to>], 
         ["p", <pubkey> <relay-url>],
+        
         ...
     ],
     ...
 }
 ```
+
+## Kind 104: Communicate the Shared-Secret
+
+Upon adding a new member to a encrypted group of kind 140, the creator of the channel should send a direct message ( of kind 104) to each of the other participants, which will have the channel's shared-secret private/public keys. The direct message should of `kind` 104; it must follow the message construction rules as are there for `kind 4` messages, except for the difference in value of `kind`.
+
+The format of that message is:
+
+`App Encrypted Channels: inviting you to encrypted channel <channel id> encrypted using private public keys <shared private key> <corresponding shared public key>`
+
+The three id's mentioned should each be 64 byte long hex encoded strings. No quotes are used.
+
+Clients that support this NIP will read that and know that they're invited to join the given encrypted channel, and they can use the given secret key to send/read messages in that channel.
+
+Other clients will decrypt this message, and ignore it, but the user can read that they have been invited to such a channel.
+
+
 
 ### Encryption
 
@@ -137,6 +146,8 @@ This is the easiest way to allow the use of group chat with select group of peop
 Drawbacks
 ---------
 The meta-data for any message is practically much public in nostr. So such group chat should not be considered private. Anybody can see who is sending message(s) to what channel, and when.
+
+Once members are 'removed' by using the kind 141 event for a channel, they can continue to read the new messages posted in the group, because currently there is no provision to change the shared secret of a single group. The remaining users, may howerver choose to create a new group where the recently-removed member is not a member, and which would have a new shared-secret. 
 
 Further, if any single participant of the group chat leaks the shared secret ( whether intentionally or by accident), all the messages (past or future) can then be decrypted by others.
 

--- a/38.md
+++ b/38.md
@@ -53,7 +53,7 @@ Update an encrypted channel's public metadata including its particpants.
 
 Clients and relays SHOULD handle kind 141 events similar to kind 0 `metadata` events.
 
-Clients SHOULD ignore kind 141s from pubkeys other than the pubkey that created the given channel using the corresponding kind 140 event. In other words, only the creator of channel can send kind 141 events for a given channel; kind 141 sent by other people, even participants, are ignored.
+Clients SHOULD ignore kind 141s from pubkeys other than the pubkey that created the given channel using the corresponding kind 140 event. In other words, only the creator of channel can send kind 141 events for a given channel; kind 141 for any channel sent by other people, even participants of that channel, are ignored.
 
 Clients SHOULD support basic metadata fields:
 
@@ -73,9 +73,9 @@ Clients SHOULD use [NIP-10](10.md) marked "e" tags to recommend a relay.
 }
 ```
 
-Further, the main use case of kind 141 event is to update the participants list. New p tags may be added, and old ones removed with the 141 event for an encrypted channel. Client will internally then manage participants. It should be noted that since the shared-secret is not changeable,  the 'removed' members can continue to read all channel messages. So effectively, it may be said that removal does not really work. However, addition of new members just shares the shared-secret with new members, and may be useful. 
+Further, the main use case of kind 141 event is to update the participants list. New p tags may be added, and old ones removed with the 141 event for an encrypted channel. Client will internally then manage participants. It should be noted that since the shared-secret is not changeable,  the 'removed' members can continue to read all channel messages. So effectively, it may be said that removal does not really work. However, addition of new members just shares the shared-secret with new members, and will prove useful when required.
 
-If new members are added, then its the responsibility of the client to share the shared-secret with them as mentioned in kind 140 section. 
+If new members are added, then its the responsibility of the creator's client to share the shared-secret with them as mentioned in kind 140 section. 
 
 ## Kind 142: Send encrypted message to encrypted group channel
 
@@ -132,7 +132,7 @@ We reserve event kinds 143-149 for other events related to chat, to potentially 
 
 Motivation
 ----------
-This is one step to make some private channels. 
+This is the easiest way to allow the use of group chat with select group of people. 
 
 Drawbacks
 ---------

--- a/38.md
+++ b/38.md
@@ -47,7 +47,7 @@ Other clients will decrypt this message, and ignore it, but the user can read th
 
 Note: Clients for a user may create a channel where the only participant is the creator of the channel. Then new members can be added by sending a kind 141 message, as discussed further. 
 
-## Kind 141: Set Encrypted channel metadata
+## Kind 141: Update metadata and Add participants
 
 Update an encrypted channel's public metadata including its particpants.
 

--- a/38.md
+++ b/38.md
@@ -22,7 +22,7 @@ It reserves three event kinds (140-142) for immediate use and 7 event kinds (143
 
 Create a Encrypted chat channel.
 
-In the channel creation `content` field, Client SHOULD include basic channel metadata (`name`, `about`, `picture` as specified in kind 41).
+In the channel creation `content` field, Client SHOULD include basic channel metadata (`name`, `about` and `picture`).
 
 ```json
 {
@@ -31,7 +31,7 @@ In the channel creation `content` field, Client SHOULD include basic channel met
 }
 ```
 
-The members of the group ( people who are allowed to post there) should be added as p tags to this event.
+The members of the group ( people who are allowed to post there) should be added as p tags to this event. The creator should also add themselves as p tag, if they want to participate there too.
 
 Further, the creator of the channel should send a Direct Message to each of the other participants, which will have the channel's shared-secret private/public keys. The Direct message should be sent by a kind other than 4; but presently kind 4 direct messages are used. 
 
@@ -42,7 +42,10 @@ The format of that message is:
 The three id's mentioned should each be 64 byte long hex encoded strings. No quotes are used.
 
 Clients that support this NIP will read that and know that they're invited to join the given encrypted channel, and they can use the given secret key to send/read messages in that channel.
+
 Other clients will decrypt this message, and ignore it, but the user can read that they have been invited to such a channel.
+
+Note: Clients for a user may create a channel where the only participant is the creator of the channel. Then new members can be added by sending a kind 141 message, as discussed further. 
 
 ## Kind 141: Set Encrypted channel metadata
 
@@ -50,7 +53,7 @@ Update an encrypted channel's public metadata including its particpants.
 
 Clients and relays SHOULD handle kind 141 events similar to kind 0 `metadata` events.
 
-Clients SHOULD ignore kind 141s from pubkeys other than the kind 140 pubkey.
+Clients SHOULD ignore kind 141s from pubkeys other than the pubkey that created the given channel using the corresponding kind 140 event. In other words, only the creator of channel can send kind 141 events for a given channel; kind 141 sent by other people, even participants, are ignored.
 
 Clients SHOULD support basic metadata fields:
 
@@ -70,10 +73,12 @@ Clients SHOULD use [NIP-10](10.md) marked "e" tags to recommend a relay.
 }
 ```
 
+Further, the main use case of kind 141 event is to update the participants list. New p tags may be added, and old ones removed with the 141 event for an encrypted channel. Client will internally then manage participants. It should be noted that since the shared-secret is not changeable,  the 'removed' members can continue to read all channel messages. So effectively, it may be said that removal does not really work. However, addition of new members just shares the shared-secret with new members, and may be useful. 
 
-## Kind 142: Create encrypted channel message
+If new members are added, then its the responsibility of the client to share the shared-secret with them as mentioned in kind 140 section. 
 
-Send a text message to an encrypted channel.
+## Kind 142: Send encrypted message to encrypted group channel
+
 
 Clients SHOULD use [NIP-10](10.md) marked "e" tags to recommend a relay and specify whether it is a reply or root message.
 

--- a/38.md
+++ b/38.md
@@ -135,6 +135,8 @@ Once a group is created, all participants know the shared-secret, so to remove a
 
 The applications on looking at that tag can find out which was the precursor channel to this new channel, and display both the old and new channel seamlessly to the user, if that's needed.
 
+The creation of a new channel can also be used to add new participants in situations where the new participants should not be able to read the old messages of the original group. 
+
 
 ## NIP-10 relay recommendations
 


### PR DESCRIPTION
NIP-38 is modeled on NIP-28, group chat. Main difference is use of a shared secret, and using p-tags to mention members in channel create and update events. Simplicity is one of the main goals.

Implementation for the events mentioned ( 140-142) is in Nostr Console 0.0.9 beta release. 

Note 1: One important aspect of this NIP-38 ( kind 14x) is that they have a participant list. The 4x group chat is public by design, and it is unlikely that it will have a participant list anytime in future ( though it can add a PoW condition to participate easily). So the 14x public chat, whether it has secret shared secret, or even in case where its 'shared secret' is public, can still serve well because it allows the channel creator to mention as p-tags in 140/141 events who are the participants of the group. 

Edit: pull request made more for discussion. 