### PR TITLE
Fixed typo referencing 'relay-id' instead of 'reply-id'.

### DIFF
--- a/10.md
+++ b/10.md
@@ -48,7 +48,7 @@ Where:
 
 **The order of marked "e" tags is not relevant.**  Those marked with `"reply"` denote the `<reply-id>`.  Those marked with `"root"` denote the root id of the reply thread.
 
->This scheme is preferred because it allows events to mention others without confusing them with `<relay-id>` or `<root-id>`.  
+>This scheme is preferred because it allows events to mention others without confusing them with `<reply-id>` or `<root-id>`.  
 
 
 ## The "p" tag


### PR DESCRIPTION
Fixed typo referencing 'relay-id' instead of 'reply-id'.