### PR TITLE
NIP-04: clarify how shared secret is computed

### DIFF
--- a/04.md
+++ b/04.md
@@ -14,6 +14,8 @@ A special event with kind `4`, meaning "encrypted direct message". It is suppose
 
 **`tags`** MAY contain an entry identifying the previous message in a conversation or a message we are explicitly replying to (such that contextual, more organized conversations may happen), in the form `["e", "<event_id>"]`.
 
+**Note**: By default in the [libsecp256k1](https://github.com/bitcoin-core/secp256k1) ECDH implementation, the secret is the SHA256 hash of the shared point (both X and Y coorinates). In Nostr, only the X coordinate of the shared point is used as the secret and it is NOT hashed. If using libsecp256k1, a custom function that copies the X coordinate must be passed as the `hashfp` argument in `secp256k1_ecdh`. See [here](https://github.com/bitcoin-core/secp256k1/blob/master/src/modules/ecdh/main_impl.h#L29).
+
 Code sample for generating such an event in JavaScript:
 
 ```js


### PR DESCRIPTION
Adds note on the differences between default behavior in libsecp256k1 and how it's done in nostr.