### PR TITLE
Add method for deriving an HMAC key from the private key.

### DIFF
--- a/07.md
+++ b/07.md
@@ -12,6 +12,7 @@ That object must define the following methods:
 
 ```
 async window.nostr.getPublicKey(): string // returns a public key as hex
+async window.nostr.getDerivedKey(key: string): string // returns a key derived from hmac(key, prvkey).
 async window.nostr.signEvent(event: Event): Event // takes an event object, adds `id`, `pubkey` and `sig` and returns it
 ```
 


### PR DESCRIPTION
I ran into an issue where I want to derive child-keys from the parent private key, but there is currently no way to do this with the current spec.

I propose adding a `window.nostr.getDerivedKey(key: string): string` method to the spec, which is a simple HMAC method using the private key and a user supplied key. HMAC has wide-spread support in the WebCrypto spec, and is easy to implement.

https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto

Here is some reference code for performing a simple HMAC operation using WebCrypto API:
```ts
async function hmac (
  // Perform an HMAC signing operation.
  key   : Uint8Array,
  data : Uint8Array,
  fmt   : string = 'SHA-256'
) : Promise<Uint8Array> {
  const cryptoKey = await importKey(key, fmt)
  return crypto.subtle
    .sign('HMAC', cryptoKey, data)
    .then((buffer) => new Uint8Array(buffer))
}
async function importKey (
  // Create a CryptoKey from the 
  // supplied key and format string.
  key : Uint8Array,
  fmt : string = 'SHA-256'
) : Promise<CryptoKey> {
  const config = { name: 'HMAC', hash: fmt }
  return crypto.subtle.importKey(
    'raw', key, config, false, ['sign', 'verify']
  )
}
```

An example use-case would be generating key material, in order to create key-pairs that are derived from the master key in a deterministic way.

This would be useful to create sub-accounts, delegated accounts, or key-pairs used to create channels and group chats (where the key-pair is used to publish updates to the state of the group).

This proposal does not involve key-tweaking or HD-wallets, although you could easily create such a scheme using key material from an HMAC-512 operation to initiate the wallet.