### PR TITLE
Note on nip-22 about moving old posts to a new relay

### DIFF
--- a/22.md
+++ b/22.md
@@ -26,6 +26,9 @@ The event `created_at` field is just a unix timestamp and can be set to a time i
 
 A wide adoption of this nip could create a better user experience as it would decrease the amount of events that appear wildly out of order or even from impossible dates in the distant past or future.
 
+Keep in mind that there is a use case where a user migrates their old posts onto a new relay. If a relay rejects events that were not recently created, it cannot serve this use case.
+
+
 Python Example
 --------------
 


### PR DESCRIPTION
When I first read NIP-22 I was concerned that many relays would reject events that were not created recently. I propose adding this small note so that relay developers/operators can more easily be aware of what use cases they are (or are not) catering to.