### PR TITLE
nip-39 digital identites in metadata

### DIFF
--- a/39.md
+++ b/39.md
@@ -1,0 +1,36 @@
+NIP-39
+======
+
+Digital Identities in Profile
+-----------------
+
+`draft` `optional` `author:pseudozach` `author:semisol`
+
+## Abstract
+
+Nostr protocol users may have other online identities such as usernames, profile pages, keypairs etc. they control and they may want to include this data in their profile metadata so clients can parse, validate and display this information.
+
+## `identities` field in metadata content
+
+A new optional `identities` field is introduced for `kind 0` metadata event contents in addition to name, about, picture fields as included in [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md):
+```json
+{
+    "id": "123",
+    "pubkey": "xxx",
+    ...
+    "content": {
+        "name": "asd",
+        ...
+        "identites": [
+            {"type": "twitter", "claim": "Semisol_Public", "proof": "https://twitter.com/Semisol_Public/status/xxx"},
+            {"type": "github", "claim": "semisol", "proof": "https://github.com/Semisol"},
+        ]
+    }
+}
+```
+`identities` field is an array of objects that include:
+* `type` may be the name of the service, website, a protocol or other identity system like `bitcoin` or `paynym` depending on what's being claimed.
+* `claim` should be the name of the digital estate like the profile name or bitcoin address.
+* `proof` should point to a URL that includes a way to prove that the digital identity being claimed is indeed controlled by the pubkey that signed this event.
+
+Clients should validate the information locally when possible or crawlers can remotely check the claim being made before displaying the claims as verified to other users e.g. the linked twitter proof indeed includes a statement such as "I control pubkey xxx" where xxx is the pubkey that published this kind 0 event.


### PR DESCRIPTION
@Semisol please check and let me know if this looks good or if you prefer to be removed from author list.
background discussion link: https://t.me/nostr_protocol/77441

Currently this NIP is supported on 1 client nostr.directory for github identity claims.

Seeking comments and review.