### PR TITLE
Clarify how NIP 45 works with multiple COUNT filters.

### DIFF
--- a/45.md
+++ b/45.md
@@ -14,7 +14,7 @@ Some queries a client may want to execute against connected relays are prohibiti
 
 ## Filters and return values
 
-This NIP defines a verb called `COUNT`, which accepts a subscription id and filters as specified in [NIP 01](01.md).
+This NIP defines a verb called `COUNT`, which accepts a subscription id and filters as specified in [NIP 01](01.md). Multiple filters are OR'd together and aggregated into a single count result.
 
 ```
 ["COUNT", <subscription_id>, <filters JSON>...]

--- a/45.md
+++ b/45.md
@@ -6,21 +6,21 @@ Event Counts
 
 `draft` `optional` `author:staab`
 
-Relays may support the `COUNT` verb, which provides a mechanism for obtaining event counts.
+Relays may support the verb `COUNT`, which provides a mechanism for obtaining event counts.
 
 ## Motivation
 
-Some queries a client may want to execute against connected relays are prohibitively expensive, for example, in order to retrieve follower counts for a given pubkey, a client must query all kind-3 events referring to a given pubkey and count them. The result may be cached, either by a client or by a separate indexing server as an alternative, but both options erode the decentralization of the network by creating a second-layer protocol on top of Nostr.
+Some queries a client may want to execute against connected relays are prohibitively expensive, for example, in order to retrieve follower counts for a given pubkey, a client must query all kind-3 events referring to a given pubkey only to count them. The result may be cached, either by a client or by a separate indexing server as an alternative, but both options erode the decentralization of the network by creating a second-layer protocol on top of Nostr.
 
 ## Filters and return values
 
-This NIP defines a verb called `COUNT`, which accepts a subscription id and filters as specified in [NIP 01](01.md). Multiple filters are OR'd together and aggregated into a single count result.
+This NIP defines the verb `COUNT`, which accepts a subscription id and filters as specified in [NIP 01](01.md) for the verb `REQ`. Multiple filters are OR'd together and aggregated into a single count result.
 
 ```
 ["COUNT", <subscription_id>, <filters JSON>...]
 ```
 
-Counts are returned using a `COUNT` response in the form `{count: <integer>}`. Relays may use probabilistic counts to reduce compute requirements.
+Counts are returned using a `COUNT` response in the form `{"count": <integer>}`. Relays may use probabilistic counts to reduce compute requirements.
 
 ```
 ["COUNT", <subscription_id>, {"count": <integer>}]


### PR DESCRIPTION
Incorporates changes from https://github.com/nostr-protocol/nips/pull/503 and clarifies behavior.