### PR TITLE
Fix docs from kind0 to kind33

### DIFF
--- a/28.md
+++ b/28.md
@@ -37,7 +37,7 @@ In the channel creation `content` field, Client SHOULD include basic channel met
 
 Update a channel's public metadata.
 
-Clients and relays SHOULD handle kind 41 events similar to kind 0 `metadata` events.
+Clients and relays SHOULD handle kind 41 events similar to kind 33 replaceable events, where the information is used to update the metadata, without modifying the event id for the channel.
 
 Clients SHOULD ignore kind 41s from pubkeys other than the kind 40 pubkey.
 

--- a/28.md
+++ b/28.md
@@ -37,7 +37,7 @@ In the channel creation `content` field, Client SHOULD include basic channel met
 
 Update a channel's public metadata.
 
-Clients and relays SHOULD handle kind 41 events similar to kind 33 replaceable events, where the information is used to update the metadata, without modifying the event id for the channel.
+Clients and relays SHOULD handle kind 41 events similar to kind 33 replaceable events, where the information is used to update the metadata, without modifying the event id for the channel.  Only the most recent kind 41 is needed to be stored.
 
 Clients SHOULD ignore kind 41s from pubkeys other than the kind 40 pubkey.
 


### PR DESCRIPTION
The purposes of kind41 is to "update the kind40 metadata" without changing the "channel id" that is immutable.   kind41 events can replace each other, like kind33 replaceable events.   Only the most recent kind41 is needed.   We still need to keep the kind40 event, because it's the immutable event "id" and maintains the "owner" of the channel.

see issue https://github.com/nostr-protocol/nips/issues/376