### PR TITLE
Typo in kind of Regular Events

### DIFF
--- a/16.md
+++ b/16.md
@@ -13,6 +13,10 @@ Regular Events
 A *regular event* is defined as an event with a kind in range `0 <= n < 10000` without events with kinds `0, 3, and 41` which are replaceable events.
 Upon a regular event being received, the relay SHOULD send it to all clients with a matching filter, and SHOULD store it. New events of the same kind do not affect previous events in any way.
 
+- plaintext notes should use kind `0 <= n < 999`
+- Non-plaintext notes should use kind `1000 <= n < 10000`
+- Events kinds `0, 3 and 41` are Replaceable Events defined in Previous NIP's
+
 Replaceable Events
 ------------------
 A *replaceable event* is defined as an event with a kind `0, 3, 41` and range `10000 <= n < 20000`.

--- a/16.md
+++ b/16.md
@@ -10,7 +10,7 @@ Relays may decide to allow replaceable and/or ephemeral events.
 
 Regular Events
 ------------------
-A *regular event* is defined as an event with a kind `1000 <= n < 10000`.
+A *regular event* is defined as an event with a kind `0 <= n < 10000`.
 Upon a regular event being received, the relay SHOULD send it to all clients with a matching filter, and SHOULD store it. New events of the same kind do not affect previous events in any way.
 
 Replaceable Events

--- a/16.md
+++ b/16.md
@@ -13,9 +13,8 @@ Regular Events
 A *regular event* is defined as an event with a kind in range `0 <= n < 10000` without events with kinds `0, 3, and 41` which are replaceable events.
 Upon a regular event being received, the relay SHOULD send it to all clients with a matching filter, and SHOULD store it. New events of the same kind do not affect previous events in any way.
 
-- plaintext notes should use kind `0 <= n < 999`
+### Additional rules
 - Non-plaintext notes should use kind `1000 <= n < 10000`
-- Events kinds `0, 3 and 41` are Replaceable Events defined in Previous NIP's
 
 Replaceable Events
 ------------------

--- a/16.md
+++ b/16.md
@@ -10,12 +10,12 @@ Relays may decide to allow replaceable and/or ephemeral events.
 
 Regular Events
 ------------------
-A *regular event* is defined as an event with a kind `0 <= n < 10000`.
+A *regular event* is defined as an event with a kind in range `0 <= n < 10000` without events with kinds `0, 3, and 41` which are replaceable events.
 Upon a regular event being received, the relay SHOULD send it to all clients with a matching filter, and SHOULD store it. New events of the same kind do not affect previous events in any way.
 
 Replaceable Events
 ------------------
-A *replaceable event* is defined as an event with a kind `10000 <= n < 20000`.
+A *replaceable event* is defined as an event with a kind `0, 3, 41` and range `10000 <= n < 20000`.
 Upon a replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind being received, and signed by the same key, the old event SHOULD be discarded and replaced with the newer event.
 
 Ephemeral Events


### PR DESCRIPTION
Regular events are all events from 0 to 10 000. Not from 1 000 to 10 000.