### PR TITLE
Revert 'add NOTICE optional subscription_id'

### DIFF
--- a/01.md
+++ b/01.md
@@ -89,7 +89,7 @@ The `limit` property of a filter is only valid for the initial query and can be 
 Relays can send 2 types of messages, which must also be JSON arrays, according to the following patterns:
 
   * `["EVENT", <subscription_id>, <event JSON as defined above>]`, used to send events requested by clients.
-  * `["NOTICE", <message>, <subscription_id>]`, used to send human-readable error messages or other things to clients. Relays might optionally send a `subscription_id` this notice was caused by.
+  * `["NOTICE", <message>]`, used to send human-readable error messages or other things to clients. 
 
 This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 


### PR DESCRIPTION
Reverts 88009bea8509d004672551be7346a03c373491d0

Since this is optional, it probably should be in another NIP (which I will propose shortly). It is probably best for it to be an object, since
1. that can be extended
2. you can specify if the subscription was closed, since currently a NOTICE on a sub doesn't indicate if it was closed or not