### PR TITLE
Nip 05 security proposal

### DIFF
--- a/05.md
+++ b/05.md
@@ -35,7 +35,7 @@ It will make a GET request to `https://example.com/.well-known/nostr.json?name=b
 }
 ````
 
-or with the **optional** `"relays"` attribute:
+or with the **optional** `"relays"` and/or `"account_uris"` attributes:
 
 ```json
 {
@@ -44,6 +44,9 @@ or with the **optional** `"relays"` attribute:
   },
   "relays": {
     "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9": [ "wss://relay.example.com", "wss://relay2.example.com" ]
+  },
+  "account_uris": {
+    "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9": "https://bob.com/profile/bob"
   }
 }
 ````
@@ -51,6 +54,8 @@ or with the **optional** `"relays"` attribute:
 If the pubkey matches the one given in `"names"` (as in the example above) that means the association is right and the `"nip05"` identifier is valid and can be displayed.
 
 The optional `"relays"` attribute may contain an object with public keys as properties and arrays of relay URLs as values. When present, that can be used to help clients learn in which relays that user may be found. Web servers which serve `/.well-known/nostr.json` files dynamically based on the query string SHOULD also serve the relays data for any name they serve in the same reply when that is available.
+
+The optional `"account_uris"` attribute may contain an object with public keys as properties and URIs as values.  When present, this allows clients to direct their users to a URI which provides more information about the account on the server which was used to validate the given public key.  Clients should ignore any URIs which don't include the server's `<domain>`.
 
 ## Finding users from their NIP-05 identifier
 
@@ -65,6 +70,10 @@ For example, if after finding that `bob@bob.com` has the public key `abc...def`,
 ### Public keys must be in hex format
 
 Keys must be returned in hex format. Keys in NIP-19 `npub` format are are only meant to be used for display in client UIs, not in this NIP.
+
+### Clients should display the name used to verify the public key
+
+While users can choose their own Nostr username, displaying that username beside the "verified" icon and the name of the verifying server alone is an invitation for abuse.  A malicious user could verify their public key using one account name, and then display a different account name within Nostr, misleading users into thinking they are someone else.  To prevent this, clients should display the user's account name on the verifying server, rather than (or in addition to) their self-selected username within Nostr.
 
 ### User Discovery implementation suggestion
 


### PR DESCRIPTION
Proposing a couple of changes to the NIP-05 protocol to reduce the chance of fraudulent use of "verified" public keys.  At present, I could create an account on a well-known verifying server under a random name, and then send DMs pretending to be someone else, and there's no easy way for users to tell who the verifying account actually belongs to.

As well as displaying the name of the account on the verifying server, this PR suggests an enhancement to the JSON data being returned so that clients can redirect the user to the user's profile page on the server.  This will make it much easier for users to check that someone who claims to have verified their Nostr account is who they claim to be.