### PR TITLE
Bech32 encoded relay entities

### DIFF
--- a/19.md
+++ b/19.md
@@ -42,10 +42,10 @@ These possible standardized `TLV` types are indicated here:
   - depends on the bech32 prefix:
     - for `nprofile` it will be the 32 bytes of the profile public key
     - for `nevent` it will be the 32 bytes of the event id
-    - for `nrelay`, this is reserved.
+    - for `nrelay`, this is the relay URL.
+  - for `nprofile`, `nevent` and `nrelay` this may be included only once.
 - `1`: `relay`
   - A relay in which the entity (profile or event) is more likely to be found, encoded as UTF-8. This may be included multiple times.
-  - This may be included only once if the prefix is `nrelay`.
 
 ## Examples
 

--- a/19.md
+++ b/19.md
@@ -34,6 +34,7 @@ These are the possible bech32 prefixes with `TLV`:
 
   - `nprofile`: a nostr profile
   - `nevent`: a nostr event
+  - `nrelay`: a nostr relay
 
 These possible standardized `TLV` types are indicated here:
 
@@ -41,8 +42,10 @@ These possible standardized `TLV` types are indicated here:
   - depends on the bech32 prefix:
     - for `nprofile` it will be the 32 bytes of the profile public key
     - for `nevent` it will be the 32 bytes of the event id
+    - for `nrelay`, this is reserved.
 - `1`: `relay`
   - A relay in which the entity (profile or event) is more likely to be found, encoded as UTF-8. This may be included multiple times.
+  - This may be included only once if the prefix is `nrelay`.
 
 ## Examples
 

--- a/19.md
+++ b/19.md
@@ -46,7 +46,7 @@ These possible standardized `TLV` types are indicated here:
   - for `nprofile`, `nevent` and `nrelay` this may be included only once.
 - `1`: `relay`
   - A relay in which the entity (profile or event) is more likely to be found, encoded as UTF-8. This may be included multiple times.
-
+  - not applicable to `nrelay`.
 ## Examples
 
 - `npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6` should decode into the public key hex `3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d` and vice-versa


### PR DESCRIPTION
the main purpose for this to be included as a `nostr:` URI.

some design choices:
- type `0` is reserved for relay since a relay type already exists (`1`)
- only one relay can be included in the encoded entity so that if metadata is added in the future there is no confusion on which relay it applies to.