### PR TITLE
add NIP-39 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-28: Public Chat](28.md)
 - [NIP-33: Parameterized Replaceable Events](33.md)
 - [NIP-36: Sensitive Content](36.md)
+- [NIP-39: External Identities in Profiles](39.md)
 - [NIP-40: Expiration Timestamp](40.md)
 - [NIP-42: Authentication of clients to relays](42.md)
 - [NIP-46: Nostr Connect](46.md)
@@ -111,6 +112,7 @@ When experimenting with kinds, keep in mind the classification introduced by [NI
 | nonce      | random                  |                   | [13](13.md)              |
 | subject    | subject                 |                   | [14](14.md)              |
 | d          | identifier              |                   | [33](33.md)              |
+| i          | platform:identity       |  proof            | [39](39.md)              |
 | expiration | unix timestamp (string) |                   | [40](40.md)              |
 
 ## Criteria for acceptance of NIPs


### PR DESCRIPTION
I have included `i` tag in Standardized Tags, but if it isn't needed, will remove it.