### PR TITLE
NIP-97 Event Recommendations

### DIFF
--- a/97.md
+++ b/97.md
@@ -41,7 +41,7 @@ Clients can request recommendations at will using a kind `20020` ephemeral event
   "tags": [
     ["p", "<service pubkey>"],
     ["p", "91cf9..4e5ca", "wss://relay1.com"],
-	["p", "30223..14aeb", "wss://relay2.com"],
+    ["p", "30223..14aeb", "wss://relay2.com"],
   ],
   "content": "{ \"filters\": [<FILTER1>, <FILTER2>, ...]}",
   ...other fields

--- a/97.md
+++ b/97.md
@@ -18,14 +18,14 @@ For example:
 
 ```json
 {
-  "kind": 10020,
-  "tags": [
-    ["p", "91cf9..4e5ca", "wss://provider1.com/"],
-    ["p", "14aeb..8dad4", "wss://provider2.com/nostr"],
-    ["p", "612ae..e610f", "ws://provider3.com/ws"]
-  ],
-  "content": "<private list>",
-  ...other fields
+  "kind": 10020,
+  "tags": [
+    ["p", "91cf9..4e5ca", "wss://provider1.com/"],
+    ["p", "14aeb..8dad4", "wss://provider2.com/nostr"],
+    ["p", "612ae..e610f", "ws://provider3.com/ws"]
+  ],
+  "content": "<private list>",
+  ...other fields
 }
 ```
 
@@ -37,13 +37,13 @@ Clients can request recommendations at will using a kind `20020` ephemeral event
 
 ```json
 {
-  "kind": 20020,
-  "tags": [
-    ["p", "<service pubkey>"],
-    ["p", "91cf9..4e5ca", "wss://relay1.com"],
-  ],
-  "content": "{ \"filters\": [<FILTER1>, <FILTER2>, ...]}",
-  ...other fields
+  "kind": 20020,
+  "tags": [
+    ["p", "<service pubkey>"],
+    ["p", "91cf9..4e5ca", "wss://relay1.com"],
+  ],
+  "content": "{ \"filters\": [<FILTER1>, <FILTER2>, ...]}",
+  ...other fields
 }
 ```
 
@@ -59,17 +59,17 @@ Providers respond with an ephemeral event with kind `20021`. This event MUST con
 
 ```json
 {
-  "kind": 20021,
-  "tags": [
-    ["p", "<Request Pub Key>"]
-	["e", "<Request Event ID>"]
-    ["e", "91cf9..4e5ca", "wss://alicerelay.com/", <score>],
-    ["a", "30223:14aeb..8dad4:myblogpost", "wss://bobrelay.com/nostr", <score>],
-    ["p", "612ae..e610f", "ws://carolrelay.com/ws", <score>],
-	["r", "http://nostr.com", "", <score>],
-	["t", "bitcoin", "", <score>],
-  ],
-  ...other fields
+  "kind": 20021,
+  "tags": [
+    ["p", "<Request Pub Key>"]
+    ["e", "<Request Event ID>"]
+    ["e", "91cf9..4e5ca", "wss://alicerelay.com/", <score>],
+    ["a", "30223:14aeb..8dad4:myblogpost", "wss://bobrelay.com/nostr", <score>],
+    ["p", "612ae..e610f", "ws://carolrelay.com/ws", <score>],
+    ["r", "http://nostr.com", "", <score>],
+    ["t", "bitcoin", "", <score>],
+  ],
+  ...other fields
 }
 ```
 

--- a/97.md
+++ b/97.md
@@ -33,12 +33,13 @@ Providers can offer as many algorithms as they way as long as they offer one per
 
 # Recommendation Request
 
