### PR TITLE
NIP-26: Advice on using after operators in conditions query string

### DIFF
--- a/26.md
+++ b/26.md
@@ -31,6 +31,26 @@ The **delegation token** should be a 64-byte Schnorr signature of the sha256 has
 nostr:delegation:<pubkey of publisher (delegatee)>:<conditions query string>
 ```
 
+##### Conditions Query String
+
+The following fields and operators are supported in the above query string:
+
+*Fields*:
+1. `kind`
+   -  *Operators*:
+      -  `=${KIND_NUMBER}` - delegator may only sign events of this kind
+2. `created_at`
+   -  *Operators*:
+      -  `<${TIMESTAMP}` - delegator may only sign events created ***before*** the specified timestamp
+      -  `>${TIMESTAMP}` - delegator may only sign events created ***after*** the specified timestamp
+
+In order to create a single condition, you must use a supported field and operator. Multiple conditions can be used in a single query string, including on the same field. Conditions must be combined with `&`.
+
+For example, the following condition strings are valid:
+
+- `kind=1&created_at<1675721813`
+- `kind=0&kind=1&created_at>1675721813`
+- `kind=1&created_at>1674777689&created_at<1675721813`
 
 #### Example
 

--- a/26.md
+++ b/26.md
@@ -52,7 +52,7 @@ For example, the following condition strings are valid:
 - `kind=0&kind=1&created_at>1675721813`
 - `kind=1&created_at>1674777689&created_at<1675721813`
 
-For the vast majority of use-cases, it is advisable that query strings should include a `created_at` ***after*** condition reflecting the current time to prevent delegatee's from publishing historic notes on delegator's behalves.
+For the vast majority of use-cases, it is advisable that query strings should include a `created_at` ***after*** condition reflecting the current time, to prevent delegatee's from publishing historic notes on delegator's behalves.
 
 #### Example
 
@@ -103,18 +103,4 @@ Clients should display the delegated note as if it was published directly by the
 
 #### Relay & Client Querying Support
 
-Relays should answer requests such as `["REQ", "", {"authors": ["A"]}]` by querying both the `pubkey` and delegation tags `[1]` value.  
-
-[
-  0,
-  "477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396",
-  1677426298,
-  1,
-  [
-      "delegation",
-      "8e0d3d3eb2881ec137a11debe736a9086715a8c8beeeda615780064d68bc25dd",
-      "kind=1&created_at>1674834236&created_at<1677426236",
-      "6f44d7fe4f1c09f3954640fb58bd12bae8bb8ff4120853c4693106c82e920e2b898f1f9ba9bd65449a987c39c0423426ab7b53910c0c6abfb41b30bc16e5f524"
-  ],
-  Hello, world!
-]
+Relays should answer requests such as `["REQ", "", {"authors": ["A"]}]` by querying both the `pubkey` and delegation tags `[1]` value.

--- a/26.md
+++ b/26.md
@@ -52,7 +52,7 @@ For example, the following condition strings are valid:
 - `kind=0&kind=1&created_at>1675721813`
 - `kind=1&created_at>1674777689&created_at<1675721813`
 
-It is advisable when constructing a delegation token query string with a `created_at` ***before*** operator, that a `created_at` ***after*** operator is also provided to precisely scope the time window that the delegation token is valid for. This prevents the delegatee from publishing historic notes on the delegator's behalf.
+For the vast majority of use-cases, it is advisable that query strings should include a `created_at` ***after*** condition to prevent delegatee's from publishing historic notes on delegator's behalves.
 
 #### Example
 
@@ -104,3 +104,17 @@ Clients should display the delegated note as if it was published directly by the
 #### Relay & Client Querying Support
 
 Relays should answer requests such as `["REQ", "", {"authors": ["A"]}]` by querying both the `pubkey` and delegation tags `[1]` value.  
+
+[
+  0,
+  "477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396",
+  1677426298,
+  1,
+  [
+      "delegation",
+      "8e0d3d3eb2881ec137a11debe736a9086715a8c8beeeda615780064d68bc25dd",
+      "kind=1&created_at>1674834236&created_at<1677426236",
+      "6f44d7fe4f1c09f3954640fb58bd12bae8bb8ff4120853c4693106c82e920e2b898f1f9ba9bd65449a987c39c0423426ab7b53910c0c6abfb41b30bc16e5f524"
+  ],
+  Hello, world!
+]

--- a/26.md
+++ b/26.md
@@ -52,7 +52,7 @@ For example, the following condition strings are valid:
 - `kind=0&kind=1&created_at>1675721813`
 - `kind=1&created_at>1674777689&created_at<1675721813`
 
-For the vast majority of use-cases, it is advisable that query strings should include a created_at after condition reflecting the current time, to prevent the delegatee from publishing historic notes on the delegator's behalf.
+For the vast majority of use-cases, it is advisable that query strings should include a created_at ***after*** condition reflecting the current time, to prevent the delegatee from publishing historic notes on the delegator's behalf.
 
 #### Example
 

--- a/26.md
+++ b/26.md
@@ -52,7 +52,7 @@ For example, the following condition strings are valid:
 - `kind=0&kind=1&created_at>1675721813`
 - `kind=1&created_at>1674777689&created_at<1675721813`
 
-For the vast majority of use-cases, it is advisable that query strings should include a `created_at` ***after*** condition reflecting the current time, to prevent delegatee's from publishing historic notes on delegator's behalves.
+For the vast majority of use-cases, it is advisable that query strings should include a `created_at` ***after*** condition reflecting the current time to prevent delegatee's from publishing historic notes on delegator's behalves.
 
 #### Example
 

--- a/26.md
+++ b/26.md
@@ -19,7 +19,7 @@ This NIP introduces a new tag: `delegation` which is formatted as follows:
   "delegation",
   <pubkey of the delegator>,
   <conditions query string>,
-  <64-bytes schnorr signature of the sha256 hash of the delegation token>
+  <64-byte Schnorr signature of the sha256 hash of the delegation token>
 ]
 ```
 
