### PR TITLE
Update NIP 11 to support relay recommendations

### DIFF
--- a/11.md
+++ b/11.md
@@ -17,6 +17,7 @@ When a relay receives an HTTP(s) request with an `Accept` header of `application
   pubkey: <administrative contact pubkey>,
   contact: <administrative alternate contact>,
   supported_nips: <a list of NIP numbers supported by the relay>,
+  extensions: <a list of nip number, url tuples>
   software: <string identifying relay software URL>,
   version: <string version identifier>
 }
@@ -48,6 +49,10 @@ An alternative contact may be listed under the `contact` field as well, with the
 ### Supported NIPs ###
 
 As the Nostr protocol evolves, some functionality may only be available by relays that implement a specific `NIP`.  This field is an array of the integer identifiers of `NIP`s that are implemented in the relay.  Examples would include `1`, for `"NIP-01"` and `9`, for `"NIP-09"`.  Client-side `NIPs` SHOULD NOT be advertised, and can be ignored by clients.
+
+### Extensions ###
+
+Some NIPs may be more burdensome than others for relays to implement. Relays may advertise support for these NIPs as `extensions` by advertising other relays that support those NIPs for some or all of the given relay's events. For example, if a relay that functioned as a read replica wanted to advertise support for NIP 42 on the master relay it follows, it would set its `extensions` key to `[["NIP-42", "wss://my-master.example.com"]]`.
 
 ### Software ###
 


### PR DESCRIPTION
The intention of this NIP is to create space in the protocol for specifying NIPs for more advanced use cases without forcing relays to implement them or be considered a partial implementation.

Some use cases that would be prohibitively expensive for hobby relays:

- Content recommendations and search
- Social graph analysis
- Network analytics

Without discoverability, clients will hard-code special-purpose relays, creating a centralizing pressure on the network. In addition, some relays might not be picked up by the known/hard-coded add-on services, leaving their data out of calculations.

Recommendations would allow relays to advertise complementary relays to clients. Complementary might mean that it's run by the same people, contains the same data, or is a preferred source for the given functionality. Master/slave configurations could be set up using this scheme too — master relays would not support requests, while slaves would not support publishing events.

The downside of this is that it relies on clients being smart and following these references. Someone told me about how dApps used to follow this model, but it slowed things down and developers ended up getting lazy and hardcoding services anyway.