-Clients can request recommendations at will using the ephemeral event with kind `20020`. `p` tags in this event contain the group of users to make the recommendation for and the `.content` field contains an array of NOSTR `REQ` filters ([NIP-1 - Basic Protocol](1.md)) that describe the type and constraints of the requested recommendation events.
+Clients can request recommendations at will using a kind `20020` ephemeral event. `p` tags MUST contain the group of users to make the recommendation for as well as the pub key of the service provider. The `.content` field MUST contains an array of NOSTR `REQ` filters ([NIP-1 - Basic Protocol](1.md)) that describe the type and constraints of the requested recommendation events.
 
 ```json
 {
   "kind": 20020,
   "tags": [
+    ["p", "<service pubkey>"],
     ["p", "91cf9..4e5ca", "wss://relay1.com"],
   ],
   "content": "[<FILTER1>, <FILTER2>, ...]",
@@ -54,15 +55,17 @@ Clients MAY send requests to any provider or to just the select few the user is 
 
 # Recommendation Response
 
-Providers respond with an ephemeral event with kind `20021` that contains tags to the recommended event ids, the relays to find them and an optional ranking score from 0 (least interesting) to 1 (most interesting)
+Providers respond with an ephemeral event with kind `20021`. This event MUST contains the tags to the recommended event ids and the relays to find them. An optional ranking score from 0 (least interesting) to 1 (most interesting) can be added per tag. The `p` tag of the requester and the `e` tag for the requesting event SHOULD be added as well. 
 
 ```json
 {
   "kind": 20021,
   "tags": [
-    ["e", "91cf9..4e5ca", "wss://alicerelay.com/", <ranking>],
-    ["e", "14aeb..8dad4", "wss://bobrelay.com/nostr", <ranking>],
-    ["e", "612ae..e610f", "ws://carolrelay.com/ws", <ranking>]
+    ["p", "<Request Pub Key>"]
+	["e", "<Request Event ID>"]
+    ["e", "91cf9..4e5ca", "wss://alicerelay.com/", <score>],
+    ["e", "14aeb..8dad4", "wss://bobrelay.com/nostr", <score>],
+    ["e", "612ae..e610f", "ws://carolrelay.com/ws", <score>]
   ],
   ...other fields
 }
@@ -76,4 +79,4 @@ Service providers MAY exclude spam and reported events from results.
 
 # Use Cases
 
-Two common use cases are Kind=1 recommendations for a text-first social media app, kind-40 recommendations for public chats and 1063 events for a picture or video feed.
+Three common use cases are Kind=1 recommendations for a text-first social media app, kind-40 recommendations for public chats and 1063 events for a picture or video feed.

--- a/97.md
+++ b/97.md
@@ -1,8 +1,8 @@
 NIP-97
 ======
 
-Content Recommendation Services
--------------------------------
+Event Recommendation Services
+-----------------------------
 
 `draft` `optional` `author:vitorpamplona`
 

--- a/97.md
+++ b/97.md
@@ -41,6 +41,7 @@ Clients can request recommendations at will using a kind `20020` ephemeral event
   "tags": [
     ["p", "<service pubkey>"],
     ["p", "91cf9..4e5ca", "wss://relay1.com"],
+	["p", "30223..14aeb", "wss://relay2.com"],
   ],
   "content": "{ \"filters\": [<FILTER1>, <FILTER2>, ...]}",
   ...other fields
