### PR TITLE
A universal web-of-trust reputation protocol on Nostr. UniWoT.

### DIFF
--- a/55.md
+++ b/55.md
@@ -1,5 +1,6 @@
 Universal relative web-of-trust reputation protocol on Nostr - UniWoT
 
+
 Clients may submit and query reputation events denoted by kind=9400 and
 that contain tags representing the reputation rating.
 

--- a/55.md
+++ b/55.md
@@ -1,0 +1,437 @@
+Universal relative web-of-trust reputation protocol on Nostr - UniWoT
+
+Clients may submit and query reputation events denoted by kind=9400 and
+that contain tags representing the reputation rating.
+
+The reputation query mechanism relies on the existing NIP-12 Generic Tag
+Queries.
+
+This NIP is a data type definition and does not require any change to
+relays.
+
+A reputation definition comprises a dimension, category, scale, rater,
+rated, comment and optionally an expiry date. Also, the elements
+informant, ratingProofType and externalRatingProof will allow external
+ratings to be recognised by Nostr (to be described in a future NIP).
+
+Dimension = dimension of reputation. E.g. 'judge', 'creator',
+'businessPartner', 'employee'. Stored in tag 'y'
+
+Category = the dimension's context. E.g. 'politics', 'gardening',
+'socialMedia', 'contract'. Stored in tag 'x'
+
+Scale = -1 to +1, enabling positive and negative ratings. Stored in tag
+'scale'
+
+Comment = optional text comment provided by the rater to compliment the
+reputation rating. Stored in event.content
+
+Whitelisted/blacklisted IP address = tag 'p'.
+
+Expiry Date = optional date of expiry of the reputation event. Stored in
+the 'expiration' tag.
+
+Apps can decide the categories and dimensions they wish to use. There is
+no centrally-defined list of categories or dimensions. Other apps may
+adopt or query reputation events made by other apps if they are
+interesting to them. Clients may synthesise disparate reputations that
+will enable wholly new use cases to emerge.
+
+Regarding blacklist/whitelist registration. It is recognised that
+blacklist/whitelist detection and management is a complex issue and
+outside the scope of this NIP. The whitelist/blacklist tag is just to
+bring such lists in-protocol, allow sharding and enable efficient
+selective replication.
+
+**Examples**
+------------
+
+// rate someone as a good judge of 'AustrianEcon' content
+
+{
+
+\"id\": \"\...\",
+
+\"kind\": 9400,
+
+"pubkey": informant // Nostr pubkey in this case.
+
+\"tags\": \[
+
+\[\"w\", raterID\], // Nostr pubkey in this case.
+
+\[\"p\", ratedID\], // Nostr pubkey in this case.
+
+\[\"ratingprooftype\", "1"\], // Nostr-native rating.
+
+\[\"x\", "AustrianEcon"\],
+
+\[\"y", "judge\"\],
+
+\[\"scale\", 80\]
+
+\],
+
+\"content\": \"Paul follows a wide breadth of quite good Austrian econ
+commentators.\"
+
+}
+
+// rate someone as a producer of 'AustrianEcon' content
+
+{
+
+\"id\": \"\...\",
+
+\"kind\": 9400,
+
+"pubkey": informant // Nostr pubkey in this case.
+
+\"tags\": \[
+
+\[\"w\", raterID\], // Nostr pubkey in this case.
+
+\[\"p\", ratedID\], // Nostr pubkey in this case.
+
+\[\"ratingprooftype\", "1"\], // Nostr-native rating.
+
+\[\"x\", "AustrianEcon"\],
+
+\[\"y", "blogger\"\],
+
+\[\"scale\", -20\]
+
+\],
+
+\"content\": \"Paul's Austrian econ commentary is somewhat interesting
+but not highly insightful.\"
+
+}
+
+// rate someone as a good judge of 'MilitaryAnalysis' content
+
+{
+
+\"id\": \"\...\",
+
+\"kind\": 9400,
+
+"pubkey": informant // Nostr pubkey in this case.
+
+\"tags\": \[
+
+\[\"w\", raterID\], // Nostr pubkey in this case.
+
+\[\"p\", ratedID\], // Nostr pubkey in this case.
+
+\[\"ratingprooftype\", "1"\], // Nostr-native rating.
+
+\[\"x\", "MilitaryAnalysis"\],
+
+\[\"y", "judge\"\],
+
+\[\"scale\", 30\]
+
+\],
+
+\"content\": \"Paul follows a mixed bag of military analysts, some good,
+some not so good.\"
+
+}
+
+// rate someone as a good producer of 'gardening / orchids' content
+
+{
+
+\"id\": \"\...\",
+
+\"kind\": 9400,
+
+"pubkey": informant // Nostr pubkey in this case.
+
+\"tags\": \[
+
+\[\"w\", raterID\], // Nostr pubkey in this case.
+
+\[\"p\", ratedID\], // Nostr pubkey in this case.
+
+\[\"ratingprooftype\", "1"\], // Nostr-native rating.
+
+\[\"x\", "Gardening"\],
+
+\[\"y", "orchids\"\],
+
+\[\"scale\", 100\]
+
+\],
+
+\"content\": \"His series of first places in the national orchid growing
+competitions 2019-2022 makes him an authority on this subject.\"
+
+}
+
+// declare someone as a paid subscriber to relay class XYZ
+
+{
+
+\"id\": \"\...\",
+
+\"kind\": 9400,
+
+"pubkey": informant // Nostr pubkey in this case.
+
+\"tags\": \[
+
+\[\"w\", raterID\], // Nostr pubkey in this case.
+
+\[\"p\", ratedID\], // Nostr pubkey in this case.
+
+\[\"x\", "PaidSubscriptionExpiry"\],
+
+\[\"y", "XYZRelayAccess\"\],
+
+\[\"expiration\", "3248923749287"\]
+
+\]
+
+}
+
+// blacklist user from relay 'branle'
+
+{
+
+\"id\": \"\...\",
+
+\"kind\": 9400,
+
+"pubkey": informant // Nostr pubkey in this case.
+
+\"tags\": \[
+
+\[\"w\", raterID\], // Nostr pubkey in this case.
+
+\[\"p\", ratedID\], // Nostr pubkey in this case.
+
+\[\"x\", "branle"\],
+
+\[\"y", "blacklist\"\]
+
+\]
+
+}
+
+// blacklist IP from relay 'branle'
+
+{
+
+\"id\": \"\...\",
+
+\"kind\": 9400,
+
+"pubkey": informant // Nostr pubkey in this case.
+
+\"tags\": \[
+
+\[\"w\", raterID\], // Nostr pubkey in this case.
+
+\[\"p\", blacklisted/whitelisted\_IP\_address\],
+
+\[\"x\", "branle"\],
+
+\[\"y", "blacklist\"\]
+
+\]
+
+}
+
+// rate user in respect of their contractworhiness.
+
+{
+
+\"id\": \"\...\",
+
+\"kind\": 9400,
+
+"pubkey": informant // Nostr pubkey in this case.
+
+\"tags\": \[
+
+\[\"w\", raterID\], // Nostr pubkey in this case.
+
+\[\"p\", ratedID\], // Nostr pubkey in this case.
+
+\[\"ratingprooftype\", "1"\], // Nostr-native rating.
+
+\[\"x\", "Contract"\],
+
+\[\"y", "contractworthiness\"\],
+
+\[\"scale\", 90\]
+
+\],
+
+\"content\": \"This entity has performed well as a trading partner.\"
+
+}
+
+// private rating
+
+{
+
+\"id\": \"\...\",
+
+\"kind\": 9400,
+
+"pubkey": informant // Nostr pubkey in this case.
+
+\"tags\": \[
+
+\[\"w\", raterID\], // Nostr pubkey in this case.
+
+\[\"p\", encryptedRatedID\], // Nostr pubkey in this case.
+
+\[\"ratingprooftype\", "1"\], // Nostr-native rating.
+
+\[\"x\", "Gardening"\],
+
+\[\"y", "orchids\"\],
+
+\[\"scale\", encryptedScaleValue\]
+
+\],
+
+\"content\": encryptedComment
+
+}
+
+// private rating
+
+{
+
+\"id\": \"\...\",
+
+\"kind\": 9400,
+
+"pubkey": informant // Nostr pubkey in this case.
+
+\"tags\": \[
+
+\[\"w\", raterID\], // Nostr pubkey in this case.
+
+\[\"p\", encryptedRatedID\], // Nostr pubkey in this case.
+
+\[\"ratingprooftype\", "1"\], // Nostr-native rating.
+
+\[\"x\", encryptedCategoryeValue\],
+
+\[\"y", encryptedDimensioneValue\],
+
+\[\"scale\", encryptedScaleValue\]
+
+\],
+
+\"content\": encryptedComment
+
+}
+
+// declare someone as an employee
+
+{
+
+\"id\": \"\...\",
+
+\"kind\": 9400,
+
+"pubkey": informant // Nostr pubkey in this case.
+
+\"tags\": \[
+
+\[\"w\", raterID\], // Nostr pubkey. Employer
+
+\[\"p\", ratedID\], // Nostr pubkey. Employee.
+
+\[\"x\", "employment"\],
+
+\[\"y", "CEOrole\"\]
+
+\]
+
+}
+
+**Suggested Use Cases**
+-----------------------
+
+Motivating examples for reputation events
+
+-   Allow an entity to rate other entities, thereby building a web of
+    > trust. Allow reputation ratings to be numerically scaled and to be
+    > positive or negative.
+
+-   Allow an entity to determine a trust score for entities outside
+    > their web of trust.
+
+-   Allow multi-dimensional reputation to be established in any domain,
+    > including social media, ride sharing, business partnership
+    > ratings, employment/employer ratings, DeFi lending, decentralised
+    > ratings agencies. More generally, enables a flexible mechanism of
+    > reputation to emerge.
+
+-   Social media app which automatically suggests content to a user
+    > using ratings automatically calculated from their existing web of
+    > trust ratings of other users
+
+-   Ride sharing app users to rate drivers and vice-versa.
+
+-   Marketplace platform to allow buyers and sellers to rate each other.
+
+-   Business partners to rate each others' contract performance in
+    > various dimensions.
+
+-   Decentralised finance lending platforms to permit lenders to
+    > nominate and rate trusted users so as to extend favourable lending
+    > terms, thus introducing a new model of DeFi lending in addition to
+    > the currently capital-inefficient over collateralised lending
+    > model.
+
+-   Bounty platform clients and service providers to rate each other in
+    > various dimensions so as to provide extra heuristics of reputation
+    > when choosing partners and negotiating contract terms.
+
+-   Employment listing platforms to provide the extra heuristics of
+    > reputation of both employees and employers in various dimensions
+    > to allow better decision-making for both parties.
+
+-   DeFi insurance providers to use an extra heuristic of reputation in
+    > determining an insured party's risk in calculating insurance
+    > premiums.
+
+-   Blacklist/whitelists: Any community (such as a Nostr client app, for
+    > example) or individual to register a user or an IP address on a
+    > specific blacklist or whitelist.
+
+-   Rating agency to rate entities. If one chooses to trust the rating
+    > agency, the rating agency's ratings then appear in their WoT.
+
+-   Attestations: allows an entity to declare a generalised attestation
+    > regarding another entity. e.g. effectively declare 'Bob is the CTO
+    > of Swan Bitcoin," via a proof provided by Swan Bitcoin.
+
+-   Allow an entity to issue an accreditation to another entity, with an
+    > optional time-limit.
+
+-   The above two examples largely intersect with the facility of
+    > soulbound tokens.
+
+-   And more.
+
+-   The motivating philosophy for this NIP is to better enable the
+    > decentralised economy via a flexible, extensible, relative
+    > web-of-trust reputation protocol, better manage spam and improve
+    > censorship resistance. This reputation model is conceptualised to
+    > enable organisations and individuals to establish and maintain
+    > their reputation as a valuable asset to facilitate interactions
+    > and seek favourable trading terms without involvement of third
+    > parties. This circumvents coercion by state actors, the censorship
+    > of the establishment financial system and dystopian WEF/UN ideals.
+    > A universal WoT reputation can be a key factor in enabling a
+    > global, pseudonymous economy. UniWoT.

--- a/55.md
+++ b/55.md
@@ -1,438 +1,346 @@
-Universal relative web-of-trust reputation protocol on Nostr - UniWoT
+A universal relative web-of-trust reputation protocol on Nostr. UniWoT.
+
+Authors: @brainspacer, @distbit0
+
+Overview
+
+Reputation is multi-dimensional and sharding can be implemented to allow relays to handle specific dimensions of reputation, achieving load balancing and increased federation/censorship resistance. A more general reputation model can be used, denoted by Category, Dimension, and Scale. Each reputation rating is given in a single event, including the elements ratedID, raterID, category, dimension and scale (refer to the spec below for further details). This allows for a greater range of reputation use cases and increased adoption. Use cases include whitelisting and blacklisting and many more. Additionally, external reputation ratings can be recognised by Nostr, thereby enabling it to overcome any network effects of existing silos of reputation data. 
+
+Clients may submit and query reputation events denoted by kind=9400 and that contain tags representing the reputation rating.
+
+The reputation query mechanism relies on the existing NIP-12 Generic Tag Queries.
+
+This NIP is a data type definition and does not require any change to relays.  
+
+A reputation definition comprises a dimension, category, scale, rater, rated, comment and optionally an expiry date. Also, the elements informant, ratingProofType and externalRatingProof will allow external ratings to be recognised by Nostr (to be described in a future NIP).
 
 
-Clients may submit and query reputation events denoted by kind=9400 and
-that contain tags representing the reputation rating.
 
-The reputation query mechanism relies on the existing NIP-12 Generic Tag
-Queries.
+<table>
+  <tr>
+   <td><strong>Element</strong>
+   </td>
+   <td><strong>Description</strong>
+   </td>
+   <td><strong>Nostr Implementation</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>Rater
+   </td>
+   <td>For Nostr-native ratings, this is the rater’s pubkey. For external ratings, this is the external identifier.
+   </td>
+   <td>Tag ‘w’
+   </td>
+  </tr>
+  <tr>
+   <td>Rated
+   </td>
+   <td>This holds the rated party’s ID.
+<p>
+Sometimes, this will be a Nostr pubkey and sometimes not.
+<p>
+<strong>Nostr-native ratings:</strong>
+<p>
+It will be a Nostr pubkey when the rated is a known Nostr pubkey. 
+<p>
+It will be a non-Nostr identifier where the rated party does not have a Nostr pubkey. E.g. when rating the Fed. :)
+<p>
+<strong>Imported external ratings:</strong>
+<p>
+It will be a non-Nostr identifier for imported external ratings.
+   </td>
+   <td>Tag ‘p’ 
+   </td>
+  </tr>
+  <tr>
+   <td>Dimension 
+   </td>
+   <td>akin to the tags in the example given in the earlier proposals
+   </td>
+   <td>Tag ‘y’
+   </td>
+  </tr>
+  <tr>
+   <td>Category
+   </td>
+   <td>Used to categorise Dimensions and allow re-use of Dimensions in different contexts and thus differentiate different uses of a given Dimension. 
+<p>
+For example, if someone is deemed a good “judge” of others in the field of, say, Austrian economics, that same good judgement may not apply in the field of, say, orchid gardening. Category allows for ratings to be filtered (by clients or relays) for more than one purpose and allows for applications to more flexibly share and reuse ratings. 
+   </td>
+   <td>Tag ‘x’
+   </td>
+  </tr>
+  <tr>
+   <td>Scale
+   </td>
+   <td>Could be -1 to 1, say, and thus support positive and negative ratings - similar to the earlier proposals.
+   </td>
+   <td>Tag ‘scale’
+   </td>
+  </tr>
+  <tr>
+   <td>Comment
+<p>
+(optional)
+   </td>
+   <td>Used to optionally provide supporting text.  
+   </td>
+   <td>event.content
+   </td>
+  </tr>
+  <tr>
+   <td>Expiration timestamp 
+<p>
+(optional)  
+   </td>
+   <td>This allows reputation events to be used as time-limited accreditations. 
+   </td>
+   <td>Tag ‘expiration’
+   </td>
+  </tr>
+  <tr>
+   <td>RatingProofType
+   </td>
+   <td>Indicates the method by which proof of the rating can be achieved. For example, ‘Type 2 = check that external rater has contributed to a Github project.’ Inextricably related to the Nostr rating’s Dimension.
+<p>
+Type 1 = internal Nostr rating.
+   </td>
+   <td>Tag ‘rateprooftype’
+   </td>
+  </tr>
+  <tr>
+   <td>ExternalRatingProof
+   </td>
+   <td>(conditionally required, depending on Rating Proof Type)
+<p>
+This field is required for any external rating. May be a URL. Will be described more fully in an upcoming NIP to allow external proofs. 
+   </td>
+   <td>Tag ‘exrateproof’
+   </td>
+  </tr>
+  <tr>
+   <td>Informant
+   </td>
+   <td>Given this scheme supports Nostr recognising external ratings, the informant will be the Nostr pubkey who creates the Nostr record. This is not necessarily the rater. 
+   </td>
+   <td>event.pubkey
+   </td>
+  </tr>
+  <tr>
+   <td>Whitelisted/blacklisted IP address
+   </td>
+   <td>
+   </td>
+   <td>Tag ‘p’
+   </td>
+  </tr>
+</table>
 
-This NIP is a data type definition and does not require any change to
-relays.
 
-A reputation definition comprises a dimension, category, scale, rater,
-rated, comment and optionally an expiry date. Also, the elements
-informant, ratingProofType and externalRatingProof will allow external
-ratings to be recognised by Nostr (to be described in a future NIP).
 
-Dimension = dimension of reputation. E.g. 'judge', 'creator',
-'businessPartner', 'employee'. Stored in tag 'y'
 
-Category = the dimension's context. E.g. 'politics', 'gardening',
-'socialMedia', 'contract'. Stored in tag 'x'
 
-Scale = -1 to +1, enabling positive and negative ratings. Stored in tag
-'scale'
+Apps can decide the categories and dimensions they wish to use. There is no centrally-defined list of categories or dimensions. Other apps may adopt or query reputation events made by other apps if they are interesting to them. Clients may synthesise disparate reputations that will enable wholly new use cases to emerge. 
 
-Comment = optional text comment provided by the rater to compliment the
-reputation rating. Stored in event.content
+Regarding blacklist/whitelist registration. It is recognised that blacklist/whitelist detection and management is a complex issue and outside the scope of this NIP. The whitelist/blacklist tag is just to bring such lists in-protocol, allow sharding and enable efficient selective replication. 
 
-Whitelisted/blacklisted IP address = tag 'p'.
 
-Expiry Date = optional date of expiry of the reputation event. Stored in
-the 'expiration' tag.
-
-Apps can decide the categories and dimensions they wish to use. There is
-no centrally-defined list of categories or dimensions. Other apps may
-adopt or query reputation events made by other apps if they are
-interesting to them. Clients may synthesise disparate reputations that
-will enable wholly new use cases to emerge.
-
-Regarding blacklist/whitelist registration. It is recognised that
-blacklist/whitelist detection and management is a complex issue and
-outside the scope of this NIP. The whitelist/blacklist tag is just to
-bring such lists in-protocol, allow sharding and enable efficient
-selective replication.
-
+## 
 **Examples**
-------------
 
+
+```
 // rate someone as a good judge of 'AustrianEcon' content
-
 {
-
-\"id\": \"\...\",
-
-\"kind\": 9400,
-
-"pubkey": informant // Nostr pubkey in this case.
-
-\"tags\": \[
-
-\[\"w\", raterID\], // Nostr pubkey in this case.
-
-\[\"p\", ratedID\], // Nostr pubkey in this case.
-
-\[\"ratingprooftype\", "1"\], // Nostr-native rating.
-
-\[\"x\", "AustrianEcon"\],
-
-\[\"y", "judge\"\],
-
-\[\"scale\", 80\]
-
-\],
-
-\"content\": \"Paul follows a wide breadth of quite good Austrian econ
-commentators.\"
-
+  "id": "...",
+  "kind": 9400,
+  "pubkey": informant			// Nostr pubkey in this case.
+  "tags": [
+    ["w", raterID],			// Nostr pubkey in this case.
+    ["p", ratedID],			// Nostr pubkey in this case.
+    ["ratingprooftype", "1"], 	// Nostr-native rating.
+    ["x", "AustrianEcon"],
+    ["y", "judge"],
+    ["scale", 80]
+  ],
+  "content": "Paul follows a wide breadth of quite good Austrian econ commentators."
 }
 
 // rate someone as a producer of 'AustrianEcon' content
-
 {
-
-\"id\": \"\...\",
-
-\"kind\": 9400,
-
-"pubkey": informant // Nostr pubkey in this case.
-
-\"tags\": \[
-
-\[\"w\", raterID\], // Nostr pubkey in this case.
-
-\[\"p\", ratedID\], // Nostr pubkey in this case.
-
-\[\"ratingprooftype\", "1"\], // Nostr-native rating.
-
-\[\"x\", "AustrianEcon"\],
-
-\[\"y", "blogger\"\],
-
-\[\"scale\", -20\]
-
-\],
-
-\"content\": \"Paul's Austrian econ commentary is somewhat interesting
-but not highly insightful.\"
-
+  "id": "...",
+  "kind": 9400,
+  "pubkey": informant			// Nostr pubkey in this case.
+  "tags": [
+    ["w", raterID],			// Nostr pubkey in this case.
+    ["p", ratedID],			// Nostr pubkey in this case.
+    ["ratingprooftype", "1"], 	// Nostr-native rating.
+    ["x", "AustrianEcon"],
+    ["y", "blogger"],
+    ["scale", -20]
+  ],
+  "content": "Paul's Austrian econ commentary is somewhat interesting but not highly insightful."
 }
 
 // rate someone as a good judge of 'MilitaryAnalysis' content
-
 {
-
-\"id\": \"\...\",
-
-\"kind\": 9400,
-
-"pubkey": informant // Nostr pubkey in this case.
-
-\"tags\": \[
-
-\[\"w\", raterID\], // Nostr pubkey in this case.
-
-\[\"p\", ratedID\], // Nostr pubkey in this case.
-
-\[\"ratingprooftype\", "1"\], // Nostr-native rating.
-
-\[\"x\", "MilitaryAnalysis"\],
-
-\[\"y", "judge\"\],
-
-\[\"scale\", 30\]
-
-\],
-
-\"content\": \"Paul follows a mixed bag of military analysts, some good,
-some not so good.\"
-
+  "id": "...",
+  "kind": 9400,
+  "pubkey": informant			// Nostr pubkey in this case.
+  "tags": [
+    ["w", raterID],			// Nostr pubkey in this case.
+    ["p", ratedID],			// Nostr pubkey in this case.
+    ["ratingprooftype", "1"], 	// Nostr-native rating.
+    ["x", "MilitaryAnalysis"],
+    ["y", "judge"],
+    ["scale", 30]
+  ],
+  "content": "Paul follows a mixed bag of military analysts, some good, some not so good."
 }
 
 // rate someone as a good producer of 'gardening / orchids' content
-
 {
-
-\"id\": \"\...\",
-
-\"kind\": 9400,
-
-"pubkey": informant // Nostr pubkey in this case.
-
-\"tags\": \[
-
-\[\"w\", raterID\], // Nostr pubkey in this case.
-
-\[\"p\", ratedID\], // Nostr pubkey in this case.
-
-\[\"ratingprooftype\", "1"\], // Nostr-native rating.
-
-\[\"x\", "Gardening"\],
-
-\[\"y", "orchids\"\],
-
-\[\"scale\", 100\]
-
-\],
-
-\"content\": \"His series of first places in the national orchid growing
-competitions 2019-2022 makes him an authority on this subject.\"
-
+  "id": "...",
+  "kind": 9400,
+  "pubkey": informant			// Nostr pubkey in this case.
+  "tags": [
+    ["w", raterID],			// Nostr pubkey in this case.
+    ["p", ratedID],			// Nostr pubkey in this case.
+    ["ratingprooftype", "1"], 	// Nostr-native rating.
+    ["x", "Gardening"],
+    ["y", "orchids"],
+    ["scale", 100]
+  ],
+  "content": "His series of first places in the national orchid growing competitions 2019-2022 makes him an authority on this subject."
 }
 
-// declare someone as a paid subscriber to relay class XYZ
-
+// declare someone as a paid subscriber to relay class XYZ 
 {
-
-\"id\": \"\...\",
-
-\"kind\": 9400,
-
-"pubkey": informant // Nostr pubkey in this case.
-
-\"tags\": \[
-
-\[\"w\", raterID\], // Nostr pubkey in this case.
-
-\[\"p\", ratedID\], // Nostr pubkey in this case.
-
-\[\"x\", "PaidSubscriptionExpiry"\],
-
-\[\"y", "XYZRelayAccess\"\],
-
-\[\"expiration\", "3248923749287"\]
-
-\]
-
+  "id": "...",
+  "kind": 9400,
+  "pubkey": informant			// Nostr pubkey in this case.
+  "tags": [
+    ["w", raterID],			// Nostr pubkey in this case.
+    ["p", ratedID],			// Nostr pubkey in this case.
+    ["x", "PaidSubscriptionExpiry"],
+    ["y", "XYZRelayAccess"],
+    ["expiration", "3248923749287"]
+  ]
 }
 
 // blacklist user from relay 'branle'
-
 {
-
-\"id\": \"\...\",
-
-\"kind\": 9400,
-
-"pubkey": informant // Nostr pubkey in this case.
-
-\"tags\": \[
-
-\[\"w\", raterID\], // Nostr pubkey in this case.
-
-\[\"p\", ratedID\], // Nostr pubkey in this case.
-
-\[\"x\", "branle"\],
-
-\[\"y", "blacklist\"\]
-
-\]
-
+  "id": "...",
+  "kind": 9400,
+  "pubkey": informant			// Nostr pubkey in this case.
+  "tags": [
+    ["w", raterID],			// Nostr pubkey in this case.
+    ["p", ratedID],			// Nostr pubkey in this case.
+    ["x", "branle"],
+    ["y", "blacklist"]
+  ]
 }
 
 // blacklist IP from relay 'branle'
-
 {
-
-\"id\": \"\...\",
-
-\"kind\": 9400,
-
-"pubkey": informant // Nostr pubkey in this case.
-
-\"tags\": \[
-
-\[\"w\", raterID\], // Nostr pubkey in this case.
-
-\[\"p\", blacklisted/whitelisted\_IP\_address\],
-
-\[\"x\", "branle"\],
-
-\[\"y", "blacklist\"\]
-
-\]
-
+  "id": "...",
+  "kind": 9400,
+  "pubkey": informant			// Nostr pubkey in this case.
+  "tags": [
+    ["w", raterID],			// Nostr pubkey in this case.
+    ["p", blacklisted/whitelisted_IP_address],
+    ["x", "branle"],
+    ["y", "blacklist"]
+  ]
 }
 
 // rate user in respect of their contractworhiness.
-
 {
-
-\"id\": \"\...\",
-
-\"kind\": 9400,
-
-"pubkey": informant // Nostr pubkey in this case.
-
-\"tags\": \[
-
-\[\"w\", raterID\], // Nostr pubkey in this case.
-
-\[\"p\", ratedID\], // Nostr pubkey in this case.
-
-\[\"ratingprooftype\", "1"\], // Nostr-native rating.
-
-\[\"x\", "Contract"\],
-
-\[\"y", "contractworthiness\"\],
-
-\[\"scale\", 90\]
-
-\],
-
-\"content\": \"This entity has performed well as a trading partner.\"
-
+  "id": "...",
+  "kind": 9400,
+  "pubkey": informant			// Nostr pubkey in this case.
+  "tags": [
+    ["w", raterID],			// Nostr pubkey in this case.
+    ["p", ratedID],			// Nostr pubkey in this case.
+    ["ratingprooftype", "1"], 	// Nostr-native rating.
+    ["x", "Contract"],
+    ["y", "contractworthiness"],
+    ["scale", 90]
+  ],
+  "content": "This entity has performed well as a trading partner."
 }
 
-// private rating
-
+// private rating 
 {
-
-\"id\": \"\...\",
-
-\"kind\": 9400,
-
-"pubkey": informant // Nostr pubkey in this case.
-
-\"tags\": \[
-
-\[\"w\", raterID\], // Nostr pubkey in this case.
-
-\[\"p\", encryptedRatedID\], // Nostr pubkey in this case.
-
-\[\"ratingprooftype\", "1"\], // Nostr-native rating.
-
-\[\"x\", "Gardening"\],
-
-\[\"y", "orchids\"\],
-
-\[\"scale\", encryptedScaleValue\]
-
-\],
-
-\"content\": encryptedComment
-
+  "id": "...",
+  "kind": 9400,
+  "pubkey": informant			// Nostr pubkey in this case.
+  "tags": [
+    ["w", raterID],			// Nostr pubkey in this case.
+    ["p", encryptedRatedID],	// Nostr pubkey in this case.
+    ["ratingprooftype", "1"], 	// Nostr-native rating.
+    ["x", "Gardening"],
+    ["y", "orchids"],
+    ["scale", encryptedScaleValue]
+  ],
+  "content": encryptedComment
 }
 
-// private rating
-
+// private rating 
 {
-
-\"id\": \"\...\",
-
-\"kind\": 9400,
-
-"pubkey": informant // Nostr pubkey in this case.
-
-\"tags\": \[
-
-\[\"w\", raterID\], // Nostr pubkey in this case.
-
-\[\"p\", encryptedRatedID\], // Nostr pubkey in this case.
-
-\[\"ratingprooftype\", "1"\], // Nostr-native rating.
-
-\[\"x\", encryptedCategoryeValue\],
-
-\[\"y", encryptedDimensioneValue\],
-
-\[\"scale\", encryptedScaleValue\]
-
-\],
-
-\"content\": encryptedComment
-
+  "id": "...",
+  "kind": 9400,
+  "pubkey": informant			// Nostr pubkey in this case.
+  "tags": [
+    ["w", raterID],			// Nostr pubkey in this case.
+    ["p", encryptedRatedID],	// Nostr pubkey in this case.
+    ["ratingprooftype", "1"], 	// Nostr-native rating.
+    ["x", encryptedCategoryeValue],
+    ["y", encryptedDimensioneValue],
+    ["scale", encryptedScaleValue]
+  ],
+  "content": encryptedComment
 }
 
-// declare someone as an employee
-
+// declare someone as an employee 
 {
-
-\"id\": \"\...\",
-
-\"kind\": 9400,
-
-"pubkey": informant // Nostr pubkey in this case.
-
-\"tags\": \[
-
-\[\"w\", raterID\], // Nostr pubkey. Employer
-
-\[\"p\", ratedID\], // Nostr pubkey. Employee.
-
-\[\"x\", "employment"\],
-
-\[\"y", "CEOrole\"\]
-
-\]
-
+  "id": "...",
+  "kind": 9400,
+  "pubkey": informant			// Nostr pubkey in this case. 
+  "tags": [
+    ["w", raterID],			// Nostr pubkey. Employer
+    ["p", ratedID],			// Nostr pubkey. Employee.
+    ["x", "employment"],
+    ["y", "CEOrole"]
+  ]
 }
+```
 
+
+
+## 
 **Suggested Use Cases**
------------------------
 
 Motivating examples for reputation events
 
--   Allow an entity to rate other entities, thereby building a web of
-    > trust. Allow reputation ratings to be numerically scaled and to be
-    > positive or negative.
 
--   Allow an entity to determine a trust score for entities outside
-    > their web of trust.
 
--   Allow multi-dimensional reputation to be established in any domain,
-    > including social media, ride sharing, business partnership
-    > ratings, employment/employer ratings, DeFi lending, decentralised
-    > ratings agencies. More generally, enables a flexible mechanism of
-    > reputation to emerge.
-
--   Social media app which automatically suggests content to a user
-    > using ratings automatically calculated from their existing web of
-    > trust ratings of other users
-
--   Ride sharing app users to rate drivers and vice-versa.
-
--   Marketplace platform to allow buyers and sellers to rate each other.
-
--   Business partners to rate each others' contract performance in
-    > various dimensions.
-
--   Decentralised finance lending platforms to permit lenders to
-    > nominate and rate trusted users so as to extend favourable lending
-    > terms, thus introducing a new model of DeFi lending in addition to
-    > the currently capital-inefficient over collateralised lending
-    > model.
-
--   Bounty platform clients and service providers to rate each other in
-    > various dimensions so as to provide extra heuristics of reputation
-    > when choosing partners and negotiating contract terms.
-
--   Employment listing platforms to provide the extra heuristics of
-    > reputation of both employees and employers in various dimensions
-    > to allow better decision-making for both parties.
-
--   DeFi insurance providers to use an extra heuristic of reputation in
-    > determining an insured party's risk in calculating insurance
-    > premiums.
-
--   Blacklist/whitelists: Any community (such as a Nostr client app, for
-    > example) or individual to register a user or an IP address on a
-    > specific blacklist or whitelist.
-
--   Rating agency to rate entities. If one chooses to trust the rating
-    > agency, the rating agency's ratings then appear in their WoT.
-
--   Attestations: allows an entity to declare a generalised attestation
-    > regarding another entity. e.g. effectively declare 'Bob is the CTO
-    > of Swan Bitcoin," via a proof provided by Swan Bitcoin.
-
--   Allow an entity to issue an accreditation to another entity, with an
-    > optional time-limit.
-
--   The above two examples largely intersect with the facility of
-    > soulbound tokens.
-
--   And more.
-
--   The motivating philosophy for this NIP is to better enable the
-    > decentralised economy via a flexible, extensible, relative
-    > web-of-trust reputation protocol, better manage spam and improve
-    > censorship resistance. This reputation model is conceptualised to
-    > enable organisations and individuals to establish and maintain
-    > their reputation as a valuable asset to facilitate interactions
-    > and seek favourable trading terms without involvement of third
-    > parties. This circumvents coercion by state actors, the censorship
-    > of the establishment financial system and dystopian WEF/UN ideals.
-    > A universal WoT reputation can be a key factor in enabling a
-    > global, pseudonymous economy. UniWoT.
+* Allow an entity to rate other entities, thereby building a web of trust. Allow reputation ratings to be numerically scaled and to be positive or negative. 
+* Allow an entity to determine a trust score for entities outside their web of trust.
+* Allow multi-dimensional reputation to be established in any domain, including social media, ride sharing, business partnership ratings, employment/employer ratings, DeFi lending, decentralised ratings agencies. More generally, enables a flexible mechanism of reputation to emerge.  
+* Social media app which automatically suggests content to a user using ratings automatically calculated from their existing web of trust ratings of other users
+* Ride sharing app users to rate drivers and vice-versa.
+* Marketplace platform to allow buyers and sellers to rate each other.
+* Business partners to rate each others’ contract performance in various dimensions.
+* Decentralised finance lending platforms to permit lenders to nominate and rate trusted users so as to extend favourable lending terms, thus introducing a new model of DeFi lending in addition to the currently capital-inefficient over collateralised lending model.
+* Bounty platform clients and service providers to rate each other in various dimensions so as to provide extra heuristics of reputation when choosing partners and negotiating contract terms.
+* Employment listing platforms to provide the extra heuristics of reputation of both employees and employers in various dimensions to allow better decision-making for both parties.
+* DeFi insurance providers to use an extra heuristic of reputation in determining an insured party’s risk in calculating insurance premiums.
+* Blacklist/whitelists: Any community (such as a Nostr client app, for example) or individual to register a user or an IP address on a specific blacklist or whitelist.
+* Rating agency to rate entities. If one chooses to trust the rating agency, the rating agency’s ratings then appear in their WoT.  
+* Attestations: allows an entity to declare a generalised attestation regarding another entity. e.g. effectively declare ‘Bob is the CTO of Swan Bitcoin,” via a proof provided by Swan Bitcoin.
+* Allow an entity to issue an accreditation to another entity, with an optional time-limit.
+* The above two examples largely intersect with the facility of soulbound tokens.
+* And more.
+* The motivating philosophy for this NIP is to better enable the decentralised economy via a flexible, extensible, relative web-of-trust reputation protocol, better manage spam and improve censorship resistance. This reputation model is conceptualised to enable organisations and individuals to establish and maintain their reputation as a valuable asset to facilitate interactions and seek favourable trading terms without involvement of third parties. This circumvents coercion by state actors, the censorship of the establishment financial system and dystopian WEF/UN ideals. A universal WoT reputation can be a key factor in enabling a global, pseudonymous economy. UniWoT.      


### PR DESCRIPTION
A universal relative web-of-trust reputation protocol on Nostr. UniWoT.
https://github.com/brainspacer/nips/blob/master/55.md

Authors: @brainspacer, @distbit0

Overview

Reputation is multi-dimensional and sharding can be implemented to allow relays to handle specific dimensions of reputation, achieving load balancing and increased federation/censorship resistance. A more general reputation model can be used, denoted by Category, Dimension, and Scale. Each reputation rating is given in a single event, including the elements ratedID, raterID, category, dimension and scale (refer to the spec below for further details). This allows for a greater range of reputation use cases and increased adoption. Use cases include whitelisting and blacklisting and many more. Additionally, external reputation ratings can be recognised by Nostr, thereby enabling it to overcome any network effects of existing silos of reputation data. 

—-

As some earlier nostr reputation models have proposed, reputation is multi-dimensional and different clients will be interested in different reputation dimensions. 

Here are a few issues that I suggest pertain to the proposals so far:



* Sharding is not easily facilitated with the above reputation model - leading to relay bloat and fewer opportunities to load-balance and achieve improved federation/censorship resistance.
* The comment in the ‘content’ field has to be general in nature because it does not pertain to a specific dimension of reputation.  
* The reputation model proposed above narrowly defines a reputation model, which may limit adoption and its applicability to a more general set of use cases. For example, there might be a myriad of distinctions in how one would rate someone as a good ‘judge’.  
* In-protocol blacklist and whitelist may be better facilitated with separate events that specify the context of the blacklist/whitelist. And separate events could better support explicit replication of any reputation types another relay may be interested in, including whitelists/blacklists.
* There is no manner to recognise ratings where the rater does not have a Nostr public key (i.e. can’t recognise/import ratings from outside of Nostr)
* There is no manner to recognise ratings where the rated does not have a Nostr public key (i.e. can’t rate entities from outside of Nostr)

Given reputation will become progressively important in many apps that employ Nostr and in general, it warrants thought to address the above issues. Additionally, apps outside of social media will be vectors for Nostr adoption because they can also employ Nostr-based reputation. My thoughts on all this and how to implement it are laid out below.

**Sharding**

The earlier proposals rely on relays storing the full reputation from one user to another user (in the set of tags in a single Nostr event). There is a way to shard reputations and thus allow a relay to handle select dimensions of reputation. 

A more ideal setup could be that relays can specialise in handling dimensions of reputation that they are interested in/incentivised to handle. This enables load balancing and sharding. This also facilitates selected replication and further federation/censorship resistance via the selected replication model described in the discussion here ==> [https://github.com/Cameri/Nostream/issues/41](https://github.com/Cameri/nostream/issues/41). 

**Import existing external ratings**

For ratings where the rater does not have a Nostr public key (i.e. where the rating is outside of Nostr) to be expressed as a Nostr rating, this will require the ability for the Nostr rating event to specify the non-Nostr rater identifier and also to include the proof of the rating that is external to Nostr. 

A separate NIP will describe how to achieve recognition of external ratings within Nostr. This post describes a reputation rating scheme NIP contained to ensure ‘remote ratings’ are not locked out from being incorporated into Nostr at some future time - by including in this spec the additional elements of Informant, RaterID, ProofType and ExternalRatingProof.

The benefit for Nostr in being able to import external ratings is to overcome the network effect of ratings stored in external systems. Therefore, if any Nostr users/communities are interested in reputation data, it can be made available in-protocol irrespective of origin.

Reputation importers can specialise in importing reputation to Nostr and are trusted to not DoS clients, which allows for network and computationally intensive external reputation proofs to be verified by clients.

Clients can also opt to only verify proofs of ratings which their trusted reputation importers disagree on, thereby significantly reducing client-side computational load.

Reputation importers can determine which ratings to import based on which external entities their users/subscribers trust and hence which external ratings their users/subscribers care about. This takes the burden of verifying external ratings in order to prevent clients being DoS'd, off of relays, and places it on specialised, incentivised reputation importers.

 

Examples might include the following:



* Proof X follows Y on Twitter
* Proof X has accepted pull requests from Y on github
* Proof X has rated Y business on trip advisor
* Proof X is in DAO Y’s multisig
* Proof X rated Y w/ five stars on localbitcoins
* (also, see the section below regarding future possible relay-side proof verification) 

**How to implement**

Reputation can be denoted by not just a single reputation dimension (e.g. “judge” or “driver” in the earlier proposals) but can be more generally denoted using the following data structure: 


<table>
  <tr>
   <td><strong>Element</strong>
   </td>
   <td><strong>Description</strong>
   </td>
   <td><strong>Nostr Implementation</strong>
   </td>
  </tr>
  <tr>
   <td>Rater
   </td>
   <td>For Nostr-native ratings, this is the rater’s pubkey. For external ratings, this is the external identifier.
   </td>
   <td>Tag ‘w’
   </td>
  </tr>
  <tr>
   <td>Rated
   </td>
   <td>This holds the rated party’s ID.
<p>
Sometimes, this will be a Nostr pubkey and sometimes not.
<p>
<strong>Nostr-native ratings:</strong>
<p>
It will be a Nostr pubkey when the rated is a known Nostr pubkey. 
<p>
It will be a non-Nostr identifier where the rated party does not have a Nostr pubkey. E.g. when rating the Fed. :)
<p>
<strong>Imported external ratings:</strong>
<p>
It will be a non-Nostr identifier for imported external ratings.
   </td>
   <td>Tag ‘p’ 
   </td>
  </tr>
  <tr>
   <td>Dimension 
   </td>
   <td>akin to the tags in the example given in the earlier proposals
   </td>
   <td>Tag ‘y’
   </td>
  </tr>
  <tr>
   <td>Category
   </td>
   <td>Used to categorise Dimensions and allow re-use of Dimensions in different contexts and thus differentiate different uses of a given Dimension. 
<p>
For example, if someone is deemed a good “judge” of others in the field of, say, Austrian economics, that same good judgement may not apply in the field of, say, orchid gardening. Category allows for ratings to be filtered (by clients or relays) for more than one purpose and allows for applications to more flexibly share and reuse ratings. 
   </td>
   <td>Tag ‘x’
   </td>
  </tr>
  <tr>
   <td>Scale
   </td>
   <td>Could be -1 to 1, say, and thus support positive and negative ratings - similar to the earlier proposals.
   </td>
   <td>Tag ‘scale’
   </td>
  </tr>
  <tr>
   <td>Comment
<p>
(optional)
   </td>
   <td>Used to optionally provide supporting text.  
   </td>
   <td>event.content
   </td>
  </tr>
  <tr>
   <td>Expiration timestamp 
<p>
(optional)  
   </td>
   <td>This allows reputation events to be used as time-limited accreditations. 
   </td>
   <td>Tag ‘expiration’
   </td>
  </tr>
  <tr>
   <td>RatingProofType
   </td>
   <td>Indicates the method by which proof of the rating can be achieved. For example, ‘Type 2 = check that external rater has contributed to a Github project.’ Inextricably related to the Nostr rating’s Dimension.
<p>
Type 1 = internal Nostr rating.
   </td>
   <td>Tag ‘rateprooftype’
   </td>
  </tr>
  <tr>
   <td>ExternalRatingProof
   </td>
   <td>(conditionally required, depending on Rating Proof Type)
<p>
This field is required for any external rating. May be a URL. Will be described more fully in an upcoming NIP to allow external proofs. 
   </td>
   <td>Tag ‘exrateproof’
   </td>
  </tr>
  <tr>
   <td>Informant
   </td>
   <td>Given this scheme supports Nostr recognising external ratings, the informant will be the Nostr pubkey who creates the Nostr record. This is not necessarily the rater. 
   </td>
   <td>event.pubkey
   </td>
  </tr>
  <tr>
   <td>Whitelisted/blacklisted IP address
   </td>
   <td>
   </td>
   <td>Tag ‘p’
   </td>
  </tr>
</table>


**Private ratings**

A user may wish to maintain a list of ratings which are private. To achieve this, some elements of a rating can be encrypted, such as the following:



* Scale. With Scale encrypted, others may see that a user has rated someone in a certain dimension, but are unable to see whether that is a positive or negative rating. 
* Comment. Any comment fields can be hidden to other users. 
* RatedID. The identity of the rated entity can be hidden to other users. 

A user may also encrypt other elements of the rating, such as Category and Dimension to  hide more elements of the rating. However, this may pose issues including the following:



* Relays may selectively accept (or reject) certain ratings based on Category and Dimension and therefore this may limit a user’s ability to store such ratings. 
* Selective replication (as described in the discussion [https://github.com/Cameri/Nostream/issues/41](https://github.com/Cameri/nostream/issues/41)) may not replicate such ratings given they are not able to identify the Category or Dimension.    
* Allow certain fields to be encrypted either with pub key of recipient or of sender for both purposes of:
    * Making rating of someone which you do not want others to be able to see unless recipient chooses to share
    * Various attestations (which are more general than just ratings)

Encrypted fields can be prefixed with, say, “##:” to indicate it is encrypted.

One reputation rating per event. Examples - see NIP-55.  55.md file


**Reason for single-letter tag names for some rating elements**

The reason for using single-letter tag names (such as ‘x’, ‘y’, category, dimension, respectively) is to allow for relay-side queries on reputation events, given Nostr’s current design where only single-letter tags are queryable ([NIP-12 Generic Tag Queries](https://github.com/nostr-protocol/nips/blob/master/12.md)). Efficient reputation event queries are important now to allow clients to select only reputation events they are interested in. Also, this better supports the future selective replication model linked above ([https://github.com/Cameri/Nostream/issues/41](https://github.com/Cameri/nostream/issues/41)) given the selective reputation relies on relay-side filtering.

Regarding tag ‘expiration’, we understand caution may be in order because NIP-40 Expiration Timestamp is not currently implemented widely by relays. The side effect if NIP-40 has not been implemented by a relay is that an expired reputation (accreditation) event will continue to be propagated. From a functional perspective for reputation (accreditation) purposes, this is not an issue so long as clients check for expiration. However, this could result in DoS of clients if some ratings are expired and renewed very frequently. Ideally, ‘expiration’ should be supported by the relay. 

**NIP**

The specification in this post requires no relay development and is currently supported by existing Nostr relays.This data type specification is described in the proposed update to the draft NIP in the heading **Reputation Datatype NIP** below.

**Future related extensions**

The reputation datatype scheme described in this post enables future NIP possibilities, as follows:



* **Relative trust score calculation: **A future relay NIP can be drafted that employs the above reputation scheme to calculate a relative trust score for an entity. This future NIP would define the weighting, scoring and calculation of the relative reputation score of one entity in relation to another entity for a specified Dimension or Category. 

    For example, for a given Dimension, the relative trust score calculated for someone is low the more distant they are from me. And someone who is close to my web of trust will have a low relative trust score if they are rated poorly by others I trust highly.


    This potential future NIP is not drafted here and will require community input to define the scoring calculation.

* **Richer tag queries and symmetric difference set handling:** Nostr relays currently support queries on tags (NIP-12 Generic Tag Queries), but these are limited to OR operations. To best support the selective replication by custom clients described in the linked discussion ([https://github.com/Cameri/Nostream/issues/41](https://github.com/Cameri/nostream/issues/41)), it will be useful to add support for AND operations on tag queries. And symmetric difference set handling, using devices such as RSA accumulators as described in the linked discussion ...issues/41. And eventually add support for a generalised relay-side rich query facility. 

    Potential NIPs for these future possibilities are not drafted here.

* **Support for multiple hashtags per rating.** The primary advantage of being able to add multiple hashtags to a rating would be that said rating would be more easily filtered/searched, allowing both clients and relays to more accurately discriminate between relevant and irrelevant ratings. This functionality however would necessitate a more flexible querying capability, as the current querying mechanism does not allow for queries to treat the contents of a tag as a list and apply an OR operator on the elements in the list.

    This potential future NIP is not drafted here.

* **Rating non-Nostr entities**

    The reputation model proposed in this post already supports the ability for Nostr ratings to be made for non-Nostr entities, which can later be linked to entities. e.g. I can auto endorse all my eBay sellers without them needing to be on Nostr reputation. When they join Nostr, they can auto claim these ratings by providing proof that they control said eBay account. This proof model to claim an ID has not been described here. 


    This potential future NIP is not drafted here.


    ~~ ~~

* **Web3/evm compatibility**

    Create a Nostr reputation on-chain oracle to prove that a rating does not exist between two parties, or attest the **rating score** of one party from another's perspective.


    The specification for this facility is not further defined here.


**Use cases**

This proposal enables a (relative) web of trust with sharding, selective replication, improved load balancing and improved federation/censorship resistance. 

This can be used by Nostr apps, increasing the utility of those Nostr apps and therefore promoting Nostr adoption. 

In addition, this permits in-protocol registration of whitelist and blacklist PKs and IPs, thus facilitating replication of blacklists/whitelists amongst relays (as per the selective replication mechanism described in the linked discussion …issues/41). 

As may be apparent by several of the example events above, this reputation model can be also used by non-Nostr apps, therefore further promoting Nostr adoption. Wholly new use cases for Nostr are enabled, in-line with ‘notes and other stuff transmitted by relays.’

For further information, see the list of motivating examples of use cases in the updated NIP proposal below.

(The authors of this post are aware of at least two Nostr clients under development that employ the reputation model proposed in this post, and others that are currently being conceptualised. We are led to believe the clients under development will soon be made open-source and can act as a reference client to enable other clients to employ this reputation model described in this post.) 

**Incentive compatible**

The reputation model described in this post enables an incentive compatible model for relays and custom replication clients to arise, whereby the events are selectively handled by sponsored relays according to their (community’s) areas of interest, achieving sharding. Incentive compatibility is critical for a network’s long-term viability. Also, the replication mechanism (...issues/41 linked above) can allow communities/clients to sponsor custom replication clients to perform the selective replication/sharding to/from the relays interested in the selective datasets.   
