### PR TITLE
nip16: clarify about the signers of replaceable events

### DIFF
--- a/16.md
+++ b/16.md
@@ -11,7 +11,7 @@ Relays may decide to allow replaceable and/or ephemeral events.
 Replaceable Events
 ------------------
 A *replaceable event* is defined as an event with a kind `10000 <= n < 20000`.
-Upon a replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind being received, the old event SHOULD be discarded and replaced with the newer event.
+Upon a replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind being received, and signed by the same key, the old event SHOULD be discarded and replaced with the newer event.
 
 Ephemeral Events
 ----------------


### PR DESCRIPTION
A newer replaceable event must be signed by the same key.