### PR TITLE
Add NIP-45 for COUNT

### DIFF
--- a/45.md
+++ b/45.md
@@ -1,0 +1,31 @@
+NIP-45
+======
+
+Event Counts
+--------------
+
+`draft` `optional` `author:staab`
+
+Relays may support the `COUNT` verb, which provide a mechanism for obtaining event counts.
+
+## Motivation
+
+Some queries a client may want to execute against connected relays are prohibitively expensive, for example, in order to retrieve follower counts for a given pubkey, a client must query all kind-3 events referring to a given pubkey and count them. The result may be cached, either by a client or by a separate indexing server as an alternative, but both options erode the decentralization of the network by creating a second-layer protocol on top of Nostr.
+
+## Filters and return values
+
+This NIP defines a verb called `COUNT`, which accepts a subscription id and a filter as specified in [NIP 01](01.md).
+
+Counts are returned using a `COUNT` response in the form `{count: <integer>}`. Relays may use probabilistic counts to reduce compute requirements.
+
+Examples:
+
+```
+# Followers count
+["COUNT", "", {kinds: [3], '#p': [<pubkey>]}]
+["COUNT", "", {count: 238}]
+
+# Count posts and reactions
+["COUNT", "", {kinds: [1, 7], authors: [<pubkey>]}]
+["COUNT", "", {count: 5}]
+```

--- a/45.md
+++ b/45.md
@@ -10,22 +10,30 @@ Relays may support the `COUNT` verb, which provide a mechanism for obtaining eve
 
 ## Motivation
 
-Some queries a client may want to execute against connected relays are prohibitively expensive, for example, in order to retrieve follower counts for a given pubkey, a client must query all kind-3 events referring to a given pubkey and count them. The result may be cached, either by a client or by a separate indexing server as an alternative, but both options erode the decentralization of the network by creating a second-layer protocol on top of Nostr.
+Some queries a client may want to execute against connected relays are prohibitively expensive, for example, in order to retrieve follower counts for a given pubkey, a client must query all kind-3 events referring to a given pubkey and count them.
 
 ## Filters and return values
 
-This NIP defines a verb called `COUNT`, which accepts a subscription id and a filter as specified in [NIP 01](01.md).
+This NIP defines a verb called `COUNT`, which accepts a subscription id and one or more filters as specified in [NIP 01](01.md).
 
-Counts are returned using a `COUNT` response in the form `{count: <integer>}`. Relays may use probabilistic counts to reduce compute requirements.
+Counts are returned using a `COUNT` response in the form `{count: <integer>}`. If multiple filters were specified in the request, the same number of results MUST be returned. Relays may use probabilistic counts to reduce compute requirements.
+
+Relays MAY support an additional `group_by` parameter which specifies a list of event properties to group by. Results will be returned as a list of counts for each group with the `group_by` parameter included.
+
+Some counts may be burdensome for relays to fulfill, relays MAY impose a limit on number of groups returned, and SHOULD raise a NOTICE if a request cannot be fulfilled.
 
 Examples:
 
-```
-# Followers count
-["COUNT", "", {kinds: [3], '#p': [<pubkey>]}]
-["COUNT", "", {count: 238}]
+```json
+// Followers count
+["COUNT", "subid", {"kinds": [3], "#p": [<pubkey>]}]
+["COUNT", "subid", {"count": 238}]
 
-# Count posts and reactions
-["COUNT", "", {kinds: [1, 7], authors: [<pubkey>]}]
-["COUNT", "", {count: 5}]
+// Count posts and reactions
+["COUNT", "subid", {"kinds": [1, 7], "authors": [<pubkey>]}]
+["COUNT", "subid", {"count": 5}]
+
+// Count posts by author
+["COUNT", "subid", {"kinds": [1]}, {"kinds": [1], "group_by": ["pubkey"]}]
+["COUNT", "subid", {"count": 32}, [{"count": 3, "pubkey": <pubkey1>}, {"count": 29, "pubkey": <pubkey2>}]]
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-39: External Identities in Profiles](39.md)
 - [NIP-40: Expiration Timestamp](40.md)
 - [NIP-42: Authentication of clients to relays](42.md)
+- [NIP-45: Counting results](45.md)
 - [NIP-46: Nostr Connect](46.md)
 - [NIP-50: Keywords filter](50.md)
 - [NIP-51: Lists](51.md)
@@ -88,6 +89,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 | REQ   | used to request events and subscribe to new updates | [1](01.md)  |
 | CLOSE | used to stop previous subscriptions                 | [1](01.md)  |
 | AUTH  | used to send authentication events                  | [42](42.md) |
+| COUNT | used to request event counts                        | [45](45.md) |
 
 ### Relay to Client
 | type   | description                                             | NIP         |
@@ -97,6 +99,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 | EOSE   | used to notify clients all stored events have been sent | [15](15.md) |
 | OK     | used to notify clients if an EVENT was successful       | [20](20.md) |
 | AUTH   | used to send authentication challenges                  | [42](42.md) |
+| COUNT  | used to send requested event counts to clients          | [45](45.md)  |
 
 Please update these lists when proposing NIPs introducing new event kinds.
 


### PR DESCRIPTION
This is the beginning of sort of a second-layer indexing scheme, I came across the need for it when implementing follower count. Currently I'm downloading ~4000 events in the case of jack, and throwing them away just to get the count.