### PR TITLE
Update NIP-10 to clarify usage of reposts and quote posts

### DIFF
--- a/08.md
+++ b/08.md
@@ -12,6 +12,6 @@ Clients that want to allow tagged mentions they MUST show an autocomplete compon
 
 Once a mention is identified, for example, the pubkey `27866e9d854c78ae625b867eefdfa9580434bc3e675be08d2acb526610d96fbe`, the client MUST add that pubkey to the `.tags` with the tag `p`, then replace its textual reference (inside `.content`) with the notation `#[index]` in which "index" is equal to the 0-based index of the related tag in the tags array.
 
-The same process applies for mentioning event IDs.
+The same process is used to indicate related events. See NIP-10 for more information.
 
 A client that receives a `text_note` event with such `#[index]` mentions in its `.content` CAN do a search-and-replace using the actual contents from the `.tags` array with the actual pubkey or event ID that is mentioned, doing any desired context augmentation (for example, linking to the pubkey or showing a preview of the mentioned event contents) it wants in the process.

--- a/10.md
+++ b/10.md
@@ -28,7 +28,7 @@ Where:
 
 When `"mention"` is used, the event content MUST include an index marker with the notation `#[index]` as specified in NIP-08, where the index matches the position of the `"e"` tag in the tags array. Note that a repost is a quote post without comment. For example, a quote post's content may look like `hello world\n#[0]`, while a repost would contain only `#[0]`.
 
-Clients MUST NOT include multiple `"e"` tags with the same marker in an event. The order of "e" tags is not relevant.
+Clients MUST NOT include multiple `"e"` tags with `"reply"` or `"root"` markers. The order of "e" tags is not relevant.
 
 ## The "p" tag
 Used in a text event contains a list of pubkeys used to record who is involved in a reply thread.

--- a/10.md
+++ b/10.md
@@ -1,39 +1,13 @@
 NIP-10
 ======
 
-Replies, Reposts, and Quote Posts in Text Events (kind 1).
---------------------------------------------
+Replies, Reposts, and Quote Posts in Text Events (kind 1)
+---------------------------------------------------------
 
 `draft` `optional` `author:unclebobmartin` `author:alexgleason`
 
 ## Abstract
 This NIP describes how to use "e" and "p" tags in text events to denote replies, reposts, and quote posts.
-
-## Positional "e" tags (DEPRECATED)
->This scheme is in common use; but should be considered deprecated.
-`["e", <event-id>, <relay-url>]`  as per NIP-01.
-
-Where:
-
- * `<event-id>` is the id of the event being referenced.
- * `<relay-url>` is the URL of a recommended relay associated with the reference.  Many clients treat this field as optional.
-
-**The positions of the "e" tags within the event denote specific meanings as follows**:
-
- * No "e" tag: <br>
- This event is not a reply to, nor does it refer to, any other event.
-
- * One "e" tag: <br>
- `["e", <id>]`: The id of the event to which this event is a reply.
-
- * Two "e" tags:  `["e", <root-id>]`, `["e", <reply-id>]` <br>
- `<root-id>` is the id of the event at the root of the reply chain.  `<reply-id>` is the id of the article to which this event is a reply.  
-
- * Many "e" tags: `["e", <root-id>]` `["e", <mention-id>]`, ..., `["e", <reply-id>]`<br>
-There may be any number of `<mention-ids>`.  These are the ids of events which may, or may not be in the reply chain.  
-They are citings from this event.  `root-id` and `reply-id` are as above.
-
->This scheme is deprecated because it creates ambiguities that are difficult, or impossible to resolve when an event references another but is not a reply.
 
 ## The "e" tag
 Used to associate an event with another event.
@@ -63,3 +37,39 @@ When replying to a text event E the reply event's "p" tags should contain all of
 
 Example:  Given a text event authored by `a1` with "p" tags [`p1`, `p2`, `p3`] then the "p" tags of the reply should be [`a1`, `p1`, `p2`, `p3`] 
 in no particular order.
