### PR TITLE
Improve README.md markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 NIPs stand for **Nostr Implementation Possibilities**. They exist to document what may be implemented by [Nostr](https://github.com/fiatjaf/nostr)-compatible _relay_ and _client_ software.
 
+---
+
+- [List](#list)
+- [Event Kinds](#event-kinds)
+  - [Event Kind Ranges](#event-kind-ranges)
+- [Message Types](#message-types)
+  - [Client to Relay](#client-to-relay)
+  - [Relay to Client](#relay-to-client)
+- [Standardized Tags](#standardized-tags)
+- [Criteria for acceptance of NIPs](#criteria-for-acceptance-of-nips)
+- [License](#license)
+
+---
+
+## List
+
 - [NIP-01: Basic protocol flow description](01.md)
 - [NIP-02: Contact List and Petnames](02.md)
 - [NIP-03: OpenTimestamps Attestations for Events](03.md)

--- a/README.md
+++ b/README.md
@@ -61,38 +61,38 @@ They exist to document what may be implemented by [Nostr](https://github.com/fia
 
 ## Event Kinds
 
-| kind     | description                | NIP         |
-| -------- | -------------------------- | ----------- |
-| `0`      | Metadata                   | [1](01.md)  |
-| `1`      | Short Text Note            | [1](01.md)  |
-| `2`      | Recommend Relay            | [1](01.md)  |
-| `3`      | Contacts                   | [2](02.md)  |
-| `4`      | Encrypted Direct Messages  | [4](04.md)  |
-| `5`      | Event Deletion             | [9](09.md)  |
-| `6`      | Reposts                    | [18](18.md) |
-| `7`      | Reaction                   | [25](25.md) |
-| `8`      | Badge Award                | [58](58.md) |
-| `40`     | Channel Creation           | [28](28.md) |
-| `41`     | Channel Metadata           | [28](28.md) |
-| `42`     | Channel Message            | [28](28.md) |
-| `43`     | Channel Hide Message       | [28](28.md) |
-| `44`     | Channel Mute User          | [28](28.md) |
-| `1984`   | Reporting                  | [56](56.md) |
-| `9734`   | Zap Request                | [57](57.md) |
-| `9735`   | Zap                        | [57](57.md) |
-| `10000`  | Mute List                  | [51](51.md) |
-| `10001`  | Pin List                   | [51](51.md) |
-| `10002`  | Relay List Metadata        | [65](65.md) |
-| `22242`  | Client Authentication      | [42](42.md) |
-| `24133`  | Nostr Connect              | [46](46.md) |
-| `30000`  | Categorized People List    | [51](51.md) |
-| `30001`  | Categorized Bookmark List  | [51](51.md) |
-| `30008`  | Profile Badges             | [58](58.md) |
-| `30009`  | Badge Definition           | [58](58.md) |
-| `30017`  | Create or update a stall   | [15](15.md) |
-| `30018`  | Create or update a product | [15](15.md) |
-| `30023`  | Long-form Content          | [23](23.md) |
-| `30078`  | Application-specific Data  | [78](78.md) |
+| kind    | description                | NIP         |
+| ------- | -------------------------- | ----------- |
+| `0`     | Metadata                   | [1](01.md)  |
+| `1`     | Short Text Note            | [1](01.md)  |
+| `2`     | Recommend Relay            | [1](01.md)  |
+| `3`     | Contacts                   | [2](02.md)  |
+| `4`     | Encrypted Direct Messages  | [4](04.md)  |
+| `5`     | Event Deletion             | [9](09.md)  |
+| `6`     | Reposts                    | [18](18.md) |
+| `7`     | Reaction                   | [25](25.md) |
+| `8`     | Badge Award                | [58](58.md) |
+| `40`    | Channel Creation           | [28](28.md) |
+| `41`    | Channel Metadata           | [28](28.md) |
+| `42`    | Channel Message            | [28](28.md) |
+| `43`    | Channel Hide Message       | [28](28.md) |
+| `44`    | Channel Mute User          | [28](28.md) |
+| `1984`  | Reporting                  | [56](56.md) |
+| `9734`  | Zap Request                | [57](57.md) |
+| `9735`  | Zap                        | [57](57.md) |
+| `10000` | Mute List                  | [51](51.md) |
+| `10001` | Pin List                   | [51](51.md) |
+| `10002` | Relay List Metadata        | [65](65.md) |
+| `22242` | Client Authentication      | [42](42.md) |
+| `24133` | Nostr Connect              | [46](46.md) |
+| `30000` | Categorized People List    | [51](51.md) |
+| `30001` | Categorized Bookmark List  | [51](51.md) |
+| `30008` | Profile Badges             | [58](58.md) |
+| `30009` | Badge Definition           | [58](58.md) |
+| `30017` | Create or update a stall   | [15](15.md) |
+| `30018` | Create or update a product | [15](15.md) |
+| `30023` | Long-form Content          | [23](23.md) |
+| `30078` | Application-specific Data  | [78](78.md) |
 
 ### Event Kind Ranges
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NIPs
 
-NIPs stand for **Nostr Implementation Possibilities**. They exist to document what may be implemented by [Nostr](https://github.com/fiatjaf/nostr)-compatible _relay_ and _client_ software.
+NIPs stand for **Nostr Implementation Possibilities**.
+They exist to document what may be implemented by [Nostr](https://github.com/fiatjaf/nostr)-compatible _relay_ and _client_ software.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -106,18 +106,36 @@ When experimenting with kinds, keep in mind the classification introduced by [NI
 
 ## Standardized Tags
 
-| name       | value                   | other parameters  | NIP                      |
-| ---------- | ----------------------- | ----------------- | ------------------------ |
-| e          | event id (hex)          | relay URL, marker | [1](01.md), [10](10.md)  |
-| p          | pubkey (hex)            | relay URL         | [1](01.md)               |
-| a          | coordinates to an event | relay URL         | [33](33.md), [23](23.md) |
-| r          | a reference (URL, etc)  |                   | [12](12.md)              |
-| t          | hashtag                 |                   | [12](12.md)              |
-| g          | geohash                 |                   | [12](12.md)              |
-| nonce      | random                  |                   | [13](13.md)              |
-| subject    | subject                 |                   | [14](14.md)              |
-| d          | identifier              |                   | [33](33.md)              |
-| expiration | unix timestamp (string) |                   | [40](40.md)              |
+| name           | value                                | other parameters     | NIP                      |
+| -------------- | ------------------------------------ | -------------------- | ------------------------ |
+| `a`            | coordinates to an event              | relay URL            | [33](33.md), [23](23.md) |
+| `d`            | identifier                           | --                   | [33](33.md)              |
+| `e`            | event id (hex)                       | relay URL, marker    | [1](01.md), [10](10.md)  |
+| `g`            | geohash                              | --                   | [12](12.md)              |
+| `i`            | identity                             | proof                | [39](39.md)              |
+| `p`            | pubkey (hex)                         | relay URL            | [1](01.md)               |
+| `r`            | a reference (URL, etc)               | --                   | [12](12.md)              |
+| `t`            | hashtag                              | --                   | [12](12.md)              |
+| `amount`       | millisats                            | --                   | [57](57.md)              |
+| `bolt11`       | `bolt11` invoice                     | --                   | [57](57.md)              |
+| `challenge`    | challenge string                     | --                   | [42](42.md)              |
+| `delegation`   | pubkey, conditions, delegation token | --                   | [26](26.md)              |
+| `description`  | badge description                    | --                   | [58](58.md)              |
+| `description`  | invoice description                  | --                   | [57](57.md)              |
+| `expiration`   | unix timestamp (string)              | --                   | [40](40.md)              |
+| `image`        | image URL                            | dimensions in pixels | [23](23.md), [58](58.md) |
+| `lnurl`        | `bech32` encoded `lnurl`             | --                   | [57](57.md)              |
+| `name`         | badge name                           | --                   | [58](58.md)              |
+| `nonce`        | random                               | --                   | [13](13.md)              |
+| `preimage`     | hash of `bolt11` invoice             | --                   | [57](57.md)              |
+| `published_at` | unix timestamp (string)              | --                   | [23](23.md)              |
+| `relay`        | relay url                            | --                   | [42](42.md)              |
+| `relays`       | relay list                           | --                   | [57](57.md)              |
+| `subject`      | subject                              | --                   | [14](14.md)              |
+| `summary`      | article summary                      | --                   | [23](23.md)              |
+| `thumb`        | badge thumbnail                      | dimensions in pixels | [58](58.md)              |
+| `title`        | article title                        | --                   | [23](23.md)              |
+| `zap`          | profile name                         | type of value        | [57](57.md)              |
 
 ## Criteria for acceptance of NIPs
 

--- a/README.md
+++ b/README.md
@@ -82,23 +82,25 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 ## Message types
 
 ### Client to Relay
-| type  | description                                         | NIP         |
-|-------|-----------------------------------------------------|-------------|
-| EVENT | used to publish events                              | [1](01.md)  |
-| REQ   | used to request events and subscribe to new updates | [1](01.md)  |
-| CLOSE | used to stop previous subscriptions                 | [1](01.md)  |
-| AUTH  | used to send authentication events                  | [42](42.md) |
-| COUNT | used to request event counts                        | [45](45.md) |
+
+| type    | description                                         | NIP         |
+| ------- | --------------------------------------------------- | ----------- |
+| `AUTH`  | used to send authentication events                  | [42](42.md) |
+| `CLOSE` | used to stop previous subscriptions                 | [1](01.md)  |
+| `COUNT` | used to request event counts                        | [45](45.md) |
+| `EVENT` | used to publish events                              | [1](01.md)  |
+| `REQ`   | used to request events and subscribe to new updates | [1](01.md)  |
 
 ### Relay to Client
-| type   | description                                             | NIP         |
-|--------|---------------------------------------------------------|-------------|
-| EVENT  | used to send events requested to clients                | [1](01.md)  |
-| NOTICE | used to send human-readable messages to clients         | [1](01.md)  |
-| EOSE   | used to notify clients all stored events have been sent | [1](01.md) |
-| OK     | used to notify clients if an EVENT was successful       | [20](20.md) |
-| AUTH   | used to send authentication challenges                  | [42](42.md) |
-| COUNT  | used to send requested event counts to clients          | [45](45.md)  |
+
+| type     | description                                             | NIP         |
+| -------- | ------------------------------------------------------- | ----------- |
+| `AUTH`   | used to send authentication challenges                  | [42](42.md) |
+| `COUNT`  | used to send requested event counts to clients          | [45](45.md) |
+| `EOSE`   | used to notify clients all stored events have been sent | [1](01.md)  |
+| `EVENT`  | used to send events requested to clients                | [1](01.md)  |
+| `NOTICE` | used to send human-readable messages to clients         | [1](01.md)  |
+| `OK`     | used to notify clients if an EVENT was successful       | [20](20.md) |
 
 Please update these lists when proposing NIPs introducing new event kinds.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/fia
 - [NIP-05: Mapping Nostr keys to DNS-based internet identifiers](05.md)
 - [NIP-06: Basic key derivation from mnemonic seed phrase](06.md)
 - [NIP-07: `window.nostr` capability for web browsers](07.md)
-- [NIP-08: Handling Mentions](08.md) – `unrecommended`: deprecated in favor of [NIP-27](27.md)
+- [NIP-08: Handling Mentions](08.md) --- **unrecommended**: deprecated in favor of [NIP-27](27.md)
 - [NIP-09: Event Deletion](09.md)
 - [NIP-10: Conventions for clients' use of `e` and `p` tags in text events](10.md)
 - [NIP-11: Relay Information Document](11.md)

--- a/README.md
+++ b/README.md
@@ -74,10 +74,15 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 | 30009         | Badge Definition                 | [58](58.md) |
 | 30023         | Long-form Content                | [23](23.md) |
 | 30078         | Application-specific Data        | [78](78.md) |
-| 1000-9999     | Regular Events                   | [16](16.md) |
-| 10000-19999   | Replaceable Events               | [16](16.md) |
-| 20000-29999   | Ephemeral Events                 | [16](16.md) |
-| 30000-39999   | Parameterized Replaceable Events | [33](33.md) |
+
+### Event Kind Ranges
+
+| range            | description                      | NIP         |
+| ---------------- | -------------------------------- | ----------- |
+| `1000`--`9999`   | Regular Events                   | [16](16.md) |
+| `10000`--`19999` | Replaceable Events               | [16](16.md) |
+| `20000`--`29999` | Ephemeral Events                 | [16](16.md) |
+| `30000`--`39999` | Parameterized Replaceable Events | [33](33.md) |
 
 ## Message types
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 
 Please update these lists when proposing NIPs introducing new event kinds.
 
-When experimenting with kinds, keep in mind the classification introduced by [NIP-16](16.md).
+When experimenting with kinds, keep in mind the classification introduced by [NIP-16](16.md) and [NIP-33](33.md).
 
 ## Standardized Tags
 

--- a/README.md
+++ b/README.md
@@ -44,36 +44,38 @@ NIPs stand for **Nostr Implementation Possibilities**. They exist to document wh
 
 ## Event Kinds
 
-| kind          | description                      | NIP         |
-| ------------- | -------------------------------- | ----------- |
-| 0             | Metadata                         | [1](01.md)  |
-| 1             | Short Text Note                  | [1](01.md)  |
-| 2             | Recommend Relay                  | [1](01.md)  |
-| 3             | Contacts                         | [2](02.md)  |
-| 4             | Encrypted Direct Messages        | [4](04.md)  |
-| 5             | Event Deletion                   | [9](09.md)  |
-| 6             | Reposts                          | [18](18.md) |
-| 7             | Reaction                         | [25](25.md) |
-| 8             | Badge Award                      | [58](58.md) |
-| 40            | Channel Creation                 | [28](28.md) |
-| 41            | Channel Metadata                 | [28](28.md) |
-| 42            | Channel Message                  | [28](28.md) |
-| 43            | Channel Hide Message             | [28](28.md) |
-| 44            | Channel Mute User                | [28](28.md) |
-| 1984          | Reporting                        | [56](56.md) |
-| 9734          | Zap Request                      | [57](57.md) |
-| 9735          | Zap                              | [57](57.md) |
-| 10000         | Mute List                        | [51](51.md) |
-| 10001         | Pin List                         | [51](51.md) |
-| 10002         | Relay List Metadata              | [65](65.md) |
-| 22242         | Client Authentication            | [42](42.md) |
-| 24133         | Nostr Connect                    | [46](46.md) |
-| 30000         | Categorized People List          | [51](51.md) |
-| 30001         | Categorized Bookmark List        | [51](51.md) |
-| 30008         | Profile Badges                   | [58](58.md) |
-| 30009         | Badge Definition                 | [58](58.md) |
-| 30023         | Long-form Content                | [23](23.md) |
-| 30078         | Application-specific Data        | [78](78.md) |
+| kind     | description                | NIP         |
+| -------- | -------------------------- | ----------- |
+| `0`      | Metadata                   | [1](01.md)  |
+| `1`      | Short Text Note            | [1](01.md)  |
+| `2`      | Recommend Relay            | [1](01.md)  |
+| `3`      | Contacts                   | [2](02.md)  |
+| `4`      | Encrypted Direct Messages  | [4](04.md)  |
+| `5`      | Event Deletion             | [9](09.md)  |
+| `6`      | Reposts                    | [18](18.md) |
+| `7`      | Reaction                   | [25](25.md) |
+| `8`      | Badge Award                | [58](58.md) |
+| `40`     | Channel Creation           | [28](28.md) |
+| `41`     | Channel Metadata           | [28](28.md) |
+| `42`     | Channel Message            | [28](28.md) |
+| `43`     | Channel Hide Message       | [28](28.md) |
+| `44`     | Channel Mute User          | [28](28.md) |
+| `1984`   | Reporting                  | [56](56.md) |
+| `9734`   | Zap Request                | [57](57.md) |
+| `9735`   | Zap                        | [57](57.md) |
+| `10000`  | Mute List                  | [51](51.md) |
+| `10001`  | Pin List                   | [51](51.md) |
+| `10002`  | Relay List Metadata        | [65](65.md) |
+| `22242`  | Client Authentication      | [42](42.md) |
+| `24133`  | Nostr Connect              | [46](46.md) |
+| `30000`  | Categorized People List    | [51](51.md) |
+| `30001`  | Categorized Bookmark List  | [51](51.md) |
+| `30008`  | Profile Badges             | [58](58.md) |
+| `30009`  | Badge Definition           | [58](58.md) |
+| `30017`  | Create or update a stall   | [15](15.md) |
+| `30018`  | Create or update a product | [15](15.md) |
+| `30023`  | Long-form Content          | [23](23.md) |
+| `30078`  | Application-specific Data  | [78](78.md) |
 
 ### Event Kind Ranges
 


### PR DESCRIPTION
Improvements to the `README.md` file.

Improvements include:

- added a Table of Contents to the file's top
- separated the kind ranges from the specific kind list
- added reference to NIP-33 to the note suggesting the reader to take heed of already defined kind ranges
- added all missing tags in approved NIPs
- tidied up tables
- minimal style changes to "unrecommended" notice
- ensured "one sentence per line" so as to minimize future diffs

:)