### PR TITLE
NIP-35 fixes

### DIFF
--- a/35.md
+++ b/35.md
@@ -34,7 +34,7 @@ This NIP proposes an optional additional key like this:
   },
   "relays": {
     "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9": [ "wss://relay.example.com", "wss://relay2.example.com" ]
-  },
+  }
 }
 ````
 

--- a/35.md
+++ b/35.md
@@ -39,3 +39,5 @@ This NIP proposes an optional additional key like this:
 ````
 
 The `relays` key contains an object with public keys as properties and arrays of relays as values.
+
+Web servers which serve nostr.json files dynamically responding to the query string SHOULD also serve the relays data for any name they serve in the same reply.


### PR DESCRIPTION
Fixing a JSON comma

Also thought it was worthwhile to mention that if a webserver dynamically serves a public key based on the query string, it should also include the relays in the response.