### PR TITLE
NIP-11 pubkey prefix allowed

### DIFF
--- a/11.md
+++ b/11.md
@@ -14,7 +14,7 @@ When a relay receives an HTTP(s) request with an `Accept` header of `application
 {
   "name": <string identifying relay>,
   "description": <string with detailed information>,
-  "pubkey": <administrative contact pubkey>,
+  "pubkey": <administrative contact pubkey or prefix thereof>,
   "contact": <administrative alternate contact>,
   "supported_nips": <a list of NIP numbers supported by the relay>,
   "software": <string identifying relay software URL>,
@@ -37,7 +37,7 @@ Detailed plain-text information about the relay may be contained in the `descrip
 
 ### Pubkey ###
 
-An administrative contact may be listed with a `pubkey`, in the same format as Nostr events (32-byte hex for a `secp256k1` public key).  If a contact is listed, this provides clients with a recommended address to send encrypted direct messages (See `NIP-04`) to a system administrator.  Expected uses of this address are to report abuse or illegal content, file bug reports, or request other technical assistance.
+An administrative contact may be listed with a `pubkey` or prefix thereof, in the same format as Nostr events (32-byte hex for a `secp256k1` public key or prefix thereof).  If a contact is listed, this provides clients with a recommended address to send encrypted direct messages (See `NIP-04`) to a system administrator.  Expected uses of this address are to report abuse or illegal content, file bug reports, or request other technical assistance.
 
 Relay operators have no obligation to respond to direct messages.
 


### PR DESCRIPTION
I notice in my gossip logs a lot of invalid NIP-11s.  Digging in, it turns out people are putting significant prefixes of their pubkey, not the entire pubkey (possibly for plausable deniability?).

This PR changes NIP-11 to provide for that.