### PR TITLE
NIP-42 - External Embed Sizes

### DIFF
--- a/42.md
+++ b/42.md
@@ -1,0 +1,44 @@
+NIP-42
+======
+
+External Embed Sizing
+---------------
+
+`draft` `optional` `author:deanpress`
+
+An `embed-sizes` array in notes that allows relays to store information about the filesizes of external embeddable media (i.e. URLs to images and other media in posts and avatars).
+
+Clients can auto-embed small media within a configured limit, and not auto-embed larger media by default (and give the user an option to click "View Embedded Media"), to save user bandwidth and prevent abuse.
+
+Spec
+---------------
+```
+tag: embed-sizes
+values:
+ - [array of strings of filesizes in bytes, in order of urls in note content]: required
+```
+
+Example
+---------------
+```json
+{
+    "pubkey": "<pub-key>",
+    "created_at": 1000000000,
+    "kind": 1,
+    "tags": [
+      ["embed-sizes", ["500000", "1500000", "0"]]
+    ],
+    "content": "https://imgur.com/1.png and https://imgur.com/2.png and https://imgu2.com/3.png.",
+    "id": "<event-id>"
+}
+```
+In this example the `1.png` embed is 500kb, `2.png` is 1.5MB, and `3.png` was not estimated (due to no `Content-Length` header, or the header doesn't match the real content's size).
+
+Client Behavior
+---------------
+Clients SHOULD check the `embed-sizes` array for each externally linked embeddable media url in a note and only auto-embed the media if it's within the client's (or user's) configured max allowed auto-embeddable filesize. If the `embed-sizes` value of the media embed is `"0"`, also don't auto-embed the media.
+
+Relay Behavior
+---------------
+* Relays SHOULD check external URL embeds for a `Content-Length` header. If `Content-Length` exists and is within the Relay's configured max filesize limit for embeddable content, verify the size is correct by attempting to download the file to a temporary cache (up to the `Content-Length`) and storing the filesize (in bytes) in the note's `embed-sizes` array if it matches. If the `Content-Length` header does not exist, or the file is not fully downloaded after reaching the `Content-Length` limit, set the value belonging to the URL's array key in `embed-sizes` to `"0"`.
+* Relays SHOULD delete cached media after the above filesize validation process was completed.

--- a/42.md
+++ b/42.md
@@ -12,11 +12,7 @@ Clients can auto-embed small media within a configured limit, and not auto-embed
 
 Spec
 ---------------
-```
-tag: embed-sizes
-values:
- - [array of strings of filesizes in bytes, in order of urls in note content]: required
-```
+*TO-DO* - The relay needs a way to send filesize estimates belonging to embeddable URLs of a note to the client, either through a separate event or notice, or as unsigned data along with the note.
 
 Example
 ---------------


### PR DESCRIPTION
This is a draft NIP to look into the issue of auto-embeds from external URLs in notes wasting user bandwidth.