### PR TITLE
nip57: add lnurl tag to prevent custodial replay attacks

### DIFF
--- a/57.md
+++ b/57.md
@@ -30,7 +30,17 @@ Having lightning receipts on nostr allows clients to display lightning payments 
 
 3. Clients may choose to display a lightning zap button on each post or on the users profile, if the user's lnurl pay request endpoint supports nostr, the client SHOULD generate a `zap invoice` instead of a normal lnurl invoice.
 
-4. To generate a `zap invoice`, call the `callback` url with `amount` set to the milli-satoshi amount value. A `nostr` querystring value MUST be set as well. It is a uri-encoded `zap request` note signed by the user's key. The `zap request` note contains an `e` tag of the note it is zapping, and a `p` tag of the target user's pubkey. The `e` tag is optional which allows profile tipping. The `zap request` note must also have a `relays` tag, which is gathered from the user's configured relays. The `zap request` note SHOULD contain an `amount` tag, which is the milli-satoshi value of the zap which clients SHOULD verify being equal to the amount of the invoice. The `content` MAY be an additional comment from the user which can be displayed when listing zaps on posts and profiles.
+4. To generate a `zap invoice`, call the `callback` url with `amount` set to the milli-satoshi amount value. A `nostr` querystring value MUST be set as well. It is a uri-encoded `zap request` note signed by the user's key.
+
+The `zap request` note:
+
+	- MUST contain an optional `e` tag of the note it is zapping, and a `p` tag of the target user's pubkey. The optional `e` tag allows profile tipping. 
+
+	- MUST contain a `relays` tag, which is gathered from the user's configured relays. 
+
+	- SHOULD contain an `amount` tag, which is the milli-satoshi value of the zap which clients SHOULD verify being equal to the amount of the invoice. 
+
+	- Have a `content` that MAY be an additional comment from the user which can be displayed when listing zaps on posts and profiles.
 
 5. Pay this invoice or pass it to an app that can pay the invoice. Once it's paid, a `zap note` will be created by the `zapper`.
 

--- a/57.md
+++ b/57.md
@@ -40,6 +40,8 @@ The `zap request` note:
 
 	- SHOULD contain an `amount` tag, which is the milli-satoshi value of the zap which clients SHOULD verify being equal to the amount of the invoice. 
 
+	- SHOULD contain a `lnurl` tag, which is the resolved lnurl for the target user. The resolved lnurl is either the `lud06` field or the `lud16` field converted to an lnurl: `alice@zaps.com` => `bech32("lnurl", "https://zaps.com/.well-known/lnurlp/alice")`. The purpose of this is to prevent an attack where a user replays their `zap request` note to another user that shares the same nostrPubkey. This tricks the `zapper` to send a zap note to another pubkey even if the invoice being paid is to someone else on the same server. Clients MUST match the `lnurl` field against the `zap request` `p`-tag user's resolved lnurl to prevent these kinds of attacks.
+
 	- Have a `content` that MAY be an additional comment from the user which can be displayed when listing zaps on posts and profiles.
 
 5. Pay this invoice or pass it to an app that can pay the invoice. Once it's paid, a `zap note` will be created by the `zapper`.


### PR DESCRIPTION
Add a new condition to `zap request`s: 

- SHOULD contain a `lnurl` tag, which is the resolved lnurl for the target user. The resolved lnurl is either the `lud06` field or the `lud16` field converted to an lnurl: `alice@zaps.com` => `bech32("lnurl", "https://zaps.com/.well-known/lnurlp/alice")`. The purpose of this is to prevent an attack where a user replays their `zap request` note to another user that shares the same nostrPubkey. This tricks the `zapper` to send a zap note to another pubkey even if the invoice being paid is to someone else on the same server. Clients MUST match the `lnurl` field against the `zap request` `p`-tag user's resolved lnurl to prevent these kinds of attacks.