### PR TITLE
NIP-80: Preventing False Tag Reference Matches

### DIFF
--- a/80.md
+++ b/80.md
@@ -1,0 +1,10 @@
+NIP-80
+======
+
+Preventing False Tag Reference Matches
+--------------------------------------
+
+`draft` `mandatory` `author:shafemtol`
+
+This NIP defines the `ign` tag for handling false matches of `#[index]` notation
+as used in NIP-08 and NIP-23.


### PR DESCRIPTION
WIP, opening PR to reserve the NIP number.

Addresses the remaining part of #319, complementing #328.