### PR TITLE
NIP-23 Revisions (relay list)

### DIFF
--- a/23.md
+++ b/23.md
@@ -40,7 +40,7 @@ _Invalid event.content: missing `write` member_
 "{\"wss://relayer.somewhere.xyz\":{\"read\": \"true\"}}"
 ```
 
-### Purposes
+### Use Cases
 
 This NIP serves two purposes: (1) backup and interoperability of relay lists and relay specific rules between clients; and (2) sharing of relay URLs between users.
 

--- a/23.md
+++ b/23.md
@@ -30,10 +30,6 @@ _Valid event.content_
 "{\"wss://relayer.somewhere.xyz\":{\"read\": \"true\",\"write\": \"true\"}}"
 ```
 
-_Invalid event.content: trailing slash_
-```
-"{\"wss://relayer.somewhere.xyz/\":{\"read\": \"true\",\"write\": \"true\"}}"
-```
 
 _Invalid event.content: missing `write` member_
 ```

--- a/23.md
+++ b/23.md
@@ -12,6 +12,8 @@ This kind is identical to kind 2, except that it is a transition to the replacab
 
 The tags array is empty.
 
+The object member key, being the relay URL, **must** omit the trailing slash. Good: `wss://nostr.someone.xyz`, Bad: `wss://nostr.someone.xyz/` 
+
 The `read` value operates on the values of the [NIP-01](01.md) **filter** object, while the `write` rule operates on the values of the **event** object. 
 
 When the `read` value equals `false` for a given **filter** the client SHOULD NOT send that filter in a `REQ` message to that relay.

--- a/23.md
+++ b/23.md
@@ -46,7 +46,7 @@ This NIP serves two purposes: (1) backup and interoperability of relay lists and
 
 The first use case is meant to make it so users can open their client -- or different clients -- in different devices and have their list of relays automatically fetched from a default relay and start using their relays list without having to set everything up again.
 
-For the second purpose, if any client decides to, they can show to the user what relays other users are using, suggest that or automatically add these to the user's relay list. The possibility of sharing a list of relays in standardized format is good for spreading information about relays and contributes to the censorship-resistance of the network.
+Another use case is to display which relays other users are using, suggest connecting to them or automatically add these to the user's relay list. The possibility of sharing a list of relays in standardized format is good for spreading information about relays and contributes to the censorship-resistance of the network.
 
 ### Use cases
   - User selects relays from any number of sources and manages their relays' read and write capabilities.

--- a/23.md
+++ b/23.md
@@ -8,7 +8,7 @@ Relays List
 
 A special event with kind `10001`, meaning "relay list" is defined as a stringified content field containing an object where each member represents a relay the author uses.
 
-This kind is identical to kind 2, except that it is a transition to the replacable-kind-space [kind range: 10000-29999]
+This kind is similar to kind 2, but migrates towards kind 10001 to discourage relay bloat and encourage more consistent implementation. 
 
 The tags array is empty.
 

--- a/23.md
+++ b/23.md
@@ -37,9 +37,11 @@ This NIP can be extended at a later date to include more advanced rules while re
 ### Schema
 
 _literal_
