### PR TITLE
NIP-26: adding section documenting valid fields and operators for conditions string

### DIFF
--- a/26.md
+++ b/26.md
@@ -35,12 +35,12 @@ nostr:delegation:<pubkey of publisher (delegatee)>:<conditions query string>
 
 The following fields and operators are supported in the above query string:
 
-###### Fields:
+*Fields*:
 1. `kind`
-   -  ###### Operators:
+   -  *Operators*:
       -  `=${KIND_NUMBER}` - delegator may only sign events of this kind
 2. `created_at`
-   -  ###### Operators:
+   -  *Operators*:
       -  `<${TIMESTAMP}` - delegator may only sign events created ***before*** the specified timestamp
       -  `>${TIMESTAMP}` - delegator may only sign events created ***after*** the specified timestamp
 

--- a/26.md
+++ b/26.md
@@ -50,7 +50,7 @@ For example, the following condition strings are valid:
 
 - `kind=1&created_at<1675721813`
 - `kind=0&kind=1&created_at>1675721813`
-- `kind=1&created_at>1675721813&created_at<1674777689`
+- `kind=1&created_at>1674777689&created_at<1675721813`
 
 #### Example
 

--- a/26.md
+++ b/26.md
@@ -31,6 +31,26 @@ The **delegation token** should be a 64-byte Schnorr signature of the sha256 has
 nostr:delegation:<pubkey of publisher (delegatee)>:<conditions query string>
 ```
 
+##### Supported Conditions
+
+The following fields and operators are supported in the above query string:
+
+**Fields**:
+1. `kind`
+   -  **Operators**:
+      -  `=${KIND_NUMBER}` - delegator may only sign events of this kind
+2. `created_at`
+   -  **Operators**:
+      -  `<${TIMESTAMP}` - delegator may only sign events created ***before*** the specified timestamp
+      -  `>${TIMESTAMP}` - delegator may only sign events created ***after*** the specified timestamp
+
+In order to create a single condition, you must use a supported field and operator. Multiple conditions can be used in a single query string, including on the same field. Conditions must be combined with `&`.
+
+For example, the following condition strings are valid:
+
+- `kind=1&created_at<1675721813`
+- `kind=0&kind=1&created_at>1675721813`
+- `kind=1&created_at>1675721813&created_at<1674777689`
 
 #### Example
 

--- a/26.md
+++ b/26.md
@@ -31,16 +31,16 @@ The **delegation token** should be a 64-byte Schnorr signature of the sha256 has
 nostr:delegation:<pubkey of publisher (delegatee)>:<conditions query string>
 ```
 
-##### Supported Conditions
+##### Conditions Query String
 
 The following fields and operators are supported in the above query string:
 
-**Fields**:
+###### Fields:
 1. `kind`
-   -  **Operators**:
+   -  ###### Operators:
       -  `=${KIND_NUMBER}` - delegator may only sign events of this kind
 2. `created_at`
-   -  **Operators**:
+   -  ###### Operators:
       -  `<${TIMESTAMP}` - delegator may only sign events created ***before*** the specified timestamp
       -  `>${TIMESTAMP}` - delegator may only sign events created ***after*** the specified timestamp
 


### PR DESCRIPTION
This MR adds a section clarifying fields and operators supported when specifying condition strings for NIP-26, following the discussion [here](https://github.com/nostr-protocol/nips/pull/157).

We could potentially allow other conditions as well, however `kind` and `created_at` currently are the only I've specified here.