### PR TITLE
Update NIP-10: add 'mention' marker

### DIFF
--- a/10.md
+++ b/10.md
@@ -44,9 +44,9 @@ Where:
 
  * `<event-id>` is the id of the event being referenced.
  * `<relay-url>` is the URL of a recommended relay associated with the reference.  It is NOT optional.
- * `<marker>` is optional and if present is one of `"reply"` or `"root"`
+ * `<marker>` is optional and if present is one of `"reply"`, `"root"`, or `"mention"`
 
-**The order of marked "e" tags is not relevant.**  Those marked with `"reply"` denote the `<reply-id>`.  Those marked with `"root"` denote the root id of the reply thread.
+**The order of marked "e" tags is not relevant.**  Those marked with `"reply"` denote the `<reply-id>`.  Those marked with `"root"` denote the root id of the reply thread. Those marked `"mention"` denote id of events that are tagged and are not the `"reply"` nor `"root"`.
 
 >This scheme is preferred because it allows events to mention others without confusing them with `<reply-id>` or `<root-id>`.  
 

--- a/10.md
+++ b/10.md
@@ -46,7 +46,7 @@ Where:
  * `<relay-url>` is the URL of a recommended relay associated with the reference.  It is NOT optional.
  * `<marker>` is optional and if present is one of `"reply"`, `"root"`, or `"mention"`
 
-**The order of marked "e" tags is not relevant.**  Those marked with `"reply"` denote the `<reply-id>`.  Those marked with `"root"` denote the root id of the reply thread. Those marked `"mention"` denote id of events that are tagged and are not the `"reply"` nor `"root"`.
+**The order of marked "e" tags is not relevant.**  Those marked with `"reply"` denote the `<reply-id>`.  Those marked with `"root"` denote the root id of the reply thread. Those marked with `"mention"` denote a quoted or reposted event id.
 
 >This scheme is preferred because it allows events to mention others without confusing them with `<reply-id>` or `<root-id>`.  
 

--- a/10.md
+++ b/10.md
@@ -46,7 +46,7 @@ Where:
  * `<relay-url>` is the URL of a recommended relay associated with the reference.  It is NOT optional.
  * `<marker>` is optional and if present is one of `"reply"`, `"root"`, or `"mention"`
 
-**The order of marked "e" tags is not relevant.**  Those marked with `"reply"` denote the `<reply-id>`.  Those marked with `"root"` denote the root id of the reply thread. Those marked with `"mention"` denote a quoted or reposted event id.
+**The order of marked "e" tags is not relevant.**  Those marked with `"reply"` denote the id of the reply event being responded to.  Those marked with `"root"` denote the root id of the reply thread being responded to. For top level replies (those replying directly to the root event), only the `"root"` marker should be used. Those marked with `"mention"` denote a quoted or reposted event id.
 
 >This scheme is preferred because it allows events to mention others without confusing them with `<reply-id>` or `<root-id>`.  
 


### PR DESCRIPTION
I think that adding a mention marker would eliminate ambiguity for clients supporting both the deprecated and preferred conventions. I also think that this would allow for extensibility in adding new types of event mentions (for example if we want to add context for a note).

just thought I would throw this out there, let me know what you think.