### PR TITLE
make NIP-15 mandatory

### DIFF
--- a/15.md
+++ b/15.md
@@ -4,18 +4,14 @@ NIP-15
 End of Stored Events Notice
 ---------------------------
 
-`final` `optional` `author:Semisol`
+`final` `mandatory` `author:Semisol`
 
-Relays may support notifying clients when all stored events have been sent.
+Relays MUST support notifying clients when all stored events have been sent.
 
-If a relay supports this NIP, the relay SHOULD send the client a `EOSE` message in the format `["EOSE", <subscription_id>]` after it has sent all the events it has persisted and it indicates all the events that come after this message are newly published.
+The relay SHOULD send the client an `EOSE` message in the format `["EOSE", <subscription_id>]` after it has sent all the events it has persisted and it indicates all the events that come after this message are newly published.
 
 Client Behavior
 ---------------
 
-Clients SHOULD use the `supported_nips` field to learn if a relay supports end of stored events notices.
-
-Motivation
-----------
-
-The motivation for this proposal is to reduce uncertainty when all events have been sent by a relay to make client code possibly less complex.
+Clients may use the `supported_nips` field to learn if a relay supports end of stored events notices.
+Clients MUST unsubscribe when they get an `EOSE` message from the relay.


### PR DESCRIPTION
sending an `EOSE` message from the relay must be mandatory not optional.