### PR TITLE
added pubkey zap-tag

### DIFF
--- a/57.md
+++ b/57.md
@@ -168,7 +168,15 @@ A client can retrieve `zap receipts` on events and pubkeys using a NIP-01 filter
 
 ### Appendix G: `zap` tag on zapped event
 
-When an event includes a `zap` tag, clients SHOULD calculate the lnurl pay request based on it's value instead of the profile's field. An optional third argument on the tag specifies the type of value, either `lud06` or `lud16`.
+When an event includes a `zap` tag, clients SHOULD calculate the lnurl pay request endpoint based on it's value. A third argument on the tag specifies the type of value, either `pubkey`, `lud06` or `lud16`.
+
+- `lud06` : Calculate lnurl pay request endpoint according to [lud06](https://github.com/lnurl/luds/blob/luds/06.md)
+- `lud16` : Calculate lnurl pay request endpoint according to [lud16](https://github.com/lnurl/luds/blob/luds/16.md)
+- `pubkey`: Find either a lud06 or lud16 property in this pubkeys metadata and calculate lnurl pay request endpoint accordingly
+
+#### Client best-practices
+
+When creating zap-able events clients SHOULD default to the pubkey-type, as this allows events to stay zap-able for a long time, even if users choose to change their wallet or provider.
 
 ```json
 {


### PR DESCRIPTION
PR https://github.com/nostr-protocol/nips/pull/402 has recently introduced the zap-tag in NIP-57, allowing clients to reference a static zap-destination in events. This can lead to events having stale zap-destinations in them, when users decide to switch to a new address or provider.

This PR introduces a third type for the zap-tag `pubkey`, with a flow quite similar to the base spec, but allowing clients to specify someone elses pubkey, essentially allowing "redirecting" zaps.

Both PRs lay the groundwork for client-side payment splitting, which will be included in a subsequent PR.