### PR TITLE
Nip21 patch - Change URL to URI

### DIFF
--- a/21.md
+++ b/21.md
@@ -1,12 +1,12 @@
 NIP-21
 ======
 
-`nostr:` URL scheme
+`nostr:` URI scheme
 -------------------
 
 `draft` `optional` `author:fiatjaf`
 
-This NIP standardizes the usage of a common URL scheme for maximum interoperability and openness in the network.
+This NIP standardizes the usage of a common URI scheme for maximum interoperability and openness in the network.
 
 The scheme is `nostr:`.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 - [NIP-16: Event Treatment](16.md)
 - [NIP-19: bech32-encoded entities](19.md)
 - [NIP-20: Command Results](20.md)
-- [NIP-21: `nostr:` URL scheme](21.md)
+- [NIP-21: `nostr:` URI scheme](21.md)
 - [NIP-22: Event `created_at` Limits](22.md)
 - [NIP-23: Long-form Content](23.md)
 - [NIP-25: Reactions](25.md)


### PR DESCRIPTION
Changes proposed as per RFC3986 URI specification and not a URL.

Since we want to _identify_ (`uri`) nostr recources, and not _locate_ (`url`) `nostr:` resrouces I propose to change this accordingly.