### PR TITLE
NIP-23: long-form content

### DIFF
--- a/19.md
+++ b/19.md
@@ -35,6 +35,7 @@ These are the possible bech32 prefixes with `TLV`:
   - `nprofile`: a nostr profile
   - `nevent`: a nostr event
   - `nrelay`: a nostr relay
+  - `nref`: a nostr parameterized replaceable event coordinate (NIP-33)
 
 These possible standardized `TLV` types are indicated here:
 
@@ -42,11 +43,15 @@ These possible standardized `TLV` types are indicated here:
   - depends on the bech32 prefix:
     - for `nprofile` it will be the 32 bytes of the profile public key
     - for `nevent` it will be the 32 bytes of the event id
-    - for `nrelay`, this is the relay URL.
+    - for `nrelay`, this is the relay URL
+    - for `nref`, it is the identifier (the `"d"` tag) of the event being referenced
   - for `nprofile`, `nevent` and `nrelay` this may be included only once.
 - `1`: `relay`
-  - A relay in which the entity (profile or event) is more likely to be found, encoded as UTF-8. This may be included multiple times.
-  - not applicable to `nrelay`.
+  - for `nprofile`, `nevent` and `nref`, a relay in which the entity (profile or event) is more likely to be found, encoded as UTF-8. This may be included multiple times
+- `2`: `author`
+  - for `nref`, the 32 bytes of the pubkey of the event
+
+
 ## Examples
 
 - `npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6` should decode into the public key hex `3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d` and vice-versa

--- a/19.md
+++ b/19.md
@@ -45,11 +45,13 @@ These possible standardized `TLV` types are indicated here:
     - for `nevent` it will be the 32 bytes of the event id
     - for `nrelay`, this is the relay URL
     - for `nitem`, it is the identifier (the `"d"` tag) of the event being referenced
-  - for `nprofile`, `nevent` and `nrelay` this may be included only once.
 - `1`: `relay`
-  - for `nprofile`, `nevent` and `nitem`, a relay in which the entity (profile or event) is more likely to be found, encoded as UTF-8. This may be included multiple times
+  - for `nprofile`, `nevent` and `nitem`, a relay in which the entity (profile or event) is more likely to be found, encoded as ascii
+  - this may be included multiple times
 - `2`: `author`
   - for `nitem`, the 32 bytes of the pubkey of the event
+- `3`: `kind`
+  - for `nitem`, the 32-bit unsigned integer of the kind, big-endian
 
 
 ## Examples

--- a/19.md
+++ b/19.md
@@ -35,7 +35,7 @@ These are the possible bech32 prefixes with `TLV`:
   - `nprofile`: a nostr profile
   - `nevent`: a nostr event
   - `nrelay`: a nostr relay
-  - `nitem`: a nostr parameterized replaceable event coordinate (NIP-33)
+  - `naddr`: a nostr parameterized replaceable event coordinate (NIP-33)
 
 These possible standardized `TLV` types are indicated here:
 
@@ -44,14 +44,14 @@ These possible standardized `TLV` types are indicated here:
     - for `nprofile` it will be the 32 bytes of the profile public key
     - for `nevent` it will be the 32 bytes of the event id
     - for `nrelay`, this is the relay URL
-    - for `nitem`, it is the identifier (the `"d"` tag) of the event being referenced
+    - for `naddr`, it is the identifier (the `"d"` tag) of the event being referenced
 - `1`: `relay`
-  - for `nprofile`, `nevent` and `nitem`, a relay in which the entity (profile or event) is more likely to be found, encoded as ascii
+  - for `nprofile`, `nevent` and `naddr`, a relay in which the entity (profile or event) is more likely to be found, encoded as ascii
   - this may be included multiple times
 - `2`: `author`
-  - for `nitem`, the 32 bytes of the pubkey of the event
+  - for `naddr`, the 32 bytes of the pubkey of the event
 - `3`: `kind`
-  - for `nitem`, the 32-bit unsigned integer of the kind, big-endian
+  - for `naddr`, the 32-bit unsigned integer of the kind, big-endian
 
 
 ## Examples

--- a/19.md
+++ b/19.md
@@ -35,7 +35,7 @@ These are the possible bech32 prefixes with `TLV`:
   - `nprofile`: a nostr profile
   - `nevent`: a nostr event
   - `nrelay`: a nostr relay
-  - `nref`: a nostr parameterized replaceable event coordinate (NIP-33)
+  - `nitem`: a nostr parameterized replaceable event coordinate (NIP-33)
 
 These possible standardized `TLV` types are indicated here:
 
