### PR TITLE
Drop #[index] notation

### DIFF
--- a/08.md
+++ b/08.md
@@ -10,10 +10,8 @@ This document standardizes the treatment given by clients of inline mentions of 
 
 Clients that want to allow tagged mentions they MUST show an autocomplete component or something analogous to that whenever the user starts typing a special key (for example, "@") or presses some button to include a mention etc -- or these clients can come up with other ways to unambiguously differentiate between mentions and normal text.
 
-Once a mention is identified, for example, the pubkey `27866e9d854c78ae625b867eefdfa9580434bc3e675be08d2acb526610d96fbe`, the client MUST add that pubkey to the `.tags` with the tag `p`, then replace its textual reference (inside `.content`) with the notation `#[index]` in which "index" is equal to the 0-based index of the related tag in the tags array.
+Once a mention is identified, for example, the pubkey `27866e9d854c78ae625b867eefdfa9580434bc3e675be08d2acb526610d96fbe`, the client MUST replace its textual reference (inside `.content`) with the notation `nostr:nprofile1qqsw3dy8cpu...6x2argwghx6egsqstvg` as per NIP-21. If client doesn't support NIP-21, it can instead use a regular http link to a nostr client such as `https://snort.social/p/nprofile1qqsw3dy8cpu...6x2argwghx6egsqstvg`. The client MAY add that pubkey to the `.tags` with the tag `p` if it wishes to notify mentioned user.
 
-The same process applies for mentioning event IDs.
+The same process applies for mentioning event IDs, except that the client SHOULD NOT add the event id to the `.tags` with the tag `e` so to not negatively impact thread loading.
 
-A client that receives a `text_note` event with such `#[index]` mentions in its `.content` CAN do a search-and-replace using the actual contents from the `.tags` array with the actual pubkey or event ID that is mentioned, doing any desired context augmentation (for example, linking to the pubkey or showing a preview of the mentioned event contents) it wants in the process.
-
-Where `#[index]` has an `index` that is outside the range of the tags array or points to a tag that is not an `e` or `p` tag or a tag otherwise declared to support this notation, the client MUST NOT perform such replacement or augmentation, but instead display it as normal text.
+A client that receives a `text_note` event with such `nostr:...` mentions in its `.content` CAN do any desired context augmentation (for example, linking to the pubkey or showing a preview of the mentioned event contents) it wants in the process.


### PR DESCRIPTION
Searching for regular http urls (or `nostr:...` for clients supporting NIP-21) inside note content and replacing them with images, videos or links is already being done by nostr clients.

So the `#[index]` notation isn't bringing extra functionallity to the table.

In fact, such notation is doing more harm than good, because it requires adding `e` tags which negatively interferes with thread loading.
