### PR TITLE
remove tiny duplicate text

### DIFF
--- a/01.md
+++ b/01.md
@@ -16,7 +16,7 @@ The only object type that exists is the `event`, which has the following format 
 
 ```json
 {
-  "id": <32-bytes lowercase hex-encoded sha256 of the the serialized event data>
+  "id": <32-bytes lowercase hex-encoded sha256 of the serialized event data>
   "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>,
   "created_at": <unix timestamp in seconds>,
   "kind": <integer>,


### PR DESCRIPTION
fixed "the the serialized event data" => "the serialized event data"