### PR TITLE
Markdown improvements - 03

### DIFF
--- a/03.md
+++ b/03.md
@@ -1,23 +1,20 @@
-NIP-03
-======
-
-OpenTimestamps Attestations for Events
---------------------------------------
+# NIP-03
 
 `draft` `optional` `author:fiatjaf`
 
-When there is an OTS available it MAY be included in the existing event body under the `ots` key:
+## OpenTimestamps Attestations for Events
 
-```
+When there is an OTS available it **MAY** be included in the existing event body under the `ots` key:
+
+```json
 {
   "id": ...,
   "kind": ...,
-  ...,
   ...,
   "ots": <base64-encoded OTS file data>
 }
 ```
 
-The _event id_ MUST be used as the raw hash to be included in the OpenTimestamps merkle tree.
+The `event.id` **MUST** be used as the raw hash to be included in the [OpenTimestamps](https://opentimestamps.org) Merkle tree.
 
-The attestation can be either provided by relays automatically (and the OTS binary contents just appended to the events it receives) or by clients themselves when they first upload the event to relays — and used by clients to show that an event is really "at least as old as [OTS date]".
+The attestation can be either provided by relays automatically (and the OTS binary contents just appended to the events it receives) or by clients themselves when they first upload the event to relays --- and used by clients to show that an event is really _"at least as old as [OTS date]"_.


### PR DESCRIPTION
- Unify heading styles to use `#` only at the start of lines
- Ensure all fenced code blocks have a (correct-ish) language tag associated to them
- Remove all non-ASCII characters
- Move tags to top (immediately after NIP title)
- Use **THIS STYLE** for all occurrences of the keywords on [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119)
- Capitalize proper names: "Merkle"
- Add links to OpenTimestamps