### PR TITLE
NWC PR: incorporate feedback

### DIFF
--- a/47.md
+++ b/47.md
@@ -17,13 +17,16 @@ This NIP describes a way for clients to access a remote Lightning wallet through
 
 ## Events
 
-There are two event kinds:
+There are three event kinds:
+- `NIP-47 info event`: 13194
 - `NIP-47 request`: 23194
 - `NIP-47 response`: 23195
 
+The info event should be a replaceable event that is published by the **wallet service** on the relay to indicate which commands it supports. The content should be
+a plaintext string with the supported commands, space-seperated, eg. `pay_invoice get_balance`. Only the `pay_invoice` command is described in this NIP, but other commands might be defined in different NIPs.
 Both the request and response events SHOULD contain one `p` tag, containing the public key of the **wallet service** if this is a request, and the public key of the **client** if this is a response. The response event SHOULD contain an `e` tag with the id of the request event it is responding to.
 
-The content is encrypted with [NIP04](https://github.com/nostr-protocol/nips/blob/master/04.md), and is a JSON-RPCish object with a semi-fixed structure:
+The content of requests and responses is encrypted with [NIP04](https://github.com/nostr-protocol/nips/blob/master/04.md), and is a JSON-RPCish object with a semi-fixed structure:
 
 Request:
 ```jsonc
@@ -75,26 +78,7 @@ The **client** should then store this connection and use it when the user wants 
 nostr+walletconnect:b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4?relay=wss%3A%2F%2Frelay.damus.io&secret=71a8c14c1407c113601079c4302dab36460f0ccd0ad506f1f2dc73b5100e4f3c
 ```
 
-## Commands
-
-### `get_info`
-
-Description: Get information about the wallet and service.
-
-Request: Empty object.
-
-Response:
-```jsonc
-{
-    "balance": 100000, // balance in msat, int
-                       // this should be capped at the quota allowed for this client
-                       // to not report unspendable balance.
-    "implemented_commands": ["get_info", "pay_invoice"]  // commands supported, string array
-                            // extensions can be specified via command+extension:
-                            // get_info+node_info
-}
-```
-### `pay_invoice`
+## `pay_invoice`
 
 Description: Requests payment of an invoice.
 

--- a/47.md
+++ b/47.md
@@ -21,7 +21,7 @@ There are two event kinds:
 - `NIP-47 request`: 23194
 - `NIP-47 response`: 23195
 
-Both the request and response events SHOULD only contain one `p` tag, containing the public key of the **wallet service** if this is a request, and the public key of the **client** if this is a response.
+Both the request and response events SHOULD contain one `p` tag, containing the public key of the **wallet service** if this is a request, and the public key of the **client** if this is a response. The response event SHOULD contain an `e` tag with the id of the request event it is responding to.
 
 The content is encrypted with [NIP04](https://github.com/nostr-protocol/nips/blob/master/04.md), and is a JSON object. The content depends on the kind.
 

--- a/47.md
+++ b/47.md
@@ -61,7 +61,7 @@ We refer to the [JSON-RPC](https://www.jsonrpc.org/specification) error codes fo
 
 The **wallet service** generates this connection URI with protocol `nostr+walletconnect:` and base path it's hex-encoded `pubkey` with the following query string parameters: 
 
-- `relay` Required. URL of the relay where the **wallet service** is connected and will be listening for events. May be more than one.
+- `relay` Required. URL of the relay where the **wallet service** is connected and will be listening for events.
 - `secret` Required. 32-byte randomly generated hex encoded string. The **client** should use this to sign events when communicating with the **wallet service**.
     - Authorization does not require passing keys back and forth.
     - The user can have different keys for different applications. Keys can be revoked and created at will and have arbitrary constraints (eg. budgets).

--- a/47.md
+++ b/47.md
@@ -65,7 +65,7 @@ We refer to the [JSON-RPC](https://www.jsonrpc.org/specification) error codes fo
 The **wallet service** generates this connection URI with protocol `nostr+walletconnect:` and base path it's hex-encoded `pubkey` with the following query string parameters: 
 
 - `relay` Required. URL of the relay where the **wallet service** is connected and will be listening for events.
-- `secret` Required. 32-byte randomly generated hex encoded string. The **client** should use this to sign events when communicating with the **wallet service**.
+- `secret` Required. 32-byte randomly generated hex encoded string. The **client** MUST use this to sign events and encrypt payloads when communicating with the **wallet service**.
     - Authorization does not require passing keys back and forth.
     - The user can have different keys for different applications. Keys can be revoked and created at will and have arbitrary constraints (eg. budgets).
     - The key is harder to leak since it is not shown to the user and backed up.

--- a/47.md
+++ b/47.md
@@ -23,13 +23,13 @@ There are two event kinds:
 
 Both the request and response events SHOULD contain one `p` tag, containing the public key of the **wallet service** if this is a request, and the public key of the **client** if this is a response. The response event SHOULD contain an `e` tag with the id of the request event it is responding to.
 
-The content is encrypted with [NIP04](https://github.com/nostr-protocol/nips/blob/master/04.md), and is a JSON object. The content depends on the kind.
+The content is encrypted with [NIP04](https://github.com/nostr-protocol/nips/blob/master/04.md), and is a JSON-RPCish object with a semi-fixed structure:
 
 Request:
 ```jsonc
 {
-    "cmd": "pay_invoice", // command, string
-    "data": { // data, object
+    "method": "pay_invoice", // method, string
+    "params": { // params, object
         "invoice": "lnbc50n1..." // command-related data
     }
 }
@@ -38,25 +38,23 @@ Request:
 Response:
 ```jsonc
 {
-    "status": "ok", // status, "ok" | "error"
-    "event": "0123456789abcdef...", // event the command is in response to, string
-    "data": { // response data
+    "result_type": "pay_invoice", //indicates the structure of the result field
+    "error": { //object, non-null in case of error
+        "code": -32601, //integer, JSON-RPC error code https://www.jsonrpc.org/specification
+        "message": "human readable error message"
+    },
+    "result": { // result, object. null in case of error.
         "preimage": "0123456789abcdef..." // command-related data
     }
 }
 ```
 
-The data field SHOULD contain a `message` field with a human readable error message and a `code` field with the error code if the status is `error`.
+The `result_type` field MUST contain the name of the method that this event is responding to.
+The `error` field MUST contain a `message` field with a human readable error message and a `code` field with the error code if the command was not succesful.
+If the command was succesful, the `error` field must be null.
 
 ### Error codes
-- `RATE_LIMITED`: The client is sending commands too fast. It should retry in a few seconds.
-- `NOT_IMPLEMENTED`: The command is not known or is intentionally not implemented.
-- `INSUFFICIENT_BALANCE`: The wallet does not have enough funds to cover a fee reserve or the payment amount.
-- `QUOTA_EXCEEDED`: The wallet has exceeded
-- `RESTRICTED`: This public key is not allowed to do this operation.
-- `UNAUTHORIZED`: This public key has no wallet connected.
-- `INTERNAL`: An internal error.
-- `OTHER`: Other error.
+We refer to the [JSON-RPC](https://www.jsonrpc.org/specification) error codes for generic errors like not found, invalid request or internal error. Specific commands may have specific error codes defined. 
 
 ## Nostr Wallet Connect URI
 **client** discovers **wallet service** by scanning a QR code, handling a deeplink or pasting in a URI.
@@ -103,14 +101,20 @@ Description: Requests payment of an invoice.
 Request:
 ```jsonc
 {
-    "invoice": "lnbc50n1..." // BOLT11 invoice, string
+    "method": "pay_invoice",
+    "params": {
+        "invoice": "lnbc50n1..." // bolt11 invoice
+    }
 }
 ```
 
 Response:
 ```jsonc
 {
-    "preimage": "0123456789abcdef..." // preimage after payment, string
+    "result_type": "pay_invoice",
+    "result": { 
+        "preimage": "0123456789abcdef..." // preimage of the payment
+    }
 }
 ```
 

--- a/47.md
+++ b/47.md
@@ -96,28 +96,6 @@ Response:
                             // get_info+node_info
 }
 ```
-
-### `create_invoice`
-
-Description: Requests creation of an invoice.
-
-Request:
-```jsonc
-{
-    "amount": 1000, // amount in msat, int
-                    // must be a whole number of sats unless
-                    // create_invoice+msat_amount is implemented.
-    "description": "memo" // a description, string, optional
-}
-```
-
-Response:
-```jsonc
-{
-    "invoice": "lnbc50n1..." // BOLT11 invoice, string
-}
-```
-
 ### `pay_invoice`
 
 Description: Requests payment of an invoice.


### PR DESCRIPTION
I think I have included all the feedback from the discussion, while ensuring that the scope of the NIP stays manageable.

- JSON-RPCish payloads with a field indicating the type of the response.
- Info is a replaceable event.
- Only describe the `pay_invoice` command.
- Only use a single relay.
- Responses should have an `e` tag to indicate what they are responding to.