### PR TITLE
NIP-08: Specify nonmatch behavior

### DIFF
--- a/08.md
+++ b/08.md
@@ -15,3 +15,5 @@ Once a mention is identified, for example, the pubkey `27866e9d854c78ae625b867ee
 The same process applies for mentioning event IDs.
 
 A client that receives a `text_note` event with such `#[index]` mentions in its `.content` CAN do a search-and-replace using the actual contents from the `.tags` array with the actual pubkey or event ID that is mentioned, doing any desired context augmentation (for example, linking to the pubkey or showing a preview of the mentioned event contents) it wants in the process.
+
+Where `#[index]` has an `index` that is outside the range of the tags array or points to a tag that is not an `e` or `p` tag or a tag otherwise declared to support this notation, the client MUST NOT perform such replacement or augmentation, but instead display it as normal text.


### PR DESCRIPTION
This addition addresses one part of #319, to address false-positive NIP-08 matches in viewing clients.

Although NIP-08 is declared `final`, I think this addition should go into NIP-08 itself, as it defines until now undefined behavior and intends to limit problematic use of NIP-08 where some clients take its application beyond current and intended specification.