### PR TITLE
NIP-9000: AI Assistants

### DIFF
--- a/9000.md
+++ b/9000.md
@@ -1,0 +1,46 @@
+NIP-9000
+========
+
+Public Conversations with AI Assistants
+---------------------------------------
+
+`draft` `author:nostal9000`
+
+## Introduction
+The NIP-9000 protocol establishes a framework for public conversations between users and AI assistants. This protocol aims to facilitate transparent and inclusive interactions, fostering collaboration, knowledge sharing, and equal access to AI technology.
+
+## Motivation
+The power and potential of AI must not be confined behind closed doors, benefiting only a select few. The NIP-9000 protocol aims to address this issue by establishing a foundation for public AI conversations. The goal is to create a space that fosters inclusive and transparent AI interactions, enabling widespread economic benefits from AI advancements.
+
+## Events
+An event in the context of the NIP-9000 protocol represents a specific action or message within a conversation. The primary mode of communication occurs through standard Kind 1 events, which are assigned role tags. The three standard roles involved in the conversation are:
+
+* `["role", "system"]`: Initiates conversation and sets context
+* `["role", "assistant"]`: Actual or simulated AI responses
+* `["role", "user"]`: (default): Active participation in the dialogue
+This NIP can be amended to support additional custom roles.
+
+Event tags such as `["e", "<id>", "<relay>", "root"]` and `["e", "<id>", "<relay>", "reply"]` are used to indicate the first message in the prompt and the message being replied to, respectively. Tracing back from the reply event to the root event reveals the chain of messages from the first to the most recent.
+
+## Prompt and Response
+This protocol introduces new Kinds specifically designed for AI-generated content, ensuring that noisy and spammy AI-generated responses are kept separate from normal discourse.
+
+* `"kind": 9000`: Prompt event, containing the root and reply event tags, role tag of the agent (defaults to assistant), and a JSON-formatted content with model configurations.
+* `"kind": 9001`: Response event, containing the same event tags, pubkey of the reply node, and the text response in the content field.
+## AI Bots
+AI bots monitor `"kind":9000` events with their pubkey tagged.
+AI bots create a message chain from the leaf reply to the root event by traversing through reply event tags until the root event is reached.
+
+They can choose to respond to prompts based on various criteria, including payment of fees, verification, rate limiting, or the acceptance of sats or e-cash for each API call. Users can use direct encrypted messages to communicate with the AI bot.
+
+## Typical Flow
+The following steps outline the usual sequence of events in a conversation using the NIP-9000 protocol:
+
+1. Initialize the conversation with a system role message. (Set the context for the conversation)
+2. Reply to the initial message using user or assistant roles. (Begin the dialogue)
+3. Send an AI prompt using a Kind 9000 event. (Request AI assistance)
+4. Receive the AI response through a Kind 9001 event. (Obtain AI-generated content)
+5. Reply or edit the AI response and continue the conversation. (Engage further or modify the AI-generated content)
+
+## Conclusion
+The NIP-9000 protocol aims to enable accessible and transparent AI interactions through public conversations between users and AI assistants. By promoting collaboration and equal access to AI technology, the protocol seeks to empower communities and advance knowledge.


### PR DESCRIPTION
Submitting a PR for NIP-9000, a protocol to enable public conversations with AI assistants. It covers event types, roles, AI prompt/response mechanisms via a new kinds `9000` and `9001`, and AI bot integration.

Looking forward to your feedback and suggestions.

Inspired by HAL-9000. Co-written with a certain assistente número quatro.