### PR TITLE
NIP-07: Add NIP-26 createDelegation function

### DIFF
--- a/07.md
+++ b/07.md
@@ -20,6 +20,7 @@ Aside from these two basic above, the following functions can also be implemente
 async window.nostr.getRelays(): { [url: string]: {read: boolean, write: boolean} } // returns a basic map of relay urls to relay policies
 async window.nostr.nip04.encrypt(pubkey, plaintext): string // returns ciphertext and iv as specified in nip-04
 async window.nostr.nip04.decrypt(pubkey, ciphertext): string // takes ciphertext and iv as specified in nip-04
+async window.nostr.nip26.createDelegation(parameters): string // takes delegator parameters and returns a delgation token using the stored private key
 ```
 
 ### Implementation


### PR DESCRIPTION
In order to implement [NIP-26](https://github.com/nostr-protocol/nips/blob/master/26.md) by way of [NIP-07](https://github.com/nostr-protocol/nips/blob/master/07.md), a createDelegation function needs to be exposed by the NIP-07 extension.

