### PR TITLE
[NIP-26] Minor change to make delegation token/string naming consistent

### DIFF
--- a/26.md
+++ b/26.md
@@ -19,7 +19,7 @@ This NIP introduces a new tag: `delegation` which is formatted as follows:
   "delegation",
   <pubkey of the delegator>,
   <conditions query string>,
-  <64-byte Schnorr signature of the sha256 hash of the delegation token>
+  <delegation token: 64-byte Schnorr signature of the sha256 hash of the delegation string>
 ]
 ```
 


### PR DESCRIPTION
Typo fix: the delegation token spec mentioned a hash of delegation _token_, correctly it is of the delegation _string_.