### PR TITLE
Update NIP-01 to clarify since and until filters

### DIFF
--- a/01.md
+++ b/01.md
@@ -66,8 +66,8 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
   "kinds": <a list of a kind numbers>,
   "#e": <a list of event ids that are referenced in an "e" tag>,
   "#p": <a list of pubkeys that are referenced in a "p" tag>,
-  "since": <a timestamp, events must be newer than this to pass>,
-  "until": <a timestamp, events must be older than this to pass>,
+  "since": <an integer unix timestamp, events must be newer than this to pass>,
+  "until": <an integer unix timestamp, events must be older than this to pass>,
   "limit": <maximum number of events to be returned in the initial query>
 }
 ```


### PR DESCRIPTION
The since and until filters does not clarify integer format and some relays fail to recognize filters with a float based timestamp.