### PR TITLE
NIP-12: add 'delegation' exception and 'l' for language

### DIFF
--- a/12.md
+++ b/12.md
@@ -32,6 +32,12 @@ Rationale
 
 The decision to reserve only single-letter tags to be usable in queries allow applications to make use of tags for all sorts of metadata, as it is their main purpose, without worrying that they might be bloating relay indexes. That also makes relays more lightweight, of course. And if some application or user is abusing single-letter tags with the intention of bloating relays that becomes easier to detect as single-letter tags will hardly be confused with some actually meaningful metadata some application really wanted to attach to the event with no spammy intentions.
 
+Exceptions
+---------
+
+There are certain tags that are multi-letter and still queryable:
+* `"delegation"` - see [NIP-26: Delegated Event Signing](26.md)
+
 Suggested Use Cases
 -------------------
 
@@ -40,3 +46,4 @@ Motivating examples for generic tag queries are provided below.  This NIP does n
 * Decentralized Commenting System: clients can comment on arbitrary web pages, and easily search for other comments, by using a `r` ("reference", in this case an URL) tag and value.
 * Location-specific Posts: clients can use a `g` ("geohash") tag to associate a post with a physical location. Clients can search for a set of geohashes of varying precisions near them to find local content.
 * Hashtags: clients can use simple `t` ("hashtag") tags to associate an event with an easily searchable topic name. Since Nostr events themselves are not searchable through the protocol, this provides a mechanism for user-driven search.
+* Language-specific Posts: clients can use a `l` ("language") tag to associate a post with a particular language (see [browser standard for language codes](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language)). This allows clients to search for posts by language.


### PR DESCRIPTION
two parts to this:
1. explicitly calling out 'delegation' as an exception to only single letter tags being queryable
2. adding use case of 'l' being used to identify language

I think #1 should definitely be added. happy to drop #2 if people disagree.