### PR TITLE
Add user experience recommendation about NIP-07

### DIFF
--- a/07.md
+++ b/07.md
@@ -22,10 +22,9 @@ async window.nostr.nip04.encrypt(pubkey, plaintext): string // returns ciphertex
 async window.nostr.nip04.decrypt(pubkey, ciphertext): string // takes ciphertext and iv as specified in nip-04
 ```
 
-### Recommendation to Implementers
-When `window.nostr` is injected by a browser extension, it may not be fully available until a certain point in the page's lifecycle.  Hence, it is a good idea to invoke the first `window.nostr` based functionality after a user-action on the web page (like a button click), and not during the page load.
+### Recommendation to Extension Authors
+To make sure that the `window.nostr` is available to nostr clients on page load, the authors who create Chromium and Firefox extensions should load their scripts by specifying `"run_at": "document_end"` in the extension's manifest.
 
-Calling the `window.nostr` based methods during the page load runs the risk of intermittent issues due to race conditions between the client page's script and the extension's script
 
 ### Implementation
 


### PR DESCRIPTION
Invoking NIP-07 methods as a part of page-load event listener creates intermittent issues due to race conditions between the browser's extension script and the client's page scripts.