### PR TITLE
NIP-04: fix bug in code sample

### DIFF
--- a/04.md
+++ b/04.md
@@ -23,12 +23,12 @@ import crypto from 'crypto'
 import * as secp from 'noble-secp256k1'
 
 let sharedPoint = secp.getSharedSecret(ourPrivateKey, '02' + theirPublicKey)
-let sharedX = sharedPoint.slice(2, 67)
+let sharedX = sharedPoint.slice(1, 33)
 
 let iv = crypto.randomFillSync(new Uint8Array(16))
 var cipher = crypto.createCipheriv(
   'aes-256-cbc',
-  Buffer.from(sharedX, 'hex'),
+  Buffer.from(sharedX),
   iv
 )
 let encryptedMessage = cipher.update(text, 'utf8', 'base64')


### PR DESCRIPTION
The code sample assumed that a `Uint8Array` was actually a hex string.