### PR TITLE
Partial-Content - Transmitting file chunks over nostr

### DIFF
--- a/41.md
+++ b/41.md
@@ -1,4 +1,4 @@
-NIP-XX
+NIP-41
 ======
 
 Partial-Content
@@ -16,7 +16,7 @@ In order to handle files in the most decentralised and convenient way, we implem
 
 #### Spec
 
-This NIP introduces two new kinds `X`, `Y`, as well as a couple of tags.
+This NIP introduces two new kinds `11`, `12`, as well as a couple of tags.
 
 ```
 tags:
@@ -30,9 +30,9 @@ kinds:
 ```
 
 Files are not attached to the content key of a single event, but instead are split into chunks. The size of the chunks is not defined in this NIP and will be set by the client. Lower chunk size will increase potential decentralization, but decrease convenience.
-The client construct an event of kind `Y` for every single chunk, attach the chunk encoded as HEX string to it's data key. Also the client set the events `Content-Length` tag to the total amount of bytes the file has, the `Content-Range` tag to range of bytes a chunk carries and `Content-Type` to the MIME type of the file.
+The client construct an event of kind `12` for every single chunk, attach the chunk encoded as HEX string to it's data key. Also the client set the events `Content-Length` tag to the total amount of bytes the file has, the `Content-Range` tag to range of bytes a chunk carries and `Content-Type` to the MIME type of the file.
 
-Once the client has built an event for every single data chunk, it creates a single event of kind `X` that will act as a directory for this file transmission. This event will have the `Content-Length` and the `Content-Type` tags as well. The content key of this event will have a comma seperated list of all the events of type `Y` the client has built for this file transfer in the right order.
+Once the client has built an event for every single data chunk, it creates a single event of kind `11` that will act as a directory for this file transmission. This event will have the `Content-Length` and the `Content-Type` tags as well. The content key of this event will have a comma seperated list of all the events of type `12` the client has built for this file transfer in the right order.
 
 After building all the required events, the client will transmit them to the relays.
 
