### PR TITLE
Make kind 7 act as parameterized repleaceable event

### DIFF
--- a/25.md
+++ b/25.md
@@ -24,26 +24,26 @@ or the client MAY display this emoji reaction on the post.
 Tags
 ----
 
-The reaction event SHOULD include `e` and `p` tags from the note the user is
+The reaction event MUST include a `d` tag with the `id` of the note that is being reacted to.
+Including it enables clients to pull all the reactions associated with individual posts.
+Relays that support NIP-33 SHOULD treat a reaction as a Parameterized Replaceable Event to avoid duplicates.
+
+The reaction event SHOULD include `p` tags from the note the user is
 reacting to. This allows users to be notified of reactions to posts they were
-mentioned in. Including the `e` tags enables clients to pull all the reactions
-associated with individual posts or all the posts in a thread.
-
-The last `e` tag MUST be the `id` of the note that is being reacted to. 
-
-The last `p` tag MUST be the `pubkey` of the event being reacted to.
+mentioned in. The last `p` tag MUST be the `pubkey` of the event being reacted to.
 
 Example code
 
 ```swift
 func make_like_event(pubkey: String, privkey: String, liked: NostrEvent) -> NostrEvent {
-    var tags: [[String]] = liked.tags.filter { 
-    	tag in tag.count >= 2 && (tag[0] == "e" || tag[0] == "p") 
+    var tags: [[String]] = liked.tags.filter {
+    	tag in tag.count >= 2 && tag[0] == "p"
     }
-    tags.append(["e", liked.id])
+    tags.append(["d", liked.id])
     tags.append(["p", liked.pubkey])
     let ev = NostrEvent(content: "+", pubkey: pubkey, kind: 7, tags: tags)
     ev.calculate_id()
     ev.sign(privkey: privkey)
     return ev
 }
+```


### PR DESCRIPTION
Considering NIP-25 is marked as a draft, thought of a way of fixing some problems with the reactions while not breaking current clients. Although the possible values of the `d` tag may look unusual, it is just specific to kind 7.

This should make it possible to:
- react to all kinds of events (but ephemeral) or to a pubkey (profile)
- react once to save relay disk space
- allow edits to content
- re-use relays existing parameterized repleaceable event handling logic to do edits
- request just the reactions to an event (using `{ "kinds": [7], "#d": ["note id"] }` filter),  instead of including all thread reactions

I think it would be better to also suggest to include just 2 tags, the `d` tag (required) and only one `p` so that the owner of the reacted to post/profile can be notified, instead of everybody in the thread, while also saving space. But i didn't add it to not make current clients mad.