### PR TITLE
Add `content` restriction to NIP-26

### DIFF
--- a/26.md
+++ b/26.md
@@ -43,6 +43,9 @@ The following fields and operators are supported in the above query string:
    -  *Operators*:
       -  `<${TIMESTAMP}` - delegatee may only sign events created ***before*** the specified timestamp
       -  `>${TIMESTAMP}` - delegatee may only sign events created ***after*** the specified timestamp
+3. `content`
+   -  *Operators*:
+      -  `=${CONTENT}` - delegatee may only sign events with this content
 
 In order to create a single condition, you must use a supported field and operator. Multiple conditions can be used in a single query string, including on the same field. Conditions must be combined with `&`.
 

--- a/26.md
+++ b/26.md
@@ -45,7 +45,7 @@ The following fields and operators are supported in the above query string:
       -  `>${TIMESTAMP}` - delegatee may only sign events created ***after*** the specified timestamp
 3. `content`
    -  *Operators*:
-      -  `=${CONTENT}` - delegatee may only sign events with this content in RFC 3986 URI encoding
+      -  `=${SHA256(CONTENT)}` - delegatee may only sign events with content that sha256s to the specified hash
 
 In order to create a single condition, you must use a supported field and operator. Multiple conditions can be used in a single query string, including on the same field. Conditions must be combined with `&`.
 
@@ -54,7 +54,7 @@ For example, the following condition strings are valid:
 - `kind=1&created_at<1675721813`
 - `kind=0&kind=1&created_at>1675721813`
 - `kind=1&created_at>1674777689&created_at<1675721813`
-- `kind=1&created_at>1674777689&content=Hello%20world`
+- `kind=1&content=315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3
 
 For the vast majority of use-cases, it is advisable that query strings should include a `created_at` ***after*** condition reflecting the current time, to prevent the delegatee from publishing historic notes on the delegator's behalf.
 

--- a/26.md
+++ b/26.md
@@ -45,7 +45,7 @@ The following fields and operators are supported in the above query string:
       -  `>${TIMESTAMP}` - delegatee may only sign events created ***after*** the specified timestamp
 3. `content`
    -  *Operators*:
-      -  `=${CONTENT}` - delegatee may only sign events with this content
+      -  `=${CONTENT}` - delegatee may only sign events with this content in RFC 3986 URI encoding
 
 In order to create a single condition, you must use a supported field and operator. Multiple conditions can be used in a single query string, including on the same field. Conditions must be combined with `&`.
 
@@ -54,6 +54,7 @@ For example, the following condition strings are valid:
 - `kind=1&created_at<1675721813`
 - `kind=0&kind=1&created_at>1675721813`
 - `kind=1&created_at>1674777689&created_at<1675721813`
+- `kind=1&created_at>1674777689&content=Hello%20world`
 
 For the vast majority of use-cases, it is advisable that query strings should include a `created_at` ***after*** condition reflecting the current time, to prevent the delegatee from publishing historic notes on the delegator's behalf.
 


### PR DESCRIPTION
This PR adds a `content` condition, so delegates are limited to signing a specific `content` payload instead of being able to sign anything.