### PR TITLE
NIP-10: Clarify marked e-tags for direct replies

### DIFF
--- a/10.md
+++ b/10.md
@@ -48,7 +48,7 @@ Where:
 
 **The order of marked "e" tags is not relevant.**  Those marked with `"reply"` denote the `<reply-id>`.  Those marked with `"root"` denote the root id of the reply thread.
 
-A direct reply to the root of a thread should have a single marked "e" tag of type "reply".
+A direct reply to the root of a thread should have a single marked "e" tag of type "root".
 
 >This scheme is preferred because it allows events to mention others without confusing them with `<reply-id>` or `<root-id>`.  
 

--- a/10.md
+++ b/10.md
@@ -48,6 +48,8 @@ Where:
 
 **The order of marked "e" tags is not relevant.**  Those marked with `"reply"` denote the `<reply-id>`.  Those marked with `"root"` denote the root id of the reply thread.
 
+A direct reply to the root of a thread should have a single marked "e" tag of type "reply".
+
 >This scheme is preferred because it allows events to mention others without confusing them with `<reply-id>` or `<root-id>`.  
 
 


### PR DESCRIPTION
AFAIK different clients implement this differently. Some add both marker tags (`root` and `reply`) for direct replies, some add one, some add the other.

This PR suggests a way to clarify that confusion.