### PR TITLE
WIP:  NIP-70 Signature Requests and Responses using Nostr

### DIFF
--- a/70.md
+++ b/70.md
@@ -6,9 +6,9 @@ Signature Request Event
 
 `draft` `rfc` `optional` `author:3yekn`
 
-> I need to do a bit more research to determine whether the event kind should be ephemeral or not. I originally thought 'yes', but now leaning no, so I've changed the kind to `9999`.
+> I need to do a bit more research to determine whether the event kind should be ephemeral or not. 
 
-An event type with kind `9999` representing a peer-to-peer request for signature of a specific payload. 
+This proposal introduces an event type with kind `9991` representing a peer-to-peer request for signature of a specific payload and event kind `9992` as the signature response.
 
 The initial purpose of this event type is for requesting approval of [partially signed bitcoin transactions](https://river.com/learn/terms/p/partially-signed-bitcoin-transaction-psbt/) (PSBT), but the event type may also be used in more general purpose approval-style workflows.
 
@@ -25,15 +25,15 @@ This feature set could replace common legal document approval/signature applicat
 ### Notes & RFC
 - The content may or may not be encrypted (?).
 - It will likely be common for this to be used on private or permissioned relays.
-- The `p` tag is for tagging a specific account, such as `@Bob` or `@Charlie`. It supports an text string for each account being tagged. See example below.
-- Bitcoin signature request URIs have been proposed over the years but it is unclear how many wallets support them. The content in a `20010` event may contain a URI encoded PSBT or a non-URI encoded PSBT.
+- The `p` tag is for tagging a specific account, such as `@Bob` or `@Charlie`. See example below.
+- Bitcoin signature request URIs have been proposed over the years but it is unclear how many wallets support them. The content in a `9991` event may contain a URI encoded PSBT or a non-URI encoded PSBT.
 
 #### Example Client Implementation
 Clients may show the event under DMs or in a specific signature-request zone.
-![image](https://user-images.githubusercontent.com/32852271/219762673-3ff42c16-15b6-415b-80a5-05f9502e3184.png | width=200)
+<img src="https://user-images.githubusercontent.com/32852271/219762673-3ff42c16-15b6-415b-80a5-05f9502e3184.png" width="200")
 
 Clients may add `Approve` or `Reject` or `...` (more) buttons directly in the client, or provide a URI to open the signature request within a bitcoin wallet (similar to the zap functionality).
-![image](https://user-images.githubusercontent.com/32852271/219763472-0f390678-2545-457a-92e6-12bbd2275996.png = width=200)
+<img src="https://user-images.githubusercontent.com/32852271/219763472-0f390678-2545-457a-92e6-12bbd2275996.png" width="200"/>
 
 ### Example
 This example event tags Bob, Charlie, David, and Erika with an optional note for each. The PSBT is in the content. For PSBTs, once signed, the resulting PSBT can be the same event type as the signature is already embedded in the PSBT specification. For non-PSBT use cases, only the signature may be returned or appended to the content and returned.
@@ -75,7 +75,7 @@ Alice approves of having cheesecake tonight.
       "wss://r1.hashed.systems"
     ],
   ],
