### PR TITLE
Add browsers to the extension list

### DIFF
--- a/07.md
+++ b/07.md
@@ -24,7 +24,7 @@ async window.nostr.nip04.decrypt(pubkey, ciphertext): string // takes ciphertext
 
 ### Implementation
 
-- [nos2x](https://github.com/fiatjaf/nos2x)
-- [Alby](https://getalby.com)
-- [Blockcore](https://www.blockcore.net/wallet)
-- [nos2x-fox](https://diegogurpegui.com/nos2x-fox/)
+- [nos2x](https://github.com/fiatjaf/nos2x) (Chrome and derivatives)
+- [Alby](https://getalby.com) (Chrome and derivatives, Firefox, Safari)
+- [Blockcore](https://www.blockcore.net/wallet) (Chrome and derivatives)
+- [nos2x-fox](https://diegogurpegui.com/nos2x-fox/) (Firefox)


### PR DESCRIPTION
I believe this is current.

The linked Alby repo suggests that Safari is not supported, but their [macOS installer](https://github.com/getAlby/alby-installer-macos) suggests it is. I haven't verified.