### PR TITLE
NIP-43: Bitcoin-Funded Public Keys to Prevent Spam

### DIFF
--- a/43.md
+++ b/43.md
@@ -1,7 +1,7 @@
 NIP-43
 ======
 
-Public Key Bitcoin Funding to Prevent Spam
+Bitcoin-Funded Public Keys to Prevent Spam
 -------------
 
 `draft` `optional` `author:brunneis`

--- a/43.md
+++ b/43.md
@@ -1,0 +1,72 @@
+NIP-43
+======
+
+Public Key Bitcoin Funding to Prevent Spam
+-------------
+
+`draft` `optional` `author:brunneis`
+
+This NIP specifies that Nostr relays can implement a filter to check the balance of a bitcoin address derived from a Nostr public key. The filter will be triggered whenever an event is received from a client. If the current balance of the bitcoin address is less than the minimum configured by the relay, the message will be rejected, and an error message will be returned to the client through a `NOTICE`. If the balance is sufficient, the message will be normally processed.
+
+```
+["NOTICE", "Public key not sufficiently funded (NIP-43)."]
+```
+
+Address generation
+------
+
+Given a Nostr public key, we can derive a Pay-to-Witness-Script-Hash (P2WSH) address, more compatible than Pay-to-Taproot (P2TR). Public keys are compressed but we do not know the prefix without the private key. Thus, we have to check two addresses for each public key for the two possible prefixes: `0x02` and `0x03`.
+
+```python
+import hashlib
+import bech32
+
+
+def get_address_from_public_key(
+    prefix: bytes,
+    public_key: bytes,
+    human_readable_part: str = None,
+    witness_program: int = None
+):
+    if human_readable_part is None:
+        human_readable_part = 'bc' # Mainnet
+
+    if witness_program is None:
+        witness_program = 0 # P2WSH
+
+    sha256_hash = hashlib.sha256(prefix + public_key).digest()
+    ripemd160 = hashlib.new("ripemd160")
+    ripemd160.update(sha256_hash)
+    address_bytes = ripemd160.digest()
+
+    address = bech32.encode(
+        human_readable_part,
+        witness_program,
+        address_bytes,
+    )
+
+    return address
+```
+
+The balance of an address can be checked against any software that indexes all the Bitcoin transactions. Alternatively, a third-party API can be used (e.g., https://blockstream.info/api/address/bc1q...).
+
+
+```python
+MIN_PUBLIC_KEY_SATS = 25000
+
+def check_public_key_funds(public_key: str):
+    funded_address = False
+    for prefix in [b'\02', b'\03']:
+        address = get_address_from_public_key(
+            prefix,
+            bytes.fromhex(public_key),
+        )
+        balance = get_address_balance(address)
+        if balance >= MIN_PUBLIC_KEY_SATS:
+            print(
+                f"Public key {public_key} is funded at {address} "
+                f"with {balance} sats."
+            )
+            funded_address = True
+    return funded_address
+```


### PR DESCRIPTION
This NIP specifies that Nostr relays can implement a filter to check the balance of a bitcoin address derived from a Nostr public key. The filter will be triggered whenever an event is received from a client. If the current balance of the bitcoin address is less than the minimum configured by the relay, the message will be rejected.

PoC implemented at: https://github.com/labteral/nostrd