### PR TITLE
NIP05 Improve CORS header check command

### DIFF
--- a/05.md
+++ b/05.md
@@ -83,7 +83,7 @@ By adding the `<local-part>` as a query string instead of as part of the path th
 JavaScript Nostr apps may be restricted by browser [CORS][] policies that prevent them from accessing `/.well-known/nostr.json` on the user's domain. When CORS prevents JS from loading a resource, the JS program sees it as a network failure identical to the resource not existing, so it is not possible for a pure-JS app to tell the user for certain that the failure was caused by a CORS issue. JS Nostr apps that see network failures requesting `/.well-known/nostr.json` files may want to recommend to users that they check the CORS policy of their servers, e.g.:
 
 ```bash
-$ curl -sI https://example.com/.well-known/nostr.json?name=bob | grep ^Access-Control
+$ curl -sI https://example.com/.well-known/nostr.json?name=bob | grep -i ^Access-Control
 Access-Control-Allow-Origin: *
 ```
 


### PR DESCRIPTION
Currently the header check is case sensitive so will fail for servers which are configured correctly but with lowercase headers.

Before:

```
$ curl -sI https://static.lu.ke/.well-known/nostr.json | grep ^Access-Control
```

After:

```
$ curl -sI https://static.lu.ke/.well-known/nostr.json | grep -i ^Access-Control
access-control-allow-origin: *
```