### PR TITLE
NIP-26: fixing typo in conditions query string section

### DIFF
--- a/26.md
+++ b/26.md
@@ -38,11 +38,11 @@ The following fields and operators are supported in the above query string:
 *Fields*:
 1. `kind`
    -  *Operators*:
-      -  `=${KIND_NUMBER}` - delegator may only sign events of this kind
+      -  `=${KIND_NUMBER}` - delegatee may only sign events of this kind
 2. `created_at`
    -  *Operators*:
-      -  `<${TIMESTAMP}` - delegator may only sign events created ***before*** the specified timestamp
-      -  `>${TIMESTAMP}` - delegator may only sign events created ***after*** the specified timestamp
+      -  `<${TIMESTAMP}` - delegatee may only sign events created ***before*** the specified timestamp
+      -  `>${TIMESTAMP}` - delegatee may only sign events created ***after*** the specified timestamp
 
 In order to create a single condition, you must use a supported field and operator. Multiple conditions can be used in a single query string, including on the same field. Conditions must be combined with `&`.
 


### PR DESCRIPTION
This MR fixes a typo found by @bhayward93 in the section explaining the conditions query string for NIP-26.

I wrote "delegator" here, but this should be "delegatee".