+
+Deprecations
+------------
+
+New clients should never submit deprecated events to relays, but may wish to process them for compatibility with legacy clients.
+
+### Positional "e" tags (DEPRECATED)
+>This scheme is in common use; but should be considered deprecated.
+`["e", <event-id>, <relay-url>]`  as per NIP-01.
+
+Where:
+
+ * `<event-id>` is the id of the event being referenced.
+ * `<relay-url>` is the URL of a recommended relay associated with the reference.  Many clients treat this field as optional.
+
+**The positions of the "e" tags within the event denote specific meanings as follows**:
+
+ * No "e" tag: <br>
+ This event is not a reply to, nor does it refer to, any other event.
+
+ * One "e" tag: <br>
+ `["e", <id>]`: The id of the event to which this event is a reply.
+
+ * Two "e" tags:  `["e", <root-id>]`, `["e", <reply-id>]` <br>
+ `<root-id>` is the id of the event at the root of the reply chain.  `<reply-id>` is the id of the article to which this event is a reply.  
+
+ * Many "e" tags: `["e", <root-id>]` `["e", <mention-id>]`, ..., `["e", <reply-id>]`<br>
+There may be any number of `<mention-ids>`.  These are the ids of events which may, or may not be in the reply chain.  
+They are citings from this event.  `root-id` and `reply-id` are as above.
+
+>This scheme is deprecated because it creates ambiguities that are difficult, or impossible to resolve when an event references another but is not a reply.
+
+### Kind 6 Reposts (DEPRECATED)
+Historically, some clients used Event 6 to designate a repost. The event contained empty content (`""`) and a single "e" tag with the reposted event ID: `["e", <event-id>, <relay-url>]`.
+
+This scheme has been deprecated in favor using Event 1 with with tagged content (`"#[0]"`) and a `"mention"` marker: `["e", <event-id>, <relay-url>, "mention"]`.

--- a/10.md
+++ b/10.md
@@ -1,57 +1,33 @@
 NIP-10
 ======
 
-
-On "e" and "p" tags in Text Events (kind 1).
+Replies, Reposts, and Quote Posts in Text Events (kind 1).
 --------------------------------------------
 
-`draft` `optional` `author:unclebobmartin`
+`draft` `optional` `author:unclebobmartin` `author:alexgleason`
 
 ## Abstract
-This NIP describes how to use "e" and "p" tags in text events, especially those that are replies to other text events.  It helps clients thread the replies into a tree rooted at the original event.
+This NIP describes how to use "e" and "p" tags in text events to denote replies, reposts, and quote posts.
 
-## Positional "e" tags (DEPRECATED)
->This scheme is in common use; but should be considered deprecated.
+## The "e" tag
+Used to associate an event with another event.
 
-`["e", <event-id>, <relay-url>]`  as per NIP-01.
-
-Where:
-
- * `<event-id>` is the id of the event being referenced.
- * `<relay-url>` is the URL of a recommended relay associated with the reference.  Many clients treat this field as optional.
- 
-**The positions of the "e" tags within the event denote specific meanings as follows**:
-
- * No "e" tag: <br>
- This event is not a reply to, nor does it refer to, any other event.
-
- * One "e" tag: <br>
- `["e", <id>]`: The id of the event to which this event is a reply.
-
- * Two "e" tags:  `["e", <root-id>]`, `["e", <reply-id>]` <br>
- `<root-id>` is the id of the event at the root of the reply chain.  `<reply-id>` is the id of the article to which this event is a reply.  
-
- * Many "e" tags: `["e", <root-id>]` `["e", <mention-id>]`, ..., `["e", <reply-id>]`<br>
-There may be any number of `<mention-ids>`.  These are the ids of events which may, or may not be in the reply chain.  
-They are citings from this event.  `root-id` and `reply-id` are as above.
-
->This scheme is deprecated because it creates ambiguities that are difficult, or impossible to resolve when an event references another but is not a reply.
-
-## Marked "e" tags (PREFERRED)
 `["e", <event-id>, <relay-url>, <marker>]`  
 	
 Where:
 
  * `<event-id>` is the id of the event being referenced.
  * `<relay-url>` is the URL of a recommended relay associated with the reference. Clients SHOULD add a valid `<relay-URL>` field, but may instead leave it as `""`.
- * `<marker>` is optional and if present is one of `"reply"`, `"root"`, or `"mention"`.
+ * `<marker>` is one of `"reply"` or `"mention"`.
 
-**The order of marked "e" tags is not relevant.**  Those marked with `"reply"` denote the id of the reply event being responded to.  Those marked with `"root"` denote the root id of the reply thread being responded to. For top level replies (those replying directly to the root event), only the `"root"` marker should be used. Those marked with `"mention"` denote a quoted or reposted event id.
+ `<marker>` MUST be one of the following:
 
-A direct reply to the root of a thread should have a single marked "e" tag of type "root".
+ - `"reply"` - when the note is a reply, and the ID refers to its parent.
+ - `"mention"` - when the note is a quote post, and the ID refers to the quoted event.
 
->This scheme is preferred because it allows events to mention others without confusing them with `<reply-id>` or `<root-id>`.  
+When `"mention"` is used, the event content MUST include an index marker with the notation `#[index]` as specified in NIP-08, where the index matches the position of the `"e"` tag in the tags array. Note that a repost is a quote post without comment. For example, a quote post's content may look like `hello world\n#[0]`, while a repost would contain only `#[0]`.
 
