### PR TITLE
Add kinds 10 and 11 to prevent race conditions when updating contact lists

### DIFF
--- a/02.md
+++ b/02.md
@@ -6,7 +6,7 @@ Follow List
 
 `final` `optional`
 
-A special event with kind `3`, meaning "follow list" is defined as having a list of `p` tags, one for each of the followed/known profiles one is following.
+Three special events having kinds `3`, `10`, and `11` are defined as having a list of `p` tags. Kind `3` defines the complete set of pubkeys one is following at a given point in time; kind `10` adds one or more pubkeys to that list; and kind `11` removes one or more pubkeys from that list.
 
 Each tag entry should contain the key for the profile, a relay URL where events from that key can be found (can be set to an empty string if not needed), and a local name (or "petname") for that profile (can also be set to an empty string or not provided), i.e., `["p", <32-bytes hex key>, <main relay URL>, <petname>]`. The `content` can be anything and should be ignored.
 
@@ -28,6 +28,8 @@ For example:
 Every new following list that gets published overwrites the past ones, so it should contain all entries. Relays and clients SHOULD delete past following lists as soon as they receive a new one.
 
 Whenever new follows are added to an existing list, clients SHOULD append them to the end of the list, so they are stored in chronological order.
+
+When building a contact list, clients should query for the latest kind `3` event, and any subsequent kind `10` and `11` events that modify the original list. Contacts SHOULD use kind `10` and `11` in order to prevent race conditions when updating contact lists from multiple clients simultaneously, unless the intention is to write a canonical, complete contact list.
 
 ## Uses
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `6`           | Repost                     | [18](18.md)              |
 | `7`           | Reaction                   | [25](25.md)              |
 | `8`           | Badge Award                | [58](58.md)              |
+| `10`          | Follow Contact             | [2](02.md)               |
+| `11`          | Unfollow Contact           | [2](02.md)               |
 | `16`          | Generic Repost             | [18](18.md)              |
 | `40`          | Channel Creation           | [28](28.md)              |
 | `41`          | Channel Metadata           | [28](28.md)              |


### PR DESCRIPTION
A very common experience on Nostr is that of "losing follows" due to race conditions when sending kind `3` events. Earlier this week someone signed in to Coracle, their contact list failed to fully sync before they followed someone, and they ended up deleting all their follows. The only solution a client can implement to avoid this currently is to disallow certain functionality if a person's account isn't fully synced, but of course, you don't know what you don't have, it's always possible a user hasn't yet followed anyone.

This change is backwards compatible, and simply introduces two new event kinds to solve the above problem. There's no reason to remove kind `3`, since there are valid use cases when a user might want to definitively say, "this is my contacts list".

The same problem exists for relay lists to a less severe degree (because relay list cardinality is lower), and for https://github.com/nostr-protocol/nips/pull/183, but I figured we'd have the conversation here first.

Sources:

nostr:nevent1qyt8wumn8ghj7etyv4hzumn0wd68ytnvv9hxgtcpz4mhxue69uhhyetvv9ujuerpd46hxtnfduhszythwden5te0dehhxarj9emkjmn99uq3kamnwvaz7tmjv4kxz7fwdaexzmn8v4cxjmrv9ejx2a30qy2hwumn8ghj7un9d3shjtn4w3ux7tnrdakj7qghwaehxw309aex2mrp0yhxummnw3ezu6twvehj7qgewaehxw309aex2mrp0yhxummnw3exzarf9e3k7mf0qyt8wumn8ghj7un9d3shjtnddaehgu3wwp6kytcqyr9yfkqe2yuky5lyl6wgexn6s6wjc9erntn9zp20j5cqdlk6qywsgnfgvxn)