### PR TITLE
NIP-01 Rephrase Markdown special rule

### DIFF
--- a/01.md
+++ b/01.md
@@ -98,7 +98,8 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 ## Basic Event Kinds
 
   - `0`: `set_metadata`: the `content` is set to a stringified JSON object `{name: <username>, about: <string>, picture: <url, string>}` describing the user who created the event. A relay may delete past `set_metadata` events once it gets a new one for the same pubkey.
-  - `1`: `text_note`: the `content` is set to the plaintext content of a note (anything the user wants to say). Markdown links (`[]()` stuff) are not plaintext.
+  - `1`: `text_note`: the `content` is set to the plaintext content of a note (anything the user wants to say).\
+    Do not use Markdown! Clients should not have to guess how to interpret content like `[Example](https://example.com)`. Use different event kinds for parsable content.
   - `2`: `recommend_server`: the `content` is set to the URL (e.g., `wss://somerelay.com`) of a relay the event creator wants to recommend to its followers.
 
 A relay may choose to treat different message kinds differently, and it may or may not choose to have a default way to handle kinds it doesn't know about.


### PR DESCRIPTION
I was a bit confused about the Markdown remark and had to read up https://github.com/nostr-protocol/nips/commit/379252f992c2528e287bc4ce7faee5631aa3f73c

I guess @fiatjaf did not want to forward reference, so I tried to keep both statements:
* No markdown by example
* Mentioning other event kinds

I added the interpretation that clients should not need to infer content in IE6 manner.