### PR TITLE
Idea, add "name" tag to channel create

### DIFF
--- a/28.md
+++ b/28.md
@@ -28,6 +28,7 @@ In the channel creation `content` field, Client SHOULD include basic channel met
 ```json
 {
     "content": "{\"name\": \"Demo Channel\", \"about\": \"A test channel.\", \"picture\": \"https://placekitten.com/200/200\"}",
+    "tags": [["d", <channel name>]],
     ...
 }
 ```


### PR DESCRIPTION
It's probably going to be very helpful to search for channels by name.   Placing a recommended "d" tag, so a user can search channels by name would probably be helpful in chat implementations. 