@@ -46,7 +46,7 @@ After building all the required events, the client will transmit them to the rel
 {
     "pubkey": "<pub-key>",
     "created_at": 1000000000,
-    "kind": x,
+    "kind": 11,
     "tags": [
       ["Content-Length", 48000],
       ["Content-Type", "video/mp4"]
@@ -62,7 +62,7 @@ After building all the required events, the client will transmit them to the rel
 {
     "pubkey": "<pub-key>",
     "created_at": 1000000000,
-    "kind": x,
+    "kind": 12,
     "tags": [
       ["Content-Length", 48000],
       ["Content-Range", "0-16000/48000"]

--- a/41.md
+++ b/41.md
@@ -25,8 +25,8 @@ tags:
  - ['Content-Type', <Type of content according to MIME type spec>] 
 
 kinds:
-- x (Partial-Content-Entry)
-- y (Partial-Content-Body)
+- 11 (Partial-Content-Entry)
+- 12 (Partial-Content-Body)
 ```
 
 Files are not attached to the content key of a single event, but instead are split into chunks. The size of the chunks is not defined in this NIP and will be set by the client. Lower chunk size will increase potential decentralization, but decrease convenience.

--- a/41.md
+++ b/41.md
@@ -4,7 +4,7 @@ NIP-41
 Partial-Content
 -----------------------------------
 
-`draft` `optional` `author:egge`
+`draft` `optional` `author:Egge7`
 
 This NIP is a proposal for sending and receiving files over the nostr protocol. It mimics the HTTP 206 "Partial Content" status code to facilitate uploads of large content to a relay.
 
@@ -16,13 +16,14 @@ In order to handle files in the most decentralised and convenient way, we implem
 
 #### Spec
 
-This NIP introduces two new kinds `11`, `12`, as well as a couple of tags.
+This NIP introduces two new kinds `11`, `12`, as well as 4 tags.
 
 ```
 tags:
- - ['Content-Length', <Total Content-Length in bytes>]
+ - ['Content-Length', <Total Content-Length in bytes or '*' if live stream>]
  - ['Content-Range', <Range of bytes included in the event>] 
  - ['Content-Type', <Type of content according to MIME type spec>] 
+ - [File-id, <UUID for this transfer>]
 
 kinds:
 - 11 (Partial-Content-Entry)
@@ -30,13 +31,18 @@ kinds:
 ```
 
 Files are not attached to the content key of a single event, but instead are split into chunks. The size of the chunks is not defined in this NIP and will be set by the client. Lower chunk size will increase potential decentralization, but decrease convenience.
-The client construct an event of kind `12` for every single chunk, attach the chunk encoded as HEX string to it's data key. Also the client set the events `Content-Length` tag to the total amount of bytes the file has, the `Content-Range` tag to range of bytes a chunk carries and `Content-Type` to the MIME type of the file.
+The client constructs an event of kind `12` for every single chunk, attach the chunk encoded as HEX string to it's data key. Also the client set the events `Content-Length` tag to the total amount of bytes the file has, the `Content-Range` tag to range of bytes a chunk carries and a random `File-id` that is consistent through all the events.
 
-Once the client has built an event for every single data chunk, it creates a single event of kind `11` that will act as a directory for this file transmission. This event will have the `Content-Length` and the `Content-Type` tags as well. The content key of this event will have a comma seperated list of all the events of type `12` the client has built for this file transfer in the right order.
+Once the client has built an event for every single data chunk, it creates a single event of kind `11` that will act as an entry point for this file transmission. Clients can therefore listen to kind `11` events and only request the file once needed.
+This event will have the `Content-Length` and `File-Id` tags too, but additionally the `Content-Type` tag that defines the files MIME-type. The content of this event can be used as an alt-tag / description.
 
-After building all the required events, the client will transmit them to the relays.
+Once all events are built the clients transmits them to the relay.
 
-> Note: Instead of transmitting all event the client could publish the Partial-Content-Entry event first and give the Relay time to reject or accept the proposed upload depending on total size, content-type, successful payment etc.
+`Content-Length, '*'` indicates an ongoing broadcast / live stream of data.
+
+> Note: Instead of transmitting all event the client could publish the Partial-Content-Entry event first and give the Relay time to reject or accept the proposed upload depending on total size, content-type, successful payment etc. There could also be information about rate-limiting etc.
+
+> Second Note: If content is a live stream [NIP-40 Timestamps](40.md) can be used to reduce the storage requirements for Relays.
 
 #### Examples
 
@@ -50,8 +56,9 @@ After building all the required events, the client will transmit them to the rel
     "tags": [
       ["Content-Length", 48000],
       ["Content-Type", "video/mp4"]
+      ["File-id", "966e8d10fe1525104ccc943f74c6389e"]
     ],
-    "content": "7603a125d99eca0ccf1085959b307f64e5dd358000006d8c378af1779d2feebc,8000006d8c378af1779d2feebc7603a125d99eca0ccf1085959b307f64e5dd35,000006d8c378af1779d2feebc7603a125d99eca0ccf1085959b307f64e5dd358",
+    "content": "",
     "id": "<event-id>"
 }
 ```
@@ -65,8 +72,8 @@ After building all the required events, the client will transmit them to the rel
     "kind": 12,
     "tags": [
       ["Content-Length", 48000],
-      ["Content-Range", "0-16000/48000"]
-      ["Content-Type", "video/mp4"]
+      ["Content-Range", "0-16000"]
+      ["File-id", "966e8d10fe1525104ccc943f74c6389e"]
     ],
     "content": "<Chunk of file in HEX>",
     "id": "7603a125d99eca0ccf1085959b307f64e5dd358000006d8c378af1779d2feebc"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-35: User Discovery](35.md)
 - [NIP-36: Sensitive Content](36.md)
 - [NIP-40: Expiration Timestamp](40.md)
-- [NIP-41: Partial-Cotent](41.md)
+- [NIP-41: Partial-Content](41.md)
 
 ## Event Kinds
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-35: User Discovery](35.md)
 - [NIP-36: Sensitive Content](36.md)
 - [NIP-40: Expiration Timestamp](40.md)
+- [NIP-41: Partial-Cotent](41.md)
 
 ## Event Kinds
 
@@ -39,6 +40,8 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 | 4           | Encrypted Direct Messages   | [4](04.md)             |
 | 5           | Event Deletion              | [9](09.md)             |
 | 7           | Reaction                    | [25](25.md)            |
+| 11          | Partial-Content-Entry       | [41](41.md)            |
+| 12          | Partial-Content-Body        | [41](41.md)            |
 | 40          | Channel Creation            | [28](28.md)            |
 | 41          | Channel Metadata            | [28](28.md)            |
 | 42          | Channel Message             | [28](28.md)            |

--- a/XX.md
+++ b/XX.md
@@ -1,0 +1,60 @@
+NIP-XX
+======
+
+Partial-Content
+-----------------------------------
+
+`draft` `optional` `author:egge`
+
+This NIP is a proposal for sending and receiving files over the nostr protocol. It mimics the HTTP 206 "Partial Content" status code to facilitate uploads of large content to a relay.
+
+#### Motivation
+
+Todays social media has become much more visual than simple texts posts. In order for nostr to become a real alternative it must be able to handle non-text content like images, audio and video. So far users have solved this by uploading files to a third-party file server and including a URL in their transmissions, which make them vulnerable to censorship again. In order to solve this issue, files must be transmitted over the nostr protocol directly.
+
+In order to handle files in the most decentralised and convenient way, we implement a flow based HTTP's 206 Partial-Content.
+
+#### Spec
+
+This NIP introduces two new kinds X, Y, as well as a couple of tags.
+
+```
+tags:
+ - ['Content-Length', <Total Content-Length in bytes>] 
+ - ['Content-Range', <Range of bytes included in the event>] 
+ - ['Content-Type', <Type of content according to HTTP content types>] 
+
+kinds:
+- x (Partial-Content-Entry)
+- y (Partial-Content-Body)
+```
+
+#### Example
+
+```json
+{
+    "pubkey": "<pub-key>",
+    "created_at": 1000000000,
+    "kind": k,
+    "tags": [
+      ["partial-content", "10000", "10000-20000/210021"],
+      ["e", <32-bytes hex of the id of the previous chunk>]
+    ],
+    "content": "<FilestreamChunk>",
+    "id": "<event-id>"
+}
+```
+
+Note: e in this case will point at the previous chunks event so that a client can stich the chunks back together
+
+Client Behavior
+---------------
+
+Relay Behavior
+--------------
+
+Suggested Use Cases
+-------------------
+
+* Uploading files and media to multiple relays, introducing censorship resistance
+* Streaming of content from a source to a receiver / Live content


### PR DESCRIPTION
This draft introduces

- Two new kinds (11,12)
- Three new Tags (Content-Type, Content-Length, Content-Range)
- A general flow for transmitting files over nostr that is based on HTTP's 206 Partial Content

So far there are no clients or relays implementing these. I have written an article about a proof-of-concept that I did: https://starbackr.com/sending-images-and-files-on-nostr/