### PR TITLE
Update NIP-01 to clarify pubkey reference

### DIFF
--- a/01.md
+++ b/01.md
@@ -22,7 +22,7 @@ The only object type that exists is the `event`, which has the following format 
   "kind": <integer>,
   "tags": [
     ["e", <32-bytes hex of the id of another event>, <recommended relay URL>],
-    ["p", <32-bytes hex of the key>, <recommended relay URL>],
+    ["p", <32-bytes hex of a pubkey>, <recommended relay URL>],
     ... // other kinds of tags may be included later
   ],
   "content": <arbitrary string>,


### PR DESCRIPTION
We mean to reference any public key. "the key" was a bit unspecific.