### PR TITLE
example was incorrect

### DIFF
--- a/13.md
+++ b/13.md
@@ -10,6 +10,8 @@ This NIP defines a way to generate and interpret Proof of Work for nostr notes. 
 
 `difficulty` is defined to be the number of leading zero bits in the `NIP-01` id. For example, an id of `000000000e9d97a1ab09fc381030b346cdd7a142ad57e6df0b46dc9bef6c7e2d` has a difficulty of `36` with `36` leading 0 bits.
 
+`002f...` is `0000 0000 0010 1111...` in binary, which has 10 leading zeroes. Do not forget to count leading zeroes for hex digits <= `7`.
+
 Mining
 ------
 
@@ -36,7 +38,7 @@ Example mined note
     [
       "nonce",
       "776797",
-      "20"
+      "21"
     ]
   ],
   "content": "It's just me mining my own business",
@@ -47,33 +49,61 @@ Example mined note
 Validating
 ----------
 
-Here is some reference C code for calculating the difficulty (aka number of leading zero bits) in a nostr note id:
+Here is some reference C code for calculating the difficulty (aka number of leading zero bits) in a nostr event id:
 
 ```c
-int zero_bits(unsigned char b)
-{
-        int n = 0;
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-        if (b == 0)
-                return 8;
+int countLeadingZeroes(const char *hex) {
+    int count = 0;
 
-        while (b >>= 1)
-                n++;
+    for (int i = 0; i < strlen(hex); i++) {
+        int nibble = (int)strtol((char[]){hex[i], '\0'}, NULL, 16);
+        if (nibble == 0) {
+            count += 4;
+        } else {
+            count += __builtin_clz(nibble) - 28;
+            break;
+        }
+    }
 
-        return 7-n;
+    return count;
 }
 
-/* find the number of leading zero bits in a hash */
-int count_leading_zero_bits(unsigned char *hash)
-{
-        int bits, total, i;
-        for (i = 0, total = 0; i < 32; i++) {
-                bits = zero_bits(hash[i]);
-                total += bits;
-                if (bits != 8)
-                        break;
-        }
-        return total;
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s <hex_string>\n", argv[0]);
+        return 1;
+    }
+
+    const char *hex_string = argv[1];
+    int result = countLeadingZeroes(hex_string);
+    printf("Leading zeroes in hex string %s: %d\n", hex_string, result);
+
+    return 0;
+}
+```
+
+Here is some JavaScript code for doing the same thing:
+
+```javascript
+// hex should be a hexadecimal string (with no 0x prefix)
+function countLeadingZeroes(hex) {
+  let count = 0;
+
+  for (let i = 0; i < hex.length; i++) {
+    const nibble = parseInt(hex[i], 16);
+    if (nibble === 0) {
+      count += 4;
+    } else {
+      count += Math.clz32(nibble) - 28;
+      break;
+    }
+  }
+
+  return count;
 }
 ```
 

--- a/13.md
+++ b/13.md
@@ -18,7 +18,7 @@ Mining
 To generate PoW for a `NIP-01` note, a `nonce` tag is used:
 
 ```json
-{"content": "It's just me mining my own business", "tags": [["nonce", "1", "20"]]}
+{"content": "It's just me mining my own business", "tags": [["nonce", "1", "21"]]}
 ```
 
 When mining, the second entry to the nonce tag is updated, and then the id is recalculated (see [NIP-01](./01.md)). If the id has the desired number of leading zero bits, the note has been mined. It is recommended to update the `created_at` as well during this process.


### PR DESCRIPTION
the example event id had 21 leading zeroes, not 20

I provided new C code that has been tested to work (my tests showed the example code to be incorrect) and I provided some JavaScript code to test event ids as well.

I did not re-compute the event id for the example event; I simply changed the nonce to be 21. Since it is an example, it may not matter that the event id is not the real event id for the updated event.

The thing that matters is that people understand how to correctly count leading zeroes without an incorrect example creating confusion.