@@ -38,11 +38,11 @@ The following fields and operators are supported in the above query string:
 *Fields*:
 1. `kind`
    -  *Operators*:
-      -  `=${KIND_NUMBER}` - delegator may only sign events of this kind
+      -  `=${KIND_NUMBER}` - delegatee may only sign events of this kind
 2. `created_at`
    -  *Operators*:
-      -  `<${TIMESTAMP}` - delegator may only sign events created ***before*** the specified timestamp
-      -  `>${TIMESTAMP}` - delegator may only sign events created ***after*** the specified timestamp
+      -  `<${TIMESTAMP}` - delegatee may only sign events created ***before*** the specified timestamp
+      -  `>${TIMESTAMP}` - delegatee may only sign events created ***after*** the specified timestamp
 
 In order to create a single condition, you must use a supported field and operator. Multiple conditions can be used in a single query string, including on the same field. Conditions must be combined with `&`.
 
@@ -51,6 +51,8 @@ For example, the following condition strings are valid:
 - `kind=1&created_at<1675721813`
 - `kind=0&kind=1&created_at>1675721813`
 - `kind=1&created_at>1674777689&created_at<1675721813`
+
+It is advisable when constructing a delegation token query string with a `created_at` ***before*** operator, that a `created_at` ***after*** operator is also provided to precisely scope the time window that the delegation token is valid for. This prevents the delegatee from publishing historic notes on the delegator's behalf.
 
 #### Example
 
@@ -64,37 +66,37 @@ privkey: 777e4f60b4aa87937e13acc84f7abcc3c93cc035cb4c1e9f7a9086dd78fffce1
 pubkey:  477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396
 ```
 
-Delegation string to grant note publishing authorization to the delegatee (477318cf) for the next 30 days.
+Delegation string to grant note publishing authorization to the delegatee (477318cf) from now, for the next 30 days, given the current timestamp is `1674834236`.
 ```json
-nostr:delegation:477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396:kind=1&created_at<1675721885
+nostr:delegation:477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396:kind=1&created_at>1674834236&created_at<1677426236
 ```
 
-The delegator (8e0d3d3e) then signs the above delegation string, the result of which is the delegation token:
+The delegator (8e0d3d3e) then signs a SHA256 hash of the above delegation string, the result of which is the delegation token:
 ```
