### PR TITLE
nip47: add lud16 parameter to connection string

### DIFF
--- a/47.md
+++ b/47.md
@@ -88,6 +88,7 @@ The **wallet service** generates this connection URI with protocol `nostr+wallet
     - The user can have different keys for different applications. Keys can be revoked and created at will and have arbitrary constraints (eg. budgets).
     - The key is harder to leak since it is not shown to the user and backed up.
     - It improves privacy because the user's main key would not be linked to their payments.
+- `lud16` Recommended. A lightning address that clients can use to automatically setup the `lud16` field on the user's profile if they have none configured.
 
 The **client** should then store this connection and use it when the user wants to perform actions like paying an invoice. Due to this NIP using ephemeral events, it is recommended to pick relays that do not close connections on inactivity to not drop events.
 


### PR DESCRIPTION
This adds an optional but recommended lud16 parameter to nostr wallet connection strings. This enables seamless onboarding of new users, allowing clients to automatically configure the receive address for zaps.