### PR TITLE
NIP-56: Reporting

### DIFF
--- a/56.md
+++ b/56.md
@@ -21,9 +21,11 @@ are reporting.
 
 If reporting a note, an `e` tag MUST also be included referencing the note id.
 
-A `report` tag MUST be included which consists of the following report types:
+A `report type` string MUST be included as the 3rd entry to the `e` or `p` tag
+being reported, which consists of the following report types:
 
-- `explicit` - explicit content which may not be appropriate for minors: nudity, profanity, etc
+- `nudity` - depictions of nudity, porn, etc.
+- `profanity` - profanity, hateful speech, etc.
 - `illegal` - something which may be illegal in some jurisdiction
 - `spam` - spam
 - `impersonation` - someone pretending to be someone else
@@ -37,7 +39,7 @@ Example events
 {
   "kind": 1984,
   "tags": [
-    [ "p", <pubkey>, "explicit"]
+    [ "p", <pubkey>, "nudity"]
   ],
   "content": "",
   ...

--- a/56.md
+++ b/56.md
@@ -66,5 +66,5 @@ Relay behavior
 --------------
 
 It is not recommended that relays perform automatic moderation using reports,
-as they can be easily gamed. Admins could use reports from trused moderators to
-takedown illegal or explicit content if the relays does not allow such things.
+as they can be easily gamed. Admins could use reports from trusted moderators to
+takedown illegal or explicit content if the relay does not allow such things.

--- a/56.md
+++ b/56.md
@@ -30,27 +30,37 @@ A `report` tag MUST be included which consists of the following report types:
 
 Some report tags only make sense for profile reports, such as `impersonation`
 
-Example code
+Example events
+--------------
 
-```swift
-enum ReportType: String {
-    case explicit
-    case illegal
-    case spam
-    case impersonation
+```json
+{
+  "kind": 1984,
+  "tags": [
+    [ "p", <pubkey>, "explicit"]
+  ],
+  "content": "",
+  ...
 }
 
-func create_report_tags(target: ReportTarget, type: ReportType) -> [[String]] {
-    var tags: [[String]]
-    switch target {
-    case .user(let pubkey):
-        tags = [["p", pubkey]]
-    case .note(let notet):
-        tags = [["e", notet.note_id], ["p", notet.pubkey]]
-    }
+{
+  "kind": 1984,
+  "tags": [
+    [ "e", <eventId>, "illegal"],
+    [ "p", <pubkey>]
+  ],
+  "content": "He's insulting the king!",
+  ...
+}
 
-    tags.append(["report", type.rawValue])
-    return tags
+{
+  "kind": 1984,
+  "tags": [
+    [ "p", <impersonator pubkey>, "impersonation"],
+    [ "p", <victim pubkey>]
+  ],
+  "content": "Profile is imitating #[1]",
+  ...
 }
 ```
 

--- a/56.md
+++ b/56.md
@@ -1,0 +1,70 @@
+
+NIP-56
+======
+
+Reporting
+---------
+
+`draft` `optional` `author:jb55`
+
+A report is a `kind 1984` note that is used to report other notes for spam,
+illegal and explicit content.
+
+The content MAY contain additional information submitted by the entity
+reporting the content.
+
+Tags
+----
+
+The report event MUST include a `p` tag referencing the pubkey of the user you
+are reporting.
+
+If reporting a note, an `e` tag MUST also be included referencing the note id.
+
+A `report` tag MUST be included which consists of the following report types:
+
+- `explicit` - explicit content which may not be appropriate for minors: nudity, profanity, etc
+- `illegal` - something which may be illegal in some jurisdiction
+- `spam` - spam
+- `impersonation` - someone pretending to be someone else
+
+Some report tags only make sense for profile reports, such as `impersonation`
+
+Example code
+
+```swift
+enum ReportType: String {
+    case explicit
+    case illegal
+    case spam
+    case impersonation
+}
+
+func create_report_tags(target: ReportTarget, type: ReportType) -> [[String]] {
+    var tags: [[String]]
+    switch target {
+    case .user(let pubkey):
+        tags = [["p", pubkey]]
+    case .note(let notet):
+        tags = [["e", notet.note_id], ["p", notet.pubkey]]
+    }
+
+    tags.append(["report", type.rawValue])
+    return tags
+}
+```
+
+Client behavior
+---------------
+
+Clients can use reports from friends to make moderation decisions if they
+choose to. For instance, if 3+ of your friends report a profile as explicit,
+clients can have an option to automatically blur photos from said account.
+
+
+Relay behavior
+--------------
+
+It is not recommended that relays perform automatic moderation using reports,
+as they can be easily gamed. Admins could use reports from trused moderators to
+takedown illegal or explicit content if the relays does not allow such things.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-40: Expiration Timestamp](40.md)
 - [NIP-42: Authentication of clients to relays](42.md)
 - [NIP-50: Keywords filter](50.md)
+- [NIP-56: Reporting](56.md)
 
 ## Event Kinds
 
@@ -48,6 +49,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 | 43          | Channel Hide Message        | [28](28.md)            |
 | 44          | Channel Mute User           | [28](28.md)            |
 | 45-49       | Public Chat Reserved        | [28](28.md)            |
+| 1984        | Reporting                   | [56](56.md)            |
 | 22242       | Client Authentication       | [42](42.md)            |
 | 10000-19999 | Replaceable Events Reserved | [16](16.md)            |
 | 20000-29999 | Ephemeral Events Reserved   | [16](16.md)            |


### PR DESCRIPTION
This NIP provides a way for clients to report profiles and notes to relays.

This is currently implemented by Damus as an apple app store requirement, but may be useful in other moderation contexts.

https://github.com/nostr-protocol/nips/blob/reporting/56.md