### PR TITLE
Amend NIP-46: Return full event with id and signature in sign_event

### DIFF
--- a/46.md
+++ b/46.md
@@ -67,7 +67,7 @@ These are mandatory methods the remote signer app MUST implement:
   - result `pubkey` 
 - **sign_event**
   - params [`event`]
-  - result `signature` 
+  - result `event_with_signature` 
 
 #### optional
 
@@ -151,7 +151,7 @@ The `content` field contains encrypted message as specified by [NIP04](https://g
 
 1. The **App** will send a message to the **Signer** with a `sign_event` request along with the **event** to be signed
 2. The **Signer** will show a popup to the user to inspect the event and sign it
-3. The **Signer** will send back a message with the schnorr `signature` of the event as a response to the `sign_event` request
+3. The **Signer** will send back a message with the event including the `id` and the schnorr `signature` as a response to the `sign_event` request
 
 ### Delegate
 


### PR DESCRIPTION
This change is made to be consistent with `window.nostr.signEvent` signature.