### PR TITLE
stronger wording for relay deletion behavior

### DIFF
--- a/09.md
+++ b/09.md
@@ -27,7 +27,9 @@ For example:
 }
 ```
 
-Relays MAY delete or stop publishing any referenced events that have an identical `pubkey` as the deletion request.  Clients may hide or otherwise indicate a deletion status for referenced events.
+Relays SHOULD delete or stop publishing any referenced events that have an identical `pubkey` as the deletion request.  Clients SHOULD hide or otherwise indicate a deletion status for referenced events.
+
+Relays SHOULD continue to publish/share the deletion events indefinitely, as clients may already have the event that's intended to be deleted. Additionally, clients SHOULD broadcast deletion events to other relays which don't have it.
 
 ## Client Usage
 


### PR DESCRIPTION
- change "MAY" to "SHOULD" for removing referenced events
- suggest indefinite retention for deletion events on relays
- include recommendation for clients to rebroadcast deletion events to relays

fixes #61