### PR TITLE
NIP-04: Minor wording change

### DIFF
--- a/04.md
+++ b/04.md
@@ -46,4 +46,4 @@ let event = {
 
 ## Security Warning
 
-This standard does not go anywhere near what is considered the state-of-the-art in encrypted communication between peers, and it leaks metadata in the events, therefore it must not be used for anything you really need to keep secret, and only with relays that use `AUTH` to restrict who can read your `kind:4` events.
+This standard does not go anywhere near what is considered the state-of-the-art in encrypted communication between peers, and it leaks metadata in the events, therefore it must not be used for anything you really need to keep secret, and only with relays that use `AUTH` to restrict who can fetch your `kind:4` events.


### PR DESCRIPTION
I think "read" is misleading because the content is encrypted.