### PR TITLE
Added clarification for signature to be in hex

### DIFF
--- a/01.md
+++ b/01.md
@@ -26,7 +26,7 @@ The only object type that exists is the `event`, which has the following format 
     ... // other kinds of tags may be included later
   ],
   "content": <arbitrary string>,
-  "sig": <64-bytes signature of the sha256 hash of the serialized event data, which is the same as the "id" field>
+  "sig": <64-bytes hex of the signature of the sha256 hash of the serialized event data, which is the same as the "id" field>
 }
 ```
 


### PR DESCRIPTION
Changed the wording to be consistent with other fields like "id" and "tag". It wasn' apparent to me that the signature was in hexadecimal when I read it the first time.