@@ -48,6 +49,8 @@ Clients can request recommendations at will using a kind `20020` ephemeral event
 ```
 
 Clients may specify several recommendation filters, i.e. `[{ "kinds": [1, 1065]}, { "#p": ["91cf9..4e5ca"], limit 200}, ...]`. Clients may include `kinds`, `tags` and other filter fields to restrict recommendation results to particular event kinds.
+
+Providers SHOULD interpret the group of users as watching the feed together. If individual users within the group have safety filters in their profiles (imagine parents and kids), providers SHOULD apply the sum of safety filters to the response. 
 
 Providers SHOULD interpret the recommendation request to the best of their ability and return events that they deem interesting to the requesting pubkey group. Recommendations can also include trending events as long as they are deemed of interest.
 

--- a/97.md
+++ b/97.md
@@ -55,7 +55,7 @@ Clients MAY send requests to any provider or to just the select few the user is 
 
 # Recommendation Response
 
-Providers respond with an ephemeral event with kind `20021`. This event MUST contain the tags to the recommended `e` event ids, `p` profiles, `r` urls and `t` hashtags followed by a relay address to find them. An optional normalized score from 0 (least interesting) to 1 (most interesting) can be added as the 4th element of each tag. The `p` tag of the requester and the `e` tag for the requesting event SHOULD be added as well. 
+Providers respond with an ephemeral event with kind `20021`. This event MUST contain the tags to the recommended `e` event ids, `a` addresses, `p` profiles, `r` urls and/or `t` hashtags followed by a relay address to find them. An optional normalized score from 0 (least interesting) to 1 (most interesting) can be added as the 4th element of each tag. The `p` tag of the requester and the `e` tag for the requesting event SHOULD be added as well. 
 
 ```json
 {
@@ -64,7 +64,7 @@ Providers respond with an ephemeral event with kind `20021`. This event MUST con
     ["p", "<Request Pub Key>"]
 	["e", "<Request Event ID>"]
     ["e", "91cf9..4e5ca", "wss://alicerelay.com/", <score>],
-    ["e", "14aeb..8dad4", "wss://bobrelay.com/nostr", <score>],
+    ["a", "30223:14aeb..8dad4:myblogpost", "wss://bobrelay.com/nostr", <score>],
     ["p", "612ae..e610f", "ws://carolrelay.com/ws", <score>],
 	["r", "http://nostr.com", "", <score>],
 	["t", "bitcoin", "", <score>],

--- a/97.md
+++ b/97.md
@@ -18,60 +18,62 @@ For example:
 
 ```json
 {
-  "kind": 10020,
-  "tags": [
-    ["p", "91cf9..4e5ca", "wss://provider1.com/"],
-    ["p", "14aeb..8dad4", "wss://provider2.com/nostr"],
-    ["p", "612ae..e610f", "ws://provider3.com/ws"]
-  ],
-  "content": "<private list>",
-  ...other fields
+  "kind": 10020,
+  "tags": [
+    ["p", "91cf9..4e5ca", "wss://provider1.com/"],
+    ["p", "14aeb..8dad4", "wss://provider2.com/nostr"],
+    ["p", "612ae..e610f", "ws://provider3.com/ws"]
+  ],
+  "content": "<private list>",
+  ...other fields
 }
 ```
 
-Providers can offer as many algorithms as they way as long as they offer one per public key. 
+Providers can offer as many algorithms as they want as long as they offer one per public key. 
 
 # Recommendation Request
 
-Clients can request recommendations at will using a kind `20020` ephemeral event. `p` tags MUST contain the group of users to make the recommendation for as well as the pub key of the service provider. The `.content` field MUST contains an array of NOSTR `REQ` filters ([NIP-1 - Basic Protocol](1.md)) that describe the type and constraints of the requested recommendation events.
+Clients can request recommendations at will using a kind `20020` ephemeral event. `p` tags MUST contain the group of users to make the recommendation for as well as the pub key of the service provider. `.content` MUST contain a json-serialized object with a `filters` property whose value is an array of regular NOSTR `REQ` filters ([NIP-1 - Basic Protocol](1.md)) that describe the type and constraints of the requested recommendation events.
 
 ```json
 {
-  "kind": 20020,
-  "tags": [
-    ["p", "<service pubkey>"],
-    ["p", "91cf9..4e5ca", "wss://relay1.com"],
-  ],
-  "content": "[<FILTER1>, <FILTER2>, ...]",
-  ...other fields
+  "kind": 20020,
+  "tags": [
+    ["p", "<service pubkey>"],
+    ["p", "91cf9..4e5ca", "wss://relay1.com"],
+  ],
+  "content": "{ \"filters\": [<FILTER1>, <FILTER2>, ...]}",
+  ...other fields
 }
 ```
 
 Clients may specify several recommendation filters, i.e. `[{ "kinds": [1, 1065]}, { "#p": ["91cf9..4e5ca"], limit 200}, ...]`. Clients may include `kinds`, `tags` and other filter fields to restrict recommendation results to particular event kinds.
 
-Providers SHOULD interpret the recommendation request to the best of their ability and return events that it deems interesting to the requesting pubkey group. Recommendations can also include trending events as long as they are deemed of interest.
+Providers SHOULD interpret the recommendation request to the best of their ability and return events that they deem interesting to the requesting pubkey group. Recommendations can also include trending events as long as they are deemed of interest.
 
 Clients MAY send requests to any provider or to just the select few the user is interested in at the moment.
 
 # Recommendation Response
 
-Providers respond with an ephemeral event with kind `20021`. This event MUST contains the tags to the recommended event ids and the relays to find them. An optional ranking score from 0 (least interesting) to 1 (most interesting) can be added per tag. The `p` tag of the requester and the `e` tag for the requesting event SHOULD be added as well. 
+Providers respond with an ephemeral event with kind `20021`. This event MUST contain the tags to the recommended `e` event ids, `p` profiles, `r` urls and `t` hashtags followed by a relay address to find them. An optional normalized score from 0 (least interesting) to 1 (most interesting) can be added as the 4th element of each tag. The `p` tag of the requester and the `e` tag for the requesting event SHOULD be added as well. 
 
 ```json
 {
-  "kind": 20021,
-  "tags": [
-    ["p", "<Request Pub Key>"]
+  "kind": 20021,
+  "tags": [
+    ["p", "<Request Pub Key>"]
 	["e", "<Request Event ID>"]
-    ["e", "91cf9..4e5ca", "wss://alicerelay.com/", <score>],
-    ["e", "14aeb..8dad4", "wss://bobrelay.com/nostr", <score>],
-    ["e", "612ae..e610f", "ws://carolrelay.com/ws", <score>]
-  ],
-  ...other fields
+    ["e", "91cf9..4e5ca", "wss://alicerelay.com/", <score>],
+    ["e", "14aeb..8dad4", "wss://bobrelay.com/nostr", <score>],
+    ["p", "612ae..e610f", "ws://carolrelay.com/ws", <score>],
+	["r", "http://nostr.com", "", <score>],
+	["t", "bitcoin", "", <score>],
+  ],
+  ...other fields
 }
 ```
 
-Clients MAY merge responses from serveral providers and sort the list in any way they see fit. Clients MAY verify that events returned by the provider match the specified interest in a way that suits the client's use case and MAY stop querying providers that have low precision.
+Clients MAY merge responses from several providers and sort the list in any way they see fit. Clients MAY verify that events returned by the provider match the specified interest in a way that suits the client's use case and MAY stop querying providers that have low precision.
 
 Providers are not required to sustain consistency between calls. Every Recommendation Response can be a new list.
 
@@ -79,4 +81,4 @@ Service providers MAY exclude spam and reported events from results.
 
 # Use Cases
 
-Three common use cases are Kind=1 recommendations for a text-first social media app, kind-40 recommendations for public chats and 1063 events for a picture or video feed.
+Three common use cases are Kind=1 recommendations for a text-first social media app, kind-40 recommendations for public chats, and 1063 events for a picture or video feed.

--- a/97.md
+++ b/97.md
@@ -12,7 +12,7 @@ Service providers want to offer event recommendations to users that subscribe to
 
 # Recommendation Subscriptions list
 
-A special event with kind `10020` "Recommendation Subscription List" is defined as a [NIP-16 - Replaceable Events](16.md) of public and/or private `p` tags, one for each of the subscribed services the author intends to use. Each tag entry should contain the public key for the service provider and a relay URL where the provider hosts the recommendation events. i.e., `["p", <32-bytes hex key>, <main relay URL>]`.
+A special event with kind `10020` "Recommendation Subscription List" is defined as a [NIP-16 - Replaceable Events](16.md) of public and/or private `p` tags, one for each of the subscribed services the author intends to use. Each tag entry should contain the public key for the service provider and a relay URL where the provider respond to the recommendation requests.
 
 For example:
 
@@ -29,7 +29,7 @@ For example:
 }
 ```
 
-Providers can offer as many algorithms as they want as long as they offer one per public key. 
+Providers can offer as many algorithms as they want as long as they offer one per public key. The public key's NOSTR profile SHOULD describe the service for humans. 
 
 # Recommendation Request
 
@@ -48,17 +48,17 @@ Clients can request recommendations at will using a kind `20020` ephemeral event
 }
 ```
 
