### PR TITLE
removed kind 6 since NIP-18 has been removed from the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 | 3           | Contacts                    | [2](02.md)             |
 | 4           | Encrypted Direct Messages   | [4](04.md)             |
 | 5           | Event Deletion              | [9](09.md)             |
-| 6           | Repost                      | [18](18.md)            |
 | 7           | Reaction                    | [25](25.md)            |
 | 40          | Channel Creation            | [28](28.md)            |
 | 41          | Channel Metadata            | [28](28.md)            |


### PR DESCRIPTION
Kind 6 was still in the README.md, pointing to the removed NIP-18...