### PR TITLE
Reactions: require explicit like/dislike for emoji reactions

### DIFF
--- a/25.md
+++ b/25.md
@@ -18,8 +18,8 @@ downvote or dislike on a post. A client MAY also choose to tally likes against
 dislikes in a reddit-like system of upvotes and downvotes, or display them as
 separate tallies.
 
-The `content` MAY be an emoji, in this case it MAY be interpreted as a "like" or "dislike",
-or the client MAY display this emoji reaction on the post.
+The `content` MAY inlcude an emoji, in this case the client MAY display this
+emoji reaction on the post.
 
 Tags
 ----


### PR DESCRIPTION
This will allow clients to more easily decide how to display reactions. If a client receives a reaction event with an emoji it doesn't recognize, or doesn't want to display emoji at all, it can still be added to the up/down counts.

It also ensures consistency between clients. For instance, if a client receives a 🤣 reaction, is it a positive reaction because the post was meant to be funny, or a negative because the post is being ridiculed via emoji?