### PR TITLE
Remove username pattern requirements

### DIFF
--- a/01.md
+++ b/01.md
@@ -98,9 +98,6 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 ## Basic Event Kinds
 
   - `0`: `set_metadata`: the `content` is set to a stringified JSON object `{name: <username>, about: <string>, picture: <url, string>}` describing the user who created the event. A relay may delete past `set_metadata` events once it gets a new one for the same pubkey.
-    * Where `<username>` is a string that matches the pattern: `\w[\w\-]+\w` (java regular expression).  Or, in other words, a sequence of the following
-	   characters: `[a-zA-Z_0-9][a-zA-Z_\-0-9]+[a-zA-Z_0-9]`.  <br>
-	   Thus `George-Washington-1776` is a valid `<username>`, but `George Washington` is not. Clients may reject metadata that does not comply.
   - `1`: `text_note`: the `content` is set to the text content of a note (anything the user wants to say). Non-plaintext notes should instead use kind 1000-10000 as described in [NIP-16](16.md).
   - `2`: `recommend_server`: the `content` is set to the URL (e.g., `https://somerelay.com`) of a relay the event creator wants to recommend to its followers.
 


### PR DESCRIPTION
Most implementation ignore this line. Enforcing that usernames not include spaces, special chracters, unicode, emojis, etc has no benefit and is unnecessarily user hostile.