### PR TITLE
Markdown inprovements - 02

### DIFF
--- a/02.md
+++ b/02.md
@@ -1,14 +1,13 @@
-NIP-02
-======
-
-Contact List and Petnames
--------------------------
+# NIP-02
 
 `final` `optional` `author:fiatjaf` `author:arcbtc`
 
-A special event with kind `3`, meaning "contact list" is defined as having a list of `p` tags, one for each of the followed/known profiles one is following.
+## Contact List and Petnames
 
-Each tag entry should contain the key for the profile, a relay URL where events from that key can be found (can be set to an empty string if not needed), and a local name (or "petname") for that profile (can also be set to an empty string or not provided), i.e., `["p", <32-bytes hex key>, <main relay URL>, <petname>]`. The `content` can be anything and should be ignored.
+A special event with `kind:3`, meaning "contact list" is defined as having a list of `"p"` tags, one for each of the followed/known profiles one is following.
+
+Each tag entry should contain the key for the profile, a relay URL where events from that key can be found (can be set to an empty string if not needed), and a local name (or "petname") for that profile (can also be set to an empty string or not provided), i.e., `["p", <32-bytes hex key>, <main relay URL>, <petname>]`.
+The `content` can be anything and should be ignored.
 
 For example:
 
@@ -16,26 +15,27 @@ For example:
 {
   "kind": 3,
   "tags": [
-    ["p", "91cf9..4e5ca", "wss://alicerelay.com/", "alice"],
-    ["p", "14aeb..8dad4", "wss://bobrelay.com/nostr", "bob"],
-    ["p", "612ae..e610f", "ws://carolrelay.com/ws", "carol"]
+    ["p", "91cf9..4e5ca", "wss://alice-relay.com/", "alice"],
+    ["p", "14aeb..8dad4", "wss://bob-relay.com/nostr", "bob"],
+    ["p", "612ae..e610f", "ws://carol-relay.com/ws", "carol"]
   ],
   "content": "",
-  ...other fields
+  ...
 }
 ```
 
-Every new contact list that gets published overwrites the past ones, so it should contain all entries. Relays and clients SHOULD delete past contact lists as soon as they receive a new one.
+Every new contact list that gets published overwrites the past ones, so it should contain all entries.
+Relays and clients **SHOULD** delete past contact lists as soon as they receive a new one.
 
 ## Uses
 
 ### Contact list backup
 
-If one believes a relay will store their events for sufficient time, they can use this kind-3 event to backup their following list and recover on a different device.
+If one believes a relay will store their events for sufficient time, they can use this `kind:3` event to backup their following list and recover on a different device.
 
 ### Profile discovery and context augmentation
 
-A client may rely on the kind-3 event to display a list of followed people by profiles one is browsing; make lists of suggestions on who to follow based on the contact lists of other people one might be following or browsing; or show the data in other contexts.
+A client may rely on the `kind:3` event to display a list of followed people by profiles one is browsing; make lists of suggestions on who to follow based on the contact lists of other people one might be following or browsing; or show the data in other contexts.
 
 ### Relay sharing
 
@@ -69,6 +69,6 @@ and another from `a8bb3d884d5d90b413d9891fe4c4e46d` that says
 ]
 ```
 
-When the user sees `21df6d143fb96c2ec9d63726bf9edc71` the client can show _erin_ instead;
-When the user sees `a8bb3d884d5d90b413d9891fe4c4e46d` the client can show _david.erin_ instead;
+When the user sees `21df6d143fb96c2ec9d63726bf9edc71` the client can show _erin_ instead.
+When the user sees `a8bb3d884d5d90b413d9891fe4c4e46d` the client can show _david.erin_ instead.
 When the user sees `f57f54057d2a7af0efecc8b0b66f5708` the client can show _frank.david.erin_ instead.


### PR DESCRIPTION
- Unify heading styles to use # only at the start of lines
- Ensure a single sentence per line to minimize future diffs
- Move tags to top (immediately after NIP title)
- Use **THIS STYLE** for all occurrences of the keywords on [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119)
- Use `kind:NN` for all references to kinds
- Use `"T"` for all references to tags (both single-letter and multi-letter ones)
- Use `field` for NOSTR events' field names (viz. instead of `event.field` or `.field`)
- Try our best to have JSON fragments be as valid as possible (eg. pay attention to trailing commas and the like)