### PR TITLE
NIP-01: Specify canonical JSON for id derivation

### DIFF
--- a/01.md
+++ b/01.md
@@ -30,7 +30,9 @@ The only object type that exists is the `event`, which has the following format 
 }
 ```
 
-To obtain the `event.id`, we `sha256` the serialized event. The serialization is done over the UTF-8 JSON-serialized string (with no white space or line breaks) of the following structure:
+The object MUST conform to the I-JSON ([RFC 7493](https://www.rfc-editor.org/rfc/rfc7493.html)) subset of JSON. 
+
+To obtain the `event.id`, we `sha256` the serialized event. The event data is structured as follows and serialized according to the JSON Canonicalization Scheme ([RFC 8785](https://www.rfc-editor.org/rfc/rfc8785)):
 
 ```json
 [


### PR DESCRIPTION
Minimal changes for addressing #354.

I haven't included any specifics of JCS in NIP-01. I think it might be better to just refer to the spec rather than include parts of it, so that implementors actually go to the referenced specification and have a lesser chance of missing important details.

As mentioned in #354, all web clients most likely already conform to JCS as used here.