-  "content": "7d08c5d295ad7d5b29ba0c47e4a56323894e9b7a124a20ca59917428001b5b485d1aab20f58353b7a7e64be562d3ac5f458cc07dfe297d1850d4a5f4c18d6308",
+  "content": "signature:7d08c5d295ad7d5b29ba0c47e4a56323894e9b7a124a20ca59917428001b5b485d1aab20f58353b7a7e64be562d3ac5f458cc07dfe297d1850d4a5f4c18d6308&notes=sure thing",
   <other fields>
 }
 ```

--- a/70.md
+++ b/70.md
@@ -30,39 +30,53 @@ This feature set could replace common legal document approval/signature applicat
 
 #### Example Client Implementation
 Clients may show the event under DMs or in a specific signature-request zone.
-![image](https://user-images.githubusercontent.com/32852271/219762673-3ff42c16-15b6-415b-80a5-05f9502e3184.png)
+![image](https://user-images.githubusercontent.com/32852271/219762673-3ff42c16-15b6-415b-80a5-05f9502e3184.png | width=200)
 
 Clients may add `Approve` or `Reject` or `...` (more) buttons directly in the client, or provide a URI to open the signature request within a bitcoin wallet (similar to the zap functionality).
-![image](https://user-images.githubusercontent.com/32852271/219763472-0f390678-2545-457a-92e6-12bbd2275996.png)
+![image](https://user-images.githubusercontent.com/32852271/219763472-0f390678-2545-457a-92e6-12bbd2275996.png = width=200)
 
 ### Example
 This example event tags Bob, Charlie, David, and Erika with an optional note for each. The PSBT is in the content. For PSBTs, once signed, the resulting PSBT can be the same event type as the signature is already embedded in the PSBT specification. For non-PSBT use cases, only the signature may be returned or appended to the content and returned.
 
+#### Simple Example
+##### Signature Request - 9991
+Bob asks Alice to approve of having cheesecake tonight.
 ```json
 {
-  "kind": 9999,
+  "pubkey" : "5e79d85b377943fed828365d2a7712a0578272b6c1e0511154f6517e2a13925e", // bob 
+  "kind": 9991,
   "tags": [
     [
       "p",
-      "7b9eda7669b1075c0eb4b117a34de19be4b3c8b0d5537b5de7fa9793b0a8e9ff",
-      "Spending proposal; final milestone of deliverable"
-    ],
-    [
-      "p",
-      "6dc7f2789b04f1f20cdf3269029d8a89fa04c9051a29bea63639b6d2ef134fb3",
-      "Charlie - this is the proposal we discussed last night"
-    ],
-    [
-      "p",
-      "1e0155f4843594aabbc9decf115a9c3162c46464c9508eae412158f2a28b809a"
-    ],
-    [
-      "p",
-      "c34ac3f6d59c3580c6d30dc3fd861fe3a7cabe00dfa934e8fdef3ead788f94d6",
-      "thank you!"
+      "0e1db7418df1c6453ce42e7f4507b8823fc23e86e1f4f33d7fafc83d366e6e97", // alice
+      "wss://r1.hashed.systems"
     ]
   ],
-  "content": "cHNidP8BAF4BAAAAAV+DDmtAAKGva28N67sMIILELcGijKDI4HC/AMpaJnlFAQAAAAD+////AfQBAAAAAAAAIlEgo8GuCWDKKqRICOvQu3Tet9TG+UxW3AIufqVh7R3RGz6+7iQAAAEBK+gDAAAAAAAAIlEgHjo/ky5+XlG+TpmMzscmv7UL7OZ9aO0o8du3SnVeSOkiFcE8tczckedmNwjCOJtUexsDtwThZWS2zQAZFiPcgQzlUiMgeNsYHzDDkwhNCXCec77NmCw5KlMhKLR3x/8wF4BYcACswCEWeNsYHzDDkwhNCXCec77NmCw5KlMhKLR3x/8wF4BYcAAlAZIES0LIp4kP3TtdT4ogx9s35zqobzAi9JTkSYDum3NIkudrZyEWPLXM3JHnZjcIwjibVHsbA7cE4WVkts0AGRYj3IEM5VIFABfG89MBFyA8tczckedmNwjCOJtUexsDtwThZWS2zQAZFiPcgQzlUgEYIJIES0LIp4kP3TtdT4ogx9s35zqobzAi9JTkSYDum3NIAAA=",
-  "sig": "cbed22ff4274eebc03a9371d17efd87be52fcbc0c1d386758619b1a9d3004e7a6d93f9cbef7fbe541d5036c6c0544cf7eca98a61b5fddac1d939387211e0a253"
+  "content": "I approve of the proposal to have cheesecake tonight",
+  "id": "the_ID_of_the_signature_request_event" // derived based on NIP-01
+  <other fields>
 }
 ```
+
+##### Signature Reply - 9992
+Alice approves of having cheesecake tonight.
+```json
+{
+  "kind": 9992,
+  "tags": [
+    [
+      "p",
+      "5e79d85b377943fed828365d2a7712a0578272b6c1e0511154f6517e2a13925e",
+      "wss://r1.hashed.systems"
+    ],
+    [
+      "e",
+      "the_ID_of_the_signature_request_event",
+      "wss://r1.hashed.systems"
+    ],
+  ],
+  "content": "7d08c5d295ad7d5b29ba0c47e4a56323894e9b7a124a20ca59917428001b5b485d1aab20f58353b7a7e64be562d3ac5f458cc07dfe297d1850d4a5f4c18d6308",
+  <other fields>
+}
+```
+

--- a/70.md
+++ b/70.md
@@ -18,7 +18,7 @@ They often use popular bitcoin wallets such as Electrum or Sparrow to manage the
 The treasurers wish to improve and streamline the process using Nostr and user-friendly policy editors such as BDK's [Elephant](https://github.com/bitcoindevkit/elephant). 
 
 #### Document Signatures
-This feature set could replace common document approval/signature applications such as DocuSign. Instead of a PSBT, the content could be markdown or other information that represents the body of what is being signed by the user. Security of just 
+This feature set could replace common legal document approval/signature applications such as DocuSign or Adobe Sign. Instead of a PSBT, the content could be markdown, plain text, or content such as [OpenLaw](https://docs.openlaw.io/) markup, all of which may represents the body of what is being signed by the user. 
 
 ### Notes & RFC
 - The content may or may not be encrypted (?).
@@ -34,7 +34,7 @@ Clients may add `Approve` or `Reject` or `...` (more) buttons directly in the cl
 ![image](https://user-images.githubusercontent.com/32852271/219763472-0f390678-2545-457a-92e6-12bbd2275996.png)
 
 ### Example
-This example event tags Bob, Charlie, David, and Erika with an optional note for each. The PSBT is in the content. Once signed the resulting PSBT can be the same event type as the signature is already embedded in the PSBT specification.
+This example event tags Bob, Charlie, David, and Erika with an optional note for each. The PSBT is in the content. For PSBTs, once signed, the resulting PSBT can be the same event type as the signature is already embedded in the PSBT specification. For non-PSBT use cases, only the signature may be returned or appended to the content and returned.
 
 ```json
 {

--- a/70.md
+++ b/70.md
@@ -28,8 +28,8 @@ This feature set could replace common legal document approval/signature applicat
 - It will likely be common for this to be used on private or permissioned relays.
 - The `p` tag is for tagging a specific account, such as `@alice` and `@bob` below
 - Bitcoin signature request URIs have been proposed over the years but it is unclear how many wallets support them. The content in a `9991` event may contain a URI encoded PSBT or a non-URI encoded PSBT.
-- Kind `9991` may have `payload_to_sign` and `memo` in the content. If that does not parse, the entire `content` is assumed to be the `payload_to_sign`.
-- Kind `9992` may have `signature` and `memo` in the content. If that does not parse, the entire `content` is assumed to be the `signature`.
+- Kind `9991` MUST have a tag where the first array element is `to_sign`. If that does not parse, the `content` is assumed to be the payload to sign.
+- Kind `9992` MUST have a tag where the first array element is `signature`. If that does not parse, the `content` is assumed to be the signature.
 
 ## Example
 This example event tags Bob, Charlie, David, and Erika with an optional note for each. The PSBT is in the content. For PSBTs, once signed, the resulting PSBT can be the same event type as the signature is already embedded in the PSBT specification. For non-PSBT use cases, only the signature may be returned or appended to the content and returned.
@@ -46,9 +46,13 @@ Bob asks Alice to approve of having cheesecake tonight.
       "p",
       "0e1db7418df1c6453ce42e7f4507b8823fc23e86e1f4f33d7fafc83d366e6e97", // alice
       "wss://r1.hashed.systems"
-    ]
+    ],
+    [
+      "to_sign",
+      "I approve of the proposal to have cheesecake tonight", // payload to sign
+    ],
   ],
-  "content": "payload_to_sign=\"I approve of the proposal to have cheesecake tonight\"&memo=\"please approve this- I have already started making it\"",
+  "content": "please approve this- I have already started making it",
   "id": "the_ID_of_the_signature_request_event", // derived based on NIP-01
   "sig": <signature of the nostr event>,
   <other fields>
@@ -72,8 +76,12 @@ Alice approves of having cheesecake tonight.
       "the_ID_of_the_signature_request_event", // per reply style spec
       "wss://r1.hashed.systems"
     ],
+    [
+      "signature",
+      "7d08c5d295ad7d5b29ba0c47e4a56323894e9b7a124a20ca59917428001b5b485d1aab20f58353b7a7e64be562d3ac5f458cc07dfe297d1850d4a5f4c18d6308", // signature
+    ],
   ],
-  "content": "signature=7d08c5d295ad7d5b29ba0c47e4a56323894e9b7a124a20ca59917428001b5b485d1aab20f58353b7a7e64be562d3ac5f458cc07dfe297d1850d4a5f4c18d6308&notes=\"sure thing\"",
+  "content": "sure thing",
   "sig": <signature of the nostr event>,
   <other fields>
 }