+Clients MUST NOT include multiple `"e"` tags with the same marker in an event. The order of "e" tags is not relevant.
 
 ## The "p" tag
 Used in a text event contains a list of pubkeys used to record who is involved in a reply thread.

--- a/10.md
+++ b/10.md
@@ -9,6 +9,32 @@ Replies, Reposts, and Quote Posts in Text Events (kind 1).
 ## Abstract
 This NIP describes how to use "e" and "p" tags in text events to denote replies, reposts, and quote posts.
 
+## Positional "e" tags (DEPRECATED)
+>This scheme is in common use; but should be considered deprecated.
+`["e", <event-id>, <relay-url>]`  as per NIP-01.
+
+Where:
+
+ * `<event-id>` is the id of the event being referenced.
+ * `<relay-url>` is the URL of a recommended relay associated with the reference.  Many clients treat this field as optional.
+
+**The positions of the "e" tags within the event denote specific meanings as follows**:
+
+ * No "e" tag: <br>
+ This event is not a reply to, nor does it refer to, any other event.
+
+ * One "e" tag: <br>
+ `["e", <id>]`: The id of the event to which this event is a reply.
+
+ * Two "e" tags:  `["e", <root-id>]`, `["e", <reply-id>]` <br>
+ `<root-id>` is the id of the event at the root of the reply chain.  `<reply-id>` is the id of the article to which this event is a reply.  
+
+ * Many "e" tags: `["e", <root-id>]` `["e", <mention-id>]`, ..., `["e", <reply-id>]`<br>
+There may be any number of `<mention-ids>`.  These are the ids of events which may, or may not be in the reply chain.  
+They are citings from this event.  `root-id` and `reply-id` are as above.
+
+>This scheme is deprecated because it creates ambiguities that are difficult, or impossible to resolve when an event references another but is not a reply.
+
 ## The "e" tag
 Used to associate an event with another event.
 
@@ -18,12 +44,13 @@ Where:
 
  * `<event-id>` is the id of the event being referenced.
  * `<relay-url>` is the URL of a recommended relay associated with the reference. Clients SHOULD add a valid `<relay-URL>` field, but may instead leave it as `""`.
- * `<marker>` is one of `"reply"` or `"mention"`.
+ * `<marker>` is one of `"reply"`, `"mention"`, or `"root"`.
 
  `<marker>` MUST be one of the following:
 
  - `"reply"` - when the note is a reply, and the ID refers to its parent.
  - `"mention"` - when the note is a quote post, and the ID refers to the quoted event.
+ - `"root"` - when the note is a reply, the event SHOULD include a root marker with the ID of the highest ancestor in the thread. This helps clients obtain all posts for a thread, and is usually copied down to every descendant.
 
 When `"mention"` is used, the event content MUST include an index marker with the notation `#[index]` as specified in NIP-08, where the index matches the position of the `"e"` tag in the tags array. Note that a repost is a quote post without comment. For example, a quote post's content may look like `hello world\n#[0]`, while a repost would contain only `#[0]`.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-07: `window.nostr` capability for web browsers](07.md)
 - [NIP-08: Handling Mentions](08.md)
 - [NIP-09: Event Deletion](09.md)
-- [NIP-10: Conventions for clients' use of `e` and `p` tags in text events](10.md)
+- [NIP-10: Replies, Reposts, and Quote Posts in text events](10.md)
 - [NIP-11: Relay Information Document](11.md)
 - [NIP-12: Generic Tag Queries](12.md)
 - [NIP-13: Proof of Work](13.md)


### PR DESCRIPTION
Per our discussion in https://github.com/nostr-protocol/nips/issues/173#issuecomment-1449105521, I'm proposing some changes to NIP-10. Note that NIP-10 is still in a draft state.

1. Renamed NIP-10 from "Conventions for clients' use of `e` and `p` tags in text events" to "Replies, Reposts, and Quote Posts in text events". I think this is a more realistic title, and will help implementers find what they're looking for.
2. Removed the "DEPRECATED" section of the document. The document seems like it was originally written to solve a problem that is no longer prevalent.
3. Clarified the meaning of markers, and described how they're used specifically to create reposts and quote posts.
4. Removed the "root" marker. Someone please tell me if there's history I'm missing behind this, but I can't comprehend why a "root" marker would be needed, especially because it's often very difficult or _impossible_ to add it.
5. Clarified that reposts and quote posts MUST reference the event like `#[0]` in the event content.