### PR TITLE
Avoid using `substr` in NIP-04 example

### DIFF
--- a/04.md
+++ b/04.md
@@ -23,7 +23,7 @@ import crypto from 'crypto'
 import * as secp from 'noble-secp256k1'
 
 let sharedPoint = secp.getSharedSecret(ourPrivateKey, '02' + theirPublicKey)
-let sharedX = sharedPoint.substr(2, 64)
+let sharedX = sharedPoint.slice(2, 67)
 
 let iv = crypto.randomFillSync(new Uint8Array(16))
 var cipher = crypto.createCipheriv(


### PR DESCRIPTION
The [`substr`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) method was never standard and is considered to be deprecated. Updated the code to use [`slice`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) instead.