### PR TITLE
NIP-47: BIP-47 payment code notification via Nostr DM [Work-in-progress]

### DIFF
--- a/47.md
+++ b/47.md
@@ -9,3 +9,71 @@ BIP-47 payment code notification via Nostr DM
 For new or existing BIP-47 payment codes (and/or PayNyms), any user can derive the payment code's associated Nostr `npub1` pubkey. That opens up the possibility to DM the payer's notification to the recipient that is normally done as an onchain `OP_RETURN` in BIP-47.
 
 The onchain "pollution" of using `OP_RETURN` is a legit criticism of BIP-47. This would eliminate that problem while still being completely deterministic (as long as the recipient still has the private key that's associated with their BIP-47 payment code, they'd always be able to regain access to their Nostr DMs sent to their payment code's `npub` pubkey).
+
+
+## Overview
+### Alice notifies Bob
+Per usual BIP-47 usage, Alice and Bob have generated their respective payment codes. Bob has published his payment code for anyone to use to send him BIP-47 payments.
+
+Alice wants to notify Bob that she will begin sending him BIP-47 payments.
+
+Alice derives the corresponding NIP-47 `npub` from Bob's BIP-47 public payment code.
+
+Alice can now DM her BIP-47 payment code to Bob's NIP-47 pubkey. This replaces the BIP-47 onchain notification tx. Alice does not need to blind her payment code since the content of her DM to Bob won't be publicly exposed.
+
+However, in order to preserve her privacy and not reveal that she is interacting with Bob's NIP-47 pubkey, Alice can use a "burner" Nostr private key to DM the one-time notification to Bob.
+
+### Bob checks his NIP-47 DM notifications
+Similar to how Alice can derive Bob's NIP-47 pubkey from his BIP-47 payment code, Bob can derive the private key associated with his NIP-47 pubkey.
+
+With the associated NIP-47 private key, he can see his NIP-47 notification DMs. For convenience, Bob's NIP-47 private key can [delegate (NIP-26)](26.md) DM access to Bob's normal Nostr key so he can access his NIP-47 notification DMs without having to juggle keys.
+
+
+## Example
+Test vectors from [BIP-47](https://github.com/bitcoin/bips/blob/master/bip-0047.mediawiki):
+```
+ALICE_MNEMONIC = "response seminar brave tip suit recall often sound stick owner lottery motion"
+ALICE_PAYMENT_CODE = "PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935Ubb7q8tx9GVbh2UuRnBc3WSyJHhUrw8KhprKnn9eDznYGieTzFcwQRya4GA"
+
+BOB_MNEMONIC = "reward upper indicate eight swift arch injury crystal super wrestle already dentist"
+BOB_PAYMENT_CODE = "PM8TJS2JxQ5ztXUpBBRnpTbcUXbUHy2T1abfrb3KkAAtMEGNbey4oumH7Hc578WgQJhPjBxteQ5GHHToTYHE3A1w6p7tU6KSoFmWBVbFGjKPisZDbP97"
+BOB_NOSTR_PUBKEY = 'npub1fn5w8vzw5gzl7j049x2sv9krmds4k83hw5u93nrqc88xf5t79tvqmnnus7'
+BOB_NOSTR_PRIVATE_KEY = ''  # TODO
+```
+
+
+## Python implementation
+_Note: Move this to a separate gist?_
+```
+$ pip install embit nostr
+```
+
+### Alice derives Bob's NIP-47 pubkey from his BIP-47 payment code
+```python
+import nostr
+from binascii import 
+from embit import base58, ec
+from embit.bip32 import HDKey
+
+# Decode Bob's base58 payment code and verify the checksum
+raw_payment_code = base58.decode_check(BOB_PAYMENT_CODE)
+
+# Parse the 81-byte payment code format:
+#   0x47 0x01 0x00 (sign) (32-byte pubkey) (32-byte chain code) (13 0x00 bytes)
+pubkey = ec.PublicKey.from_string(hexlify(raw_payment_code[3:36]))
+chain_code = raw_payment_code[36:68]
+
+# Derive the 0th pubkey (normally used to generate the BIP-47 notification addr)
+key = HDKey(key=pubkey, chain_code=chain_code)
+zeroth_bip47_pubkey = key.derive([0])
+
+# Convert it to a Nostr npub:
+nostr.PublicKey(zeroth_bip47_pubkey.xonly()).bech32()
+>> 'npub1fn5w8vzw5gzl7j049x2sv9krmds4k83hw5u93nrqc88xf5t79tvqmnnus7'
+```
+
+
+### Bob derives his NIP-47 private key from his bitcoin private key
+```python
+# TODO
+```

--- a/47.md
+++ b/47.md
@@ -20,6 +20,8 @@ One big advantage of NIP-47 is that as long as the recipient still has the priva
 
 NIP-47 notifications could be built directly into bitcoin wallets, invisible to the user experience. The bitcoin wallet user wouldn't even need their own Nostr identity or client; the wallet could just generate a "burner" Nostr private key to send the one-time NIP-47 notification DM.
 
+And then that same bitcoin wallet software could easily wire itself up to monitor for incoming NIP-47 notification DMs.
+
 
 ## Overview
 ### Alice notifies Bob

--- a/47.md
+++ b/47.md
@@ -13,20 +13,20 @@ The onchain "pollution" of using `OP_RETURN` is a legit criticism of BIP-47. Thi
 
 ## Overview
 ### Alice notifies Bob
-Per usual BIP-47 usage, Alice and Bob have generated their respective payment codes. Bob has published his payment code for anyone to use to send him BIP-47 payments.
+Per usual BIP-47 usage, Alice and Bob have generated their respective BIP-47 payment codes. Bob has published his payment code for anyone to use to send him BIP-47 payments.
 
 Alice wants to notify Bob that she will begin sending him BIP-47 payments.
 
 Alice derives the corresponding NIP-47 `npub` from Bob's BIP-47 public payment code.
 
-Alice can now DM her BIP-47 payment code to Bob's NIP-47 pubkey. This replaces the BIP-47 onchain notification tx. Alice does not need to blind her payment code since the content of her DM to Bob won't be publicly exposed.
+Alice can now Nostr DM her BIP-47 payment code to Bob's NIP-47 pubkey. This replaces the BIP-47 onchain notification tx. Alice does not need to blind her payment code in the DM since the content of her DM to Bob won't be publicly exposed.
 
 However, in order to preserve her privacy and not reveal that she is interacting with Bob's NIP-47 pubkey, Alice can use a "burner" Nostr private key to DM the one-time notification to Bob.
 
 ### Bob checks his NIP-47 DM notifications
-Similar to how Alice can derive Bob's NIP-47 pubkey from his BIP-47 payment code, Bob can derive the private key associated with his NIP-47 pubkey.
+Similar to how Alice can derive Bob's NIP-47 pubkey from his BIP-47 payment code, Bob can derive the Nostr private key associated with his NIP-47 pubkey.
 
-With the associated NIP-47 private key, he can see his NIP-47 notification DMs. For convenience, Bob's NIP-47 private key can [delegate (NIP-26)](26.md) DM access to Bob's normal Nostr key so he can access his NIP-47 notification DMs without having to juggle keys.
+With the associated NIP-47 private key, he can see his NIP-47 notification DMs. For convenience, Bob's NIP-47 private key can [delegate (NIP-26)](26.md) DM access to his normal Nostr key so he can access his NIP-47 notification DMs without having to juggle keys.
 
 
 ## Example
@@ -37,6 +37,10 @@ ALICE_PAYMENT_CODE = "PM8TJTLJbPRGxSbc8EJi42Wrr6QbNSaSSVJ5Y3E4pbCYiTHUskHg13935U
 
 BOB_MNEMONIC = "reward upper indicate eight swift arch injury crystal super wrestle already dentist"
 BOB_PAYMENT_CODE = "PM8TJS2JxQ5ztXUpBBRnpTbcUXbUHy2T1abfrb3KkAAtMEGNbey4oumH7Hc578WgQJhPjBxteQ5GHHToTYHE3A1w6p7tU6KSoFmWBVbFGjKPisZDbP97"
+```
+
+```
+# Resulting NIP-47 test vectors
 BOB_NOSTR_PUBKEY = 'npub1fn5w8vzw5gzl7j049x2sv9krmds4k83hw5u93nrqc88xf5t79tvqmnnus7'
 BOB_NOSTR_PRIVATE_KEY = ''  # TODO
 ```

--- a/47.md
+++ b/47.md
@@ -16,7 +16,9 @@ Because Nostr is built around bitcoin keys, a user can take a public BIP-47 paym
 
 Alice can then send her payment code as a Nostr DM to Bob's NIP-47 pubkey.
 
-One big advantage of NIP-47 is that as long as the recipient still has the private key that controls their BIP-47 wallet, they'd always be able to regain access to their NIP-47 notification DMs. Whereas if Alice just directly DMs her payment code to Bob, that DM can be orphaned/lost if he loses his Nostr private key or migrates away to a different identity.
+One big advantage of NIP-47 is that as long as the recipient still has the private key that controls their BIP-47 wallet, they'd always be able to regain access to their NIP-47 notification DMs. Whereas if Alice were to directly DM her payment code to Bob, that DM could be orphaned/lost if he loses his Nostr private key or migrates away to a different identity.
+
+NIP-47 notifications could be built directly into bitcoin wallets, invisible to the user experience. The bitcoin wallet user wouldn't even need their own Nostr identity or client; the wallet could just generate a "burner" Nostr private key to send the one-time NIP-47 notification DM.
 
 
 ## Overview
@@ -28,8 +30,6 @@ Alice wants to notify Bob that she will begin sending him BIP-47 payments.
 Alice derives the corresponding NIP-47 pubkey from Bob's BIP-47 public payment code.
 
 Alice can now Nostr DM her BIP-47 payment code to Bob's NIP-47 pubkey. This replaces the BIP-47 onchain notification tx. Alice does not need to blind her payment code in the DM since the content of her DM to Bob won't be publicly exposed.
-
-However, in order to preserve her privacy and not reveal that she is interacting with Bob's NIP-47 pubkey, Alice can use a "burner" Nostr private key to DM the one-time notification to Bob.
 
 
 ### Bob checks his NIP-47 DM notifications

--- a/47.md
+++ b/47.md
@@ -6,3 +6,6 @@ BIP-47 payment code notification via Nostr DM
 
 `draft` `optional` `author:kdmukai`
 
+For new or existing BIP-47 payment codes (and/or PayNyms), any user can derive the payment code's associated Nostr `npub1` pubkey. That opens up the possibility to DM the payer's notification to the recipient that is normally done as an onchain `OP_RETURN` in BIP-47.
+
+The onchain "pollution" of using `OP_RETURN` is a legit criticism of BIP-47. This would eliminate that problem while still being completely deterministic (as long as the recipient still has the private key that's associated with their BIP-47 payment code, they'd always be able to regain access to their Nostr DMs sent to their payment code's `npub` pubkey).

--- a/47.md
+++ b/47.md
@@ -10,20 +10,50 @@ _Note: People use BIP-47 and PayNyms interchangeably. A PayNym is just a human-f
 
 BIP-47 normally requires an onchain tx where Alice notifies Bob that she'll be sending him BIP-47 payments. Alice blinds her BIP-47 payment code and sends it as an `OP_RETURN` to Bob's public BIP-47 notification address.
 
-The onchain "pollution" of BIP-47's notification tx is a legit criticism of BIP-47. NIP-47 eliminates that problem.
+The onchain `OP_RETURN` data storage is a point of controversy for BIP-47; it guarantees recoverability of BIP-47 payments (provided that the private key is not lost) but creates permanent additional data for all full nodes to store for the entire future of Bitcoin.
+
+NIP-47 eliminates that problem, albeit with _greatly_ reduced guarantees.
 
 Because Nostr is built around bitcoin keys, a user can take a public BIP-47 payment code and derive its associated Nostr pubkey (aka NIP-47 pubkey). Note that Bob's NIP-47 pubkey will be different from his main Nostr pubkey, even if he uses the same private key for his bitcoin wallet and for Nostr (not recommended!).
 
 Alice can then send her payment code as a Nostr DM to Bob's NIP-47 pubkey.
 
-One big advantage of NIP-47 is that as long as the recipient still has the private key that controls their BIP-47 wallet, they'd always be able to regain access to their NIP-47 notification DMs. Whereas if Alice were to directly DM her payment code to Bob, that DM could be orphaned/lost if he loses his Nostr private key or migrates away to a different identity.
-
-NIP-47 notifications could be built directly into bitcoin wallets, invisible to the user experience. The bitcoin wallet user wouldn't even need their own Nostr identity or client; the wallet could just generate a "burner" Nostr private key to send the one-time NIP-47 notification DM.
+NIP-47 notifications would ideally be built directly into bitcoin wallets, invisible to the user experience. The bitcoin wallet user wouldn't even need their own Nostr identity or client; the wallet could just generate a "burner" Nostr private key to send the one-time NIP-47 notification DM.
 
 And then that same bitcoin wallet software could easily wire itself up to monitor for incoming NIP-47 notification DMs.
 
 
+## Optional new metadata field
+Bob may choose to publicly share his NIP-47 pubkey directly in his Nostr profile metadata:
+```
+{
+    nip47: npub1...,
+    ...
+}
+```
+
+
+## Tradeoffs
+The biggest risks with this arrangment are:
+* Ensuring that the recipient successfully received the NIP-47 notification DM.
+* Preserving long-term access to the sender's payment code.
+
+### Receiving the notification DM
+The recipient's bitcoin wallet can generate its NIP-47 pubkey and publish relay metadata, just like any other Nostr user. The sender's bitcoin wallet can transform Bob's payment code into its NIP-47 pubkey (or directly access it from his profile, if listed) and retrieve the relay metadata and then broadcast the notification DM specifically to those relays.
+
+An acknowledgment from the recipient's NIP-47 pubkey could be incorporated into the notification flow as a recommended best practice. Each user or, more likely, each bitcoin wallet implementation would have to decide if the acknowledgment is a blocker before enabling the first payment.
+
+### Preserving senders' paymennt codes
+NIP-47 loses the guarantees that BIP-47's onchain notification tx provides. We cannot assume that a Nostr notification DM will be stored in a relay forever.
+
+Some help can be provided here if the recipient runs their own archival relay and adds the NIP-47 pubkey to their archive.
+
+But mostly the onus falls on the recipient and his/her wallet software to maintain regular backups of all wallet data.
+
+
 ## Overview
+_this section is probably redundant_
+
 ### Alice notifies Bob
 Per usual BIP-47 usage, Alice and Bob have generated their respective BIP-47 payment codes. Bob has published his payment code for anyone to use to send him BIP-47 payments.
 

--- a/47.md
+++ b/47.md
@@ -6,9 +6,15 @@ BIP-47 payment code notification via Nostr DM
 
 `draft` `optional` `author:kdmukai`
 
-For new or existing BIP-47 payment codes (and/or PayNyms), any user can derive the payment code's associated Nostr `npub1` pubkey. That opens up the possibility to DM the payer's notification to the recipient that is normally done as an onchain `OP_RETURN` in BIP-47.
+_Note: People use BIP-47 and PayNyms interchangeably. A PayNym is just a human-friendly identifier in a centralized directory that maps to a user's BIP-47 payment code._
 
-The onchain "pollution" of using `OP_RETURN` is a legit criticism of BIP-47. This would eliminate that problem while still being completely deterministic (as long as the recipient still has the private key that's associated with their BIP-47 payment code, they'd always be able to regain access to their Nostr DMs sent to their payment code's `npub` pubkey).
+BIP-47 normally requires an onchain tx where Alice notifies Bob that she'll be sending him BIP-47 payments. Alice blinds her BIP-47 payment code and sends it as an `OP_RETURN` to Bob's public BIP-47 notification address.
+
+Because Nostr is built around bitcoin keys, a user can take a public BIP-47 payment code and derive its associated Nostr pubkey (aka NIP-47 pubkey). Note that Bob's NIP-47 pubkey will be different from his main Nostr pubkey, even if he uses the same private key for his bitcoin wallet and for Nostr (not recommended!).
+
+Alice can then send her payment code as a Nostr DM to Bob's NIP-47 pubkey.
+
+The onchain "pollution" of BIP-47's normal notification tx is a legit criticism of BIP-47. NIP-47 would eliminate that problem while still being completely deterministic (as long as the recipient still has the private key that's associated with their BIP-47 payment code, they'd always be able to regain access to their NIP-47 DMs).
 
 
 ## Overview
@@ -17,16 +23,19 @@ Per usual BIP-47 usage, Alice and Bob have generated their respective BIP-47 pay
 
 Alice wants to notify Bob that she will begin sending him BIP-47 payments.
 
-Alice derives the corresponding NIP-47 `npub` from Bob's BIP-47 public payment code.
+Alice derives the corresponding NIP-47 pubkey from Bob's BIP-47 public payment code.
 
 Alice can now Nostr DM her BIP-47 payment code to Bob's NIP-47 pubkey. This replaces the BIP-47 onchain notification tx. Alice does not need to blind her payment code in the DM since the content of her DM to Bob won't be publicly exposed.
 
 However, in order to preserve her privacy and not reveal that she is interacting with Bob's NIP-47 pubkey, Alice can use a "burner" Nostr private key to DM the one-time notification to Bob.
 
+
 ### Bob checks his NIP-47 DM notifications
 Similar to how Alice can derive Bob's NIP-47 pubkey from his BIP-47 payment code, Bob can derive the Nostr private key associated with his NIP-47 pubkey.
 
-With the associated NIP-47 private key, he can see his NIP-47 notification DMs. For convenience, Bob's NIP-47 private key can [delegate (NIP-26)](26.md) DM access to his normal Nostr key so he can access his NIP-47 notification DMs without having to juggle keys.
+With the associated NIP-47 private key, he can see his NIP-47 notification DMs. Now that Bob can Alice's new NIP-47 notification DM, he has everything he needs (Alice's BIP-47 payment code) to begin watching for her incoming payments in his bitcoin wallet.
+
+For convenience, Bob's NIP-47 private key can [delegate (NIP-26)](26.md) DM access to his normal Nostr key so he can access his NIP-47 notification DMs without having to juggle keys.
 
 
 ## Example

--- a/47.md
+++ b/47.md
@@ -33,7 +33,7 @@ However, in order to preserve her privacy and not reveal that she is interacting
 ### Bob checks his NIP-47 DM notifications
 Similar to how Alice can derive Bob's NIP-47 pubkey from his BIP-47 payment code, Bob can derive the Nostr private key associated with his NIP-47 pubkey.
 
-With the associated NIP-47 private key, he can see his NIP-47 notification DMs. Now that Bob can Alice's new NIP-47 notification DM, he has everything he needs (Alice's BIP-47 payment code) to begin watching for her incoming payments in his bitcoin wallet.
+With the associated NIP-47 private key, he can see his NIP-47 notification DMs. Now that Bob can access Alice's new NIP-47 notification DM, he has everything he needs (Alice's BIP-47 payment code) to begin watching for her incoming payments in his bitcoin wallet.
 
 For convenience, Bob's NIP-47 private key can [delegate (NIP-26)](26.md) DM access to his normal Nostr key so he can access his NIP-47 notification DMs without having to juggle keys.
 

--- a/47.md
+++ b/47.md
@@ -1,0 +1,8 @@
+NIP-47
+======
+
+BIP-47 payment code notification via Nostr DM
+-----------------------------------
+
+`draft` `optional` `author:kdmukai`
+

--- a/47.md
+++ b/47.md
@@ -10,11 +10,13 @@ _Note: People use BIP-47 and PayNyms interchangeably. A PayNym is just a human-f
 
 BIP-47 normally requires an onchain tx where Alice notifies Bob that she'll be sending him BIP-47 payments. Alice blinds her BIP-47 payment code and sends it as an `OP_RETURN` to Bob's public BIP-47 notification address.
 
+The onchain "pollution" of BIP-47's notification tx is a legit criticism of BIP-47. NIP-47 eliminates that problem.
+
 Because Nostr is built around bitcoin keys, a user can take a public BIP-47 payment code and derive its associated Nostr pubkey (aka NIP-47 pubkey). Note that Bob's NIP-47 pubkey will be different from his main Nostr pubkey, even if he uses the same private key for his bitcoin wallet and for Nostr (not recommended!).
 
 Alice can then send her payment code as a Nostr DM to Bob's NIP-47 pubkey.
 
-The onchain "pollution" of BIP-47's normal notification tx is a legit criticism of BIP-47. NIP-47 would eliminate that problem while still being completely deterministic (as long as the recipient still has the private key that's associated with their BIP-47 payment code, they'd always be able to regain access to their NIP-47 DMs).
+One big advantage of NIP-47 is that as long as the recipient still has the private key that controls their BIP-47 wallet, they'd always be able to regain access to their NIP-47 notification DMs. Whereas if Alice just directly DMs her payment code to Bob, that DM can be orphaned/lost if he loses his Nostr private key or migrates away to a different identity.
 
 
 ## Overview


### PR DESCRIPTION
Squatting on this NIP number (for obvious reasons!) while I flesh out this concept.

For new or existing BIP-47 payment codes (and/or PayNyms), any user can derive the payment code's associated Nostr `npub1` pubkey. That opens up the possibility to DM the payer's notification to the recipient that is normally done as an onchain `OP_RETURN` in BIP-47.

The onchain "pollution" of using `OP_RETURN` is a legit criticism of BIP-47. This would eliminate that problem while still being completely deterministic (as long as the recipient still has the private key that's associated with their BIP-47 payment code, they'd always be able to regain access to their Nostr DMs sent to their payment code's `npub` pubkey).
