### PR TITLE
Adds the possibility of NIP05 identifiers in a user's contact list (NIP02).

### DIFF
--- a/02.md
+++ b/02.md
@@ -6,9 +6,9 @@ Contact List and Petnames
 
 `final` `optional` `author:fiatjaf` `author:arcbtc`
 
-A special event with kind `3`, meaning "contact list" is defined as having a list of `p` tags, one for each of the followed/known profiles one is following.
+A special event with kind `3`, meaning "contact list" is defined as having a list of `p` and `i` tags, one for each of the followed/known profiles one is following.
 
-Each tag entry should contain the key for the profile, a relay URL where events from that key can be found (can be set to an empty string if not needed), and a local name (or "petname") for that profile (can also be set to an empty string or not provided), i.e., `["p", <32-bytes hex key>, <main relay URL>, <petname>]`. The `content` can be anything and should be ignored.
+Each tag entry should contain the key (`p`) for the profile or an `i` for a NIP-05 identifier where the key can be found, a relay URL where events from that key can be found (can be set to an empty string if not needed), and a local name (or "petname") for that profile (can also be set to an empty string or not provided), i.e., `["p", <32-bytes hex key>, <main relay URL>, <petname>]`. The `content` can be anything and should be ignored.
 
 For example:
 
@@ -19,6 +19,7 @@ For example:
     ["p", "91cf9..4e5ca", "wss://alicerelay.com/", "alice"],
     ["p", "14aeb..8dad4", "wss://bobrelay.com/nostr", "bob"],
     ["p", "612ae..e610f", "ws://carolrelay.com/ws", "carol"]
+	["i", "jeff@domain.com", "ws://jeffrelay.com/ws", "jeff"]
   ],
   "content": "",
   ...other fields

--- a/02.md
+++ b/02.md
@@ -19,7 +19,7 @@ For example:
     ["p", "91cf9..4e5ca", "wss://alicerelay.com/", "alice"],
     ["p", "14aeb..8dad4", "wss://bobrelay.com/nostr", "bob"],
     ["p", "612ae..e610f", "ws://carolrelay.com/ws", "carol"]
-	["i", "jeff@domain.com", "ws://jeffrelay.com/ws", "jeff"]
+    ["i", "jeff@domain.com", "ws://jeffrelay.com/ws", "jeff"]
   ],
   "content": "",
   ...other fields


### PR DESCRIPTION
Simple extension to NIP02-Contact List and Petnames to allow users to follow NIP 05 identifiers instead of direct keys. 

The goal is to automatically migrate followers to new keys when the user rotates them. 

Since most UIs already hide the pub key when NIP05 is verified, it makes sense that users only get to know and see NIP05 IDs and thus choose to follow them as opposed to keys. NIP05 is the only identifier they trust.  