### PR TITLE
NIP-15 must be mandatory

### DIFF
--- a/15.md
+++ b/15.md
@@ -8,7 +8,7 @@ End of Stored Events Notice
 
 Relays MUST support notifying clients when all stored events have been sent.
 
-The relay SHOULD send the client an `EOSE` message in the format `["EOSE", <subscription_id>]` after it has sent all the events it has persisted and it indicates all the events that come after this message are newly published.
+The relay MUST send the client an `EOSE` message in the format `["EOSE", <subscription_id>]` after it has sent all the events it has persisted and it indicates all the events that come after this message are newly published.
 
 Client Behavior
 ---------------

--- a/15.md
+++ b/15.md
@@ -4,18 +4,14 @@ NIP-15
 End of Stored Events Notice
 ---------------------------
 
-`final` `optional` `author:Semisol`
+`final` `mandatory` `author:Semisol`
 
-Relays may support notifying clients when all stored events have been sent.
+Relays MUST support notifying clients when all stored events have been sent.
 
-If a relay supports this NIP, the relay SHOULD send the client a `EOSE` message in the format `["EOSE", <subscription_id>]` after it has sent all the events it has persisted and it indicates all the events that come after this message are newly published.
+The relay SHOULD send the client an `EOSE` message in the format `["EOSE", <subscription_id>]` after it has sent all the events it has persisted and it indicates all the events that come after this message are newly published.
 
 Client Behavior
 ---------------
 
-Clients SHOULD use the `supported_nips` field to learn if a relay supports end of stored events notices.
-
-Motivation
-----------
-
-The motivation for this proposal is to reduce uncertainty when all events have been sent by a relay to make client code possibly less complex.
+Clients may use the `supported_nips` field to learn if a relay supports end of stored events notices.
+Clients MUST unsubscribe when they get an `EOSE` message from the relay.

--- a/15.md
+++ b/15.md
@@ -14,4 +14,4 @@ Client Behavior
 ---------------
 
 Clients may use the `supported_nips` field to learn if a relay supports end of stored events notices.
-Clients MUST unsubscribe when they get an `EOSE` message from the relay.
+Clients are RECOMMENDED to implement a timeout if they have not received events for a while to help with compatibility for non-implementing relays and not hang while requesting data from relays.


### PR DESCRIPTION
sending an `EOSE` message from the relay `MUST` be `mandatory` not optional.