### PR TITLE
fix: Updating links in NIP-15 to point to intended other NIPs.

### DIFF
--- a/15.md
+++ b/15.md
@@ -38,8 +38,8 @@ A merchant can publish these events:
 | `0    ` | `set_meta`       | The merchant description (similar with any `nostr` public key).                                               | [NIP01       ](https://github.com/nostr-protocol/nips/blob/master/01.md)                            |
 | `30017` | `set_stall`      | Create or update a stall.                                                                                     | [NIP33](https://github.com/nostr-protocol/nips/blob/master/33.md) (Parameterized Replaceable Event) |
 | `30018` | `set_product`    | Create or update a product.                                                                                   | [NIP33](https://github.com/nostr-protocol/nips/blob/master/33.md) (Parameterized Replaceable Event) |
-| `4    ` | `direct_message` | Communicate with the customer. The messages can be plain-text or JSON. | [NIP09](https://github.com/nostr-protocol/nips/blob/master/09.md)                                            |
-| `5    ` | `delete`         | Delete a product or a stall.                                                                                  | [NIP05](https://github.com/nostr-protocol/nips/blob/master/05.md)                                   |
+| `4    ` | `direct_message` | Communicate with the customer. The messages can be plain-text or JSON. | [NIP04](https://github.com/nostr-protocol/nips/blob/master/04.md)                                            |
+| `5    ` | `delete`         | Delete a product or a stall.                                                                                  | [NIP09](https://github.com/nostr-protocol/nips/blob/master/09.md)                                   |
 
 ### Event `30017`: Create or update a stall.
 


### PR DESCRIPTION
In the Merchant description, fixing links to NIPs which define behaviors for private direct messaging (NIP-04) and deleting messages (NIP-05).