-
 ```json
 {
+  "id": "<hash>",
+  "signature": "<signature>",
+  "created_at": "1673363256", 
   "kind": 10001,
   "tags": [],
   "content": {
@@ -54,6 +56,9 @@ _literal_
 _stringified_ 
 ```json
 {
+  "id": "<hash>",
+  "signature": "<signature>",
+  "created_at": "1673363256", 
   "kind": 10001,
   "tags": [],
   "content": "{\"wss://relayer.somewhere.xyz\":{\"read\": \"true\",\"write\": \"true\"}}"

--- a/23.md
+++ b/23.md
@@ -8,7 +8,7 @@ Relays List
 
 A special event with kind `10001`, meaning "relay list" is defined as a stringified content field containing an object where each member represents a relay the author uses.
 
-This kind is identical to kind 3, except that it is a transition to the replacable-kind-space [kind range: 10000-29999]
+This kind is identical to kind 2, except that it is a transition to the replacable-kind-space [kind range: 10000-29999]
 
 The tags array is empty.
 
@@ -32,7 +32,7 @@ For the second purpose, if any client decides to, they can show to the user what
 
 
 ### Extension possiblities 
-This NIP can be extended at a later date to include more advanced rulesets and remain backwards compatible.
+This NIP can be extended at a later date to include more advanced rules while remaining backwards compatible.
 
 ### Schema
 

--- a/23.md
+++ b/23.md
@@ -10,8 +10,6 @@ A special event with kind `10001`, meaning "relay list" is defined as a stringif
 
 This kind is similar to kind 2 in format, but would live at kind 10001 to discourage relay bloat and encourage more consistent implementation. 
 
-The key for each object member is the `relay URL` and **must** omit the trailing slash. 
-
 The tags array is empty.
 
 The `read` value operates on the values of the [NIP-01](01.md) **filter** object, while the `write` rule operates on the values of the **event** object. 
@@ -22,18 +20,11 @@ Both the `read` and `write` values are strings, to enable extensibility and type
 
 When the `read` value equals the string `true`  then read from that relay, otherwise don't. 
 
-When the `write` value equals the string `true`  then write to that relay, otherwise don't.
-
+When the `write` value equals the string `true`  then write to that relay, otherwise don't
 
 _Valid event.content_
 ```
 "{\"wss://relayer.somewhere.xyz\":{\"read\": \"true\",\"write\": \"true\"}}"
-```
-
-
-_Invalid event.content: missing `write` member_
-```
-"{\"wss://relayer.somewhere.xyz\":{\"read\": \"true\"}}"
 ```
 
 ### Use Cases

--- a/23.md
+++ b/23.md
@@ -16,37 +16,23 @@ The key, being the relay URL, **must** omit the trailing slash.
 
 The `read` value operates on the values of the [NIP-01](01.md) **filter** object, while the `write` rule operates on the values of the **event** object. 
 
-When the `read` value equals `false` for a given **filter** the client SHOULD NOT send that filter in a `REQ` message to that relay.
+When the `read` value equals the string `false` for a given **filter** the client SHOULD NOT send that filter in a `REQ` message to that relay.
 
-When the `write` value equals `false` for a given **event** the client SHOULD NOT send that event in an `EVENT` message to that relay.
+When the `write` value equals the string `false` for a given **event** the client SHOULD NOT send that event in an `EVENT` message to that relay.
 
-_Valid_
+_Valid event.content_
 ```
-"content": {
-  "wss://relayer.somewhere.xyz": {
-    "read": "true",
-    "write": "true"
-  }
-}
+"{\"wss://relayer.somewhere.xyz\":{\"read\": \"true\",\"write\": \"true\"}}"
 ```
 
-_Invalid_
+_Invalid event.content_
 ```
-"content": {
-  "wss://relayer.somewhere.xyz/": {
-    "read": "true",
-    "write": "true"
-  }
-}
+"{\"wss://relayer.somewhere.xyz/\":{\"read\": \"true\",\"write\": \"true\"}}"
 ```
 
-_Invalid_
+_Invalid event.content_
 ```
-"content": {
-  "wss://relayer.somewhere.xyz": {
-    "read": "true",
-  }
-}
+"{\"wss://relayer.somewhere.xyz/\":{\"read\": \"true\"}}"
 ```
 
 ### Purposes
@@ -67,28 +53,12 @@ This NIP can be extended at a later date to include more advanced rules while re
 
 ### Schema
 
-_literal_
-```json
-{
-  "id": "<hash>",
-  "signature": "<signature>",
-  "created_at": "1673363256", 
-  "kind": 10001,
-  "tags": [],
-  "content": {
-    "wss://relayer.somewhere.xyz": {
-      "read": "true",
-      "write": "true"
-    }
-  }
-}
-```
-
 _stringified_ 
 ```json
 {
   "id": "<hash>",
   "signature": "<signature>",
+  "pubkey": "<pubkey>",
   "created_at": "1673363256", 
   "kind": 10001,
   "tags": [],

--- a/23.md
+++ b/23.md
@@ -54,7 +54,6 @@ This NIP can be extended at a later date to include more advanced rules while re
 
 ### Schema
 
-_stringified_ 
 ```json
 {
   "id": "<hash>",

--- a/23.md
+++ b/23.md
@@ -16,9 +16,9 @@ The key, being the relay URL, **must** omit the trailing slash.
 
 The `read` value operates on the values of the [NIP-01](01.md) **filter** object, while the `write` rule operates on the values of the **event** object. 
 
-When the `read` value equals the string `false` for a given **filter** the client SHOULD NOT send that filter in a `REQ` message to that relay.
+When the `read` value equals the string `true`  then read from that relay, otherwise don't
 
-When the `write` value equals the string `false` for a given **event** the client SHOULD NOT send that event in an `EVENT` message to that relay.
+When the `write` value equals the string `true`  then write to that relay, otherwise don't
 
 _Valid event.content_
 ```
@@ -46,7 +46,6 @@ For the second purpose, if any client decides to, they can show to the user what
 ### Use cases
   - User selects relays from any number of sources and manages their relays' read and write capabilities.
   - User authenticates to client and client loads the user's relay list. User can modify their relay list from any client and have those changes reflect in other NIP-23 supported clients.  
-
 
 ### Extension possiblities 
 This NIP can be extended at a later date to include more advanced rules while remaining backwards compatible.

--- a/23.md
+++ b/23.md
@@ -6,21 +6,17 @@ Relays List
 
 `draft` `optional` `author:fiatjaf` `author:cameri` `author:monlovesmango` `author:giszmo`
 
-A special event with kind `10001`, meaning "relay list" is defined as having a list of tags, one for each relay the author uses.
+A special event with kind `10001`, meaning "relay list" is defined as a stringified content field containing an object where each member represents a relay the author uses.
 
-The content is not used.
+This kind is identical to kind 3, except that it is a transition to the replacable-kind-space [kind range: 10000-29999]
 
-The tags consist of arrays of 3 elements: the first is the relay URL, the second is the _read_ condition, the third is the _write_ condition.
+The tags array is empty.
 
-The _read_ condition consists of a string containing a rule that follows a subset of the [runes](https://pypi.org/project/runes/) language. Specifically only the `|`, `&`, `!`, `>`, `<`, `/` and `=` operators are allowed. When the rule is an empty string it evaluates to `true`. All the operators must be tested against all possible values in the case of filter values that consist of lists of values and also in the case of event tags that can have multiple values for the same tag -- in other words, the `=` may be interpreted as a `values.any(v => v == runeValue)` instead of an `values == runeValue` operator; the `<` may be interpreted as a `values.any(v => v < runeValue)` and so on. Event tags are identified just by their tag key (for example, `e` or `p`) without the `#` prefix used in filters.
+The `read` value operates on the values of the [NIP-01](01.md) **filter** object, while the `write` rule operates on the values of the **event** object. 
 
-The `read` rule operates on the values of the [NIP-01](01.md) **filter** object, while the `write` rule operates on the values of the **event** object.
+When the `read` value equals `false` for a given **filter** the client SHOULD NOT send that filter in a `REQ` message to that relay.
 
-When a `read` rule evaluates to `false` for a given **filter** the client SHOULD NOT send that filter in a `REQ` message to that relay.
-
-When a `write` rule evaluates to `false` for a given **event** the client SHOULD NOT send that event in an `EVENT` message to that relay.
-
-When a rule is malformed or the client is unable to parse it for any reason (for example, for not having implemented all the operators) it SHOULD treat it as `true` if it is a _read_ rule and `false` if it is a _write_ rule.
+When the `write` value equals `false` for a given **event** the client SHOULD NOT send that event in an `EVENT` message to that relay.
 
 ### Purposes
 
@@ -28,66 +24,38 @@ This NIP serves two purposes: (1) backup and interoperability of relay lists and
 
 The first use case is meant to make it so users can open their client -- or different clients -- in different devices and have their list of relays automatically fetched from a default relay and start using their relays list without having to set everything up again.
 
-For the second purpose, if any client decides to, they can show to the user what relays other users are using, suggest that or automatically add these to the user's relay list, this can take into account the rules or more likely not. The possibility of sharing a list of relays in standardized format is good for spreading information about relays and contributes to the censorship-resistance of the network.
+For the second purpose, if any client decides to, they can show to the user what relays other users are using, suggest that or automatically add these to the user's relay list. The possibility of sharing a list of relays in standardized format is good for spreading information about relays and contributes to the censorship-resistance of the network.
 
 ### Use cases
+  - User selects relays from any number of sources and manages their relays' read and write capabilities.
+  - User authenticates to client and client loads the user's relay list. User can modify their relay list from any client and have those changes reflect in other NIP-23 supported clients.  
 
-A client can expose to the user a set of premade rule templates (the user doesn't have to see the rules) for common relay policies, for example:
 
-  - "do not use this relay for DMs": sets _write_  to `kind/4`
-  - "only use this relay for DMs": sets _write_ to `kind=4` and _read_ to `kinds=4`
-  - "this is Bob's personal relay, only use it to fetch Bob's events": sets _write_ to `!` and _read_ to `authors=<bob-pubkey>`
-  - "this relay is full of spambots, do not get note replies from this relay": sets _read_ to `kinds=1&e!|kinds/1`
-  - "this is my personal relay, only store my stuff in it": sets _read_ to `authors=<my-pubkey>` _write_ to `pubkey=<my-pubkey>`
+### Extension possiblities 
+This NIP can be extended at a later date to include more advanced rulesets and remain backwards compatible.
 
-### Examples
+### Schema
 
-(Public keys are shortened to 4 characters for readability.)
-
-- Rule evaluation examples:
-
-  - _read_
-
-    - for the filter `{"kinds": [0, 1, 2, 3], "authors": ["abcd", "1234"]}`
-
-      - `<empty>`: `true`
-      - `!`: `invalid` -> `true`
-      - `zjhcxb`: `invalid` -> `true`
-      - `false`: `invalid` -> `true`
-      - `true`: `invalid` -> `true`
-      - `authors=7890`: `false`
-      - `authors=7890|authors=1234`: `true`
-      - `authors=7890&authors=1234`: `false`
-      - `e!`: `true`
-      - `e=5555`: `false`
-      - `kinds=1|kinds=4`: `true`
-      - `kinds<2`: `true`
-      - `kinds>7`: `false`
-      - `kinds=1|kinds=7&authors=8543|authors=1234`: `true`
-
-  - _write_
-
-    - for the event `{"kind": 7, "content": "banana", "tags": ["p", "6677"], "created_at": 123456789, "pubkey": "e3e3"}`
-
-      - `<empty>`: `true`
-      - `!`: `invalid` -> `false`
-      - `7237237`: `invalid` -> `false`
-      - `****`: `invalid` -> `false`
-      - `pubkey=7890`: `false`
-      - `pubkey=e3e3`: `true`
-      - `kind=7&p=6677`: `true`
-      - `created_at>999999999|e=5a5a`: `false`
-
-- Full example of a kind 10001 event:
+_literal_
 
 ```json
 {
   "kind": 10001,
-  "tags": [
-    ["wss://alicerelay.com/", "", ""],
-    ["wss://bobrelay.com/", "authors=ef87", "!"],
-    ["wss://carolrelay.com/", "", ""],
-  ],
-  "content": "",
-  ...other fields
+  "tags": [],
+  "content": {
+    "wss://relayer.somewhere.xyz": {
+      "read": "true",
+      "write": "true"
+    }
+  }
+}
+```
+
+_stringified_ 
+```json
+{
+  "kind": 10001,
+  "tags": [],
+  "content": "{\"wss://relayer.somewhere.xyz\":{\"read\": \"true\",\"write\": \"true\"}}"
+}
 ```

--- a/23.md
+++ b/23.md
@@ -8,17 +8,19 @@ Relays List
 
 A special event with kind `10001`, meaning "relay list" is defined as a stringified content field containing an object where each member represents a relay the author uses.
 
-This kind is similar to kind 2, but migrates towards kind 10001 to discourage relay bloat and encourage more consistent implementation. 
+This kind is similar to kind 2 in format, but would live at kind 10001 to discourage relay bloat and encourage more consistent implementation. 
+
+The key for each object member is the `relay URL` and **must** omit the trailing slash. 
 
 The tags array is empty.
-
-The key, being the relay URL, **must** omit the trailing slash. 
 
 The `read` value operates on the values of the [NIP-01](01.md) **filter** object, while the `write` rule operates on the values of the **event** object. 
 
 When the `read` value equals the string `true`  then read from that relay, otherwise don't
 
 When the `write` value equals the string `true`  then write to that relay, otherwise don't
+
+
 
 _Valid event.content_
 ```

--- a/23.md
+++ b/23.md
@@ -12,13 +12,42 @@ This kind is identical to kind 2, except that it is a transition to the replacab
 
 The tags array is empty.
 
-The object member key, being the relay URL, **must** omit the trailing slash. Good: `wss://nostr.someone.xyz`, Bad: `wss://nostr.someone.xyz/` 
+The key, being the relay URL, **must** omit the trailing slash. 
 
 The `read` value operates on the values of the [NIP-01](01.md) **filter** object, while the `write` rule operates on the values of the **event** object. 
 
 When the `read` value equals `false` for a given **filter** the client SHOULD NOT send that filter in a `REQ` message to that relay.
 
 When the `write` value equals `false` for a given **event** the client SHOULD NOT send that event in an `EVENT` message to that relay.
+
+_Valid_
+```
+"content": {
+  "wss://relayer.somewhere.xyz": {
+    "read": "true",
+    "write": "true"
+  }
+}
+```
+
+_Invalid_
+```
+"content": {
+  "wss://relayer.somewhere.xyz/": {
+    "read": "true",
+    "write": "true"
+  }
+}
+```
+
+_Invalid_
+```
+"content": {
+  "wss://relayer.somewhere.xyz": {
+    "read": "true",
+  }
+}
+```
 
 ### Purposes
 

--- a/23.md
+++ b/23.md
@@ -16,10 +16,13 @@ The tags array is empty.
 
 The `read` value operates on the values of the [NIP-01](01.md) **filter** object, while the `write` rule operates on the values of the **event** object. 
 
-When the `read` value equals the string `true`  then read from that relay, otherwise don't
+Both `read` and `write` values are required to be set to either `true` or `false`. 
 
-When the `write` value equals the string `true`  then write to that relay, otherwise don't
+Both the `read` and `write` values are strings, to enable extensibility and type conflicts. 
 
+When the `read` value equals the string `true`  then read from that relay, otherwise don't. 
+
+When the `write` value equals the string `true`  then write to that relay, otherwise don't.
 
 
 _Valid event.content_
@@ -27,14 +30,14 @@ _Valid event.content_
 "{\"wss://relayer.somewhere.xyz\":{\"read\": \"true\",\"write\": \"true\"}}"
 ```
 
-_Invalid event.content_
+_Invalid event.content: trailing slash_
 ```
 "{\"wss://relayer.somewhere.xyz/\":{\"read\": \"true\",\"write\": \"true\"}}"
 ```
 
-_Invalid event.content_
+_Invalid event.content: missing `write` member_
 ```
-"{\"wss://relayer.somewhere.xyz/\":{\"read\": \"true\"}}"
+"{\"wss://relayer.somewhere.xyz\":{\"read\": \"true\"}}"
 ```
 
 ### Purposes


### PR DESCRIPTION
This is a PR into #32 that simplifies the specification, while encouraging the extension of this NIP, such as advanced rules.  These modifications are made in light of comments from several people since August 2022, which seemed to lead to [this comment](https://github.com/nostr-protocol/nips/pull/32#issuecomment-1365394029)

Will refer to this as NIP-23b for now. 

The changes made in this PR reduce the original spec drastically, resulting in a specification that more accurately described as a transition from using recommended relays (kind 2) as relay lists to using a more appropriate kind in the _replaceable kind-space_. This should make adoption and transition for clients extremely simple. 

The only differences between `kind 10001` [NIP-23b] and `kind 2` are as follows
- the values of `read` and `write` go from type `Boolean` to type `String`. The reason is to support extension without type handling (this is also different from [fiatjaf's comment linked above](https://github.com/nostr-protocol/nips/pull/32#issuecomment-1365394029) )
- `kind 10001` is a replacable kind, so clients can much more easily and confidently persist and retrieve changes

@fiatjaf please review. 