### PR TITLE
Creates "Anyone with link" access controls for NIP-19

### DIFF
--- a/19.md
+++ b/19.md
@@ -54,7 +54,11 @@ These possible standardized `TLV` types are indicated here:
 - `3`: `kind`
   - for `naddr`, the 32-bit unsigned integer of the kind, big-endian
   - for `nevent`, _optionally_, the 32-bit unsigned integer of the kind, big-endian
-
+- `4`: `secret`
+  - the secret, in byte array, to be used when decrypting the event or its related components
+- `5`: `nonce`
+  - the initialization vector (IV), in byte array, to be used when decrypting the event or its related components
+  
 ## Examples
 
 - `npub10elfcs4fr0l0r8af98jlmgdh9c8tcxjvz9qkw038js35mp4dma8qzvjptg` should decode into the public key hex `7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e` and vice-versa


### PR DESCRIPTION
Adds a secret and a nonce to NIP-19 uris such that only people with access to the URI can decrypt its content. 

### Current use case

Problem: Sending a private picture in NIP-04 DMs. 

Solution: 

1. Encrypt the picture with `aes-256-gcm` and send the encrypted file to an image server. 
2. Create a NIP-94 record pointing to the url WITHOUT adding the decryption keys to the event-1063's tags. 
3. Create a NIP-19 URI with the secret and nonce used. 
4. Send that URI in a NIP-04 DM. 

On the other side: 

5. Parse the NIP-19 uri
6. Download the associated NIP-94 event
7. Download the encrypted image from URL
8. Use the secret to decrypt the contents of the file
9. Display on screen.

### Generalized case

Any event that supports encryption with independent secrets can use the scheme. 