### PR TITLE
NIP-57: Add amount tag to zap request

### DIFF
--- a/57.md
+++ b/57.md
@@ -30,7 +30,7 @@ Having lightning receipts on nostr allows clients to display lightning payments 
 
 3. Clients may choose to display a lightning zap button on each post or on the users profile, if the user's lnurl pay request endpoint supports nostr, the client SHOULD generate a `zap invoice` instead of a normal lnurl invoice.
 
-4. To generate a `zap invoice`, call the `callback` url with `amount` set to the milli-satoshi amount value. A `nostr` querystring value MUST be set as well. It is a uri-encoded `zap request` note signed by the user's key. The `zap request` note contains an `e` tag of the note it is zapping, and a `p` tag of the target user's pubkey. The `e` tag is optional which allows profile tipping. The `zap request` note must also have a `relays` tag, which is gathered from the user's configured relays. The `content` MAY be an additional comment from the user which can be displayed when listing zaps on posts and profiles.
+4. To generate a `zap invoice`, call the `callback` url with `amount` set to the milli-satoshi amount value. A `nostr` querystring value MUST be set as well. It is a uri-encoded `zap request` note signed by the user's key. The `zap request` note contains an `e` tag of the note it is zapping, and a `p` tag of the target user's pubkey. The `e` tag is optional which allows profile tipping. The `zap request` note must also have a `relays` tag, which is gathered from the user's configured relays. The `zap request` note SHOULD contain an `amount` tag, which is the milli-satoshi value of the zap which clients SHOULD verify being equal to the amount of the invoice. The `content` MAY be an additional comment from the user which can be displayed when listing zaps on posts and profiles.
 
 5. Pay this invoice or pass it to an app that can pay the invoice. Once it's paid, a `zap note` will be created by the `zapper`.
 
@@ -55,6 +55,8 @@ The lnurl server will need some additional pieces of information so that clients
 	d. It MUST have either 0 or 1 e-tag
 
 	e. There should be a `relays` tag with the relays to send the `zap` note to.
+
+	f. If there is an `amount` tag, it MUST be equal to the `amount` query parameter.
 
 5. If valid, fetch a description hash invoice where the description is this note and this note only. No additional lnurl metadata is included in the description.
 


### PR DESCRIPTION
This prevents an attack where a zap request note may be used for claiming a larger zap was done by the zapper than the zapper intended.