### PR TITLE
NIP-51: remove self-referential links

### DIFF
--- a/51.md
+++ b/51.md
@@ -97,16 +97,16 @@ Then the user would create a 'Categorized People' list event like below:
 
 ### Mute List
 
-An event with kind `10000` is defined as a replaceable list event (see [NIP-51 - Lists](51.md) for listing content a user wants to mute. Any standarized tag can be included in a Mute List.
+An event with kind `10000` is defined as a replaceable list event for listing content a user wants to mute. Any standarized tag can be included in a Mute List.
 
 ### Pin List
 
-An event with kind `10001` is defined as a replaceable list event (see [NIP-51 - Lists](51.md) for listing content a user wants to pin. Any standarized tag can be included in a Pin List.
+An event with kind `10001` is defined as a replaceable list event for listing content a user wants to pin. Any standarized tag can be included in a Pin List.
 
 ### Categorized People List
 
-An event with kind `30000` is defined as a parameterized replaceable list event (see [NIP-51 - Lists](51.md)) for categorizing people. The 'd' parameter for this event holds the category name of the list. The tags included in these lists MUST follow the format of kind 3 events as defined in [NIP-02 - Contact List and Petnames](02.md).
+An event with kind `30000` is defined as a parameterized replaceable list event for categorizing people. The 'd' parameter for this event holds the category name of the list. The tags included in these lists MUST follow the format of kind 3 events as defined in [NIP-02 - Contact List and Petnames](02.md).
 
 ### Categorized Bookmarks List
 
-An event with kind `30001` is defined as a parameterized replaceable list event (see [NIP-51 - Lists](51.md)) for categorizing bookmarks. The 'd' parameter for this event holds the category name of the list. Any standarized tag can be included in a Categorized Bookmarks List.
+An event with kind `30001` is defined as a parameterized replaceable list event for categorizing bookmarks. The 'd' parameter for this event holds the category name of the list. Any standarized tag can be included in a Categorized Bookmarks List.


### PR DESCRIPTION
Removed self-referential links in the "List Event Kinds" section of NIP-51, which seemed not to help make the document easier to understand.