### PR TITLE
Change NIP-21 URL->URI

### DIFF
--- a/21.md
+++ b/21.md
@@ -1,12 +1,12 @@
 NIP-21
 ======
 
-`nostr:` URL scheme
+`nostr:` URI scheme
 -------------------
 
 `draft` `optional` `author:fiatjaf`
 
-This NIP standardizes the usage of a common URL scheme for maximum interoperability and openness in the network.
+This NIP standardizes the usage of a common URI scheme for maximum interoperability and openness in the network.
 
 The scheme is `nostr:`.
 


### PR DESCRIPTION
I think the `nostr:...` scheme is not actually a Uniform Resource Locator, because it doesn't tell you where the data is located. For instance if I see the string `nostr:npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9` I understand that this identifies a Nostr keypair but I don't know where to find data for that keypair. The scheme does fall under the definition of a Uniform Resource Identifier, or maybe even the stricter class Uniform Resource Name. But nobody talks about URNs, so maybe best to just use the less-specific term "URI" here.