### PR TITLE
RFC: Extending Nostr to support x.509 certificates

### DIFF
--- a/95.md
+++ b/95.md
@@ -10,7 +10,15 @@ This NIP introduces an optional enhancement to the existing Nostr protocol by al
 
 ## Motivation
 
-While the Nostr protocol is designed to be completely decentralized, with anyone able to generate their own private keys, the inclusion of X.509 certificates can provide additional benefits. Most certificates would be self-signed X.509 certificates by design, but this feature opens up the possibility for the root key (or the original self-signed X.509 certificate) to create and sign additional subordinate key pairs with time-to-live (TTL) values. This allows users who follow the root's pubkey to validate the identity and validity of child/subordinate keys, offering an improvement over NIP-26.
+The Nostr protocol, as described in NIP-01, relies on public-private keypairs for user identification, event signing, and event validation. However, it does not currently support any mechanism for including additional pubkey metadata, such as issuer and validity time, within events. This limitation makes it challenging to manage key rotation, validity periods, and subordinate key delegation in a more structured and secure manner.
+
+The proposed NIP aims to enhance Nostr's security and flexibility by allowing clients to embed an optional X.509 certificate in addition to the existing pubkey field. Including an X.509 certificate would enable additional pubkey metadata to be embedded, such as issuer and validity time. Since Nostr and the issuance of private keys are entirely decentralized, most certificates would be "self-signed" X.509 certificates, which is by design.
+
+The inclusion of X.509 certificates would enable the possibility of creating and signing subordinate key pairs with time-to-live (TTL) values by the root key (or the original self-signed X.509). As long as a person follows the root's pubkey, they would be able to validate the identity and validity of child/subordinate keys. This feature facilitates subordinate key rotation, ensuring that keys remain secure and up-to-date. If a subordinate key is compromised or needs to be replaced for any reason, the root key can issue a new subordinate key with a new TTL, maintaining the security of the system.
+
+This NIP would be an improvement over the existing NIP-26, as it introduces the concept of certificate TTLs for child/subordinate keys and certificates, providing a more robust and secure mechanism for key management, rotation, and delegation.
+
+By introducing support for X.509 certificates and enabling the creation of subordinate keys with TTLs, this NIP aims to provide a more secure and flexible key management system for the Nostr protocol, ultimately enhancing the overall security and user experience.
 
 ## Specification
 
@@ -30,9 +38,9 @@ The optional `x509_cert` field should not affect the event serialization and sig
 
 Clients that support this NIP should perform the following additional checks when processing events that include an `x509_cert` field:
 
-1. Verify that the X.509 certificate is valid (i.e., not expired, not revoked, and signed by a trusted root or intermediate certificate authority).
+1. Verify that the X.509 certificate is valid at the time the event was created (i.e., not expired, not revoked, and signed by a trusted root or intermediate certificate authority). Note that an event should remain valid even after the embedded certificate expires, as long as the event was created during the certificate's valid timeframe.
 2. Verify that the certificate's public key matches the `pubkey` field in the event object.
-3. If the certificate is part of a chain, verify that the entire chain is valid and that any subordinate certificates have a valid TTL.
+3. If the certificate is a subordinate, verify its parent certificates in the chain, ensuring that each certificate in the chain is valid, properly signed by a trusted root or intermediate certificate authority, and that any subordinate certificates have a valid TTL.
 
 These checks provide additional security measures for clients that support this NIP, ensuring that they only process and accept events from trusted sources.
 

--- a/95.md
+++ b/95.md
@@ -1,0 +1,43 @@
+NIP-XX
+======
+
+Optional X.509 Certificates for Decentralized Key Hierarchy and TTL
+-------------------------------------------------------------------
+
+`draft` `optional` `author:<your_username>`
+
+This NIP introduces an optional enhancement to the existing Nostr protocol by allowing clients to include an X.509 compliant certificate in addition to the existing `pubkey` field as described in NIP-01. This would enable clients to embed additional metadata about the public key, such as the issuer and validity period. This feature is intended to improve identity and validity management for child/subordinate keys, compared to the existing NIP-26.
+
+## Motivation
+
+While the Nostr protocol is designed to be completely decentralized, with anyone able to generate their own private keys, the inclusion of X.509 certificates can provide additional benefits. Most certificates would be self-signed X.509 certificates by design, but this feature opens up the possibility for the root key (or the original self-signed X.509 certificate) to create and sign additional subordinate key pairs with time-to-live (TTL) values. This allows users who follow the root's pubkey to validate the identity and validity of child/subordinate keys, offering an improvement over NIP-26.
+
+## Specification
+
+To support X.509 certificates, we extend the `event` object format in NIP-01 with an optional field:
+
+```json
+{
+  ...
+  "x509_cert": <PEM-encoded X.509 certificate string or null>,
+  ...
+}
+```
+
+The `x509_cert` field can be included in the event object to provide an optional X.509 certificate. If the field is included, it should contain a valid PEM-encoded X.509 certificate string. If the field is not included or set to `null`, it will be treated as if no certificate is provided.
+
+The optional `x509_cert` field should not affect the event serialization and signing process specified in NIP-01. The `x509_cert` field should be considered as additional metadata and should not be included in the serialized event data used for generating the `event.id` or the signature.
+
+Clients that support this NIP should perform the following additional checks when processing events that include an `x509_cert` field:
+
+1. Verify that the X.509 certificate is valid (i.e., not expired, not revoked, and signed by a trusted root or intermediate certificate authority).
+2. Verify that the certificate's public key matches the `pubkey` field in the event object.
+3. If the certificate is part of a chain, verify that the entire chain is valid and that any subordinate certificates have a valid TTL.
+
+These checks provide additional security measures for clients that support this NIP, ensuring that they only process and accept events from trusted sources.
+
+Relays supporting this NIP should store the X.509 certificates along with the events and include them in the events returned in response to client requests. Clients that do not support this NIP can safely ignore the `x509_cert` field when processing events.
+
+## Backward Compatibility
+
+This NIP is backward compatible with existing NIPs, as the `x509_cert` field is optional and can be safely ignored by clients that do not support it. Clients that support this NIP can still interact with clients and relays that do not support it, although they will not be able to take advantage of the additional security features provided by X.509 certificates.


### PR DESCRIPTION
Hi all - Very possible this has already been discussed, but had an idea last night that I'd appreciate some feedback on.  I was thinking about nip-26 and didn't _love_ how the only way for a subordinate key to become invalid was for a revocation message to be successfully propagated to all clients.  It seems to me that a configurable TTL would be ideal for subordinate key pairs, especially when these identities are tied to an organization or anything high profile where simply generating a new root key and starting fresh might not be an option.  adopting the x.509 standard would also unlock a LOT of existing PKI tooling which could unlock other additional possibilities.   