### PR TITLE
Delegation support in NIP-07

### DIFF
--- a/07.md
+++ b/07.md
@@ -4,7 +4,7 @@ NIP-07
 `window.nostr` capability for web browsers
 ------------------------------------------
 
-`draft` `optional` `author:fiatjaf`
+`draft` `optional` `author:fiatjaf` `author:ursuscamp`
 
 The `window.nostr` object may be made available by web browsers or extensions and websites or web-apps may make use of it after checking its availability.
 
@@ -12,7 +12,7 @@ That object must define the following methods:
 
 ```
 async window.nostr.getPublicKey(): string // returns a public key as hex
-async window.nostr.signEvent(event: Event): Event // takes an event object, adds `id`, `pubkey` and `sig` and returns it
+async window.nostr.signEvent(event: Event): Event // takes an event object, adds `id`, `pubkey`, `sig`, and optional `delegation` tag and returns it
 ```
 
 Aside from these two basic above, the following functions can also be implemented optionally:
@@ -22,9 +22,18 @@ async window.nostr.nip04.encrypt(pubkey, plaintext): string // returns ciphertex
 async window.nostr.nip04.decrypt(pubkey, ciphertext): string // takes ciphertext and iv as specified in nip-04
 ```
 
+### NIP-26 Considerations
+
+Delegation can be supported in an extension by allowing the user to create a delegatee identity and storing the information necessary to construct the `delegation` tag, such as the signed token. There is no need for the extension to store the delegator's private key.
+
+When operating with a delegated identity, an extension must return the _delegator's_ public key from the `getPublicKey` method, so that the user may see their normal feed upon login. Additionally, during `signEvent`, the extension must modify the event by inserting the _delegatee's_ `pubkey`, append a valid `delegation` tag to the end of the tags list and recalculate the event `id`, prior to signing the event.
+
+The client, upon receiving the returned event, need only check for the presence of a `delegation` tag to determine how to handle the event. The client must accept the `id`, `pubkey`, `sig` and `delegation` tag from the signed delegation event.
+
 ### Implementation
 
 - [nos2x](https://github.com/fiatjaf/nos2x)
 - [Alby](https://getalby.com)
 - [Blockcore](https://www.blockcore.net/wallet)
 - [nos2x-fox](https://diegogurpegui.com/nos2x-fox/)
+- [Nostore](https://github.com/ursuscamp/nostore)


### PR DESCRIPTION
While delegation support is currently limited in clients, it will probably build as demand for more key security grows.

One of the UX pain points now is that NIP-07 compatible extensions have no ability to manage delegated identities, which means it likely must be done at the client level. This may involve copying delegatee information across multiple web clients, entering delegator private keys into web clients to sign delegation tokens, etc.

This could be done more universally at the NIP-07 extension level. Extensions could allow a user to create a delegated identity key pair, and additionally store only the delegator's public key and a signed delegation token. By returning the delegator's pub key from the `getPublicKey` method, the user could sign in with their normal feed. When asked to sign an event, the extension would just need to modify the event prior to returning it, so that the event is sent and signed by the delegatee, with the `delegation` tag.

To support this, clients would only need to: A) accept the event returned from `signEvent` wholesale, which I don't believe any major client does, or B) check for the presence of a `delegation` tag and accept the minimum fields from the signed event.

I have implemented an example workflow from the perspective of both extension and client here: https://github.com/ursuscamp/nip07-delegation-example. The code comments document step-by-step the workflow, as I imagine it.

Additionally, this is currently implemented as an experimental feature in Nostore. It is in a branch, but should make it into a build in a few days: https://github.com/ursuscamp/nostore/tree/nip26

I'm not sure if you need me to code up an example web client that supports this, but I should be able to handle it if that is necessary.

