### PR TITLE
Update NIP-56 to handle more detailed content moderation and generic labeling

### DIFF
--- a/56.md
+++ b/56.md
@@ -2,66 +2,126 @@
 NIP-56
 ======
 
-Reporting
+Labeling
 ---------
 
-`draft` `optional` `author:jb55`
+`draft` `optional` `author:jb55` `author:staab` `author:michaelhall923` `author:gruruya`
 
-A report is a `kind 1984` note that is used to report other notes for spam,
-illegal and explicit content.
+A label is a `kind 1984` note that is used to report other notes for spam, illegal, explicit, or any other type of content.
 
-The content MAY contain additional information submitted by the entity
-reporting the content.
+The content MAY contain additional information submitted by the entity reporting the content.
 
-Tags
+Label Tag
 ----
 
-The report event MUST include a `p` tag referencing the pubkey of the user you
-are reporting.
+The label event MUST include one or more tags representing the object or objects being
+labeled: `e`, `p`, `r`, or `t` tags. This allows for labeling of events, people, relays,
+or topics respectively.
 
-If reporting a note, an `e` tag MUST also be included referencing the note id.
+A `label` string MAY be included as the 3rd entry to each object tag. This MAY be an unqualified string indicating the type of content based on convention, or a qualified string referring to a nomenclature external to nostr. Some examples of report types:
 
