### PR TITLE
NIP-109: Pubkey Deletion

### DIFF
--- a/109.md
+++ b/109.md
@@ -1,8 +1,8 @@
 NIP-109
 =======
 
-Public Key Revocation
----------------------
+Pubkey Deletion
+---------------
 
 `draft` `optional` `author:alexgleason`
 

--- a/109.md
+++ b/109.md
@@ -1,5 +1,5 @@
-NIP-69
-======
+NIP-109
+=======
 
 Public Key Revocation
 ---------------------

--- a/69.md
+++ b/69.md
@@ -10,7 +10,7 @@ Events of [kind `5`](09.md) may contain a "p" tag instead of "e" tags. The "p" t
 
 ### Client behavior
 
-Clients which recieve a pubkey deletion event SHOULD treat all events from that pubkey as if they were deleted in accordance with [NIP-09](09.md).
+Clients which recieve a pubkey revocation event SHOULD treat all events from that pubkey as if they were deleted in accordance with [NIP-09](09.md).
 
 Clients may give users the option to "Revoke your public key" with this type of event. Clients SHOULD display a prominent message explaining that the action is not reversible, SHOULD explain that this does not guarantee their posts are deleted forever, and SHOULD require special confirmation such as requiring the user to type a message.
 

--- a/69.md
+++ b/69.md
@@ -1,0 +1,35 @@
+NIP-69
+======
+
+Deleting a Pubkey
+-----------------
+
+`draft` `optional` `author:alexgleason`
+
+Events of [kind `5`](09.md) may contain a "p" tag instead of "e" tags. The "p" tag MUST match the `pubkey` of the signed event, and this event indicates that the author wishes for relays and clients to stop showing events for this pubkey, and to reject future events from the pubkey.
+
+### Client behavior
+
+Clients which recieve a pubkey deletion event SHOULD treat all events from that pubkey as if they were deleted in accordance with [NIP-09](09.md).
+
+Clients may give users the option to "Delete your account" with this type of event. Clients SHOULD display a prominent message explaining that the action is not reversible, and SHOULD require special confirmation such as requiring the user to type a message.
+
+### Relay behavior
+
+Relays receiving a pubkey deletion event MUST mark the pubkey as deleted, and MUST stop delivering events from this pubkey to clients, EXCEPT for events of kind `5`. Relays MAY delete events by this pubkey from their database, and SHOULD reject future events from the pubkey.
+
+Relays SHOULD preserve events of kind `5` from the pubkey, as well as continue to collect and distribute events of kind `5`.
+
+### Example event
+
+```json5
+{
+  "kind": 5,
+  "pubkey": "6027adac157831dfe9d2f988c1b8b7a75d9296a7d42a0f9ed056a320925b0e13",
+  "tags": [
+    ["p", "6027adac157831dfe9d2f988c1b8b7a75d9296a7d42a0f9ed056a320925b0e13"],
+  ],
+  "content": "", // optional message, same as NIP-09
+  // ...
+}
+```

--- a/69.md
+++ b/69.md
@@ -1,8 +1,8 @@
 NIP-69
 ======
 
-Deleting a Pubkey
------------------
+Public Key Revocation
+---------------------
 
 `draft` `optional` `author:alexgleason`
 
@@ -12,11 +12,13 @@ Events of [kind `5`](09.md) may contain a "p" tag instead of "e" tags. The "p" t
 
 Clients which recieve a pubkey deletion event SHOULD treat all events from that pubkey as if they were deleted in accordance with [NIP-09](09.md).
 
-Clients may give users the option to "Delete your account" with this type of event. Clients SHOULD display a prominent message explaining that the action is not reversible, and SHOULD require special confirmation such as requiring the user to type a message.
+Clients may give users the option to "Revoke your public key" with this type of event. Clients SHOULD display a prominent message explaining that the action is not reversible, SHOULD explain that this does not guarantee their posts are deleted forever, and SHOULD require special confirmation such as requiring the user to type a message.
+
+Clients MUST NOT show the content field in the event for security reasons.
 
 ### Relay behavior
 
