### PR TITLE
NIP-26: Change example condition to expire at a future date

### DIFF
--- a/26.md
+++ b/26.md
@@ -34,7 +34,7 @@ nostr:delegation:<pubkey of publisher (delegatee)>:<conditions query string>
 For example, the token `c33c88ba78ec3c760e49db591ac5f7b129e3887c8af7729795e85a0588007e5ac89b46549232d8f918eefd73e726cb450135314bfda419c030d0b6affe401ec1` is signed by `86f0689bd48dcd19c67a19d994f938ee34f251d8c39976290955ff585f2db42e` and consists of:
 
 ```json
-nostr:delegation:62903b1ff41559daf9ee98ef1ae67cc52f301bb5ce26d14baba3052f649c3f49:kind=1&created_at>1640995200
+nostr:delegation:62903b1ff41559daf9ee98ef1ae67cc52f301bb5ce26d14baba3052f649c3f49:kind=1&created_at<1700995200
 ```
 
 #### Example
@@ -51,7 +51,7 @@ Below is an example of an event published by `62903b1ff41559daf9ee98ef1ae67cc52f
     [
       "delegation",
       "86f0689bd48dcd19c67a19d994f938ee34f251d8c39976290955ff585f2db42e",
-      "kind=1&created_at>1640995200",
+      "kind=1&created_at<1700995200",
       "c33c88ba78ec3c760e49db591ac5f7b129e3887c8af7729795e85a0588007e5ac89b46549232d8f918eefd73e726cb450135314bfda419c030d0b6affe401ec1"
     ]
   ],

--- a/26.md
+++ b/26.md
@@ -25,40 +25,58 @@ This NIP introduces a new tag: `delegation` which is formatted as follows:
 
 ##### Delegation Token
 
-The **delegation token** should be a 64-bytes schnorr signature of the sha256 hash of the following string:
+The **delegation token** should be a 64-byte Schnorr signature of the sha256 hash of the following string:
 
 ```
 nostr:delegation:<pubkey of publisher (delegatee)>:<conditions query string>
 ```
 
-For example, the token `c33c88ba78ec3c760e49db591ac5f7b129e3887c8af7729795e85a0588007e5ac89b46549232d8f918eefd73e726cb450135314bfda419c030d0b6affe401ec1` is signed by `86f0689bd48dcd19c67a19d994f938ee34f251d8c39976290955ff585f2db42e` and consists of:
-
-```json
-nostr:delegation:62903b1ff41559daf9ee98ef1ae67cc52f301bb5ce26d14baba3052f649c3f49:kind=1&created_at<1700995200
-```
 
 #### Example
 
-Below is an example of an event published by `62903b1ff41559daf9ee98ef1ae67cc52f301bb5ce26d14baba3052f649c3f49`, on behalf of `86f0689bd48dcd19c67a19d994f938ee34f251d8c39976290955ff585f2db42e`.
+```
+# Delegator:
+privkey: ee35e8bb71131c02c1d7e73231daa48e9953d329a4b701f7133c8f46dd21139c
+pubkey:  8e0d3d3eb2881ec137a11debe736a9086715a8c8beeeda615780064d68bc25dd
 
+# Delegatee:
+privkey: 777e4f60b4aa87937e13acc84f7abcc3c93cc035cb4c1e9f7a9086dd78fffce1
+pubkey:  477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396
+```
+
+Delegation string to grant note publishing authorization to the delegatee (477318cf) for the next 30 days.
+```json
+nostr:delegation:477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396:kind=1&created_at<1675721885
+```
+
+The delegator (8e0d3d3e) then signs the above delegation string, the result of which is the delegation token:
+```
+cbc49c65fe04a3181d72fb5a9f1c627e329d5f45d300a2dfed1c3e788b7834dad48a6d27d8e244af39c77381334ede97d4fd15abe80f35fda695fd9bd732aa1e
+```
+
+The delegatee (477318cf) can now construct an event on behalf of the delegator (8e0d3d3e). The delegatee then signs the event with its own private key and publishes.
 ```json
 {
-  "id": "a080fd288b60ac2225ff2e2d815291bd730911e583e177302cc949a15dc2b2dc",
-  "pubkey": "62903b1ff41559daf9ee98ef1ae67cc52f301bb5ce26d14baba3052f649c3f49",
-  "created_at": 1660896109,
+  "id": "ac4c71e69c39b1bd605de812543ebfaf81d5af365354f061d48981fb61e00b8a",
+  "pubkey": "477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396",
+  "created_at": 1673129661,
   "kind": 1,
   "tags": [
     [
       "delegation",
-      "86f0689bd48dcd19c67a19d994f938ee34f251d8c39976290955ff585f2db42e",
-      "kind=1&created_at<1700995200",
-      "c33c88ba78ec3c760e49db591ac5f7b129e3887c8af7729795e85a0588007e5ac89b46549232d8f918eefd73e726cb450135314bfda419c030d0b6affe401ec1"
+      "8e0d3d3eb2881ec137a11debe736a9086715a8c8beeeda615780064d68bc25dd",
+      "kind=1&created_at<1675721813",
+      "cbc49c65fe04a3181d72fb5a9f1c627e329d5f45d300a2dfed1c3e788b7834dad48a6d27d8e244af39c77381334ede97d4fd15abe80f35fda695fd9bd732aa1e"
     ]
   ],
-  "content": "Hello world",
-  "sig": "cd4a3cd20dc61dcbc98324de561a07fd23b3d9702115920c0814b5fb822cc5b7c5bcdaf3fa326d24ed50c5b9c8214d66c75bae34e3a84c25e4d122afccb66eb6"
+  "content": "Hello, world!",
+  "sig": "55ed9a78d6449b8c189b6dbc34bc4bcd34dcc79e6da6c9078268fe3d7c0cbe62b1b907ffb76ba591e83895b1329bf2e6e16f3b0cd5827272e420d419c6f0f0b5"
 }
 ```
+
+The event should be considered a valid delegation if the conditions are satisfied (`kind=1` and `created_at<1675721813` in this example) and, upon validation of the delegation tokean, are found to be unchanged from the conditions in the original delegation string.
+
+Clients should display the delegated note as if it was published directly by the delegator (8e0d3d3e).
 
 
 #### Relay & Client Querying Support

--- a/26.md
+++ b/26.md
@@ -74,7 +74,7 @@ The delegatee (477318cf) can now construct an event on behalf of the delegator (
 }
 ```
 
-The event should be considered a valid delegation if the conditions are satisfied (`kind=1` and `created_at<1675721813` in this example) and, upon validation of the delegation tokean, are found to be unchanged from the conditions in the original delegation string.
+The event should be considered a valid delegation if the conditions are satisfied (`kind=1` and `created_at<1675721813` in this example) and, upon validation of the delegation token, are found to be unchanged from the conditions in the original delegation string.
 
 Clients should display the delegated note as if it was published directly by the delegator (8e0d3d3e).
 


### PR DESCRIPTION
I'm not sure what the current `created_at>1640995200` condition is accomplishing (unless there's some worry that relays might accept back-dated events?).

It seems more useful to demonstrate that the delegation token can expire after X time (e.g. a 30-day authorization).