### PR TITLE
Improve `<subscription_id>` specification

### DIFF
--- a/01.md
+++ b/01.md
@@ -55,7 +55,7 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
   * `["REQ", <subscription_id>, <filters JSON>...]`, used to request events and subscribe to new updates.
   * `["CLOSE", <subscription_id>]`, used to stop previous subscriptions.
 
-`<subscription_id>` is a random string that should be used to represent a subscription.
+`<subscription_id>` is an arbitrary, non-empty string of max length 64 chars, that should be used to represent a subscription.
 
 `<filters>` is a JSON object that determines what events will be sent in that subscription, it can have the following attributes:
 


### PR DESCRIPTION
- "random" is not an accurate description
- I've noticed long (sha256 hashes in hex) being rejected by some relays. So there seems a need to specify a max length.
- "non empty", cause an empty string could be interpreted as `null` 

To be decided:
- Max length number
- Are `subscription_id`s case sensitive?
- Will `subscription_id`s be white space trimmed?