@@ -44,12 +44,12 @@ These possible standardized `TLV` types are indicated here:
     - for `nprofile` it will be the 32 bytes of the profile public key
     - for `nevent` it will be the 32 bytes of the event id
     - for `nrelay`, this is the relay URL
-    - for `nref`, it is the identifier (the `"d"` tag) of the event being referenced
+    - for `nitem`, it is the identifier (the `"d"` tag) of the event being referenced
   - for `nprofile`, `nevent` and `nrelay` this may be included only once.
 - `1`: `relay`
-  - for `nprofile`, `nevent` and `nref`, a relay in which the entity (profile or event) is more likely to be found, encoded as UTF-8. This may be included multiple times
+  - for `nprofile`, `nevent` and `nitem`, a relay in which the entity (profile or event) is more likely to be found, encoded as UTF-8. This may be included multiple times
 - `2`: `author`
-  - for `nref`, the 32 bytes of the pubkey of the event
+  - for `nitem`, the 32 bytes of the pubkey of the event
 
 
 ## Examples

--- a/23.md
+++ b/23.md
@@ -35,7 +35,7 @@ The article may be linked to using the NIP-19 `nitem` code along with the `"i"` 
 
 ### References
 
-Writing clients should implement support for parsing pasted NIP-19 `nitem` identifiers and adding them automatically to the list of `.tags` of the event, replacing the actual content with a string like `#[tag_index]` in the same way as NIP-08 -- or, if the reference is in the form of a URL (for example, `[click here](nitem1...)`) then they should be replaced with just the tag number directly as if link with that name existed at the bottom of the Markdown (for example, `[click here][0]`).
+Clients that support publishing NIP-23 events should implement support for parsing pasted NIP-19 `nitem` identifiers and adding them automatically to the list of `.tags` of the event, replacing the actual content with a string like `#[tag_index]` in the same way as NIP-08 -- or, if the reference is in the form of a URL (for example, `[click here](nitem1...)`) then they should be replaced with just the tag number directly as if link with that name existed at the bottom of the Markdown (for example, `[click here][0]`).
 
 Reader clients should parse the Markdown and replace these references with either internal links so the referenced events can be accessed directly, with NIP-21 `nostr:nitem1...` links or direct links to web clients that will handle these references.
 

--- a/23.md
+++ b/23.md
@@ -1,0 +1,75 @@
+NIP-23
+======
+
+Long-form Content
+-----------------
+
+`draft` `optional` `author:fiatjaf`
+
+This NIP defines `kind:30023` (a parameterized replaceable event according to NIP-33) for long-form text content, generally referred to as "articles" or "blog posts".
+
+"Social" clients that deal primarily with `kind:1` notes should not be expected to implement this NIP.
+
+### Format
+
+The `.content` of these events should be a string text in Markdown syntax, including YAML front-matter for other metadata that may be necessary.
+
+### Metadata
+
+This NIP defines only `title` as the metadata. For the date of publication the event `.created_at` field should be used, and for "tags"/"hashtags" (i.e. topics about which the event might be of relevance) the `"t"` event tag should be used, as in NIP-12.
+
+### Editability
+
+These articles are meant to be editable, so they should make use of the replaceability feature of NIP-33 and include a `"d"` tag with an identifier for the article. Clients should take care to only publish and read these events from relays that implement that. If they don't do that they should also take care to hide old versions of the same article they may receive.
+
+### Linking
+
+The article may be linked to using the NIP-19 `nref` code, which should contain both the public key of the author and the article identifier (the `"d"` tag) and some relays. With that information it is possible to locate the article.
+
+### References
+
+Writing clients should implement support for parsing pasted NIP-19 `nref` identifiers and adding them automatically to the list of `.tags` of the event, replacing the actual content with a string like `#[tag_index]` in the same way as NIP-08 -- or, if the reference is in the form of a URL (for example, `[click here](nref...)`) then they should be replaced with just the tag number directly (for example, `[click here][0]`).
+
+Reader clients should parse the Markdown and replace these references with either internal links so the referenced events can be accessed directly, with NIP-21 `nostr:` links or direct links to web clients that will handle these references.
+
+The idea here is that having these tags is that reader clients can display a list of backreferences at the bottom when one article mentions another.
+
+### `kind:1` interface
+
+In case there is the desire for users or clients to share the written article on their "social" clients, a `kind:1` event must be used.
+
+Since "social" clients aren't expected to understand this NIP, these notes should contain a URL like `nostr:nref1...` specifying the `nref1` code for the article, such that it can be rendered clickable and other users can use a different client than their "social" to read the article -- and also if their client handles both kinds of posts, their client may recognize the URL and handle it internally.
+
+For clients that want to implement the ability for users to comment on these articles. `kind:1` notes should be used as the comments. They must be made in reply to another `kind:1` as above, such that other people on "social" clients can see the comments and get the context from the note above and load the article being commented on if they so desire.
+
+## Example of an event
+
+Article text:
+
+```markdown
+title: Lorem Ipsum
+---
+
+Lorem [ipsum][4] dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Read more at #[3].
+```
+
+Derived event:
+
+```json
+{
+  "kind": 30023,
+  "created_at": 1000000000,
+  "title": "Lorem Ipsum\\n---\\n\\nLorem [ipsum][4] dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\nRead more at #[3].",
+  "tags": [
+    ["d", "lorem-ipsum"],
+    ["t", "lorem"],
+    ["t", "ipsum"],
+    ["e", "b3e392b11f5d4f28321cedd09303a748acfd0487aea5a7450b3481c60b6e4f87", "wss://relay.example.com"],
+    ["e", "a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919", "wss://relay.nostr.org"]
+  ],
+  "pubkey": "...",
+  "id": "..."
+}
+```

