### PR TITLE
Minor typos and a correction to NIP-09 reference to pubkey

### DIFF
--- a/02.md
+++ b/02.md
@@ -38,7 +38,7 @@ A client may rely on the kind-3 event to display a list of followed people by pr
 
 ### Relay sharing
 
-A client may publish a full list of contacts with good relays for each of their contacts so other clients may use these to update their internal relay lists if needed, increasing censorship-resistant.
+A client may publish a full list of contacts with good relays for each of their contacts so other clients may use these to update their internal relay lists if needed, increasing censorship-resistance.
 
 ### Petname scheme
 

--- a/09.md
+++ b/09.md
@@ -27,13 +27,13 @@ For example:
 }
 ```
 
-Relays SHOULD delete or stop publishing any referenced events that have an identical `pubkey` as the deletion request.  Clients SHOULD hide or otherwise indicate a deletion status for referenced events.
+Relays SHOULD delete or stop publishing any referenced events that have an identical `id` as the deletion request.  Clients SHOULD hide or otherwise indicate a deletion status for referenced events.
 
 Relays SHOULD continue to publish/share the deletion events indefinitely, as clients may already have the event that's intended to be deleted. Additionally, clients SHOULD broadcast deletion events to other relays which don't have it.
 
 ## Client Usage
 
-Clients MAY choose to fully hide any events that are referenced by valid deletion events.  This includes text notes, direct messages, or other yet-to-be defined event kinds.  Alternatively, they MAY show the event along with an icon or other indication that the author has "disowned" the event.  The `content` field MAY also be used to replace the deleted events own content, although a user interface should clearly indicate that this is a deletion reason, not the original content.
+Clients MAY choose to fully hide any events that are referenced by valid deletion events.  This includes text notes, direct messages, or other yet-to-be defined event kinds.  Alternatively, they MAY show the event along with an icon or other indication that the author has "disowned" the event.  The `content` field MAY also be used to replace the deleted event's own content, although a user interface should clearly indicate that this is a deletion reason, not the original content.
 
 A client MUST validate that each event `pubkey` referenced in the `e` tag of the deletion request is identical to the deletion request `pubkey`, before hiding or deleting any event.  Relays can not, in general, perform this validation and should not be treated as authoritative.
 


### PR DESCRIPTION
In NIP-09, my reading of the spec leads me to believe the kind-5 events publish a list of `e` tags each of which are to refer to a event `id` which should be considered to be deleted. This corrects language that refers to the event `pubkey` instead of the `id`.