-cbc49c65fe04a3181d72fb5a9f1c627e329d5f45d300a2dfed1c3e788b7834dad48a6d27d8e244af39c77381334ede97d4fd15abe80f35fda695fd9bd732aa1e
+6f44d7fe4f1c09f3954640fb58bd12bae8bb8ff4120853c4693106c82e920e2b898f1f9ba9bd65449a987c39c0423426ab7b53910c0c6abfb41b30bc16e5f524
 ```
 
 The delegatee (477318cf) can now construct an event on behalf of the delegator (8e0d3d3e). The delegatee then signs the event with its own private key and publishes.
 ```json
 {
-  "id": "ac4c71e69c39b1bd605de812543ebfaf81d5af365354f061d48981fb61e00b8a",
+  "id": "e93c6095c3db1c31d15ac771f8fc5fb672f6e52cd25505099f62cd055523224f",
   "pubkey": "477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396",
-  "created_at": 1673129661,
+  "created_at": 1677426298,
   "kind": 1,
   "tags": [
     [
       "delegation",
       "8e0d3d3eb2881ec137a11debe736a9086715a8c8beeeda615780064d68bc25dd",
-      "kind=1&created_at<1675721813",
-      "cbc49c65fe04a3181d72fb5a9f1c627e329d5f45d300a2dfed1c3e788b7834dad48a6d27d8e244af39c77381334ede97d4fd15abe80f35fda695fd9bd732aa1e"
+      "kind=1&created_at>1674834236&created_at<1677426236",
+      "6f44d7fe4f1c09f3954640fb58bd12bae8bb8ff4120853c4693106c82e920e2b898f1f9ba9bd65449a987c39c0423426ab7b53910c0c6abfb41b30bc16e5f524"
     ]
   ],
   "content": "Hello, world!",
-  "sig": "55ed9a78d6449b8c189b6dbc34bc4bcd34dcc79e6da6c9078268fe3d7c0cbe62b1b907ffb76ba591e83895b1329bf2e6e16f3b0cd5827272e420d419c6f0f0b5"
+  "sig": "633db60e2e7082c13a47a6b19d663d45b2a2ebdeaf0b4c35ef83be2738030c54fc7fd56d139652937cdca875ee61b51904a1d0d0588a6acd6168d7be2909d693"
 }
 ```
 
-The event should be considered a valid delegation if the conditions are satisfied (`kind=1` and `created_at<1675721813` in this example) and, upon validation of the delegation token, are found to be unchanged from the conditions in the original delegation string.
+The event should be considered a valid delegation if the conditions are satisfied (`kind=1` and `created_at>1674834236` & `created_at<1677426236` in this example) and, upon validation of the delegation token, are found to be unchanged from the conditions in the original delegation string.
 
 Clients should display the delegated note as if it was published directly by the delegator (8e0d3d3e).
 

--- a/26.md
+++ b/26.md
@@ -52,7 +52,7 @@ For example, the following condition strings are valid:
 - `kind=0&kind=1&created_at>1675721813`
 - `kind=1&created_at>1674777689&created_at<1675721813`
 
-For the vast majority of use-cases, it is advisable that query strings should include a `created_at` ***after*** condition to prevent delegatee's from publishing historic notes on delegator's behalves.
+For the vast majority of use-cases, it is advisable that query strings should include a `created_at` ***after*** condition reflecting the current time, to prevent delegatee's from publishing historic notes on delegator's behalves.
 
 #### Example
 

--- a/26.md
+++ b/26.md
@@ -52,7 +52,7 @@ For example, the following condition strings are valid:
 - `kind=0&kind=1&created_at>1675721813`
 - `kind=1&created_at>1674777689&created_at<1675721813`
 
-For the vast majority of use-cases, it is advisable that query strings should include a `created_at` ***after*** condition reflecting the current time, to prevent delegatee's from publishing historic notes on delegator's behalves.
+For the vast majority of use-cases, it is advisable that query strings should include a created_at after condition reflecting the current time, to prevent the delegatee from publishing historic notes on the delegator's behalf.
 
 #### Example
 

--- a/26.md
+++ b/26.md
@@ -52,7 +52,7 @@ For example, the following condition strings are valid:
 - `kind=0&kind=1&created_at>1675721813`
 - `kind=1&created_at>1674777689&created_at<1675721813`
 
-For the vast majority of use-cases, it is advisable that query strings should include a created_at ***after*** condition reflecting the current time, to prevent the delegatee from publishing historic notes on the delegator's behalf.
+For the vast majority of use-cases, it is advisable that query strings should include a `created_at` ***after*** condition reflecting the current time, to prevent the delegatee from publishing historic notes on the delegator's behalf.
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-36: Sensitive Content](36.md)
 - [NIP-40: Expiration Timestamp](40.md)
 - [NIP-42: Authentication of clients to relays](42.md)
+- [NIP-50: Keywords filter](50.md)
 
 ## Event Kinds
 


### PR DESCRIPTION
The primary purpose of this PR is to advise delegators to precisely scope the time windows in their delegation token query strings, such that delegatees are not permitted to sign historic posts.

Additionally:

- Fixed a minor typo in the capitalization of Schnorr
- Extended the existing example to use the advice provided about scoping time windows.
- Fixed the example line (74) to indicate that you should be signing a ***SHA256 hash*** of the delegation token string. 