-Clients may specify several recommendation filters, i.e. `[{ "kinds": [1, 1065]}, { "#p": ["91cf9..4e5ca"], limit 200}, ...]`. Clients may include `kinds`, `tags` and other filter fields to restrict recommendation results to particular event kinds.
+Clients may specify several recommendation filters, i.e. `[{ "kinds": [1, 1065]}, { "#p": ["91cf9..4e5ca"], "limit": 200 }, ...]`. Clients may include `kinds`, `tags` and other filter fields to restrict recommendation results to particular event kinds. 
 
-Providers SHOULD interpret the group of users as watching the feed together. If individual users within the group have safety filters in their profiles (imagine parents and kids), providers SHOULD apply the sum of safety filters to the response. 
+Providers SHOULD interpret the group of users as watching the feed together. If individual users within the group have safety filters in their profiles (e.g. parents and kids together), providers SHOULD apply the sum of safety filters to the response. 
 
-Providers SHOULD interpret the recommendation request to the best of their ability and return events that they deem interesting to the requesting pubkey group. Recommendations can also include trending events as long as they are deemed of interest.
+Providers SHOULD interpret the recommendation request to the best of their ability and return events that they deem interesting to the requesting group. Recommendations can also include trending events as long as they are deemed of interest.
 
 Clients MAY send requests to any provider or to just the select few the user is interested in at the moment.
 
 # Recommendation Response
 