--- a/70.md
+++ b/70.md
@@ -1,0 +1,66 @@
+NIP-70
+======
+
+Signature Request Event
+-------------------
+
+`draft` `rfc` `optional` `author:3yekn`
+
+An [ephemeral event](https://github.com/nostr-protocol/nips/blob/master/16.md#ephemeral-events) type with kind `20010` representing a peer-to-peer request for signature of a specific payload. 
+
+The initial purpose of this event type is for requesting approval of [partially signed bitcoin transactions](https://river.com/learn/terms/p/partially-signed-bitcoin-transaction-psbt/) (PSBT), but the event type may also be used in more general purpose approval-style workflows.
+
+### Motivation
+Alice, Bob, Charlie, David, and Erika manage a company's bitcoin treasury that is used to pay vendors. The amounts are large, so the treasury is protected in a multisignature wallet. The payment frequency is low, so there is not a need for an L2 such as lightning. 
+
+They often use popular bitcoin wallets such as Electrum or Sparrow to manage the treasury. These wallets require that a spending proposer export the PSBT to a text file, send the file out-of-band, where the prospective approver must then import the PSBT, sign, export, and repeat. Eventually, the PSBT or combination of signatures reaches the threshold for the transaction to be finalized and broadcast.
+
+The treasurers wish to improve and streamline the process using Nostr and user-friendly policy editors such as BDK's [Elephant](https://github.com/bitcoindevkit/elephant). 
+
+#### Document Signatures
+This feature set could replace common document approval/signature applications such as DocuSign. Instead of a PSBT, the content could be markdown or other information that represents the body of what is being signed by the user. Security of just 
+
+### Notes & RFC
+- The content may or may not be encrypted (?).
+- It will likely be common for this to be used on private or permissioned relays.
+- The `p` tag is for tagging a specific account, such as `@Bob` or `@Charlie`. It supports an text string for each account being tagged. See example below.
+- Bitcoin signature request URIs have been proposed over the years but it is unclear how many wallets support them. The content in a `20010` event may contain a URI encoded PSBT or a non-URI encoded PSBT.
+
+#### Example Client Implementation
+Clients may show the event under DMs or in a specific signature-request zone.
+![image](https://user-images.githubusercontent.com/32852271/219762673-3ff42c16-15b6-415b-80a5-05f9502e3184.png)
+
+Clients may add `Approve` or `Reject` or `...` (more) buttons directly in the client, or provide a URI to open the signature request within a bitcoin wallet (similar to the zap functionality).
+![image](https://user-images.githubusercontent.com/32852271/219763472-0f390678-2545-457a-92e6-12bbd2275996.png)
+
+### Example
+This example event tags Bob, Charlie, David, and Erika with an optional note for each. The PSBT is in the content. Once signed the resulting PSBT can be the same event type as the signature is already embedded in the PSBT specification.
+
+```json
+{
+  "kind": 20010,
+  "tags": [
+    [
+      "p",
+      "7b9eda7669b1075c0eb4b117a34de19be4b3c8b0d5537b5de7fa9793b0a8e9ff",
+      "Spending proposal; final milestone of deliverable"
+    ],
+    [
+      "p",
+      "6dc7f2789b04f1f20cdf3269029d8a89fa04c9051a29bea63639b6d2ef134fb3",
+      "Charlie - this is the proposal we discussed last night"
+    ],
+    [
+      "p",
+      "1e0155f4843594aabbc9decf115a9c3162c46464c9508eae412158f2a28b809a"
+    ],
+    [
+      "p",
+      "c34ac3f6d59c3580c6d30dc3fd861fe3a7cabe00dfa934e8fdef3ead788f94d6",
+      "thank you!"
+    ]
+  ],
+  "content": "cHNidP8BAF4BAAAAAV+DDmtAAKGva28N67sMIILELcGijKDI4HC/AMpaJnlFAQAAAAD+////AfQBAAAAAAAAIlEgo8GuCWDKKqRICOvQu3Tet9TG+UxW3AIufqVh7R3RGz6+7iQAAAEBK+gDAAAAAAAAIlEgHjo/ky5+XlG+TpmMzscmv7UL7OZ9aO0o8du3SnVeSOkiFcE8tczckedmNwjCOJtUexsDtwThZWS2zQAZFiPcgQzlUiMgeNsYHzDDkwhNCXCec77NmCw5KlMhKLR3x/8wF4BYcACswCEWeNsYHzDDkwhNCXCec77NmCw5KlMhKLR3x/8wF4BYcAAlAZIES0LIp4kP3TtdT4ogx9s35zqobzAi9JTkSYDum3NIkudrZyEWPLXM3JHnZjcIwjibVHsbA7cE4WVkts0AGRYj3IEM5VIFABfG89MBFyA8tczckedmNwjCOJtUexsDtwThZWS2zQAZFiPcgQzlUgEYIJIES0LIp4kP3TtdT4ogx9s35zqobzAi9JTkSYDum3NIAAA=",
+  "sig": "cbed22ff4274eebc03a9371d17efd87be52fcbc0c1d386758619b1a9d3004e7a6d93f9cbef7fbe541d5036c6c0544cf7eca98a61b5fddac1d939387211e0a253"
+}
+```

--- a/70.md
+++ b/70.md
@@ -12,6 +12,7 @@ Signature Request Event & Response
 [] create reference implementation in rust: https://github.com/3yekn/nostr/pull/1
 [] create reference implementation in Go
 [] develop improved subscribers and verifiers
+[] add examples of encrypted signature requests
 
 This proposal introduces an event type with kind `9991` representing a peer-to-peer request for signature of a specific payload and event kind `9992` as the signature response.
 

--- a/70.md
+++ b/70.md
@@ -13,7 +13,7 @@ Signature Request Event & Response
 * [ ] create reference implementation in Go
 * [ ] develop improved subscribers and verifiers
 * [ ] add examples of encrypted signature requests
-* [ ] develop example showing combination of NIP-57 (ZAPs) for approvals
+* [ ] develop example showing combination with NIP-57 (ZAPs) in exchange for approvals
 * [ ] develop Bitcoin Proof-of-Reserves example
 
 This proposal introduces an event type with kind `10010` representing a peer-to-peer request for signature of a specific payload and event kind `10011` as the signature response.
@@ -32,15 +32,15 @@ The treasurers wish to improve and streamline the process using Nostr and user-f
 This feature set could replace common legal document approval/signature applications such as DocuSign or Adobe Sign. Instead of a PSBT, the content could be markdown, plain text, or content such as [OpenLaw](https://docs.openlaw.io/) markup, the [Accord project](https://accordproject.org/projects/cicero/), or other types of [Ricardian contracts](https://iang.org/papers/ricardian_contract.html).
 
 ## Notes & RFC
-- The content may or may not be encrypted. Some public DAO treasuries may desire open approvals although most will likely be encrypted.
+- The content may or may not be encrypted. Some public DAO treasuries may desire open approvals, although most will likely be encrypted.
 - It will likely be common for this feature to be used on private or permissioned relays.
-- The `p` tag is for tagging a specific account, such as `@alice` and `@bob` below
+- The `p` tag is for tagging a specific account, presuming requesting approval from that user. If it is common for non-approval pubkeys to also be tagged, then a new `tag` type spec for `requested_signer` should be added. (TBD)
 - Bitcoin signature request URIs have been proposed over the years but it is unclear how many wallets support them. The content in a `10010` event may contain a URI encoded PSBT or a non-URI encoded PSBT.
 - Kind `10010` MUST have a tag where the first array element is `to_sign`. If that does not parse, the `content` is assumed to be the payload to sign.
 - Kind `10011` MUST have a tag where the first array element is `signature`. If that does not parse, the `content` is assumed to be the signature.
 
 ## Example
-The simple example for illustration below is from Bob, requesting an approval from Alice. 
+The simple example for illustration below is from Bob, requesting an approval from Alice, and Alice returns it. 
 
 ### Simple Example
 #### Signature Request - 10010
@@ -89,7 +89,7 @@ Alice approves of having filet tonight.
       "7d08c5d295ad7d5b29ba0c47e4a56323894e9b7a124a20ca59917428001b5b485d1aab20f58353b7a7e64be562d3ac5f458cc07dfe297d1850d4a5f4c18d6308", // signature
     ],
   ],
-  "content": "sure thing",
+  "content": "sounds good to me",
   "sig": <signature of the nostr event>,
   <other fields>
 }
@@ -114,5 +114,7 @@ Clients may add `Approve` or `Reject` or `...` (more) buttons directly in the cl
 
 ## Miscellaneous References
 - [Bill Clinton's speech on Electronic Signatures Act](https://youtu.be/tZhqpl0nsOU)
+- [Ricardian contracts](https://iang.org/papers/ricardian_contract.html)
+- [Electronic Data Interchange](https://www.edibasics.com/what-is-edi/#), a very old yet widely used protocol for business documents
 - [Coinstr presentation](https://docs.google.com/presentation/d/1E4WwSgt4ZKr1M9SmmVELpf2ckhmqC237idLumCKP7Eg/edit?usp=sharing), bitcoin multi-custody signature orchestration using Nostr
 - [Coinstr](https://coinstr.app) website

--- a/70.md
+++ b/70.md
@@ -12,36 +12,28 @@ This proposal introduces an event type with kind `9991` representing a peer-to-p
 
 The initial purpose of this event type is for requesting approval of [partially signed bitcoin transactions](https://river.com/learn/terms/p/partially-signed-bitcoin-transaction-psbt/) (PSBT), but the event type may also be used in more general purpose approval-style workflows.
 
-### Motivation
+# Motivation
+## Bitcoin PSBTs
 Alice, Bob, Charlie, David, and Erika manage a company's bitcoin treasury that is used to pay vendors. The amounts are large, so the treasury is protected in a multisignature wallet. The payment frequency is low, so there is not a need for an L2 such as lightning. 
 
 They often use popular bitcoin wallets such as Electrum or Sparrow to manage the treasury. These wallets require that a spending proposer export the PSBT to a text file, send the file out-of-band, where the prospective approver must then import the PSBT, sign, export, and repeat. Eventually, the PSBT or combination of signatures reaches the threshold for the transaction to be finalized and broadcast.
 
 The treasurers wish to improve and streamline the process using Nostr and user-friendly policy editors such as BDK's [Elephant](https://github.com/bitcoindevkit/elephant). 
 
-#### Document Signatures
+## Document Signatures
 This feature set could replace common legal document approval/signature applications such as DocuSign or Adobe Sign. Instead of a PSBT, the content could be markdown, plain text, or content such as [OpenLaw](https://docs.openlaw.io/) markup, all of which may represents the body of what is being signed by the user. 
 
-### Notes & RFC
+# Notes & RFC
 - The content may or may not be encrypted (?).
 - It will likely be common for this to be used on private or permissioned relays.
 - The `p` tag is for tagging a specific account, such as `@Bob` or `@Charlie`. See example below.
 - Bitcoin signature request URIs have been proposed over the years but it is unclear how many wallets support them. The content in a `9991` event may contain a URI encoded PSBT or a non-URI encoded PSBT.
 
-#### Example Client Implementation
-Clients may show the event under DMs or in a specific signature-request zone.
-
-<img src="https://user-images.githubusercontent.com/32852271/219762673-3ff42c16-15b6-415b-80a5-05f9502e3184.png" width="600"/>
-
-Clients may add `Approve` or `Reject` or `...` (more) buttons directly in the client, or provide a URI to open the signature request within a bitcoin wallet (similar to the zap functionality).
-
-<img src="https://user-images.githubusercontent.com/32852271/219763472-0f390678-2545-457a-92e6-12bbd2275996.png" width="600"/>
-
-### Example
+# Example
 This example event tags Bob, Charlie, David, and Erika with an optional note for each. The PSBT is in the content. For PSBTs, once signed, the resulting PSBT can be the same event type as the signature is already embedded in the PSBT specification. For non-PSBT use cases, only the signature may be returned or appended to the content and returned.
 
-#### Simple Example
-##### Signature Request - 9991
+## Simple Example
+### Signature Request - 9991
 Bob asks Alice to approve of having cheesecake tonight.
 ```json
 {
@@ -60,7 +52,7 @@ Bob asks Alice to approve of having cheesecake tonight.
 }
 ```
 
-##### Signature Reply - 9992
+### Signature Reply - 9992
 Alice approves of having cheesecake tonight.
 ```json
 {
@@ -81,4 +73,11 @@ Alice approves of having cheesecake tonight.
   <other fields>
 }
 ```
+# Example Client Implementation
+Clients may show the event under DMs or in a specific signature-request zone.
 
+<img src="https://user-images.githubusercontent.com/32852271/219762673-3ff42c16-15b6-415b-80a5-05f9502e3184.png" width="600"/>
+
+Clients may add `Approve` or `Reject` or `...` (more) buttons directly in the client, or provide a URI to open the signature request within a bitcoin wallet (similar to the zap functionality).
+
+<img src="https://user-images.githubusercontent.com/32852271/219763472-0f390678-2545-457a-92e6-12bbd2275996.png" width="600"/>

--- a/70.md
+++ b/70.md
@@ -6,7 +6,9 @@ Signature Request Event
 
 `draft` `rfc` `optional` `author:3yekn`
 
-An [ephemeral event](https://github.com/nostr-protocol/nips/blob/master/16.md#ephemeral-events) type with kind `20010` representing a peer-to-peer request for signature of a specific payload. 
+> I need to do a bit more research to determine whether the event kind should be ephemeral or not. I originally thought 'yes', but now leaning no, so I've changed the kind to `9999`.
+
+An event type with kind `9999` representing a peer-to-peer request for signature of a specific payload. 
 
 The initial purpose of this event type is for requesting approval of [partially signed bitcoin transactions](https://river.com/learn/terms/p/partially-signed-bitcoin-transaction-psbt/) (PSBT), but the event type may also be used in more general purpose approval-style workflows.
 
@@ -38,7 +40,7 @@ This example event tags Bob, Charlie, David, and Erika with an optional note for
 
 ```json
 {
-  "kind": 20010,
+  "kind": 9999,
   "tags": [
     [
       "p",

--- a/70.md
+++ b/70.md
@@ -6,7 +6,12 @@ Signature Request Event & Response
 
 `draft` `rfc` `optional` `author:3yekn`
 
-> I need to do a bit more research to determine whether the event kind should be ephemeral or not. 
+[] transition to ephemeral event kinds and numbers
+[] create specific examples of PSBTs
+[] create specific examples of Ricardian contracts for Docusign replacement
+[] create reference implementation in rust: https://github.com/3yekn/nostr/pull/1
+[] create reference implementation in Go
+[] develop improved subscribers and verifiers
 
 This proposal introduces an event type with kind `9991` representing a peer-to-peer request for signature of a specific payload and event kind `9992` as the signature response.
 
@@ -21,7 +26,7 @@ They often use popular bitcoin wallets such as Electrum or Sparrow to manage the
 The treasurers wish to improve and streamline the process using Nostr and user-friendly policy editors such as BDK's [Elephant](https://github.com/bitcoindevkit/elephant). 
 
 ### Document Signatures
-This feature set could replace common legal document approval/signature applications such as DocuSign or Adobe Sign. Instead of a PSBT, the content could be markdown, plain text, or content such as [OpenLaw](https://docs.openlaw.io/) markup, all of which may represents the body of what is being signed by the user. 
+This feature set could replace common legal document approval/signature applications such as DocuSign or Adobe Sign. Instead of a PSBT, the content could be markdown, plain text, or content such as [OpenLaw](https://docs.openlaw.io/) markup, the [Accord project](https://accordproject.org/projects/cicero/), or other types of [Ricardian contracts](https://iang.org/papers/ricardian_contract.html).
 
 ## Notes & RFC
 - The content may or may not be encrypted (?).
@@ -36,7 +41,7 @@ This example event tags Bob, Charlie, David, and Erika with an optional note for
 
 ### Simple Example
 #### Signature Request - 9991
-Bob asks Alice to approve of having cheesecake tonight.
+Bob asks Alice to approve of having filet for dinner tonight.
 ```json
 {
   "pubkey": "5e79d85b377943fed828365d2a7712a0578272b6c1e0511154f6517e2a13925e", // bob 
@@ -49,10 +54,10 @@ Bob asks Alice to approve of having cheesecake tonight.
     ],
     [
       "to_sign",
-      "I approve of the proposal to have cheesecake tonight", // payload to sign
+      "I hereby approve of eating the filet tonight", // payload to sign
     ],
   ],
-  "content": "please approve this- I have already started making it",
+  "content": "please approve this because I already started the grill",
   "id": "the_ID_of_the_signature_request_event", // derived based on NIP-01
   "sig": <signature of the nostr event>,
   <other fields>
@@ -60,7 +65,7 @@ Bob asks Alice to approve of having cheesecake tonight.
 ```
 
 #### Signature Reply - 9992
-Alice approves of having cheesecake tonight.
+Alice approves of having filet tonight.
 ```json
 {
   "pubkey": "0e1db7418df1c6453ce42e7f4507b8823fc23e86e1f4f33d7fafc83d366e6e97", // alice
@@ -86,6 +91,12 @@ Alice approves of having cheesecake tonight.
   <other fields>
 }
 ```
+
+###
+Additional examples
+- Partially signed bitcoin transactions
+- 
+
 ## Example Client Implementation
 Clients may show the event under DMs or in a specific signature-request zone.
 

--- a/70.md
+++ b/70.md
@@ -26,8 +26,10 @@ This feature set could replace common legal document approval/signature applicat
 ## Notes & RFC
 - The content may or may not be encrypted (?).
 - It will likely be common for this to be used on private or permissioned relays.
-- The `p` tag is for tagging a specific account, such as `@Bob` or `@Charlie`. See example below.
+- The `p` tag is for tagging a specific account, such as `@alice` and `@bob` below
 - Bitcoin signature request URIs have been proposed over the years but it is unclear how many wallets support them. The content in a `9991` event may contain a URI encoded PSBT or a non-URI encoded PSBT.
+- Kind `9991` may have `payload_to_sign` and `memo` in the content. If that does not parse, the entire `content` is assumed to be the `payload_to_sign`.
+- Kind `9992` may have `signature` and `memo` in the content. If that does not parse, the entire `content` is assumed to be the `signature`.
 
 ## Example
 This example event tags Bob, Charlie, David, and Erika with an optional note for each. The PSBT is in the content. For PSBTs, once signed, the resulting PSBT can be the same event type as the signature is already embedded in the PSBT specification. For non-PSBT use cases, only the signature may be returned or appended to the content and returned.
@@ -46,7 +48,7 @@ Bob asks Alice to approve of having cheesecake tonight.
       "wss://r1.hashed.systems"
     ]
   ],
-  "content": "I approve of the proposal to have cheesecake tonight",
+  "content": "payload_to_sign=\"I approve of the proposal to have cheesecake tonight\"&memo=\"please approve this- I have already started making it\"",
   "id": "the_ID_of_the_signature_request_event", // derived based on NIP-01
   "sig": <signature of the nostr event>,
   <other fields>
@@ -71,7 +73,7 @@ Alice approves of having cheesecake tonight.
       "wss://r1.hashed.systems"
     ],
   ],
-  "content": "signature:7d08c5d295ad7d5b29ba0c47e4a56323894e9b7a124a20ca59917428001b5b485d1aab20f58353b7a7e64be562d3ac5f458cc07dfe297d1850d4a5f4c18d6308&notes=sure thing",
+  "content": "signature=7d08c5d295ad7d5b29ba0c47e4a56323894e9b7a124a20ca59917428001b5b485d1aab20f58353b7a7e64be562d3ac5f458cc07dfe297d1850d4a5f4c18d6308&notes=\"sure thing\"",
   "sig": <signature of the nostr event>,
   <other fields>
 }

--- a/70.md
+++ b/70.md
@@ -32,10 +32,18 @@ The treasurers wish to improve and streamline the process using Nostr and user-f
 This feature set could replace common legal document approval/signature applications such as DocuSign or Adobe Sign. Instead of a PSBT, the content could be markdown, plain text, or content such as [OpenLaw](https://docs.openlaw.io/) markup, the [Accord project](https://accordproject.org/projects/cicero/), or other types of [Ricardian contracts](https://iang.org/papers/ricardian_contract.html).
 
 ## Notes & RFC
+#### Privacy
 - The content may or may not be encrypted. Some public DAO treasuries may desire open approvals, although most will likely be encrypted.
 - It will likely be common for this feature to be used on private or permissioned relays.
+
+### Tagging Prospective Approvers
 - The `p` tag is for tagging a specific account, presuming requesting approval from that user. If it is common for non-approval pubkeys to also be tagged, then a new `tag` type spec for `requested_signer` should be added. (TBD)
+
+### Bitcoin PSBT and Payload Decoding
 - Bitcoin signature request URIs have been proposed over the years but it is unclear how many wallets support them. The content in a `10010` event may contain a URI encoded PSBT or a non-URI encoded PSBT.
+- Some legal agreement specifications provide templated or `handlebars`-style hydration. In these cases, an event may reference an commonly adopted template (via URL, namespace, or hash) and provide the data in the Event tags (e.g. NDA template with a name and expiration date as data fields). 
+
+### Fields Specifications
 - Kind `10010` MUST have a tag where the first array element is `to_sign`. If that does not parse, the `content` is assumed to be the payload to sign.
 - Kind `10011` MUST have a tag where the first array element is `signature`. If that does not parse, the `content` is assumed to be the signature.
 

--- a/70.md
+++ b/70.md
@@ -37,7 +37,7 @@ This example event tags Bob, Charlie, David, and Erika with an optional note for
 Bob asks Alice to approve of having cheesecake tonight.
 ```json
 {
-  "pubkey" : "5e79d85b377943fed828365d2a7712a0578272b6c1e0511154f6517e2a13925e", // bob 
+  "pubkey": "5e79d85b377943fed828365d2a7712a0578272b6c1e0511154f6517e2a13925e", // bob 
   "kind": 9991,
   "tags": [
     [
@@ -47,7 +47,8 @@ Bob asks Alice to approve of having cheesecake tonight.
     ]
   ],
   "content": "I approve of the proposal to have cheesecake tonight",
-  "id": "the_ID_of_the_signature_request_event" // derived based on NIP-01
+  "id": "the_ID_of_the_signature_request_event", // derived based on NIP-01
+  "sig": <signature of the nostr event>,
   <other fields>
 }
 ```
@@ -56,20 +57,22 @@ Bob asks Alice to approve of having cheesecake tonight.
 Alice approves of having cheesecake tonight.
 ```json
 {
+  "pubkey": "0e1db7418df1c6453ce42e7f4507b8823fc23e86e1f4f33d7fafc83d366e6e97", // alice
   "kind": 9992,
   "tags": [
     [
       "p",
-      "5e79d85b377943fed828365d2a7712a0578272b6c1e0511154f6517e2a13925e",
+      "5e79d85b377943fed828365d2a7712a0578272b6c1e0511154f6517e2a13925e", // bob
       "wss://r1.hashed.systems"
     ],
     [
       "e",
-      "the_ID_of_the_signature_request_event",
+      "the_ID_of_the_signature_request_event", // per reply style spec
       "wss://r1.hashed.systems"
     ],
   ],
   "content": "signature:7d08c5d295ad7d5b29ba0c47e4a56323894e9b7a124a20ca59917428001b5b485d1aab20f58353b7a7e64be562d3ac5f458cc07dfe297d1850d4a5f4c18d6308&notes=sure thing",
+  "sig": <signature of the nostr event>,
   <other fields>
 }
 ```

--- a/70.md
+++ b/70.md
@@ -28,7 +28,7 @@ They often use popular bitcoin wallets such as Electrum or Sparrow to manage the
 
 The treasurers wish to improve and streamline the process using Nostr and user-friendly policy editors such as BDK's [Elephant](https://github.com/bitcoindevkit/elephant). 
 
-### Document Signatures
+### Business Document Signatures
 This feature set could replace common legal document approval/signature applications such as DocuSign or Adobe Sign. Instead of a PSBT, the content could be markdown, plain text, or content such as [OpenLaw](https://docs.openlaw.io/) markup, the [Accord project](https://accordproject.org/projects/cicero/), or other types of [Ricardian contracts](https://iang.org/papers/ricardian_contract.html).
 
 ## Notes & RFC

--- a/70.md
+++ b/70.md
@@ -6,13 +6,13 @@ Signature Request Event & Response
 
 `draft` `rfc` `optional` `author:3yekn`
 
-[] transition to ephemeral event kinds and numbers
-[] create specific examples of PSBTs
-[] create specific examples of Ricardian contracts for Docusign replacement
-[] create reference implementation in rust: https://github.com/3yekn/nostr/pull/1
-[] create reference implementation in Go
-[] develop improved subscribers and verifiers
-[] add examples of encrypted signature requests
+[ ] transition to ephemeral event kinds and numbers
+[ ] create specific examples of PSBTs
+[ ] create specific examples of Ricardian contracts for Docusign replacement
+[x] create reference implementation in rust: https://github.com/3yekn/nostr/pull/1
+[ ] create reference implementation in Go
+[ ] develop improved subscribers and verifiers
+[ ] add examples of encrypted signature requests
 
 This proposal introduces an event type with kind `9991` representing a peer-to-peer request for signature of a specific payload and event kind `9992` as the signature response.
 

--- a/70.md
+++ b/70.md
@@ -1,7 +1,7 @@
 NIP-70
 ======
 
-Signature Request Event
+Signature Request Event & Response
 -------------------
 
 `draft` `rfc` `optional` `author:3yekn`
@@ -12,28 +12,28 @@ This proposal introduces an event type with kind `9991` representing a peer-to-p
 
 The initial purpose of this event type is for requesting approval of [partially signed bitcoin transactions](https://river.com/learn/terms/p/partially-signed-bitcoin-transaction-psbt/) (PSBT), but the event type may also be used in more general purpose approval-style workflows.
 
-# Motivation
-## Bitcoin PSBTs
+## Motivation
+### Bitcoin PSBTs
 Alice, Bob, Charlie, David, and Erika manage a company's bitcoin treasury that is used to pay vendors. The amounts are large, so the treasury is protected in a multisignature wallet. The payment frequency is low, so there is not a need for an L2 such as lightning. 
 
 They often use popular bitcoin wallets such as Electrum or Sparrow to manage the treasury. These wallets require that a spending proposer export the PSBT to a text file, send the file out-of-band, where the prospective approver must then import the PSBT, sign, export, and repeat. Eventually, the PSBT or combination of signatures reaches the threshold for the transaction to be finalized and broadcast.
 
 The treasurers wish to improve and streamline the process using Nostr and user-friendly policy editors such as BDK's [Elephant](https://github.com/bitcoindevkit/elephant). 
 
-## Document Signatures
+### Document Signatures
 This feature set could replace common legal document approval/signature applications such as DocuSign or Adobe Sign. Instead of a PSBT, the content could be markdown, plain text, or content such as [OpenLaw](https://docs.openlaw.io/) markup, all of which may represents the body of what is being signed by the user. 
 
-# Notes & RFC
+## Notes & RFC
 - The content may or may not be encrypted (?).
 - It will likely be common for this to be used on private or permissioned relays.
 - The `p` tag is for tagging a specific account, such as `@Bob` or `@Charlie`. See example below.
 - Bitcoin signature request URIs have been proposed over the years but it is unclear how many wallets support them. The content in a `9991` event may contain a URI encoded PSBT or a non-URI encoded PSBT.
 
-# Example
+## Example
 This example event tags Bob, Charlie, David, and Erika with an optional note for each. The PSBT is in the content. For PSBTs, once signed, the resulting PSBT can be the same event type as the signature is already embedded in the PSBT specification. For non-PSBT use cases, only the signature may be returned or appended to the content and returned.
 
-## Simple Example
-### Signature Request - 9991
+### Simple Example
+#### Signature Request - 9991
 Bob asks Alice to approve of having cheesecake tonight.
 ```json
 {
@@ -52,7 +52,7 @@ Bob asks Alice to approve of having cheesecake tonight.
 }
 ```
 
-### Signature Reply - 9992
+#### Signature Reply - 9992
 Alice approves of having cheesecake tonight.
 ```json
 {
@@ -73,7 +73,7 @@ Alice approves of having cheesecake tonight.
   <other fields>
 }
 ```
-# Example Client Implementation
+## Example Client Implementation
 Clients may show the event under DMs or in a specific signature-request zone.
 
 <img src="https://user-images.githubusercontent.com/32852271/219762673-3ff42c16-15b6-415b-80a5-05f9502e3184.png" width="600"/>

--- a/70.md
+++ b/70.md
@@ -4,7 +4,7 @@ NIP-70
 Signature Request Event & Response
 -------------------
 
-`draft` `rfc` `optional` `author:3yekn`
+`draft` `rfc` `optional` `author:3yekn` `author:npub1ws2t95pdtpna4ps62rrz75mm6ujsudjv70yj2jk4wsqjhedlw22qsqwew9`
 
 * [x] update to ephemeral event kinds and numbers
 * [ ] create specific examples of PSBTs

--- a/70.md
+++ b/70.md
@@ -6,15 +6,17 @@ Signature Request Event & Response
 
 `draft` `rfc` `optional` `author:3yekn`
 
-* [ ] transition to ephemeral event kinds and numbers
+* [x] update to ephemeral event kinds and numbers
 * [ ] create specific examples of PSBTs
 * [ ] create specific examples of Ricardian contracts for Docusign replacement
 * [x] create reference implementation in rust: https://github.com/3yekn/nostr/pull/1
 * [ ] create reference implementation in Go
 * [ ] develop improved subscribers and verifiers
 * [ ] add examples of encrypted signature requests
+* [ ] develop example showing combination of NIP-57 (ZAPs) for approvals
+* [ ] develop Bitcoin Proof-of-Reserves example
 
-This proposal introduces an event type with kind `9991` representing a peer-to-peer request for signature of a specific payload and event kind `9992` as the signature response.
+This proposal introduces an event type with kind `10010` representing a peer-to-peer request for signature of a specific payload and event kind `10011` as the signature response.
 
 The initial purpose of this event type is for requesting approval of [partially signed bitcoin transactions](https://river.com/learn/terms/p/partially-signed-bitcoin-transaction-psbt/) (PSBT), but the event type may also be used in more general purpose approval-style workflows.
 
@@ -30,23 +32,23 @@ The treasurers wish to improve and streamline the process using Nostr and user-f
 This feature set could replace common legal document approval/signature applications such as DocuSign or Adobe Sign. Instead of a PSBT, the content could be markdown, plain text, or content such as [OpenLaw](https://docs.openlaw.io/) markup, the [Accord project](https://accordproject.org/projects/cicero/), or other types of [Ricardian contracts](https://iang.org/papers/ricardian_contract.html).
 
 ## Notes & RFC
-- The content may or may not be encrypted (?).
-- It will likely be common for this to be used on private or permissioned relays.
+- The content may or may not be encrypted. Some public DAO treasuries may desire open approvals although most will likely be encrypted.
+- It will likely be common for this feature to be used on private or permissioned relays.
 - The `p` tag is for tagging a specific account, such as `@alice` and `@bob` below
-- Bitcoin signature request URIs have been proposed over the years but it is unclear how many wallets support them. The content in a `9991` event may contain a URI encoded PSBT or a non-URI encoded PSBT.
-- Kind `9991` MUST have a tag where the first array element is `to_sign`. If that does not parse, the `content` is assumed to be the payload to sign.
-- Kind `9992` MUST have a tag where the first array element is `signature`. If that does not parse, the `content` is assumed to be the signature.
+- Bitcoin signature request URIs have been proposed over the years but it is unclear how many wallets support them. The content in a `10010` event may contain a URI encoded PSBT or a non-URI encoded PSBT.
+- Kind `10010` MUST have a tag where the first array element is `to_sign`. If that does not parse, the `content` is assumed to be the payload to sign.
+- Kind `10011` MUST have a tag where the first array element is `signature`. If that does not parse, the `content` is assumed to be the signature.
 
 ## Example
-This example event tags Bob, Charlie, David, and Erika with an optional note for each. The PSBT is in the content. For PSBTs, once signed, the resulting PSBT can be the same event type as the signature is already embedded in the PSBT specification. For non-PSBT use cases, only the signature may be returned or appended to the content and returned.
+The simple example for illustration below is from Bob, requesting an approval from Alice. 
 
 ### Simple Example
-#### Signature Request - 9991
+#### Signature Request - 10010
 Bob asks Alice to approve of having filet for dinner tonight.
 ```json
 {
   "pubkey": "5e79d85b377943fed828365d2a7712a0578272b6c1e0511154f6517e2a13925e", // bob 
-  "kind": 9991,
+  "kind": 10010,
   "tags": [
     [
       "p",
@@ -65,12 +67,12 @@ Bob asks Alice to approve of having filet for dinner tonight.
 }
 ```
 
-#### Signature Reply - 9992
+#### Signature Reply - 10011
 Alice approves of having filet tonight.
 ```json
 {
   "pubkey": "0e1db7418df1c6453ce42e7f4507b8823fc23e86e1f4f33d7fafc83d366e6e97", // alice
-  "kind": 9992,
+  "kind": 10011,
   "tags": [
     [
       "p",
@@ -93,10 +95,13 @@ Alice approves of having filet tonight.
 }
 ```
 
-###
-Additional examples
+### Additional Examples
+Additional examples are planned to be developed for further illustrations.
 - Partially signed bitcoin transactions
-- 
+- Purchase Order
+- Bill of Lading
+- Non-disclosure Agreement
+- Multisignature nostr post (e.g. https://github.com/nickfarrow/frostr)
 
 ## Example Client Implementation
 Clients may show the event under DMs or in a specific signature-request zone.
@@ -106,3 +111,8 @@ Clients may show the event under DMs or in a specific signature-request zone.
 Clients may add `Approve` or `Reject` or `...` (more) buttons directly in the client, or provide a URI to open the signature request within a bitcoin wallet (similar to the zap functionality).
 
 <img src="https://user-images.githubusercontent.com/32852271/219763472-0f390678-2545-457a-92e6-12bbd2275996.png" width="600"/>
+
+## Miscellaneous References
+- [Bill Clinton's speech on Electronic Signatures Act](https://youtu.be/tZhqpl0nsOU)
+- [Coinstr presentation](https://docs.google.com/presentation/d/1E4WwSgt4ZKr1M9SmmVELpf2ckhmqC237idLumCKP7Eg/edit?usp=sharing), bitcoin multi-custody signature orchestration using Nostr
+- [Coinstr](https://coinstr.app) website

--- a/70.md
+++ b/70.md
@@ -6,13 +6,13 @@ Signature Request Event & Response
 
 `draft` `rfc` `optional` `author:3yekn`
 
-[ ] transition to ephemeral event kinds and numbers
-[ ] create specific examples of PSBTs
-[ ] create specific examples of Ricardian contracts for Docusign replacement
-[x] create reference implementation in rust: https://github.com/3yekn/nostr/pull/1
-[ ] create reference implementation in Go
-[ ] develop improved subscribers and verifiers
-[ ] add examples of encrypted signature requests
+* [ ] transition to ephemeral event kinds and numbers
+* [ ] create specific examples of PSBTs
+* [ ] create specific examples of Ricardian contracts for Docusign replacement
+* [x] create reference implementation in rust: https://github.com/3yekn/nostr/pull/1
+* [ ] create reference implementation in Go
+* [ ] develop improved subscribers and verifiers
+* [ ] add examples of encrypted signature requests
 
 This proposal introduces an event type with kind `9991` representing a peer-to-peer request for signature of a specific payload and event kind `9992` as the signature response.
 

--- a/70.md
+++ b/70.md
@@ -30,10 +30,12 @@ This feature set could replace common legal document approval/signature applicat
 
 #### Example Client Implementation
 Clients may show the event under DMs or in a specific signature-request zone.
-<img src="https://user-images.githubusercontent.com/32852271/219762673-3ff42c16-15b6-415b-80a5-05f9502e3184.png" width="200")
+
+<img src="https://user-images.githubusercontent.com/32852271/219762673-3ff42c16-15b6-415b-80a5-05f9502e3184.png" width="600"/>
 
 Clients may add `Approve` or `Reject` or `...` (more) buttons directly in the client, or provide a URI to open the signature request within a bitcoin wallet (similar to the zap functionality).
-<img src="https://user-images.githubusercontent.com/32852271/219763472-0f390678-2545-457a-92e6-12bbd2275996.png" width="200"/>
+
+<img src="https://user-images.githubusercontent.com/32852271/219763472-0f390678-2545-457a-92e6-12bbd2275996.png" width="600"/>
 
 ### Example
 This example event tags Bob, Charlie, David, and Erika with an optional note for each. The PSBT is in the content. For PSBTs, once signed, the resulting PSBT can be the same event type as the signature is already embedded in the PSBT specification. For non-PSBT use cases, only the signature may be returned or appended to the content and returned.


### PR DESCRIPTION
This proposal introduces an event type with kind `10010` representing a peer-to-peer request for signature of a specific payload and event kind `10011` as the signature response.

Motivations include support for [partially signed bitcoin transactions](https://river.com/learn/terms/p/partially-signed-bitcoin-transaction-psbt/) (PSBT) and business documents, such as ricardian contracts.

Status: Under development

Reference implementation: https://github.com/3yekn/nostr/pull/1

## Motivation
### Bitcoin PSBTs
Alice, Bob, Charlie, David, and Erika manage a company's bitcoin treasury that is used to pay vendors. The amounts are large, so the treasury is protected in a multisignature wallet. The payment frequency is low, so there is not a need for an L2 such as lightning. 

They often use popular bitcoin wallets such as Electrum or Sparrow to manage the treasury. These wallets require that a spending proposer export the PSBT to a text file, send the file out-of-band, where the prospective approver must then import the PSBT, sign, export, and repeat. Eventually, the PSBT or combination of signatures reaches the threshold for the transaction to be finalized and broadcast.

The treasurers wish to improve and streamline the process using Nostr and user-friendly policy editors such as BDK's [Elephant](https://github.com/bitcoindevkit/elephant). 

### Business Document Signatures
This feature set could replace common legal document approval/signature applications such as DocuSign or Adobe Sign. Instead of a PSBT, the content could be markdown, plain text, or content such as [OpenLaw](https://docs.openlaw.io/) markup, the [Accord project](https://accordproject.org/projects/cicero/), or other types of [Ricardian contracts](https://iang.org/papers/ricardian_contract.html).

## Notes & RFC
#### Privacy
- The content may or may not be encrypted. Some public DAO treasuries may desire open approvals, although most will likely be encrypted.
- It will likely be common for this feature to be used on private or permissioned relays.

### Tagging Prospective Approvers
- The `p` tag is for tagging a specific account, presuming requesting approval from that user. If it is common for non-approval pubkeys to also be tagged, then a new `tag` type spec for `requested_signer` should be added. (TBD)

### Bitcoin PSBT and Payload Decoding
- Bitcoin signature request URIs have been proposed over the years but it is unclear how many wallets support them. The content in a `10010` event may contain a URI encoded PSBT or a non-URI encoded PSBT.
- Some legal agreement specifications provide templated or `handlebars`-style hydration. In these cases, an event may reference an commonly adopted template (via URL, namespace, or hash) and provide the data in the Event tags (e.g. NDA template with a name and expiration date as data fields). 

### Additional Examples
Additional examples are planned to be developed for further illustrations.
- Partially signed bitcoin transactions
- Purchase Order
- Bill of Lading
- Non-disclosure Agreement
- Multisignature nostr post (e.g. https://github.com/nickfarrow/frostr)

## Example Client Implementation
Clients may show the event under DMs or in a specific signature-request zone.

<img src="https://user-images.githubusercontent.com/32852271/219762673-3ff42c16-15b6-415b-80a5-05f9502e3184.png" width="400"/>

Clients may add `Approve` or `Reject` or `...` (more) buttons directly in the client, or provide a URI to open the signature request within a bitcoin wallet (similar to the zap functionality).

<img src="https://user-images.githubusercontent.com/32852271/219763472-0f390678-2545-457a-92e6-12bbd2275996.png" width="400"/>

## Miscellaneous References
- [Bill Clinton's speech on Electronic Signatures Act](https://youtu.be/tZhqpl0nsOU)
- [Ricardian contracts](https://iang.org/papers/ricardian_contract.html)
- [Electronic Data Interchange](https://www.edibasics.com/what-is-edi/#), a very old yet widely used protocol for business documents
- [Coinstr presentation](https://docs.google.com/presentation/d/1E4WwSgt4ZKr1M9SmmVELpf2ckhmqC237idLumCKP7Eg/edit?usp=sharing), bitcoin multi-custody signature orchestration using Nostr
- [Coinstr](https://coinstr.app) website