### PR TITLE
NIP-30: Custom Emoji

### DIFF
--- a/30.md
+++ b/30.md
@@ -1,0 +1,56 @@
+NIP-30
+======
+
+Custom Emoji
+------------
+
+`draft` `optional` `author:alexgleason`
+
+Custom emoji may be added to **kind 0** and **kind 1** events by including one or more `"emoji"` tags, in the form:
+
+```
+["emoji", <shortcode>, <image-url>]
+```
+
+Where:
+
+- `<shortcode>` is a name given for the emoji, which MUST be comprised of only alphanumeric characters.
+- `<image-url>` is a URL to the corresponding image file of the emoji.
+
+For each emoji tag, clients should parse emoji shortcodes (aka "emojify") like `:shortcode:` in the event to display custom emoji.
+
+Clients may allow users to add custom emoji to an event by including `:shortcode:` identifier in the event, and adding the relevant `"emoji"` tags.
+
+### Kind 0 events
+
+In kind 0 events, the `name` and `about` fields should be emojified.
+
+```json
+{
+  "kind": 0,
+  "content": "{\"name\":\"Alex Gleason :soapbox:\"}",
+  "tags": [
+    ["emoji", "soapbox", "https://gleasonator.com/emoji/Gleasonator/soapbox.png"]
+  ],
+  "pubkey": "79c2cae114ea28a981e7559b4fe7854a473521a8d22a66bbab9fa248eb820ff6",
+  "created_at": 1682790000
+}
+```
+
+### Kind 1 events
+
+In kind 1 events, the `content` should be emojified.
+
+```json
+{
+  "kind": 1,
+  "content": "Hello :gleasonator: 😂 :ablobcatrainbow: :disputed: yolo",
+    "tags": [
+    ["emoji", "ablobcatrainbow", "https://gleasonator.com/emoji/blobcat/ablobcatrainbow.png"],
+    ["emoji", "disputed", "https://gleasonator.com/emoji/Fun/disputed.png"],
+    ["emoji", "gleasonator", "https://gleasonator.com/emoji/Gleasonator/gleasonator.png"]
+  ],
+  "pubkey": "79c2cae114ea28a981e7559b4fe7854a473521a8d22a66bbab9fa248eb820ff6",
+  "created_at": 1682630000
+}
+```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/fia
 - [NIP-26: Delegated Event Signing](26.md)
 - [NIP-27: Text Note References](27.md)
 - [NIP-28: Public Chat](28.md)
+- [NIP-30: Custom Emoji](30.md)
 - [NIP-33: Parameterized Replaceable Events](33.md)
 - [NIP-36: Sensitive Content](36.md)
 - [NIP-39: External Identities in Profiles](39.md)


### PR DESCRIPTION
Adds a NIP for custom emoji, similar to Mastodon. It is [already implemented by the Mostr bridge](https://gitlab.com/soapbox-pub/mostr/-/merge_requests/56).

A real-world event can be found here: https://www.nostr.guru/e/5e1e0e524432e524f9584f296f72dda5559fc9fe6116a744baa43ea6769c7b65