-Providers respond with an ephemeral event with kind `20021`. This event MUST contain the tags to the recommended `e` event ids, `a` addresses, `p` profiles, `r` urls and/or `t` hashtags followed by a relay address to find them. An optional normalized score from 0 (least interesting) to 1 (most interesting) can be added as the 4th element of each tag. The `p` tag of the requester and the `e` tag for the requesting event SHOULD be added as well. 
+Providers respond with an ephemeral event with kind `20021`. This event MUST contain the tags to the recommended `e` event ids, `a` addresses, `p` profiles, `r` urls and/or `t` hashtags followed by a relay address to find them. An optional normalized score from 0 (least interesting) to 1 (most interesting) SHOULD be added as the 4th element of each tag. The `p` tag of the requester and the `e` tag for the requesting event SHOULD be added as well. 
 
 ```json
 {
@@ -76,7 +76,7 @@ Providers respond with an ephemeral event with kind `20021`. This event MUST con
 }
 ```
 
-Clients MAY merge responses from several providers and sort the list in any way they see fit. Clients MAY verify that events returned by the provider match the specified interest in a way that suits the client's use case and MAY stop querying providers that have low precision.
+Clients MAY merge responses from several providers and sort the list in any way they see fit. Clients MAY verify if events returned by the provider match the specified interest in a way that suits the client's use case and MAY stop querying providers that have low precision.
 
 Providers are not required to sustain consistency between calls. Every Recommendation Response can be a new list.
 
@@ -84,4 +84,7 @@ Service providers MAY exclude spam and reported events from results.
 
 # Use Cases
 
-Three common use cases are Kind=1 recommendations for a text-first social media app, kind-40 recommendations for public chats, and 1063 events for a picture or video feed.
+Three common use cases are:
+- Kind=1 recommendations for a text-first social media app with an algorithmic timeline, 
+- Kind=40 recommendations for public chats to join, 
+- Kind=1063 events for a picture or video feed

--- a/97.md
+++ b/97.md
@@ -78,6 +78,8 @@ Providers respond with an ephemeral event with kind `20021`. This event MUST con
 
 Clients MAY merge responses from several providers and sort the list in any way they see fit. Clients MAY verify if events returned by the provider match the specified interest in a way that suits the client's use case and MAY stop querying providers that have low precision.
 
+Recommendations MUST match the requested kinds: `p` profiles, `r` urls and `t` hashtags can only be present when the requesting filter did not include a `kinds` property.
+
 Providers are not required to sustain consistency between calls. Every Recommendation Response can be a new list.
 
 Service providers MAY exclude spam and reported events from results.

--- a/97.md
+++ b/97.md
@@ -80,7 +80,7 @@ Clients MAY merge responses from several providers and sort the list in any way 
 
 Recommendations MUST match the requested kinds: `p` profiles, `r` urls and `t` hashtags can only be present when the requesting filter did not include a `kinds` property.
 
-Providers are not required to sustain consistency between calls. Every Recommendation Response can be a new list.
+Providers are not required to be time-consistent. Every Recommendation Response can be a new list.
 
 Service providers MAY exclude spam and reported events from results.
 

