### PR TITLE
Add error specification for unknown name to NIP-05

### DIFF
--- a/05.md
+++ b/05.md
@@ -37,6 +37,14 @@ It will make a GET request to `https://example.com/.well-known/nostr.json?name=b
 
 That will mean everything is alright.
 
+### Unknown Name
+
+For an unknown `name` the end point should return `404` status code and a suitable message:
+
+```json
+{"detail":"user jack not found"}
+```
+
 ## Notes
 
 ### User Discovery implementation suggestion

--- a/05.md
+++ b/05.md
@@ -37,12 +37,15 @@ It will make a GET request to `https://example.com/.well-known/nostr.json?name=b
 
 That will mean everything is alright.
 
-### Unknown Name
+### Unknown Name for dynamic servers
 
-For an unknown `name` the end point should return `404` status code and a suitable message:
+For a site serving many names (not a static file), the api should return a `404` status code and the following result
 
 ```json
-{"detail":"user jack not found"}
+{
+  "names": {},
+  "detail" : "user bob not found"
+}
 ```
 
 ## Notes


### PR DESCRIPTION
There should be some reliable response indicating a given name does not exist on the endpoint.

I've implemented this here: 

Works:
[https://v4v.app/.well-known/nostr.json?name=brianoflondon](https://v4v.app/.well-known/nostr.json?name=brianoflondon)

404:
[https://v4v.app/.well-known/nostr.json?name=123bad](https://v4v.app/.well-known/nostr.json?name=123bad)