### PR TITLE
NIP-93: Secret Events

### DIFF
--- a/93.md
+++ b/93.md
@@ -1,0 +1,46 @@
+NIP-93
+======
+
+Secret Events
+-------------
+`draft` `optional` `author:shafemtol`
+
+A secret event is an event with encrypted contents and no distinguishable
+metadata apart from its `kind`, `created_at` value and the length of its
+contents. Its `pubkey` is a unique key not used on any other event.
+
+A stored secret event has kind `9993`, while an ephemeral secret event has kind
+`29993`.
+
+`content` MUST be the base64 encoded string of the ciphertext with no added
+whitespace. The raw ciphertext MUST be indistinguishable from random binary data
+to anyone except those who have the secret to decrypt it. The length of the raw
+ciphertext MUST be on the form `5n * 2**k`, where `n` is in `(12,14,16,18,21)`
+and `k` is a non-negative integer. Equivalently, the length of the `content`
+string MUST be on the form `8n * 2**k`, with no base64 padding.
+
+`tags` SHOULD be an empty list.
+
+`created_at` SHOULD be generated independently of any timestamp within the
+encrypted data.
+
+A relay MAY explicitly indicate support for this NIP as per `NIP-11`. If it
+does, it SHOULD check for and reject secret events that do not meet the
+requirements given in this NIP. In particular, it SHOULD reject secret events
+where `pubkey` is known to be already associated with another event, where
+`content` is not a base64-encoded string with a valid length, or where `tags` is
+not empty.
+
+
+Rationale
+---------
+
+The purpose of secret events is to enable storage and delivery of secrets with
+minimal public metadata. Applications include secure messaging and storage of
+private notes and settings.
+
+Restricting content length to a small set of allowed values limits the leakage
+of information about message size. The parameters are chosen such that for sizes
+down to 52 bytes, the maximum overhead is 16.7% and the average overhead is
+7.5%. By making the length a multiple of 5 bytes, no characters in the base64
+encoding are wasted on base64 padding.

--- a/93.md
+++ b/93.md
@@ -15,9 +15,9 @@ A stored secret event has kind `9993`, while an ephemeral secret event has kind
 `content` MUST be the base64 encoded string of the ciphertext with no added
 whitespace. The raw ciphertext MUST be indistinguishable from random binary data
 to anyone except those who have the secret to decrypt it. The length of the raw
-ciphertext MUST be on the form `5n * 2**k`, where `n` is in `(12,14,16,18,21)`
+ciphertext MUST be on the form `3n * 2**k`, where `n` is in `(12,14,16,18,21)`
 and `k` is a non-negative integer. Equivalently, the length of the `content`
-string MUST be on the form `8n * 2**k`, with no base64 padding.
+string MUST be on the form `4n * 2**k`, with no base64 padding.
 
 `tags` SHOULD be an empty list.
 
@@ -41,6 +41,6 @@ private notes and settings.
 
 Restricting content length to a small set of allowed values limits the leakage
 of information about message size. The parameters are chosen such that for sizes
-down to 52 bytes, the maximum overhead is 16.7% and the average overhead is
-7.5%. By making the length a multiple of 5 bytes, no characters in the base64
+down to 31 bytes, the maximum overhead is 16.7% and the average overhead is
+7.5%. By making the length a multiple of 3 bytes, no characters in the base64
 encoding are wasted on base64 padding.


### PR DESCRIPTION
This NIP defines **secret events**.

> A secret event is an event with encrypted contents and no distinguishable
metadata apart from its `kind`, `created_at` value and the length of its
contents. Its `pubkey` is a unique key not used on any other event.

This NIP is intended as one of the building blocks for a new secure direct messaging system.

The main concern of this NIP is to standardize how secret events appear publicly, making sure that they cannot be distinguished by anything other than their size and timestamp. It therefore does not at the moment cover things like key exchange/management, cipher selection, ciphertext structure etc. Some of these things might be worth including as recommendations, would like to know other people's thoughts on what to include here.

An obvious question might be how to use this in a messaging system if there's no "destination address". The main idea is to use the event's `pubkey` for addressing, with the sender somehow secretly and anonymously communicating the event's `pubkey` to the intended recipient. For this problem I plan to introduce the concept of _rendezvous beacons_ in a separate NIP.