--- a/23.md
+++ b/23.md
@@ -21,7 +21,7 @@ For the date of the last update the `.created_at` field should be used, for "tag
 Other metadata fields can be added as tags to the event as necessary. Here we standardize 4 that may be useful, although they remain strictly optional:
 
 - `"title"`, for the article title
-- `"image"`, for an image to be shown along with the title
+- `"image"`, for a URL pointing to an image to be shown along with the title
 - `"summary"`, for the article summary
 - `"published_at"`, for the timestamp in unix seconds (stringified) of the first time the article was published
 

--- a/23.md
+++ b/23.md
@@ -49,7 +49,7 @@ The same principles can be applied to `nevent1...`, `note1...`, `nprofile1...` o
 {
   "kind": 30023,
   "created_at": 1675642635,
-  "title": "Lorem [ipsum][4] dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\nRead more at #[3].",
+  "content": "Lorem [ipsum][4] dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\nRead more at #[3].",
   "tags": [
     ["d", "lorem-ipsum"],
     ["title", "Lorem Ipsum"],

--- a/23.md
+++ b/23.md
@@ -24,13 +24,13 @@ These articles are meant to be editable, so they should make use of the replacea
 
 ### Linking
 
-The article may be linked to using the NIP-19 `nref` code along with the `"f"` tag (see NIP-33 and NIP-19).
+The article may be linked to using the NIP-19 `nitem` code along with the `"i"` tag (see NIP-33 and NIP-19).
 
 ### References
 
-Writing clients should implement support for parsing pasted NIP-19 `nref` identifiers and adding them automatically to the list of `.tags` of the event, replacing the actual content with a string like `#[tag_index]` in the same way as NIP-08 -- or, if the reference is in the form of a URL (for example, `[click here](nref1...)`) then they should be replaced with just the tag number directly as if link with that name existed at the bottom of the Markdown (for example, `[click here][0]`).
+Writing clients should implement support for parsing pasted NIP-19 `nitem` identifiers and adding them automatically to the list of `.tags` of the event, replacing the actual content with a string like `#[tag_index]` in the same way as NIP-08 -- or, if the reference is in the form of a URL (for example, `[click here](nitem1...)`) then they should be replaced with just the tag number directly as if link with that name existed at the bottom of the Markdown (for example, `[click here][0]`).
 
-Reader clients should parse the Markdown and replace these references with either internal links so the referenced events can be accessed directly, with NIP-21 `nostr:nref1...` links or direct links to web clients that will handle these references.
+Reader clients should parse the Markdown and replace these references with either internal links so the referenced events can be accessed directly, with NIP-21 `nostr:nitem1...` links or direct links to web clients that will handle these references.
 
 The idea here is that having these tags is that reader clients can display a list of backreferences at the bottom when one article mentions another.
 
@@ -44,9 +44,9 @@ Article text:
 title: Lorem Ipsum
 ---
 
-Lorem [ipsum][4] dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Lorem [ipsum][3] dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
-Read more at #[3].
+Read more at #[2].
 ```
 
 Derived event:
@@ -58,10 +58,9 @@ Derived event:
   "title": "Lorem Ipsum\\n---\\n\\nLorem [ipsum][4] dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\nRead more at #[3].",
   "tags": [
     ["d", "lorem-ipsum"],
-    ["t", "lorem"],
-    ["t", "ipsum"],
+    ["t", "plceholder"],
     ["e", "b3e392b11f5d4f28321cedd09303a748acfd0487aea5a7450b3481c60b6e4f87", "wss://relay.example.com"],
-    ["f", "a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum", "wss://relay.nostr.org"]
+    ["i", "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum", "wss://relay.nostr.org"]
   ],
   "pubkey": "...",
   "id": "..."

--- a/23.md
+++ b/23.md
@@ -12,11 +12,18 @@ This NIP defines `kind:30023` (a parameterized replaceable event according to NI
 
 ### Format
 
-The `.content` of these events should be a string text in Markdown syntax, including YAML front-matter for other metadata that may be necessary.
+The `.content` of these events should be a string text in Markdown syntax.
 
 ### Metadata
 
-This NIP defines only `title` as the metadata. For the date of publication the event `.created_at` field should be used, and for "tags"/"hashtags" (i.e. topics about which the event might be of relevance) the `"t"` event tag should be used, as in NIP-12.
+For the date of the last update the `.created_at` field should be used, for "tags"/"hashtags" (i.e. topics about which the event might be of relevance) the `"t"` event tag should be used, as per NIP-12.
+
+Other metadata fields can be added as tags to the event as necessary. Here we standardize 4 that may be useful, although they remain strictly optional:
+
+- `"title"`, for the article title
+- `"image"`, for an image to be shown along with the title
+- `"summary"`, for the article summary
+- `"published_at"`, for the timestamp in unix seconds (stringified) of the first time the article was published
 
 ### Editability
 
@@ -36,29 +43,18 @@ The idea here is that having these tags is that reader clients can display a lis
 
 The same principles can be applied to `nevent1...`, `note1...`, `nprofile1...` or `npub1...`.
 
-## Example of an event
-
-Article text:
-
-```markdown
-title: Lorem Ipsum
----
-
-Lorem [ipsum][3] dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-
-Read more at #[2].
-```
-
-Derived event:
+## Example Event
 
 ```json
 {
   "kind": 30023,
-  "created_at": 1000000000,
-  "title": "Lorem Ipsum\\n---\\n\\nLorem [ipsum][4] dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\nRead more at #[3].",
+  "created_at": 1675642635,
+  "title": "Lorem [ipsum][4] dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\nRead more at #[3].",
   "tags": [
     ["d", "lorem-ipsum"],
-    ["t", "plceholder"],
+    ["title", "Lorem Ipsum"],
+    ["published_at", "1296962229"],
+    ["t", "placeholder"],
     ["e", "b3e392b11f5d4f28321cedd09303a748acfd0487aea5a7450b3481c60b6e4f87", "wss://relay.example.com"],
     ["i", "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum", "wss://relay.nostr.org"]
   ],

--- a/23.md
+++ b/23.md
@@ -31,13 +31,13 @@ These articles are meant to be editable, so they should make use of the replacea
 
 ### Linking
 
-The article may be linked to using the NIP-19 `nitem` code along with the `"i"` tag (see NIP-33 and NIP-19).
+The article may be linked to using the NIP-19 `naddr` code along with the `"a"` tag (see NIP-33 and NIP-19).
 
 ### References
 
-Clients that support publishing NIP-23 events should implement support for parsing pasted NIP-19 `nitem` identifiers and adding them automatically to the list of `.tags` of the event, replacing the actual content with a string like `#[tag_index]` in the same way as NIP-08 -- or, if the reference is in the form of a URL (for example, `[click here](nitem1...)`) then they should be replaced with just the tag number directly as if link with that name existed at the bottom of the Markdown (for example, `[click here][0]`).
+Clients that support publishing NIP-23 events should implement support for parsing pasted NIP-19 `naddr` identifiers and adding them automatically to the list of `.tags` of the event, replacing the actual content with a string like `#[tag_index]` in the same way as NIP-08 -- or, if the reference is in the form of a URL (for example, `[click here](naddr1...)`) then they should be replaced with just the tag number directly as if link with that name existed at the bottom of the Markdown (for example, `[click here][0]`).
 
-Reader clients should parse the Markdown and replace these references with either internal links so the referenced events can be accessed directly, with NIP-21 `nostr:nitem1...` links or direct links to web clients that will handle these references.
+Reader clients should parse the Markdown and replace these references with either internal links so the referenced events can be accessed directly, with NIP-21 `nostr:naddr1...` links or direct links to web clients that will handle these references.
 
 The idea here is that having these tags is that reader clients can display a list of backreferences at the bottom when one article mentions another.
 
@@ -56,7 +56,7 @@ The same principles can be applied to `nevent1...`, `note1...`, `nprofile1...` o
     ["published_at", "1296962229"],
     ["t", "placeholder"],
     ["e", "b3e392b11f5d4f28321cedd09303a748acfd0487aea5a7450b3481c60b6e4f87", "wss://relay.example.com"],
-    ["i", "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum", "wss://relay.nostr.org"]
+    ["a", "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum", "wss://relay.nostr.org"]
   ],
   "pubkey": "...",
   "id": "..."

--- a/23.md
+++ b/23.md
@@ -24,23 +24,17 @@ These articles are meant to be editable, so they should make use of the replacea
 
 ### Linking
 
-The article may be linked to using the NIP-19 `nref` code, which should contain both the public key of the author and the article identifier (the `"d"` tag) and some relays. With that information it is possible to locate the article.
+The article may be linked to using the NIP-19 `nref` code along with the `"f"` tag (see NIP-33 and NIP-19).
 
 ### References
 
-Writing clients should implement support for parsing pasted NIP-19 `nref` identifiers and adding them automatically to the list of `.tags` of the event, replacing the actual content with a string like `#[tag_index]` in the same way as NIP-08 -- or, if the reference is in the form of a URL (for example, `[click here](nref...)`) then they should be replaced with just the tag number directly (for example, `[click here][0]`).
+Writing clients should implement support for parsing pasted NIP-19 `nref` identifiers and adding them automatically to the list of `.tags` of the event, replacing the actual content with a string like `#[tag_index]` in the same way as NIP-08 -- or, if the reference is in the form of a URL (for example, `[click here](nref1...)`) then they should be replaced with just the tag number directly as if link with that name existed at the bottom of the Markdown (for example, `[click here][0]`).
 
-Reader clients should parse the Markdown and replace these references with either internal links so the referenced events can be accessed directly, with NIP-21 `nostr:` links or direct links to web clients that will handle these references.
+Reader clients should parse the Markdown and replace these references with either internal links so the referenced events can be accessed directly, with NIP-21 `nostr:nref1...` links or direct links to web clients that will handle these references.
 
 The idea here is that having these tags is that reader clients can display a list of backreferences at the bottom when one article mentions another.
 
-### `kind:1` interface
-
-In case there is the desire for users or clients to share the written article on their "social" clients, a `kind:1` event must be used.
-
-Since "social" clients aren't expected to understand this NIP, these notes should contain a URL like `nostr:nref1...` specifying the `nref1` code for the article, such that it can be rendered clickable and other users can use a different client than their "social" to read the article -- and also if their client handles both kinds of posts, their client may recognize the URL and handle it internally.
-
-For clients that want to implement the ability for users to comment on these articles. `kind:1` notes should be used as the comments. They must be made in reply to another `kind:1` as above, such that other people on "social" clients can see the comments and get the context from the note above and load the article being commented on if they so desire.
+The same principles can be applied to `nevent1...`, `note1...`, `nprofile1...` or `npub1...`.
 
 ## Example of an event
 
@@ -67,7 +61,7 @@ Derived event:
     ["t", "lorem"],
     ["t", "ipsum"],
     ["e", "b3e392b11f5d4f28321cedd09303a748acfd0487aea5a7450b3481c60b6e4f87", "wss://relay.example.com"],
-    ["e", "a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919", "wss://relay.nostr.org"]
+    ["f", "a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum", "wss://relay.nostr.org"]
   ],
   "pubkey": "...",
   "id": "..."

--- a/33.md
+++ b/33.md
@@ -38,11 +38,11 @@ Normally (as per NIP-01, NIP-12) the `"p"` tag is used for referencing public ke
 equivalents for event tags (i.e. an `nprofile` is generally translated into a tag
 `["p", "<event hex id>", "<relay url>"]`).
 
-To support linking to parameterized replaceable events, the `nitem` code is introduced on
+To support linking to parameterized replaceable events, the `naddr` code is introduced on
 NIP-19. It includes the public key of the event author and the `d` tag (and relays) such that
 the referenced combination of public key and `d` tag can be found.
 
-The equivalent in `tags` to the `nitem` code is the tag `"i"`, comprised of `["i", "<kind>:<pubkey>:<d-identifier>", "<relay url>"]`.
+The equivalent in `tags` to the `naddr` code is the tag `"a"`, comprised of `["a", "<kind>:<pubkey>:<d-identifier>", "<relay url>"]`.
 
 Client Behavior
 ---------------

--- a/33.md
+++ b/33.md
@@ -12,10 +12,10 @@ Implementation
 --------------
 The value of a tag is defined as the first parameter of a tag after the tag name.
 
-A *parameterized replaceable event* is defined as an event with a kind `30000 <= n < 40000`.  
+A *parameterized replaceable event* is defined as an event with a kind `30000 <= n < 40000`.
 Upon a parameterized replaceable event with a newer timestamp than the currently known latest
 replaceable event with the same kind and first `d` tag value being received, the old event
-SHOULD be discarded and replaced with the newer event.  
+SHOULD be discarded and replaced with the newer event.
 A missing or a `d` tag with no value should be interpreted equivalent to a `d` tag with the
 value as an empty string. Events from the same author with any of the following `tags`
 replace each other:
@@ -29,6 +29,20 @@ replace each other:
 * `"tags":[["d","test","1"]]`: only the value is considered (`test`)
 
 Clients SHOULD NOT use `d` tags with multiple values and SHOULD include the `d` tag even if it has no value to allow querying using the `#d` filter.
+
+Referencing and tagging
+-----------------------
+
+Normally (as per NIP-01, NIP-12) the `"p"` tag is used for referencing public keys and the
+`"e"` tag for referencing event ids and the `note`, `npub`, `nprofile` or `nevent` are their
+equivalents for event tags (i.e. an `nprofile` is generally translated into a tag
+`["p", "<event hex id>", "<relay url>"]`).
+
+To support linking to parameterized replaceable events, the `nref` code is introduced on
+NIP-19. It includes the public key of the event author and the `d` tag (and relays) such that
+the referenced combination of public key and `d` tag can be found.
+
+The equivalent in `tags` to the `nref` code is the tag `"f"`, comprised of `["f", "<pubkey>:<d-identifier>", "<relay url>"]`.
 
 Client Behavior
 ---------------

--- a/33.md
+++ b/33.md
@@ -38,11 +38,11 @@ Normally (as per NIP-01, NIP-12) the `"p"` tag is used for referencing public ke
 equivalents for event tags (i.e. an `nprofile` is generally translated into a tag
 `["p", "<event hex id>", "<relay url>"]`).
 
-To support linking to parameterized replaceable events, the `nref` code is introduced on
+To support linking to parameterized replaceable events, the `nitem` code is introduced on
 NIP-19. It includes the public key of the event author and the `d` tag (and relays) such that
 the referenced combination of public key and `d` tag can be found.
 
-The equivalent in `tags` to the `nref` code is the tag `"f"`, comprised of `["f", "<pubkey>:<d-identifier>", "<relay url>"]`.
+The equivalent in `tags` to the `nitem` code is the tag `"i"`, comprised of `["i", "<kind>:<pubkey>:<d-identifier>", "<relay url>"]`.
 
 Client Behavior
 ---------------

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ When experimenting with kinds, keep in mind the classification introduced by [NI
 | ---------- | ----------------------- | ----------------- | ------------------------ |
 | e          | event id (hex)          | relay URL, marker | [1](01.md), [10](10.md)  |
 | p          | pubkey (hex)            | relay URL         | [1](01.md)               |
+| a          | coordinates to an event | relay URL         | [33](33.md), [23](23.md) |
 | r          | a reference (URL, etc)  |                   | [12](12.md)              |
 | t          | hashtag                 |                   | [12](12.md)              |
 | g          | geohash                 |                   | [12](12.md)              |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 | 3           | Contacts                    | [2](02.md)             |
 | 4           | Encrypted Direct Messages   | [4](04.md)             |
 | 5           | Event Deletion              | [9](09.md)             |
+| 30023       | Long-form Content           | [23](23.md)            |
 | 7           | Reaction                    | [25](25.md)            |
 | 40          | Channel Creation            | [28](28.md)            |
 | 41          | Channel Metadata            | [28](28.md)            |


### PR DESCRIPTION
This one is much larger than I thought it would be. I lost my patience in the middle of it so the quality might have degraded.

This PR also modifies NIP-33 and NIP-19 to introduce a new canonical way of referring to parameterized replaceable events.