### PR TITLE
NIP-17: Tracking Git Commits with Nostr

### DIFF
--- a/17.md
+++ b/17.md
@@ -110,4 +110,5 @@ Related Work
 
 - http://git.jb55.com/git-nostr-tools/file/README.txt.html
 - https://github.com/fiatjaf/git-remote-nostr
+- https://nostrgit.com/
 

--- a/17.md
+++ b/17.md
@@ -1,0 +1,113 @@
+NIP-17
+======
+
+Tracking Git Commits with Nostr
+-------------------------------
+
+`draft` `optional` `author:melvincarvalho`
+
+- Reserves:  `kind 17`
+
+Do not merge until implemented, work in progress
+------------------------------------------------
+
+Status: This NIP is an early draft and work in progress.  Implementations are being developed which will incorporate what is learnt.
+
+
+Introduction
+------------
+
+Tracking Git Commits with Nostr enables **use cases** similar to:
+
+- [github actions](https://github.com/features/actions)
+- [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration)
+- [continuous deplyment](https://en.wikipedia.org/wiki/Continuous_deployment)
+- [travis](https://travis-ci.org/)
+
+but without central points of failure.  The aim is to create continuous distributed software development processes, without having to rely on complex or centralized services.  The first implementations will be designed to illustrate these use cases in more detail.
+
+You need only know the **nostr ID or bech32 form of a repo** and you will be able to discover all versions, its origins and its history.  The repo itself will be able to communicate with nostr.
+
+Git object data is not designed to be stored in nostr, instead, nostr will store the signaling, update, version or commit data.  Git object data will live in existing git repositories, github, gitlab, gitea, gogs, ssh, file system etc.
+
+
+New Kind
+========
+
+A special event with kind `17`, can be used to indicate git commit messages. This number was selected to be hopefully easy to remember : `G-1-7`.  
+
+
+New Tag
+=======
+
+A new tag "c" will be used to store commit hashes from git a new version of the repo 
+
+
+Bech32
+======
+
+The prefix `nrepo` can be used in front ends that support it, to allow easier copy and paste.  An example would be similar to the popular npub system e.g. `nrepo1ris1683fw6n2mvhl5h6dhqd8mqfv3wmxnz4qph83ua4dk4006ezsrt5c24`
+
+
+Event Structure
+===============
+
+```JSON
+{
+  "id": "32-bytes lowercase hex-encoded sha256 of the the serialized event data",
+  "pubkey": "32-bytes lowercase hex-encoded public key of the repo",
+  "created_at": "git_author_date",
+  "kind": 17,
+  "tags": [
+    ["c", "git hash", "recommended git URI"],
+    ["e", "previous commit id"]
+  ],
+  "content": "arbitrary string",
+  "sig": "64-bytes hex of the signature of the sha256 hash of the serialized event data, which is the same as the id field"
+}
+```
+
+Git events over nostr have the following attributes:
+
+**`created_at`** SHOULD be equal to git *author date*.  This is the same number format as nostr.
+
+**`tags`** MUST contain tag "c" which is equal to the hex-encoded git commit hash.  Typically this will be a 40 character sha-1 hash, but git will soon be allowing sha-2 hashes too
+
+MAY contain an entry identifying the previous commit, if one exists, in the form `["e", "<event_id>"]`.  
+
+Further tags can be developed in future to capture informative git information such as major/minor versioning.
+
+**`pubkey`** SHOULD be associated with a given repo.  This could be communicated out of band, or, for example MAY be included in a file in the root directory of the repo, `nostr.json`
+
+**`content`** empty, reserved for future use
+
+
+nostr.json
+==========
+
+The design of this NIP is such that each repo will have a public key used to send updates to a relay.  The repos itself will be able to interact with nostr.
+
+That key SHOULD appear in the top level directory of the repo in a file called `nostr.json`
+
+```JSON
+{
+    "pubkey": "abcd123...",
+    "nrepo": "nrepo1ris1683fw6n2mvhl5h6dhqd8mqfv3wmxnz4qph83ua4dk4006ezsrt5c24"
+}
+```
+
+Optionally a bech32 "nrepo" field can be added for convenience of copy and paste
+
+
+Extensions
+==========
+
+The current NIP is designed to do one thing well.  It can be combined with other NIPs to provide more holistic solutions in future.
+
+
+Related Work
+============
+
+- http://git.jb55.com/git-nostr-tools/file/README.txt.html
+- https://github.com/fiatjaf/git-remote-nostr
+


### PR DESCRIPTION
This NIP has been redone with a new title and new scope, as the previous was confusing.  

The aim is to use nostr to track commits in open source code.  It is not git over nostr, or github over nostr.

Work in progress.  It will only be apparent what it does after an implementation is ready. 

Constructive comments only please, until there is an implementation in place, which will appear at : https://nip17.com/