-A `report type` string MUST be included as the 3rd entry to the `e` or `p` tag
-being reported, which consists of the following report types:
+- `#t/footstr` - the publisher thinks the given event should have the `footstr` topic applied.
+- `#p/<pubkey>` - the publisher things the given event should be tagged with with `<pubkey>`
+- `MeSH/D005528` - ["Foot"](https://meshb.nlm.nih.gov/record/ui?ui=D005528) from NIH's Medical Subject Headings vocabulary
+- `GeoNames/3173435` - [Milan, Italy](https://www.geonames.org/3173435/milan.html) using the GeoNames coding system
+- `ISO-3166-2/IT-MI` - Milano, Italy using ISO 3166-2.
+- `nudity`, `profanity`, `illegal`, `spam`, `impersonation` - informal, but potentially useful content-based reports
 
-- `nudity` - depictions of nudity, porn, etc.
-- `profanity` - profanity, hateful speech, etc.
-- `illegal` - something which may be illegal in some jurisdiction
-- `spam` - spam
-- `impersonation` - someone pretending to be someone else
+As much as possible, fully-qualified labels should be used if the goal is precision, for
+example for moderation. Otherwise, convention should be the rule.
 
-Some report tags only make sense for profile reports, such as `impersonation`
+When associating standard nostr tags with one another via a label, clients SHOULD provide
+two tags defining the same association in reverse order so that the association is searchable.
+For example, if you wanted to say `<pubkey>` is related to `#pizza`, you would include
+`["p", "<pubkey>", "#t/pizza"]` as well as `["t", "pizza", "#p/<pubkey>"]` in the tags array.
+
+Other Tags
+-----
+
+The label event MAY include a `quality` tag with a value of 0 to 1. This allows for an
+absolute, granular scale that can be represented in any way (5 stars, color scale, etc).
+
+The label event MAY include a `confidence` tag with a value of 0 to 1. This indicates the certainty which the author has about their rating.
+
+The label event MAY include one or more `context` tags to provide references to further
+information about the report or content. The remainder of this tag can be any tag, for
+example to cite an event's author, you would use `["context", "p", "pubkey"]`. This tag may
+also include an additional mark to describe the reason it has been included. Relay urls are
+not included in each `context` tag (as described in NIP-10), since they can be added using a separate `context` tag.
 
 Example events
 --------------
+
+A report that an event contains nudity, including where the event was seen, and who the author was.
 
 ```json
 {
   "kind": 1984,
   "tags": [
-    [ "p", <pubkey>, "nudity"]
+    ["e", <id>, "nudity"]
+    ["context", "r", <url>]
+    ["context", "p", <pubkey>]
   ],
   "content": "",
   ...
 }
+```
 
+A report of impersonation, citing the impersonator, and the victim.
+
+```json
 {
   "kind": 1984,
   "tags": [
-    [ "e", <eventId>, "illegal"],
-    [ "p", <pubkey>]
+    ["p", <impersonator pubkey>, "impersonation"],
+    ["context", "p", <victim pubkey>, "victim"]
   ],
-  "content": "He's insulting the king!",
+  "content": "Profile is imitating <npub>",
   ...
 }
+```
 
+Bidirectional association of a pubkey with a topic.
+
+```json
 {
   "kind": 1984,
   "tags": [
-    [ "p", <impersonator pubkey>, "impersonation"],
-    [ "p", <victim pubkey>]
+    ["p", <pubkey>, "#t/permies"],
+    ["t", "permies", "#p/<pubkey>"],
   ],
-  "content": "Profile is imitating #[1]",
+  "content": "",
+  ...
+}
+```
+
+A review of a relay, as relates to certain topics, including additional dimensions. The author
+is indicating here that `relay_url` is related to the bitcoin topic, but they're not very sure
+that's the case.
+
+```json
+{
+  "kind": 1984,
+  "tags": [
+    ["r", <relay_url>, "#t/bitcoin"],
+    ["quality", 0.7],
+    ["confidence", 0.2],
+  ],
+  "content": "I think this relay is mostly just bitcoiners.",
+  ...
+}
+```
+
+A review of a relay, independent of context.
+
+```json
+{
+  "kind": 1984,
+  "tags": [
+    ["r", <relay_url>],
+    ["quality", 0.1],
+  ],
+  "content": "This relay is full of mean people.",
   ...
 }
 ```
@@ -72,7 +132,6 @@ Client behavior
 Clients can use reports from friends to make moderation decisions if they
 choose to. For instance, if 3+ of your friends report a profile as explicit,
 clients can have an option to automatically blur photos from said account.
-
 
 Relay behavior
 --------------


### PR DESCRIPTION
# Purpose

Content reporting is a type of labeling. In https://github.com/nostr-protocol/nips/pull/459, @gruruya proposed expanding NIP-56 to encompass labeling.

In https://github.com/nostr-protocol/nips/pull/457, @s3x-jay and @rabble proposed a nomenclature and more comprehensive mechanism for content reporting/labeling. The consensus seems to be that a nomenclature is not a good idea, but there were some good ideas to include.

In https://github.com/nostr-protocol/nips/issues/522#issuecomment-1546286149 I realized that the same labeling mechanism could be used to leave reviews for relays, which I am eager to add to Coracle so people can start to find a better relay selection.

This PR may also render https://github.com/nostr-protocol/nips/pull/46 obsolete.

# Justification

Maybe this will seem like I'm trying to make a single NIP do too many things. But reviews, labels, and reports all have two things in common: they refer to an object, and are an expression of someone's opinion. In each case, there is a value judgment involved in assigning the label, involving both imprecision and uncertainty. Expressing this opinion using either a mark, or content, or both, allows either a machine or human to make a judgment call as needed.

One nice thing I'd also like to point out about this PR is if clients follow the bi-directional tagging rule, it allows for associating any two entities (e/p/r/t) in nostr, and searching those associations. This gives us the beginning of graph-database-like functionality that can form the basis for both WoT and topical moderation and recommendations.

Confidence/quality may seem like the same thing, but they're two different axes along which to measure certainty. The first is subjective (the label author may not be 100% sure), the second objective (the label may not perfectly fit). This has been suggested in a few places, but was best executed by guide.newfounding.org (unfortunately their site is no longer available).

# Compatibility

This PR should be backwards-compatible "enough" with the old version of NIP-56, but if there's disagreement on it, I can re-draft as a separate NIP. I'm particularly interested here in @jb55's feedback since he wrote the original version and is probably the only person who is relying on its implementation. 

The only backwards-incompatible change I had to make is that context must now be marked by a `context` tag. My sense is that the `p` tag was originally required so that a given event could be located.  I don't expect that anyone has implemented any automatic routing based on the `p` tag, and clients that continue to include a `p` tag will simply be reporting the pubkey in addition to the event, which seems to be acceptable semantically.

Other minor changes:

- `e` tag is now optional
- The report type (now "label") is now optional, and is no longer required to use a given vocabulary. Tags without labels are allowed, since sometimes it might make sense to only leave a review in `content`, or if the `quality` and `confidence` tags are sufficient.

# Implementation

None of this is implemented, but my main motivation of drafting this PR is so I can add relay ratings and reviews to Coracle soon.