--- a/97.md
+++ b/97.md
@@ -1,0 +1,77 @@
+NIP-97
+======
+
+Content Recommendation Services
+-------------------------------
+
+`draft` `optional` `author:vitorpamplona`
+
+## Abstract
+
+Service providers can offer event recommendations to users that subscribe to it. Specifics of the recommendation algorithms will differ between event kinds and provider implementations. This NIP describes a general extensible framework for subscribing and performing recommendation requests.
+
+# Recommendation Subscriptions list
+
+A special event with kind `10020` "Recommendation Subscription List" is defined as a [NIP-16 - Replaceable Events](16.md) of public and/or private `p` tags, one for each of the subscribed services the author is following. Each tag entry should contain the public key for the service provider and a relay URL where the provider hosts the recommendation events. i.e., `["p", <32-bytes hex key>, <main relay URL>]`. 
+
+For example:
+
+```json
+{
+  "kind": 10020,
+  "tags": [
+    ["p", "91cf9..4e5ca", "wss://provider1.com/"],
+    ["p", "14aeb..8dad4", "wss://provider2.com/nostr"],
+    ["p", "612ae..e610f", "ws://provider3.com/ws"]
+  ],
+  "content": "<private list>",
+  ...other fields
+}
+```
+
+# Recommendation Request
+
+Clients can request recommendations at will using the ephemeral event with kind `20020`. `p` tags in this event contain the group of users to make the recommendation for and the `.content` field contains an array of NOSTR `REQ` filters ([NIP-1 - Basic Protocol](1.md)) that describe the type and constraints of the requested recommendation. 
+
+```json
+{
+  "kind": 20020,
+  "tags": [
+    ["p", "91cf9..4e5ca", "wss://relay1.com"],
+  ],
+  "content": "[<FILTER1>, <FILTER2>, ...]",
+  ...other fields
+}
+```
+
+Clients may specify several recommendation filters, i.e. `[{ "kinds": [1, 2]}, { "#p": ["91cf9..4e5ca"], limit 200}, ...]`. Clients may include `kinds`, `tags` and other filter field to restrict recommendation results to particular event kinds.
+
+Providers SHOULD interpret the recommendation request to the best of their ability and return events that it deems interesting to the requesting pubkeys individually. Recommendations can also include trending events as long as the they are deemed of interest to each user. 
+
+Clients MAY send `requests` to any provider or to just the select few the user is interested at the moment. 
+
+# Recommendation Response
+
+Providers respond with an ephemeral event with kind `20021` that contains tags to the recommended events. 
+
+```json
+{
+  "kind": 20021,
+  "tags": [
+    ["e", "91cf9..4e5ca", "wss://alicerelay.com/"],
+    ["e", "14aeb..8dad4", "wss://bobrelay.com/nostr"],
+    ["e", "612ae..e610f", "ws://carolrelay.com/ws"]
+  ],
+  ...other fields
+}
+```
+
+Clients SHOULD consider the list sorted by insterest strength. Clients MAY verify that events returned by provider match the specified interest in a way that suits the client's use case, and MAY stop querying providers that have low precision.
+
+Providers are not required to sustain consistency. Every reply can be a new list. 
+
+Service providers MAY exclude spam and reported events from results.
+
+# Use Cases
+
+Two common use cases are Kind=1 recommendations for a text-oriented social media app and NIP-94 events for a picture or video feed. 

--- a/97.md
+++ b/97.md
@@ -8,11 +8,11 @@ Content Recommendation Services
 
 ## Abstract
 
-Service providers can offer event recommendations to users that subscribe to it. Specifics of the recommendation algorithms will differ between event kinds and provider implementations. This NIP describes a general extensible framework for subscribing and performing recommendation requests.
+Service providers want to offer event recommendations to users that subscribe to them. Specifics of the recommendation algorithms will differ between event kinds and provider implementations. This NIP describes a general framework for subscribing and performing recommendation requests.
 
 # Recommendation Subscriptions list
 
-A special event with kind `10020` "Recommendation Subscription List" is defined as a [NIP-16 - Replaceable Events](16.md) of public and/or private `p` tags, one for each of the subscribed services the author is following. Each tag entry should contain the public key for the service provider and a relay URL where the provider hosts the recommendation events. i.e., `["p", <32-bytes hex key>, <main relay URL>]`. 
+A special event with kind `10020` "Recommendation Subscription List" is defined as a [NIP-16 - Replaceable Events](16.md) of public and/or private `p` tags, one for each of the subscribed services the author intends to use. Each tag entry should contain the public key for the service provider and a relay URL where the provider hosts the recommendation events. i.e., `["p", <32-bytes hex key>, <main relay URL>]`.
 
 For example:
 
