### PR TITLE
feat: support counting by multiple filters

### DIFF
--- a/45.md
+++ b/45.md
@@ -14,18 +14,26 @@ Some queries a client may want to execute against connected relays are prohibiti
 
 ## Filters and return values
 
-This NIP defines a verb called `COUNT`, which accepts a subscription id and a filter as specified in [NIP 01](01.md).
+This NIP defines a verb called `COUNT`, which accepts a subscription id and filters as specified in [NIP 01](01.md).
+
+```
+["COUNT", <subscription_id>, <filters JSON>...]
+```
 
 Counts are returned using a `COUNT` response in the form `{count: <integer>}`. Relays may use probabilistic counts to reduce compute requirements.
+
+```
+["COUNT", <subscription_id>, {"count": <integer>}]
+```
 
 Examples:
 
 ```
 # Followers count
-["COUNT", "", {kinds: [3], '#p': [<pubkey>]}]
-["COUNT", "", {count: 238}]
+["COUNT", <subscription_id>, {"kinds": [3], "#p": [<pubkey>]}]
+["COUNT", <subscription_id>, {"count": 238}]
 
 # Count posts and reactions
-["COUNT", "", {kinds: [1, 7], authors: [<pubkey>]}]
-["COUNT", "", {count: 5}]
+["COUNT", <subscription_id>, {"kinds": [1, 7], "authors": [<pubkey>]}]
+["COUNT", <subscription_id>, {"count": 5}]
 ```


### PR DESCRIPTION
May need to be consistent with NIP-01, support couting by multiple filters.

In addition, some double quotes were added.