-Relays receiving a pubkey deletion event MUST mark the pubkey as deleted, and MUST stop delivering events from this pubkey to clients, EXCEPT for events of kind `5`. Relays MAY delete events by this pubkey from their database, and SHOULD reject future events from the pubkey.
+Relays receiving a pubkey revocation event MUST mark the pubkey as revoked, and MUST stop delivering events from this pubkey to clients, EXCEPT for events of kind `5`. Relays MAY delete events by this pubkey from their database, and SHOULD reject future events from the pubkey.
 
 Relays SHOULD preserve events of kind `5` from the pubkey, as well as continue to collect and distribute events of kind `5`.
 
@@ -29,7 +31,7 @@ Relays SHOULD preserve events of kind `5` from the pubkey, as well as continue t
   "tags": [
     ["p", "6027adac157831dfe9d2f988c1b8b7a75d9296a7d42a0f9ed056a320925b0e13"],
   ],
-  "content": "", // optional message, same as NIP-09
+  "content": "",
   // ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-57: Lightning Zaps](57.md)
 - [NIP-58: Badges](58.md)
 - [NIP-65: Relay List Metadata](65.md)
+- [NIP-69: Deleting a Pubkey](69.md)
 - [NIP-78: Application-specific data](78.md)
 
 ## Event Kinds

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-57: Lightning Zaps](57.md)
 - [NIP-58: Badges](58.md)
 - [NIP-65: Relay List Metadata](65.md)
-- [NIP-69: Deleting a Pubkey](69.md)
+- [NIP-69: Public Key Revocation](69.md)
 - [NIP-78: Application-specific data](78.md)
 
 ## Event Kinds

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-57: Lightning Zaps](57.md)
 - [NIP-58: Badges](58.md)
 - [NIP-65: Relay List Metadata](65.md)
-- [NIP-69: Public Key Revocation](69.md)
 - [NIP-78: Application-specific data](78.md)
+- [NIP-109: Public Key Revocation](109.md)
 
 ## Event Kinds
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-58: Badges](58.md)
 - [NIP-65: Relay List Metadata](65.md)
 - [NIP-78: Application-specific data](78.md)
-- [NIP-109: Public Key Revocation](109.md)
+- [NIP-109: Pubkey Deletion](109.md)
 
 ## Event Kinds
 


### PR DESCRIPTION
This NIP provides a way for users to delete their own account. Supported relays would delete all events from the pubkey and prevent new ones from being added. This option enhances user privacy and helps with disaster recovery.

Currently events can only be deleted one-at-a-time. However, users expect a "delete account" option, which I believe will be necessary for mainstream adoption of Nostr.

**Precedent**

If an attacker steals your private key, you can already protect against them submitting new events by monitoring relays and submitting deletion requests automatically. Here is an example of such a bot: https://gitlab.com/alexgleason/plan-b

A better solution would be for **relays to become friendlier about deleting user content.** I propose Event<5> on a pubkey. When this happens, relays excommunicate the pubkey as described in this document:

:arrow_right: **NIP-109** https://github.com/alexgleason/nips/blob/delete-pubkey/109.md

### FAQ

- **Shouldn't relays handle this?** That's exactly what this NIP proposes.
- **Why 109?** Event deletions are defined in [NIP-09](https://github.com/nostr-protocol/nips/blob/master/09.md). 109 is the smallest available NIP ending in "9".
- **Why extend kind 5 instead of a new kind?** Relays already implement special behavior for kind 5 events. That behavior is desired, in addition to it making sense semantically.

P.S. I'm [not the only one thinking about this](https://iris.to/note1da5tmnwpa0pm745q8jc9fwnkedef7ktaewf96zdqh70zkudw5qvs97d8zw).