### PR TITLE
NIP-26 allow delegator to delete events published by delegatee

### DIFF
--- a/26.md
+++ b/26.md
@@ -101,6 +101,8 @@ The event should be considered a valid delegation if the conditions are satisfie
 Clients should display the delegated note as if it was published directly by the delegator (8e0d3d3e).
 
 
-#### Relay & Client Querying Support
+#### Relay & Client Support
 
 Relays should answer requests such as `["REQ", "", {"authors": ["A"]}]` by querying both the `pubkey` and delegation tags `[1]` value.
+
+Relays SHOULD allow the delegator (8e0d3d3e) to delete the events published by the delegatee (477318cf).


### PR DESCRIPTION
I think the delegator has the right to delete the events published by the delegatee.