### PR TITLE
More precise wording on delegation conditions in NIP-26

### DIFF
--- a/26.md
+++ b/26.md
@@ -44,7 +44,7 @@ The following fields and operators are supported in the above query string:
       -  `<${TIMESTAMP}` - delegatee may only sign events created ***before*** the specified timestamp
       -  `>${TIMESTAMP}` - delegatee may only sign events created ***after*** the specified timestamp
 
-In order to create a single condition, you must use a supported field and operator. Multiple conditions can be used in a single query string, including on the same field. Conditions must be combined with `&`.
+In order to create a single condition, you must use a supported field and operator. Multiple conditions can be used in a single query string. Conditions can be combined with `&`. Multiple `kind=` conditions mean that the delegation token can be used to sign any of the specified event kinds. Multiple `created_at>` or `created_at<` conditions should not be combined.
 
 For example, the following condition strings are valid:
 
@@ -52,7 +52,7 @@ For example, the following condition strings are valid:
 - `kind=0&kind=1&created_at>1675721813`
 - `kind=1&created_at>1674777689&created_at<1675721813`
 
-For the vast majority of use-cases, it is advisable that query strings should include a `created_at` ***after*** condition reflecting the current time, to prevent the delegatee from publishing historic notes on the delegator's behalf.
+For the vast majority of use-cases, it is advisable that query strings should include a `created_at>` condition reflecting the current time, to prevent the delegatee from publishing historic notes on the delegator's behalf.
 
 #### Example
 


### PR DESCRIPTION
NIP-26 says that conditions can be combined using `&`, but does not explain what it means to combine multiple conditions. For example, the `&` does not necessarily mean _and_. For `kind=` conditions, it actually means _or_. For multiples of `created_at>` and `created_at<` conditions, it's unclear if `&` should be allowed. I think it's best to say that such conditions should not be combined.