### PR TITLE
NIP28: Make explicit that root event tag is compulsory

### DIFF
--- a/28.md
+++ b/28.md
@@ -84,6 +84,7 @@ Reply to another message:
 {
     "content": <string>,
     "tags": [
+        ["e", <kind_40_event_id>, <relay-url>, "root"],
         ["e", <kind_42_event_id>, <relay-url>, "reply"],
         ["p", <pubkey>, <relay-url>],
         ...


### PR DESCRIPTION
NIP28 kind 42

Make explicit that root event tag is compulsory when replying to someone else's message