### PR TITLE
[NIP-26] Fix for multiple `kind`s in delegation conditions

### DIFF
--- a/26.md
+++ b/26.md
@@ -38,19 +38,34 @@ The following fields and operators are supported in the above query string:
 *Fields*:
 1. `kind`
    -  *Operators*:
-      -  `=${KIND_NUMBER}` - delegatee may only sign events of this kind
+      -  `=${KIND_NUMBERS}` - delegatee may only sign events of listed kind(s) (comma-separated)
 2. `created_at`
    -  *Operators*:
-      -  `<${TIMESTAMP}` - delegatee may only sign events created ***before*** the specified timestamp
-      -  `>${TIMESTAMP}` - delegatee may only sign events created ***after*** the specified timestamp
+      -  `<${TIMESTAMP}` - delegatee may only sign events whose `created_at` is ***before*** the specified timestamp
+      -  `>${TIMESTAMP}` - delegatee may only sign events whose `created_at` is ***after*** the specified timestamp
 
-In order to create a single condition, you must use a supported field and operator. Multiple conditions can be used in a single query string, including on the same field. Conditions must be combined with `&`.
+Multiple conditions can be used in a single query string, including on the same field. Conditions must be combined with `&`.
+
+Multiple conditions should be treated as `AND` requirements; all conditions must be true for the delegated event to be valid.
+
+Multiple comma-separated `kind` values should be interpreted as:
+```
+# kind=0,1,3000
+... AND (kind == 0 OR kind == 1 OR kind == 3000) AND ...
+```
 
 For example, the following condition strings are valid:
-
+- `kind=1`
+- `created_at<1675721813`
 - `kind=1&created_at<1675721813`
-- `kind=0&kind=1&created_at>1675721813`
+- `kind=0,1,3000&created_at>1675721813`
 - `kind=1&created_at>1674777689&created_at<1675721813`
+
+However, specifying multiple _separate_ `kind` conditions is impossible to satisfy:
+- `kind=1&kind=5`
+
+There is no way for an event to satisfy the `AND` requirement of being both `kind`s simultaneously.
+
 
 #### Example
 


### PR DESCRIPTION
Multiple delegation conditions are implicitly `AND`  (`created_at` < X AND `created_at` > Y) so it's inconsistent to allow multiple separate `kind` conditions (e.g. `kind=0&kind=1&kind=3000`).

In my testing, relays reject delegation tokens with multiple `kind`s specified this way.

see: [`nostr-rs-relay`](https://github.com/scsibug/nostr-rs-relay/blob/4fd76439078b38a482083b7385601f05c145da97/src/delegation.rs#L170-L173)

When given `kind=0&kind=1&kind=3000`, the relay is enforcing that `kind` must equal 0. And then it requires that `kind` must also equal 1. And so on.

Relays DO accept `kind=0,1,3000` conditions:
https://snort.social/e/note132uwuffvahjns77plwggtjjf9ssttl7wjagzgkw0mcs0djp0cdwqqf6lm5

```
{
  "id": "8ab8ee252cede5387bc1fb9085ca492c20b5ffce97502459cfde20f6c82fc35c",
  "pubkey": "d9023798840aa4172873c98c87f09493a35682da3538704727204c46c81f78fa",
  "created_at": 1675123680,
  "kind": 1,
  "tags": [
    [
      "delegation",
      "617fa8be17df3d708c2be0e300eaf7d21b91702a5161950d43e2f31d90acaa7a",
      "kind=1,3,7,3000&created_at>1675058400&created_at<1677650400",
      "6f33f71e92e8f9b6547929e16aa28062cfc54be14b622471033963261532b6591373abf142762130f3bf2f637d7a8c5128d98afff184a5079a5e8da98395fc6a"
    ]
  ],
  "content": "This is my second post! But I didn't sign it!! My NIP-26 delegated Nostr key (`npub1pr0xy`) signed it for me!\n\n#nip26",
  "sig": "d9cfe9f8012a82354d652e9cbdc43376c1162ead521c5b5b9a191a1a30d5a11a4e57caafeb4801466b0caa2fc85e8789212119b2bd43e033140c706be8c7419e",
  "relays": [
    "wss://nostr-pub.wellorder.net"
  ]
}
```