### PR TITLE
add optional subscription_id to NOTICE

### DIFF
--- a/01.md
+++ b/01.md
@@ -89,7 +89,7 @@ The `limit` property of a filter is only valid for the initial query and can be 
 Relays can send 2 types of messages, which must also be JSON arrays, according to the following patterns:
 
   * `["EVENT", <subscription_id>, <event JSON as defined above>]`, used to send events requested by clients.
-  * `["NOTICE", <message>]`, used to send human-readable error messages or other things to clients.
+  * `["NOTICE", <message>, <subscription_id>]`, used to send human-readable error messages or other things to clients. Relays might optionally send a `subscription_id` this notice was caused by.
 
 This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 


### PR DESCRIPTION
Often, a relay sends a `NOTICE` as a response to a `REQ` (such as rate-limiting, erroneous queries, etc); it would be useful if clients could associate a `NOTICE` to a previous `REQ`.