### PR TITLE
NIP-33: Add example for more than one value

### DIFF
--- a/33.md
+++ b/33.md
@@ -10,6 +10,8 @@ This NIP adds a new event range that allows for replacement of events that have 
 
 Implementation
 --------------
+The value of a tag is defined as the first parameter of a tag after the tag name.
+
 A *parameterized replaceable event* is defined as an event with a kind `30000 <= n < 40000`.  
 Upon a parameterized replaceable event with a newer timestamp than the currently known latest
 replaceable event with the same kind and first `d` tag value being received, the old event
@@ -25,6 +27,8 @@ replace each other:
 * `"tags":[["d"],["d","some value"]]`: only first `d` tag is considered
 * `"tags":[["e"]]`: same as no tags
 * `"tags":[["d","test","1"]]`: only the value is considered (`test`)
+
+Clients SHOULD NOT use `d` tags with multiple values and SHOULD include the `d` tag even if it has no value to allow querying using the `#d` filter.
 
 Client Behavior
 ---------------

--- a/33.md
+++ b/33.md
@@ -10,10 +10,10 @@ This NIP adds a new event range that allows for replacement of events that have 
 
 Implementation
 --------------
-A *parameterized replaceable event* is defined as an event with a kind `30000 <= n < 40000`.
+A *parameterized replaceable event* is defined as an event with a kind `30000 <= n < 40000`.  
 Upon a parameterized replaceable event with a newer timestamp than the currently known latest
 replaceable event with the same kind and first `d` tag value being received, the old event
-SHOULD be discarded and replaced with the newer event.
+SHOULD be discarded and replaced with the newer event.  
 A missing or a `d` tag with no value should be interpreted equivalent to a `d` tag with the
 value as an empty string. Events from the same author with any of the following `tags`
 replace each other:
@@ -24,6 +24,7 @@ replace each other:
 * `"tags":[["d",""],["d","not empty"]]`: only first `d` tag is considered
 * `"tags":[["d"],["d","some value"]]`: only first `d` tag is considered
 * `"tags":[["e"]]`: same as no tags
+* `"tags":[["d","test","1"]]`: only the value is considered (`test`)
 
 Client Behavior
 ---------------


### PR DESCRIPTION
Going to merge this if it gets an approval, this behavior is already in the NIP. Also improves formatting.

See: 
> Upon a parameterized replaceable event with a newer timestamp than the currently known latest replaceable event with the same kind and **first `d` tag value** being received, the old event SHOULD be discarded and replaced with the newer event.  

The NIP *is* ambiguous, but the NIP also recommends using the `#d` tag to query + if I remember correctly while writing this I only intended the first parameter to be used so there is reason to believe this is the right implementation.