### PR TITLE
explain blurhash clearly in NIP-94

### DIFF
--- a/94.md
+++ b/94.md
@@ -15,7 +15,7 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
 * `size` (optional) size of file in bytes
 * `magnet` (optional) URI to magnet file
 * `i` (optional) torrent infohash
-* `blurhash`(optional) for cosmetic purposes 
+* `blurhash`(optional) the [blurhash](https://github.com/woltapp/blurhash) to show while the file is being loaded by the client 
 
 ```json
 {


### PR DESCRIPTION
Currently, the `blurhash` property's description says 'cosmetic purposes'. This PR removes the vagueness in this description.