### PR TITLE
NIP-54: Inline Image Metadata

### DIFF
--- a/54.md
+++ b/54.md
@@ -6,8 +6,10 @@ Inline Image Metadata
 
 `draft` `optional` `author:jb55`
 
-This NIP describes additional information associated with urls in notes that
-clients can use to provide a better experience when loading images.
+Inline image metadata is additional information associated with urls in notes
+that clients can use to provide a better experience when loading images. This
+is different than NIP94, which is more for file attachment metadata. NIP94 is
+not well suited for backwards-compatible inline image url metadata.
 
 This additional information is an `imeta` tag that looks like this:
 

--- a/54.md
+++ b/54.md
@@ -1,0 +1,74 @@
+NIP-54
+======
+
+Inline Image Metadata
+---------------------
+
+`draft` `optional` `author:jb55`
+
+This NIP describes additional information associated with urls in notes that
+clients can use to provide a better experience when loading images.
+
+This additional information is an `imeta` tag that looks like this:
+
+```json
+{
+  "content": "More image metadata tests don’t mind me https://nostr.build/i/863321bb1ae68830ebcf9a343ca0a5e0ce2323d0a55b7fbe86f7a886cf61db8d.jpg ",
+  "kind": 1,
+  "tags": [
+    [
+      "imeta",
+      "https://nostr.build/i/863321bb1ae68830ebcf9a343ca0a5e0ce2323d0a55b7fbe86f7a886cf61db8d.jpg",
+      "Picture of a scenic view overlooking the coast near Uvita, with a person holding a coffee cup",
+      "3024x4032",
+      "eVF$^OI:${M{o#*0-nNFxakD-?xVM}WEWB%iNKxvR-oetmo#R-aen$"
+    ]
+  ]
+}
+```
+
+There can be multiple `imeta` tags for each image url in the content.
+
+The `imeta` tag MUST have a `url`, and MUST have at least one piece of metadata
+(`alt-text`, `dimensions`, `blurhash`, or `sha256`). Otherwise it is invalid.
+
+
+## Fields
+
+`imeta` has the following metadata fields:
+
+```
+["imeta", url, alt-text, dimensions, blurhash, sha256]
+```
+
+- `url`: The url referencing the url in the content
+
+- `alt-text`: Accessible text label that describes the image
+
+- `dimensions`: The width and height of the image
+
+- `blurhash`: The [blurhash][blurhash] of the image. Can be used to show blurry
+  previews before the url has been downloaded.
+
+- `sha256`: The sha256 of the image. Used to check if the image has changed or
+  not.
+
+If the client just wants to provide dimensions, the tag would be:
+
+```
+["imeta", "https://example.com/image.png", "", "512x512"]
+```
+
+[blurhash]: https://github.com/woltapp/blurhash
+
+
+## Recommended client behavior
+
+When uploading images during a new post, clients can include this metadata
+after the image is uploaded and included in the post.
+
+When pasting urls during post composition, the client could download the image
+and add this metadata before the post is sent.
+
+Clients can use this tag to add accessible text for people who prefer not to
+load images, visibility-impaired users, or text clients.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/fia
 - [NIP-46: Nostr Connect](46.md)
 - [NIP-50: Keywords filter](50.md)
 - [NIP-51: Lists](51.md)
+- [NIP-54: Image Metadata](54.md)
 - [NIP-56: Reporting](56.md)
 - [NIP-57: Lightning Zaps](57.md)
 - [NIP-58: Badges](58.md)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/fia
 - [NIP-46: Nostr Connect](46.md)
 - [NIP-50: Keywords filter](50.md)
 - [NIP-51: Lists](51.md)
-- [NIP-54: Image Metadata](54.md)
+- [NIP-54: Inline Image Metadata](54.md)
 - [NIP-56: Reporting](56.md)
 - [NIP-57: Lightning Zaps](57.md)
 - [NIP-58: Badges](58.md)


### PR DESCRIPTION
Inline Image metadata is additional information associated with urls in notes that
clients can use to provide a better experience when loading images.