### PR TITLE
Reword NIP-01 to clarify no line breaks.

### DIFF
--- a/01.md
+++ b/01.md
@@ -30,7 +30,7 @@ The only object type that exists is the `event`, which has the following format 
 }
 ```
 
-To obtain the `event.id`, we `sha256` the serialized event. The serialization is done over the UTF-8 JSON-serialized string (with no indentation or extra spaces) of the following structure:
+To obtain the `event.id`, we `sha256` the serialized event. The serialization is done over the UTF-8 JSON-serialized string (with no white space or line breaks) of the following structure:
 
 ```json
 [


### PR DESCRIPTION
Existing language of "indentation" implies line breaks.

After looking at other people's code and interacting with relays it became clear people were not putting in line breaks when taking the signature.  So either the NIP should be reworded, or everybody is doing it wrong. 