### PR TITLE
Quote json keys (NIP-03 and NIP-11)

### DIFF
--- a/03.md
+++ b/03.md
@@ -10,11 +10,11 @@ When there is an OTS available it MAY be included in the existing event body und
 
 ```
 {
-  id: ...,
-  kind: ...,
+  "id": ...,
+  "kind": ...,
   ...,
   ...,
-  ots: <base64-encoded OTS file data>
+  "ots": <base64-encoded OTS file data>
 }
 ```
 

--- a/11.md
+++ b/11.md
@@ -12,13 +12,13 @@ When a relay receives an HTTP(s) request with an `Accept` header of `application
 
 ```json
 {
-  name: <string identifying relay>,
-  description: <string with detailed information>,
-  pubkey: <administrative contact pubkey>,
-  contact: <administrative alternate contact>,
-  supported_nips: <a list of NIP numbers supported by the relay>,
-  software: <string identifying relay software URL>,
-  version: <string version identifier>
+  "name": <string identifying relay>,
+  "description": <string with detailed information>,
+  "pubkey": <administrative contact pubkey>,
+  "contact": <administrative alternate contact>,
+  "supported_nips": <a list of NIP numbers supported by the relay>,
+  "software": <string identifying relay software URL>,
+  "version": <string version identifier>
 }
 ```
 


### PR DESCRIPTION
Several NIP examples (3, 11) weren't quoting the field keys (JSON keys must be quoted)