@@ -29,9 +29,11 @@ For example:
 }
 ```
 
+Providers can offer as many algorithms as they way as long as they offer one per public key. 
+
 # Recommendation Request
 
-Clients can request recommendations at will using the ephemeral event with kind `20020`. `p` tags in this event contain the group of users to make the recommendation for and the `.content` field contains an array of NOSTR `REQ` filters ([NIP-1 - Basic Protocol](1.md)) that describe the type and constraints of the requested recommendation. 
+Clients can request recommendations at will using the ephemeral event with kind `20020`. `p` tags in this event contain the group of users to make the recommendation for and the `.content` field contains an array of NOSTR `REQ` filters ([NIP-1 - Basic Protocol](1.md)) that describe the type and constraints of the requested recommendation events.
 
 ```json
 {
@@ -44,34 +46,34 @@ Clients can request recommendations at will using the ephemeral event with kind 
 }
 ```
 
-Clients may specify several recommendation filters, i.e. `[{ "kinds": [1, 2]}, { "#p": ["91cf9..4e5ca"], limit 200}, ...]`. Clients may include `kinds`, `tags` and other filter field to restrict recommendation results to particular event kinds.
+Clients may specify several recommendation filters, i.e. `[{ "kinds": [1, 1065]}, { "#p": ["91cf9..4e5ca"], limit 200}, ...]`. Clients may include `kinds`, `tags` and other filter fields to restrict recommendation results to particular event kinds.
 
-Providers SHOULD interpret the recommendation request to the best of their ability and return events that it deems interesting to the requesting pubkeys individually. Recommendations can also include trending events as long as the they are deemed of interest to each user. 
+Providers SHOULD interpret the recommendation request to the best of their ability and return events that it deems interesting to the requesting pubkey group. Recommendations can also include trending events as long as they are deemed of interest.
 
-Clients MAY send `requests` to any provider or to just the select few the user is interested at the moment. 
+Clients MAY send requests to any provider or to just the select few the user is interested in at the moment.
 
 # Recommendation Response
 
-Providers respond with an ephemeral event with kind `20021` that contains tags to the recommended events. 
+Providers respond with an ephemeral event with kind `20021` that contains tags to the recommended event ids, the relays to find them and an optional ranking score from 0 (least interesting) to 1 (most interesting)
 
 ```json
 {
   "kind": 20021,
   "tags": [
-    ["e", "91cf9..4e5ca", "wss://alicerelay.com/"],
-    ["e", "14aeb..8dad4", "wss://bobrelay.com/nostr"],
-    ["e", "612ae..e610f", "ws://carolrelay.com/ws"]
+    ["e", "91cf9..4e5ca", "wss://alicerelay.com/", <ranking>],
+    ["e", "14aeb..8dad4", "wss://bobrelay.com/nostr", <ranking>],
+    ["e", "612ae..e610f", "ws://carolrelay.com/ws", <ranking>]
   ],
   ...other fields
 }
 ```
 
-Clients SHOULD consider the list sorted by insterest strength. Clients MAY verify that events returned by provider match the specified interest in a way that suits the client's use case, and MAY stop querying providers that have low precision.
+Clients MAY merge responses from serveral providers and sort the list in any way they see fit. Clients MAY verify that events returned by the provider match the specified interest in a way that suits the client's use case and MAY stop querying providers that have low precision.
 
-Providers are not required to sustain consistency. Every reply can be a new list. 
+Providers are not required to sustain consistency between calls. Every Recommendation Response can be a new list.
 
 Service providers MAY exclude spam and reported events from results.
 
 # Use Cases
 
-Two common use cases are Kind=1 recommendations for a text-oriented social media app and NIP-94 events for a picture or video feed. 
+Two common use cases are Kind=1 recommendations for a text-first social media app, kind-40 recommendations for public chats and 1063 events for a picture or video feed.


### PR DESCRIPTION
This NIP defines a simple protocol for NOSTR-native feed recommendation services as ephemeral requests between two Nostr pub keys: the user and a recommendation provider.

Client applications allow users to subscribe to such services, request recommendations at will and display them on the screen in any way they see fit. 

Let me know your thoughts. 