### PR TITLE
Amend nip46 describe and delegate methods

### DIFF
--- a/46.md
+++ b/46.md
@@ -61,7 +61,7 @@ These are mandatory methods the remote signer app MUST implement:
 
 - **describe**
   - params []
-  - result `{"get_public_key": { params: [], result: anything }}`  
+  - result `["describe", "get_public_key", "sign_event", "connect", "disconnect", "delegate", ...]`  
 - **get_public_key**
   - params []
   - result `pubkey` 

--- a/46.md
+++ b/46.md
@@ -77,8 +77,8 @@ These are mandatory methods the remote signer app MUST implement:
 - **disconnect**
   - params []
 - **delegate** 
-  - params [`pubkey`, `conditions query string`]
-  - result `nip26 delegation token`
+  - params [`delegatee`, `{ kind: number, since: number, until: number }`]
+  - result `nip26 delegation signature`
 - **get_relays**
   - params []
   - result `{ [url: string]: {read: boolean, write: boolean} }` 

--- a/46.md
+++ b/46.md
@@ -78,7 +78,7 @@ These are mandatory methods the remote signer app MUST implement:
   - params []
 - **delegate** 
   - params [`delegatee`, `{ kind: number, since: number, until: number }`]
-  - result `nip26 delegation signature`
+  - result `{ from: string, to: string, cond: string, sig: string }`
 - **get_relays**
   - params []
   - result `{ [url: string]: {read: boolean, write: boolean} }` 


### PR DESCRIPTION
After discussing with app developers, we decided to amend the spec of the methods of `describe` and `delegate` to improve the signatures of the methods to better serve implementers.

Already implemented in Nostrum