### PR TITLE
add filters in url scheme (NIP 21)

### DIFF
--- a/21.md
+++ b/21.md
@@ -18,3 +18,12 @@ The identifiers that come after are expected to be the same as those defined in 
 - `nostr:nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p`
 - `nostr:note1fntxtkcy9pjwucqwa9mddn7v03wwwsu9j330jj350nvhpky2tuaspk6nqc`
 - `nostr:nevent1qqstna2yrezu5wghjvswqqculvvwxsrcvu7uc0f78gan4xqhvz49d9spr3mhxue69uhkummnw3ez6un9d3shjtn4de6x2argwghx6egpr4mhxue69uhkummnw3ez6ur4vgh8wetvd3hhyer9wghxuet5nxnepm`
+
+## Proposed filter ideas
+- User: `nostr://user:npub`
+- Note: `nostr://note:note_id`
+- Hashtag: `nostr://hashtag:hashtag_text`
+- Channel: `nostr://channel:channel_id`
+- Channel message: `nostr://channel_message:channel_id:message_id`
+- Suggest relay: `nostr://suggest_relay:relay_url1,relay_url2,relay_url3`
+- Search: `nostr://search:search_terms`


### PR DESCRIPTION
Hello everyone!

#### what are you proposing?
More use cases for NIP 21. 

#### why?
I would like to contribute to the decentralized network protocol: nostr. In this regard, I saw this issue: ["Open nostr links in app"](https://github.com/nostr-protocol/nips/issues/390) and thought I would help.

#### how?
An initial suggestion would be to include more use cases for NIP 21. In this regard, this is where my help is to be found. Please see this:
> "This already exists, see https://github.com/nostr-protocol/nips/blob/8362ff8f79d913ac1dfded9668cd31dcc8c73f22/21.md. Feel free to open a pull request to NIP 19 for use cases that aren't yet supported."

"The filter would help the identification of the data, meaning if we are sharing a link to a profile, link to a note, etc. Proposed filter ideas are below."
