### PR TITLE
Make it clear that NIP-05 Keys should be in Hex

### DIFF
--- a/05.md
+++ b/05.md
@@ -10,7 +10,7 @@ On events of kind `0` (`set_metadata`) one can specify the key `"nip05"` with an
 
 Upon seeing that, the client splits the identifier into `<local-part>` and `<domain>` and use these values to make a GET request to `https://<domain>/.well-known/nostr.json?name=<local-part>`.
 
-The result should be a JSON document object with a key `"names"` that should then be a mapping of names to public keys. If the public key for the given `<name>` matches the `pubkey` from the `set_metadata` event, the client then concludes that the given pubkey can indeed be referenced by its identifier.
+The result should be a JSON document object with a key `"names"` that should then be a mapping of names to hex formatted public keys. If the public key for the given `<name>` matches the `pubkey` from the `set_metadata` event, the client then concludes that the given pubkey can indeed be referenced by its identifier.
 
 ### Example
 
@@ -46,6 +46,10 @@ A client may implement support for finding users' public keys from _internet ide
 ### Clients must always follow public keys, not NIP-05 addresses
 
 For example, if after finding that `bob@bob.com` has the public key `abc...def`, the user clicks a button to follow that profile, the client must keep a primary reference to `abc...def`, not `bob@bob.com`. If, for any reason, the address `https://bob.com/.well-known/nostr.json?name=bob` starts returning the public key `1d2...e3f` at any time in the future, the client must not replace `abc...def` in his list of followed profiles for the user (but it should stop displaying "bob@bob.com" for that user, as that will have become an invalid `"nip05"` property).
+
+### Public keys must be in Hex format
+
+Keys must be returned in Hex format. Keys returned in npub format are not supported by this spec.
 
 ### User Discovery implementation suggestion
 


### PR DESCRIPTION
There has been some confusion about whether npub keys are supported by this spec. According to @fiatjaf only Hex keys are supported. https://twitter.com/fiatjaf/status/1608606752987316224?s=20&t=6fJLD3077byuoTm96kva1g