### PR TITLE
NIP-100: WebRTC Signaling over nostr

### DIFF
--- a/100.md
+++ b/100.md
@@ -1,8 +1,10 @@
-# NIP-100
-## WebRTC
+# NIP-100 WebRTC
 `draft` `optional` `author:jacany`
 
 This NIP defines how to do WebRTC communication over nostr
+
+## Defining Rooms
+Rooms are essentially the space that you will be connected to. This must be defined by a `r` tag following the pubkey of the person you are connected to or some other identifier (maybe a lobby id for a joinable voice channel, etc.)
 
 ### Broadcasting that you are present
 Announces that you are here, and ready to connect to others.
@@ -12,7 +14,8 @@ The connection ID is inferred from the provided pubkey.
     "kind": 25050,
     "pubkey": "<sender pubkey>",
     "tags": [
-        ["type", "connect"]
+        ["type", "connect"],
+        ["r", "<room id>"]
     ]
 }
 ```
@@ -23,7 +26,8 @@ The connection ID is inferred from the provided pubkey.
     "kind": 25050,
     "pubkey": "<sender pubkey>",
     "tags": [
-        ["type", "disconnect"]
+        ["type", "disconnect"],
+        ["r", "<room id>"]
     ]
 }
 ```
@@ -36,7 +40,8 @@ Used when responding to a `type:connect`. Offering to connect to that peer.
     "pubkey": "<sender pubkey>",
     "tags": [
         ["type", "offer"],
-        ["p", "<reciever pubkey>"]
+        ["p", "<reciever pubkey>"],
+        ["r", "<room id>"]
     ],
     "content": {
         "offer": "<offer>",
@@ -52,7 +57,8 @@ Used when responding to a `type:connect`. Offering to connect to that peer.
     "pubkey": "<sender pubkey>",
     "tags": [
         ["type", "answer"],
-        ["p", "<reciever pubkey>"]
+        ["p", "<reciever pubkey>"],
+        ["r", "<room id>"]
     ],
     "content": {
         "sdp": "<sdp>",
@@ -68,7 +74,8 @@ Used when responding to a `type:connect`. Offering to connect to that peer.
     "pubkey": "<sender pubkey>",
     "tags": [
         ["type", "answer"],
-        ["p", "<reciever pubkey>"]
+        ["p", "<reciever pubkey>"],
+        ["r", "<room id>"]
     ],
     "content": {
         "candidate": "<sdp>",

--- a/100.md
+++ b/100.md
@@ -1,0 +1,80 @@
+# NIP-100
+## WebRTC
+`draft` `optional` `author:jacany`
+
+This NIP defines how to do WebRTC communication over nostr
+
+### Broadcasting that you are present
+Announces that you are here, and ready to connect to others.
+The connection ID is inferred from the provided pubkey.
+```json
+{
+    "kind": 25050,
+    "pubkey": "<sender pubkey>",
+    "tags": [
+        ["type", "connect"]
+    ]
+}
+```
+
+### Closing
+```json
+{
+    "kind": 25050,
+    "pubkey": "<sender pubkey>",
+    "tags": [
+        ["type", "disconnect"]
+    ]
+}
+```
+
+### Offering to connect
+Used when responding to a `type:connect`. Offering to connect to that peer.
+```json
+{
+    "kind": 25050,
+    "pubkey": "<sender pubkey>",
+    "tags": [
+        ["type", "offer"],
+        ["p", "<reciever pubkey>"]
+    ],
+    "content": {
+        "offer": "<offer>",
+        "type": "offer"
+    }
+}
+```
+
+### Answering an Offer
+```json
+{
+    "kind": 25050,
+    "pubkey": "<sender pubkey>",
+    "tags": [
+        ["type", "answer"],
+        ["p", "<reciever pubkey>"]
+    ],
+    "content": {
+        "sdp": "<sdp>",
+        "type": "answer"
+    }
+}
+```
+
+### Broadcasting ICE Candidate
+```json
+{
+    "kind": 25050,
+    "pubkey": "<sender pubkey>",
+    "tags": [
+        ["type", "answer"],
+        ["p", "<reciever pubkey>"]
+    ],
+    "content": {
+        "candidate": "<sdp>",
+        <misc>
+    }
+}
+```
+
+Essentially, just directly feed what comes out of the WebRTC functions straight into the `content` field. It makes things cleaner and easier.


### PR DESCRIPTION
This NIP allows for nostr ephermeral kind `25050` to act as a signaling layer for Peer-to-peer WebRTC connections

**Potential Uses:**
- Video Conferencing App
- [Nostr Nests](https://nostrnests.com) over nostr
- Discord-like app
- Direct Phone Calls

What's next for this NIP is making connection data securely encrypted, this ensures that nobody can peek into who you're communicating with, or see your connection addresses.