### PR TITLE
Add account_index for infinite NIP-06 key generation

### DIFF
--- a/06.md
+++ b/06.md
@@ -8,8 +8,8 @@ Basic key derivation from mnemonic seed phrase
 
 [BIP39](https://bips.xyz/39) is used to generate mnemonic seed words and derive a binary seed from them.
 
-[BIP32](https://bips.xyz/32) is used to derive the path `m/44'/1237'/0'/0/0` (according to the Nostr entry on [SLIP44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)).
+[BIP32](https://bips.xyz/32) is used to derive the path `m/44'/1237'/0'/0/<address_index>` (according to the Nostr entry on [SLIP44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)).
 
-This is the default for a basic, normal, single-key client.
+A basic client can simply use an `address_index` of `0` to derive a single key. For more advanced use-cases you can increment `address_index`, allowing generation of practically infinite keys from the 5-level path.
 
 Other types of clients can still get fancy and use other derivation paths for their own other purposes.

--- a/06.md
+++ b/06.md
@@ -8,8 +8,8 @@ Basic key derivation from mnemonic seed phrase
 
 [BIP39](https://bips.xyz/39) is used to generate mnemonic seed words and derive a binary seed from them.
 
-[BIP32](https://bips.xyz/32) is used to derive the path `m/44'/1237'/0'/0/<address_index>` (according to the Nostr entry on [SLIP44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)).
+[BIP32](https://bips.xyz/32) is used to derive the path `m/44'/1237'/<account>'/0/0` (according to the Nostr entry on [SLIP44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)).
 
-A basic client can simply use an `address_index` of `0` to derive a single key. For more advanced use-cases you can increment `address_index`, allowing generation of practically infinite keys from the 5-level path.
+A basic client can simply use an `account` of `0` to derive a single key. For more advanced use-cases you can increment `account`, allowing generation of practically infinite keys from the 5-level path with hardened derivation.
 
 Other types of clients can still get fancy and use other derivation paths for their own other purposes.


### PR DESCRIPTION
I propose a change to NIP-06 that would allow the generation of infinite root keys by using the `account` field of the 5-level path used to derive Nostr keys under BIP32.

The current 5-level path used for NIP-06 is `m/44'/1237'/0'/0/0`, and only generates one private key. By changing it to `m/44'/1237'/<account>'/0/0`, we can generate multiple keys from a single parent bitcoin seed.