### PR TITLE
NIP-81 Modeling Files / Filesharing

### DIFF
--- a/81.md
+++ b/81.md
@@ -1,0 +1,103 @@
+NIP-81
+======
+
+Modeling Files
+--------------
+
+`draft` `optional` `author:lovvtide`
+
+This NIP introduces a "file" event (kind `2001`) for modeling files on nostr in a way that is simple and extensible. The file event is served by relays like any other event and contains metadata that clients can use to download, verify, and display the file's data. Specifically, this proposal:
+
+- Defines standard metadata to describe a file in the nostr ecosystem
+- Makes it possible for relays to index file metadata, thereby enabling clients to query for files
+- Mitigates the problem of dead links and generally increases resilience/censorship-resistance by utilizing BitTorrent as a fallback when there are no servers hosting a file
+
+
+## Event Model
+
+``` 
+{
+    "content": <description_of_file>,
+    "kind": 2001,
+    "tags": [
+        ["x", <hash_value>, <hash_algorithm>],
+        ["m", <mime_type>],
+        ["size", <byte_length>]
+        ["name", <file_name>],
+        ["url", <url_of_file>]
+    ],
+    ...
+}
+```
+
+The kind `2001` event makes use of three required tags (containing the identifying hash(es), file type, and file size) and two optional tags (containing the file name and url(s) to download the file). Each tag is explained as follows:
+
+- `x` (required) - Hash of the file and the name of the hashing algorithm used to generate the hash. Each event MUST contain at least one `x` tag with the `sha256` hash of the file. The event MAY also include additional `x` tags with different hashes of the same file (such as the torrent `infohash`). For any `x` tag, if the name of the hashing algorithm is omitted, it should be assumed to be a `sha256` hash.
+- `m` (required) - Lowercase mime type of the file as per [the IANA's official list](https://www.iana.org/assignments/media-types/media-types.xhtml)
+- `size` (required) - Integer byte length of the file, formatted as a string
+- `name` (optional) - File name set by creator of event (recommended to improve UX when listing files on the client)
+- `url` (optional) - Link to download the file's data. Note that an event MAY contain multiple `url` tags if the file is being hosted by multiple servers.
+
+
+## Example Event
+
+```
+{
+    "content": "This is a human readable description of the file",
+    "kind": 2001,
+    "tags": [
+        ["x", "719171db19525d9d08dd69cb716a18158a249b7b3b3ec4bbdec5698dca104b7b", "sha256"]
+        ["x", "a19a70552cc801415a6071993c04b3ab21572438", "infohash"],
+        ["m", "video/mp4"],
+        ["size", "26685219"]
+        ["name", "myvideo.mp4"],
+        ["url", "https://cdn.example.com/foo/bar/a19a70552cc801415a6071993c04b3ab21572438.mp4"]
+    ],
+    "created_at": 1679552101,
+    "pubkey": "fbd992dbccdd4186f4ef25b7d72ea47387a59227493f8569b17963afae4e4d33",
+    "id": "faea2a5dbe12c877c1201e91ec909e3161a1ba8714fdca4d3077f6d4b0780191",
+    "sig": "10c0d634ea0b9ae085205c3951367da784268a0cdf4a18b969aba7c06b1a59abf96b7f5f4e2d3791389dff71ff5527c33e3405e8decad9b3e4419406124dc46a"
+}
+```
+
+In this example, you might notice that there are two `x` tags. Both are hashes of the file. To ensure interoperability, this spec requires the presence of a `sha256` hash, while the `infohash` (and any number of additional hashes) may optionally also be included.
+
+Note that the `content` field MAY contain a human-readable description of the file.
+
+
+## Querying File Events
+
+The reason why `x` (file hash) and `m` (file type) are single letter tags is to enable clients to pull file events from relays using generic tag queries (see [NIP-12](https://github.com/nostr-protocol/nips/blob/master/12.md)).
+
+For example, if a client knows any hash of a file it can fetch the corresponding event with a request filter like this:
+
+`{ #x: [ "a19a70552cc801415a6071993c04b3ab21572438" ] }`.
+
+As another example, suppose a client wants to fetch events for all the videos a relay knows about. The request might look something like this:
+
+`{ #m: [ "video/mp4", "video/wav", ... ] }`
+
+In general, clients being able to ask relays for exactly which files they're interested in is a big improvement on the current situation where clients have to download all the events and parse out links to files.
+
+
+## Discussion
+
+### Why BitTorrent?
+
+The BitTorrent protocol (created in 2001) is an old, stable, and widely supported means of decentralized file sharing. One of its biggest drawbacks, however, is that it lacks a way to verify the identity of the creator of a torrent. Nostr fixes the problem of verifying identity. It's therefore reasonable to think that BitTorrent + Nostr could be a very powerful combination.
+
+A torrent `infohash` is a special hash defined by the BitTorrent protocol used to uniquely identify a torrent. Clients can use this hash (along with a list of popular torrent trackers) to construct a magnet link and get the file's data from peers. In fact, some nostr clients have already implemented [WebTorrent](https://github.com/webtorrent/webtorrent) which supports loading torrents directly in the browser.
+
+One peculiarity of how the `infohash` is computed is that its value depends not only on the contents of the file, but also on the `name` of the torrent chosen by the torrent creator. When computing the `infohash` of a file, clients SHOULD, for the sake of consistency, ensure that the `name` passed to the torrent constructor is the same value as the `name` tag in the nostr event.
+
+For the same reason, applications should use the `sha256` hash (not the `infohash`) for deduplicating and uniquely identifying files.
+
+
+### What About IPFS?
+
+IPFS is not included as part of this spec due to its performance issues, unstable API, and de-facto reliance on centralized gateways. Still, if the creator of an event wanted to include the IPFS hash in an event, there's nothing in this spec that would stop him from doing that.
+
+
+### Extensibility
+
+It should be easy to extend this proposal in the future by standardizing additional tags and/or hashing algorithms. For now it seems best to start with a simple spec that can be easily implemented.


### PR DESCRIPTION
Here's my proposal for censorship resistant file sharing on nostr. The three main goals of this proposal:

- To define standard metadata to describe a file in the nostr ecosystem
- To make it possible for relays to index file metadata, thereby enabling clients to query for files
- To mitigate the problem of dead links and generally increase resilience/censorship-resistance by utilizing BitTorrent as a fallback when there are no servers hosting a file

I'm currently building a file manager app the implements this spec, so I should be able to show that soon as well. What do you guys think?

Here's the proposal https://github.com/lovvtide/nips/blob/NIP-81/81.md