### PR TITLE
Added NIP-04 metadata leak warning

### DIFF
--- a/04.md
+++ b/04.md
@@ -47,3 +47,7 @@ let event = {
 ## Security Warning
 
 This standard does not go anywhere near what is considered the state-of-the-art in encrypted communication between peers, and it leaks metadata in the events, therefore it must not be used for anything you really need to keep secret, and only with relays that use `AUTH` to restrict who can fetch your `kind:4` events.
+
+## Client Implementation Warning
+
+Client's *should not* search and replace public key or note references from the `.content`. If processed like a regular text note (where `@npub...` is replaced with `#[0]` with a `["p", "..."]` tag) the tags are leaked and the mentioned user will receive the message in their inbox.


### PR DESCRIPTION
Example of mentions leaking: https://nostr.build/i/nostr.build_6866d14546b73b672add42180a6486cbfbff17d828359cdc7d49a10514d394ce.jpeg