### PR TITLE
Add NIP-32 for labeling things in nostr

### DIFF
--- a/32.md
+++ b/32.md
@@ -6,7 +6,7 @@ Labeling
 
 `draft` `optional` `author:staab` `author:gruruya` `author:s3x-jay`
 
-A label is a `kind 1985` note that is used to label other entities. This supports a number of use cases:
+A label is a `kind 1985` (regular) event or `kind 32144` (replaceable) event that is used to label other entities. This supports a number of use cases:
 
 - Distributed moderation and content recommendations
 - Reviews and ratings
@@ -22,7 +22,12 @@ Label Target
 
 The label event MUST include one or more tags representing the object or objects being
 labeled: `e`, `p`, `r`, or `t` tags. This allows for labeling of events, people, relays,
-or topics respectively.
+or topics respectively. As with NIP-01, a relay hint SHOULD be included when using `e` and
+`p` tags.
+
+Any number of targets may be included when using a kind `1985` non-replaceable event. If kind
+`32144` is preferred, the event MUST have a single target tag, and its value MUST also be the
+value of the `d` tag.
 
 Label Tag
 ----
@@ -51,6 +56,12 @@ absolute, granular scale that can be represented in any way (5 stars, color scal
 
 The label event MAY include a `confidence` tag with a value of 0 to 1. This indicates the certainty which the author has about their rating.
 
+Content
+-------
+
+`l` tags should be short, meaningful strings. Longer discussions, such as for a review, or an
+explanation of why something was labeled the way it was should go in the event's `content` field.
+
 Example events
 --------------
 
@@ -64,7 +75,7 @@ cases.
   "tags": [
     ["L", "report"],
     ["l", "nudity", "report"],
-    ["e", <id>]
+    ["e", <id>, <relay_url>]
   ],
   "content": "",
   ...
@@ -78,8 +89,8 @@ namespaces may be used at the same time.
 {
   "kind": 1985,
   "tags": [
-    ["e", <id>],
-    ["p", <id>],
+    ["e", <id>, <relay_url>],
+    ["p", <id>, <relay_url>],
     ["t", "chickens"],
     ["L", "#t"]
     ["L", "ugc"]
@@ -103,8 +114,8 @@ A suggestion that multiple pubkeys be associated with the `permies` topic.
   "tags": [
     ["L", "#t"],
     ["l", "permies", "#t"],
-    ["p", <pubkey1>],
-    ["p", <pubkey2>]
+    ["p", <pubkey1>, <relay_url>],
+    ["p", <pubkey2>, <relay_url>]
   ],
   "content": "",
   ...
@@ -156,8 +167,8 @@ this spec provides for overlaying structured metadata on top of nostr.
   "tags": [
     ["L", "my-lightning-nomenclature"],
     ["l", "channel", "my-lightning-nomenclature"],
-    ["p", <pubkey1>],
-    ["p", <pubkey2>]
+    ["p", <pubkey1>, <relay_url>],
+    ["p", <pubkey2>, <relay_url>]
   ],
   "content": "<channel_id>",
   ...

--- a/32.md
+++ b/32.md
@@ -28,14 +28,15 @@ or topics respectively. As with NIP-01, a relay hint SHOULD be included when usi
 Label Tag
 ----
 
-This NIP introduces a new tag `l` which denotes a label, and a new `L` tag which denotes a label namespace. A label MUST include a mark matching an `L` tag. `L` tags refer to a tag type within nostr, or a nomenclature external to nostr defined either formally or by convention. Some examples:
+This NIP introduces a new tag `l` which denotes a label, and a new `L` tag which denotes a label namespace. A label MUST include a mark matching an `L` tag. `L` tags refer to a tag type within nostr, or a nomenclature external to nostr defined either formally or by convention. Any string can be a namespace, but publishers SHOULD ensure they are unambiguous by using a well-defined ISO standard or reverse domain name notation. Some examples:
 
 - `["l", "footstr", "#t"]` - the publisher thinks the given entity should have the `footstr` topic applied.
 - `["l", "<pubkey>", "#p"]` - the publisher things the given entity should be tagged with with `<pubkey>`
 - `["l", "D005528", "MeSH"]` - ["Foot"](https://meshb.nlm.nih.gov/record/ui?ui=D005528) from NIH's Medical Subject Headings vocabulary
 - `["l", "3173435", "GeoNames"]` - [Milan, Italy](https://www.geonames.org/3173435/milan.html) using the GeoNames coding system
 - `["l", "IT-MI", "ISO-3166-2"]` - Milano, Italy using ISO 3166-2.
-- `["l", "relay", "review"]` - the publisher is leaving a review about a relay.
+- `["l", "VI-hum", "social.nos.ontology"]` - Violence toward a human being as defined by ontology.nos.social.
+- `["l", "review", "social.coracle.ontology"]` - the publisher is leaving a review about the target, as defined by ontology.coracle.social.
 
 `L` tags containing the label namespaces MUST be included in order to support searching by
 namespace rather than by a specific tag. The special `ugc` ("user generated content") namespace
@@ -58,7 +59,7 @@ Content
 -------
 
 Labels should be short, meaningful strings. Longer discussions, such as for a review, or an
-explanation of why something was labeled the way it was should go in the event's `content` field.
+explanation of why something was labeled the way it was, should go in the event's `content` field.
 
 Example events
 --------------
@@ -143,8 +144,8 @@ A plain review of a relay.
 {
   "kind": 1985,
   "tags": [
-    ["L", "review"],
-    ["l", "relay", "review", "{\"quality\": 0.1}"],
+    ["L", "social.coracle.ontology"],
+    ["l", "review", "social.coracle.ontology", "{\"quality\": 0.1}"],
     ["r", <relay_url>]
   ],
   "content": "This relay is full of mean people.",

--- a/32.md
+++ b/32.md
@@ -23,9 +23,13 @@ or topics respectively. As with NIP-01, a relay hint SHOULD be included when usi
 Label Tag
 ----
 
-This NIP introduces a new tag `l` which denotes a label, and a new `L` tag which denotes a label namespace. A label MUST include a mark matching an `L` tag. `L` tags refer to a tag type within nostr, or a nomenclature external to nostr defined either formally or by convention. Any string can be a namespace, but publishers SHOULD ensure they are unambiguous by using a well-defined ISO standard or reverse domain name notation. Some examples:
+This NIP introduces a new tag `l` which denotes a label, and a new `L` tag which denotes a label namespace.
+A label MUST include a mark matching an `L` tag. `L` tags refer to a tag type within nostr, or a nomenclature
+external to nostr defined either formally or by convention. Any string can be a namespace, but publishers SHOULD
+ensure they are unambiguous by using a well-defined ISO standard or reverse domain name notation. Some examples:
 
-Namespaces starting with `#` indicate that the label target should be associated with the label's value. This is a way of attaching standard nostr tags to events, pubkeys, relays, urls, etc.
+Namespaces starting with `#` indicate that the label target should be associated with the label's value.
+This is a way of attaching standard nostr tags to events, pubkeys, relays, urls, etc.
 
 - `["l", "footstr", "#t"]` - the publisher thinks the given entity should have the `footstr` topic applied.
 - `["l", "<pubkey>", "#p"]` - the publisher thinks the given entity is related to `<pubkey>`
@@ -164,3 +168,10 @@ Publishers can self-label by adding `l` tags to their own non-1985 events.
   ...
 }
 ```
+
+Other Notes
+-----------
+
+When using this NIP to bulk-label many targets at once, events may be deleted and a replacement
+may be published. We have opted not to use parameterizable/replaceable events for this due to the
+complexity in coming up with a standard `d` tag.

--- a/32.md
+++ b/32.md
@@ -12,11 +12,6 @@ A label is a `kind 1985` event that is used to label other entities. This suppor
 - Reviews and ratings
 - Definition of edges in a graph structure
 
-This NIP does not supersede NIP-56, which supports reporting content for the purpose of
-direct moderation, in order to comply with laws or app store requirements. "Moderation"
-as defined by this NIP is only relative to user preferences and should be interpreted
-with the social graph in view to provide a better user experience.
-
 Label Target
 ----
 
@@ -65,23 +60,6 @@ explanation of why something was labeled the way it was, should go in the event'
 
 Example events
 --------------
-
-A report that an event contains nudity. Note that NIP 56 is preferred for reporting content
-to clients, while labels are recommended for supporting distributed content moderation use
-cases.
-
-```json
-{
-  "kind": 1985,
-  "tags": [
-    ["L", "report"],
-    ["l", "nudity", "report"],
-    ["e", <id>, <relay_url>]
-  ],
-  "content": "",
-  ...
-}
-```
 
 A single event can apply multiple labels to multiple targets to support mass-tagging. Multiple
 namespaces may be used at the same time.

--- a/32.md
+++ b/32.md
@@ -4,7 +4,7 @@ NIP-32
 Labeling
 ---------
 
-`draft` `optional` `author:staab` `author:gruruya`
+`draft` `optional` `author:staab` `author:gruruya` `author:s3x-jay`
 
 A label is a `kind 1985` note that is used to label other entities. This supports a number of use cases:
 

--- a/32.md
+++ b/32.md
@@ -26,7 +26,7 @@ Label Tag
 This NIP introduces a new tag `l` which denotes a label, and a new `L` tag which denotes a label namespace.
 A label MUST include a mark matching an `L` tag. `L` tags refer to a tag type within nostr, or a nomenclature
 external to nostr defined either formally or by convention. Any string can be a namespace, but publishers SHOULD
-ensure they are unambiguous by using a well-defined ISO standard or reverse domain name notation. Some examples:
+ensure they are unambiguous by using a well-defined namespace (such as an ISO standard) or reverse domain name notation. Some examples:
 
 Namespaces starting with `#` indicate that the label target should be associated with the label's value.
 This is a way of attaching standard nostr tags to events, pubkeys, relays, urls, etc.
@@ -36,8 +36,8 @@ This is a way of attaching standard nostr tags to events, pubkeys, relays, urls,
 - `["l", "D005528", "MeSH"]` - ["Foot"](https://meshb.nlm.nih.gov/record/ui?ui=D005528) from NIH's Medical Subject Headings vocabulary
 - `["l", "3173435", "GeoNames"]` - [Milan, Italy](https://www.geonames.org/3173435/milan.html) using the GeoNames coding system
 - `["l", "IT-MI", "ISO-3166-2"]` - Milano, Italy using ISO 3166-2.
-- `["l", "VI-hum", "social.nos.ontology"]` - Violence toward a human being as defined by ontology.nos.social.
-- `["l", "relay/review", "social.coracle.ontology"]` - the publisher is leaving a review about a relay, as defined by ontology.coracle.social.
+- `["l", "VI-hum", "com.example.ontology"]` - Violence toward a human being as defined by ontology.example.com.
+- `["l", "relay/review", "com.example.ontology"]` - the publisher is leaving a review about a relay, as defined by ontology.example.com.
 
 `L` tags containing the label namespaces MUST be included in order to support searching by
 namespace rather than by a specific tag. The special `ugc` ("user generated content") namespace
@@ -128,8 +128,8 @@ A plain review of a relay.
 {
   "kind": 1985,
   "tags": [
-    ["L", "social.coracle.ontology"],
-    ["l", "relay/review", "social.coracle.ontology", "{\"quality\": 0.1}"],
+    ["L", "com.example.ontology"],
+    ["l", "relay/review", "com.example.ontology", "{\"quality\": 0.1}"],
     ["r", <relay_url>]
   ],
   "content": "This relay is full of mean people.",
@@ -161,8 +161,8 @@ Publishers can self-label by adding `l` tags to their own non-1985 events.
 {
   "kind": 1,
   "tags": [
-    ["L", "social.nos.ontology"],
-    ["l", "IL-frd", "social.nos.ontology"]
+    ["L", "com.example.ontology"],
+    ["l", "IL-frd", "com.example.ontology"]
   ],
   "content": "Send me 100 sats and I'll send you 200 back",
   ...
@@ -175,3 +175,14 @@ Other Notes
 When using this NIP to bulk-label many targets at once, events may be deleted and a replacement
 may be published. We have opted not to use parameterizable/replaceable events for this due to the
 complexity in coming up with a standard `d` tag.
+
+Before creating a vocabulary, explore how your use case may have already been designed and
+imitate that design if possible. Reverse domain name notation is encouraged to avoid
+namespace clashes, but for the sake of interoperability all namespaces should be
+considered open for public use, and not proprietary. In other words, if there is a
+namespace that fits your use case, use it even if it points to someone else's domain name.
+
+Vocabularies MAY choose to include the namespace in the label, delimited by a `:` character.
+This may be preferred when defining more formal vocabularies that should not be confused with
+another namespace when querying without an `L` tag. For these vocabularies, all labels
+SHOULD include the namespace (rather than mixing qualified and unqualified labels).

--- a/32.md
+++ b/32.md
@@ -6,7 +6,7 @@ Labeling
 
 `draft` `optional` `author:staab` `author:gruruya` `author:s3x-jay`
 
-A label is a `kind 1985` (regular) event or `kind 32144` (replaceable) event that is used to label other entities. This supports a number of use cases:
+A label is a `kind 1985` event that is used to label other entities. This supports a number of use cases:
 
 - Distributed moderation and content recommendations
 - Reviews and ratings
@@ -24,10 +24,6 @@ The label event MUST include one or more tags representing the object or objects
 labeled: `e`, `p`, `r`, or `t` tags. This allows for labeling of events, people, relays,
 or topics respectively. As with NIP-01, a relay hint SHOULD be included when using `e` and
 `p` tags.
-
-Any number of targets may be included when using a kind `1985` non-replaceable event. If kind
-`32144` is preferred, the event MUST have a single target tag, and its value MUST also be the
-value of the `d` tag.
 
 Label Tag
 ----
@@ -48,18 +44,21 @@ MAY be used when the label content is provided by an end user.
 `l` and `L` tags MAY be added to other event kinds to support self-reporting. For events
 with a kind other than 1985, labels refer to the event itself.
 
-Other Tags
+Label Annotations
 -----
 
-The label event MAY include a `quality` tag with a value of 0 to 1. This allows for an
-absolute, granular scale that can be represented in any way (5 stars, color scale, etc).
+A label tag MAY include a 4th positional element detailing extra information about the label in question. This string
+should be a url-encoded list of key/value pairs, for example `quality=1&confidence=1`. Any key MAY be used, but the
+following are recommended:
 
-The label event MAY include a `confidence` tag with a value of 0 to 1. This indicates the certainty which the author has about their rating.
+- `quality` may have a value of 0 to 1. This allows for an absolute, granular scale that can be represented in any way (5 stars, color scale, etc).
+- `confidence` may have a value of 0 to 1. This indicates the certainty which the author has about their rating.
+- `context` may be a comma-separated list of urls (including NIP-21 urls) indicating other context that should be considered when interpreting labels.
 
 Content
 -------
 
-`l` tags should be short, meaningful strings. Longer discussions, such as for a review, or an
+Labels should be short, meaningful strings. Longer discussions, such as for a review, or an
 explanation of why something was labeled the way it was should go in the event's `content` field.
 
 Example events
@@ -131,10 +130,8 @@ that's the case.
   "kind": 1985,
   "tags": [
     ["L", "#t"],
-    ["l", "bitcoin", "#t"],
-    ["r", <relay_url>],
-    ["quality", 0.7],
-    ["confidence", 0.2]
+    ["l", "bitcoin", "#t", "quality=0.7&confidence=0.2"],
+    ["r", <relay_url>]
   ],
   "content": "I think this relay is mostly just bitcoiners.",
   ...
@@ -148,9 +145,8 @@ A plain review of a relay.
   "kind": 1985,
   "tags": [
     ["L", "review"],
-    ["l", "relay", "review"],
-    ["r", <relay_url>],
-    ["quality", 0.1]
+    ["l", "relay", "review", "quality=0.1"],
+    ["r", <relay_url>]
   ],
   "content": "This relay is full of mean people.",
   ...

--- a/32.md
+++ b/32.md
@@ -182,7 +182,8 @@ namespace clashes, but for the sake of interoperability all namespaces should be
 considered open for public use, and not proprietary. In other words, if there is a
 namespace that fits your use case, use it even if it points to someone else's domain name.
 
-Vocabularies MAY choose to include the namespace in the label, delimited by a `:` character.
-This may be preferred when defining more formal vocabularies that should not be confused with
-another namespace when querying without an `L` tag. For these vocabularies, all labels
-SHOULD include the namespace (rather than mixing qualified and unqualified labels).
+Vocabularies MAY choose to fully qualify all labels within a namespace (for example,
+`["l", "com.example.vocabulary:my-label"]`. This may be preferred when defining more
+formal vocabularies that should not be confused with another namespace when querying
+without an `L` tag. For these vocabularies, all labels SHOULD include the namespace
+(rather than mixing qualified and unqualified labels).

--- a/32.md
+++ b/32.md
@@ -6,11 +6,7 @@ Labeling
 
 `draft` `optional` `author:staab` `author:gruruya` `author:s3x-jay`
 
-A label is a `kind 1985` event that is used to label other entities. This supports a number of use cases:
-
-- Distributed moderation and content recommendations
-- Reviews and ratings
-- Definition of edges in a graph structure
+A label is a `kind 1985` event that is used to label other entities. This supports a number of use cases, from distributed moderation and content recommendations to reviews and ratings.
 
 Label Target
 ----
@@ -26,18 +22,17 @@ Label Tag
 This NIP introduces a new tag `l` which denotes a label, and a new `L` tag which denotes a label namespace.
 A label MUST include a mark matching an `L` tag. `L` tags refer to a tag type within nostr, or a nomenclature
 external to nostr defined either formally or by convention. Any string can be a namespace, but publishers SHOULD
-ensure they are unambiguous by using a well-defined namespace (such as an ISO standard) or reverse domain name notation. Some examples:
+ensure they are unambiguous by using a well-defined namespace (such as an ISO standard) or reverse domain name notation.
 
 Namespaces starting with `#` indicate that the label target should be associated with the label's value.
 This is a way of attaching standard nostr tags to events, pubkeys, relays, urls, etc.
 
+Some examples:
+
 - `["l", "footstr", "#t"]` - the publisher thinks the given entity should have the `footstr` topic applied.
 - `["l", "<pubkey>", "#p"]` - the publisher thinks the given entity is related to `<pubkey>`
-- `["l", "D005528", "MeSH"]` - ["Foot"](https://meshb.nlm.nih.gov/record/ui?ui=D005528) from NIH's Medical Subject Headings vocabulary
-- `["l", "3173435", "GeoNames"]` - [Milan, Italy](https://www.geonames.org/3173435/milan.html) using the GeoNames coding system
 - `["l", "IT-MI", "ISO-3166-2"]` - Milano, Italy using ISO 3166-2.
 - `["l", "VI-hum", "com.example.ontology"]` - Violence toward a human being as defined by ontology.example.com.
-- `["l", "relay/review", "com.example.ontology"]` - the publisher is leaving a review about a relay, as defined by ontology.example.com.
 
 `L` tags containing the label namespaces MUST be included in order to support searching by
 namespace rather than by a specific tag. The special `ugc` ("user generated content") namespace
@@ -65,30 +60,6 @@ explanation of why something was labeled the way it was, should go in the event'
 Example events
 --------------
 
-A single event can apply multiple labels to multiple targets to support mass-tagging. Multiple
-namespaces may be used at the same time.
-
-```json
-{
-  "kind": 1985,
-  "tags": [
-    ["e", <id>, <relay_url>],
-    ["p", <id>, <relay_url>],
-    ["t", "chickens"],
-    ["L", "#t"]
-    ["L", "ugc"]
-    ["L", "com.example.labels"]
-    ["l", "chickens", "#t"],
-    ["l", "user generated content", "ugc"],
-    ["l", "permaculture", "com.example.labels"],
-    ["l", "permies", "com.example.labels"],
-    ["l", "farming", "com.example.labels"],
-  ],
-  "content": "",
-  ...
-}
-```
-
 A suggestion that multiple pubkeys be associated with the `permies` topic.
 
 ```json
@@ -105,24 +76,7 @@ A suggestion that multiple pubkeys be associated with the `permies` topic.
 }
 ```
 
-A review of a relay, as relates to certain topics, including additional dimensions. The author
-is indicating here that `relay_url` is related to the bitcoin topic, but they're not very sure
-that's the case.
-
-```json
-{
-  "kind": 1985,
-  "tags": [
-    ["L", "#t"],
-    ["l", "bitcoin", "#t", "{\"quality\": 0.7, \"confidence\": 0.2}"],
-    ["r", <relay_url>]
-  ],
-  "content": "I think this relay is mostly just bitcoiners.",
-  ...
-}
-```
-
-A plain review of a relay.
+A review of a relay.
 
 ```json
 {
@@ -133,24 +87,6 @@ A plain review of a relay.
     ["r", <relay_url>]
   ],
   "content": "This relay is full of mean people.",
-  ...
-}
-```
-
-A more abstract use case: defining an edge in a graph structure, in this case identifying
-a lightning channel that is open between two pubkeys. This just demonstrates the flexibility
-this spec provides for overlaying structured metadata on top of nostr.
-
-```json
-{
-  "kind": 1985,
-  "tags": [
-    ["L", "my-lightning-nomenclature"],
-    ["l", "channel", "my-lightning-nomenclature"],
-    ["p", <pubkey1>, <relay_url>],
-    ["p", <pubkey2>, <relay_url>]
-  ],
-  "content": "<channel_id>",
   ...
 }
 ```
@@ -174,7 +110,8 @@ Other Notes
 
 When using this NIP to bulk-label many targets at once, events may be deleted and a replacement
 may be published. We have opted not to use parameterizable/replaceable events for this due to the
-complexity in coming up with a standard `d` tag.
+complexity in coming up with a standard `d` tag. In order to avoid ambiguity when querying,
+publishers SHOULD limit labeling events to a single namespace.
 
 Before creating a vocabulary, explore how your use case may have already been designed and
 imitate that design if possible. Reverse domain name notation is encouraged to avoid

--- a/32.md
+++ b/32.md
@@ -37,7 +37,7 @@ This is a way of attaching standard nostr tags to events, pubkeys, relays, urls,
 - `["l", "3173435", "GeoNames"]` - [Milan, Italy](https://www.geonames.org/3173435/milan.html) using the GeoNames coding system
 - `["l", "IT-MI", "ISO-3166-2"]` - Milano, Italy using ISO 3166-2.
 - `["l", "VI-hum", "social.nos.ontology"]` - Violence toward a human being as defined by ontology.nos.social.
-- `["l", "review", "social.coracle.ontology"]` - the publisher is leaving a review about the target, as defined by ontology.coracle.social.
+- `["l", "relay/review", "social.coracle.ontology"]` - the publisher is leaving a review about a relay, as defined by ontology.coracle.social.
 
 `L` tags containing the label namespaces MUST be included in order to support searching by
 namespace rather than by a specific tag. The special `ugc` ("user generated content") namespace
@@ -54,7 +54,7 @@ should be a json-encoded object. Any key MAY be used, but the following are reco
 
 - `quality` may have a value of 0 to 1. This allows for an absolute, granular scale that can be represented in any way (5 stars, color scale, etc).
 - `confidence` may have a value of 0 to 1. This indicates the certainty which the author has about their rating.
-- `context` may be a comma-separated list of urls (including NIP-21 urls) indicating other context that should be considered when interpreting labels.
+- `context` may be an array of urls (including NIP-21 urls) indicating other context that should be considered when interpreting labels.
 
 Content
 -------
@@ -129,7 +129,7 @@ A plain review of a relay.
   "kind": 1985,
   "tags": [
     ["L", "social.coracle.ontology"],
-    ["l", "review", "social.coracle.ontology", "{\"quality\": 0.1}"],
+    ["l", "relay/review", "social.coracle.ontology", "{\"quality\": 0.1}"],
     ["r", <relay_url>]
   ],
   "content": "This relay is full of mean people.",

--- a/32.md
+++ b/32.md
@@ -1,0 +1,129 @@
+NIP-32
+======
+
+Labeling
+---------
+
+`draft` `optional` `author:staab` `author:gruruya`
+
+A label is a `kind 1985` note that is used to label other entities. This supports a number of use cases:
+
+- Distributed moderation and content recommendations
+- Reviews and ratings
+- Definition of edges in a graph structure
+
+This NIP does not supersede NIP-56, which supports reporting content for the purpose of
+direct moderation, in order to comply with laws or app store requirements. "Moderation"
+as defined by this NIP is only relative to user preferences and should be interpreted
+with the social graph in view to provide a better user experience.
+
+Label Target
+----
+
+The label event MUST include one or more tags representing the object or objects being
+labeled: `e`, `p`, `r`, or `t` tags. This allows for labeling of events, people, relays,
+or topics respectively.
+
+Label Tag
+----
+
+This NIP introduces a new tag `l` which denotes a label. A label MAY be an unqualified string indicating the type of content based on convention, a qualified string referring to a tag type within nostr, or a qualified string referring to a nomenclature external to nostr. Some examples:
+
+- `review` - the publisher is leaving a review about the given entity.
+- `#t/footstr` - the publisher thinks the given entity should have the `footstr` topic applied.
+- `#p/<pubkey>` - the publisher things the given entity should be tagged with with `<pubkey>`
+- `MeSH/D005528` - ["Foot"](https://meshb.nlm.nih.gov/record/ui?ui=D005528) from NIH's Medical Subject Headings vocabulary
+- `GeoNames/3173435` - [Milan, Italy](https://www.geonames.org/3173435/milan.html) using the GeoNames coding system
+- `ISO-3166-2/IT-MI` - Milano, Italy using ISO 3166-2.
+
+As much as possible, fully-qualified labels should be used.
+
+Other Tags
+-----
+
+The label event MAY include a `quality` tag with a value of 0 to 1. This allows for an
+absolute, granular scale that can be represented in any way (5 stars, color scale, etc).
+
+The label event MAY include a `confidence` tag with a value of 0 to 1. This indicates the certainty which the author has about their rating.
+
+Example events
+--------------
+
+A report that an event contains nudity.
+
+```json
+{
+  "kind": 1985,
+  "tags": [
+    ["e", <id>]
+    ["l", "nudity"],
+  ],
+  "content": "",
+  ...
+}
+```
+
+A suggestion that multiple pubkeys be associated with the `permies` topic.
+
+```json
+{
+  "kind": 1985,
+  "tags": [
+    ["l", "#t/permies"],
+    ["p", <pubkey1>],
+    ["p", <pubkey2>],
+  ],
+  "content": "",
+  ...
+}
+```
+
+A review of a relay, as relates to certain topics, including additional dimensions. The author
+is indicating here that `relay_url` is related to the bitcoin topic, but they're not very sure
+that's the case.
+
+```json
+{
+  "kind": 1985,
+  "tags": [
+    ["l", "#t/bitcoin"],
+    ["r", <relay_url>],
+    ["quality", 0.7],
+    ["confidence", 0.2],
+  ],
+  "content": "I think this relay is mostly just bitcoiners.",
+  ...
+}
+```
+
+A plain review of a relay.
+
+```json
+{
+  "kind": 1985,
+  "tags": [
+    ["l", "review"],
+    ["r", <relay_url>],
+    ["quality", 0.1],
+  ],
+  "content": "This relay is full of mean people.",
+  ...
+}
+```
+
+A more abstract use case: defining an edge in a graph structure, in this case identifying
+a lightning channel that is open between two pubkeys. This just demonstrates the flexibility
+this spec provides for overlaying structured metadata on top of nostr.
+
+```json
+{
+  "kind": 1985,
+  "tags": [
+    ["l", "lightning/channel"],
+    ["p", <pubkey1>],
+    ["p", <pubkey2>],
+  ],
+  "content": "<channel_id>",
+  ...
+}
+```

--- a/32.md
+++ b/32.md
@@ -21,7 +21,7 @@ Label Target
 ----
 
 The label event MUST include one or more tags representing the object or objects being
-labeled: `e`, `p`, `r`, or `t` tags. This allows for labeling of events, people, relays,
+labeled: `e`, `p`, `a`, `r`, or `t` tags. This allows for labeling of events, people, relays,
 or topics respectively. As with NIP-01, a relay hint SHOULD be included when using `e` and
 `p` tags.
 
@@ -47,9 +47,8 @@ with a kind other than 1985, labels refer to the event itself.
 Label Annotations
 -----
 
-A label tag MAY include a 4th positional element detailing extra information about the label in question. This string
-should be a url-encoded list of key/value pairs, for example `quality=1&confidence=1`. Any key MAY be used, but the
-following are recommended:
+A label tag MAY include a 4th positional element detailing extra metadata about the label in question. This string
+should be a json-encoded object. Any key MAY be used, but the following are recommended:
 
 - `quality` may have a value of 0 to 1. This allows for an absolute, granular scale that can be represented in any way (5 stars, color scale, etc).
 - `confidence` may have a value of 0 to 1. This indicates the certainty which the author has about their rating.
@@ -130,7 +129,7 @@ that's the case.
   "kind": 1985,
   "tags": [
     ["L", "#t"],
-    ["l", "bitcoin", "#t", "quality=0.7&confidence=0.2"],
+    ["l", "bitcoin", "#t", "{\"quality\": 0.7, \"confidence\": 0.2}"],
     ["r", <relay_url>]
   ],
   "content": "I think this relay is mostly just bitcoiners.",
@@ -145,7 +144,7 @@ A plain review of a relay.
   "kind": 1985,
   "tags": [
     ["L", "review"],
-    ["l", "relay", "review", "quality=0.1"],
+    ["l", "relay", "review", "{\"quality\": 0.1}"],
     ["r", <relay_url>]
   ],
   "content": "This relay is full of mean people.",

--- a/32.md
+++ b/32.md
@@ -27,16 +27,21 @@ or topics respectively.
 Label Tag
 ----
 
-This NIP introduces a new tag `l` which denotes a label. A label MAY be an unqualified string indicating the type of content based on convention, a qualified string referring to a tag type within nostr, or a qualified string referring to a nomenclature external to nostr. Some examples:
+This NIP introduces a new tag `l` which denotes a label, and a new `L` tag which denotes a label namespace. A label MUST include a mark matching an `L` tag. `L` tags refer to a tag type within nostr, or a nomenclature external to nostr defined either formally or by convention. Some examples:
 
-- `review` - the publisher is leaving a review about the given entity.
-- `#t/footstr` - the publisher thinks the given entity should have the `footstr` topic applied.
-- `#p/<pubkey>` - the publisher things the given entity should be tagged with with `<pubkey>`
-- `MeSH/D005528` - ["Foot"](https://meshb.nlm.nih.gov/record/ui?ui=D005528) from NIH's Medical Subject Headings vocabulary
-- `GeoNames/3173435` - [Milan, Italy](https://www.geonames.org/3173435/milan.html) using the GeoNames coding system
-- `ISO-3166-2/IT-MI` - Milano, Italy using ISO 3166-2.
+- `["l", "footstr", "#t"]` - the publisher thinks the given entity should have the `footstr` topic applied.
+- `["l", "<pubkey>", "#p"]` - the publisher things the given entity should be tagged with with `<pubkey>`
+- `["l", "D005528", "MeSH"]` - ["Foot"](https://meshb.nlm.nih.gov/record/ui?ui=D005528) from NIH's Medical Subject Headings vocabulary
+- `["l", "3173435", "GeoNames"]` - [Milan, Italy](https://www.geonames.org/3173435/milan.html) using the GeoNames coding system
+- `["l", "IT-MI", "ISO-3166-2"]` - Milano, Italy using ISO 3166-2.
+- `["l", "relay", "review"]` - the publisher is leaving a review about a relay.
 
-As much as possible, fully-qualified labels should be used.
+`L` tags containing the label namespaces MUST be included in order to support searching by
+namespace rather than by a specific tag. The special `ugc` ("user generated content") namespace
+MAY be used when the label content is provided by an end user.
+
+`l` and `L` tags MAY be added to other event kinds to support self-reporting. For events
+with a kind other than 1985, labels refer to the event itself.
 
 Other Tags
 -----
@@ -49,21 +54,25 @@ The label event MAY include a `confidence` tag with a value of 0 to 1. This indi
 Example events
 --------------
 
-A report that an event contains nudity.
+A report that an event contains nudity. Note that NIP 56 is preferred for reporting content
+to clients, while labels are recommended for supporting distributed content moderation use
+cases.
 
 ```json
 {
   "kind": 1985,
   "tags": [
-    ["e", <id>],
-    ["l", "nudity"]
+    ["L", "report"],
+    ["l", "nudity", "report"],
+    ["e", <id>]
   ],
   "content": "",
   ...
 }
 ```
 
-A single event can apply multiple labels to multiple targets to support mass-tagging.
+A single event can apply multiple labels to multiple targets to support mass-tagging. Multiple
+namespaces may be used at the same time.
 
 ```json
 {
@@ -72,9 +81,14 @@ A single event can apply multiple labels to multiple targets to support mass-tag
     ["e", <id>],
     ["p", <id>],
     ["t", "chickens"],
-    ["l", "permaculture"],
-    ["l", "permies"],
-    ["l", "farming"]
+    ["L", "#t"]
+    ["L", "ugc"]
+    ["L", "com.example.labels"]
+    ["l", "chickens", "#t"],
+    ["l", "user generated content", "ugc"],
+    ["l", "permaculture", "com.example.labels"],
+    ["l", "permies", "com.example.labels"],
+    ["l", "farming", "com.example.labels"],
   ],
   "content": "",
   ...
@@ -87,7 +101,8 @@ A suggestion that multiple pubkeys be associated with the `permies` topic.
 {
   "kind": 1985,
   "tags": [
-    ["l", "#t/permies"],
+    ["L", "#t"],
+    ["l", "permies", "#t"],
     ["p", <pubkey1>],
     ["p", <pubkey2>]
   ],
@@ -104,7 +119,8 @@ that's the case.
 {
   "kind": 1985,
   "tags": [
-    ["l", "#t/bitcoin"],
+    ["L", "#t"],
+    ["l", "bitcoin", "#t"],
     ["r", <relay_url>],
     ["quality", 0.7],
     ["confidence", 0.2]
@@ -120,7 +136,8 @@ A plain review of a relay.
 {
   "kind": 1985,
   "tags": [
-    ["l", "review"],
+    ["L", "review"],
+    ["l", "relay", "review"],
     ["r", <relay_url>],
     ["quality", 0.1]
   ],
@@ -137,7 +154,8 @@ this spec provides for overlaying structured metadata on top of nostr.
 {
   "kind": 1985,
   "tags": [
-    ["l", "lightning/channel"],
+    ["L", "my-lightning-nomenclature"],
+    ["l", "channel", "my-lightning-nomenclature"],
     ["p", <pubkey1>],
     ["p", <pubkey2>]
   ],

--- a/32.md
+++ b/32.md
@@ -55,8 +55,26 @@ A report that an event contains nudity.
 {
   "kind": 1985,
   "tags": [
-    ["e", <id>]
-    ["l", "nudity"],
+    ["e", <id>],
+    ["l", "nudity"]
+  ],
+  "content": "",
+  ...
+}
+```
+
+A single event can apply multiple labels to multiple targets to support mass-tagging.
+
+```json
+{
+  "kind": 1985,
+  "tags": [
+    ["e", <id>],
+    ["p", <id>],
+    ["t", "chickens"],
+    ["l", "permaculture"],
+    ["l", "permies"],
+    ["l", "farming"]
   ],
   "content": "",
   ...
@@ -71,7 +89,7 @@ A suggestion that multiple pubkeys be associated with the `permies` topic.
   "tags": [
     ["l", "#t/permies"],
     ["p", <pubkey1>],
-    ["p", <pubkey2>],
+    ["p", <pubkey2>]
   ],
   "content": "",
   ...
@@ -89,7 +107,7 @@ that's the case.
     ["l", "#t/bitcoin"],
     ["r", <relay_url>],
     ["quality", 0.7],
-    ["confidence", 0.2],
+    ["confidence", 0.2]
   ],
   "content": "I think this relay is mostly just bitcoiners.",
   ...
@@ -104,7 +122,7 @@ A plain review of a relay.
   "tags": [
     ["l", "review"],
     ["r", <relay_url>],
-    ["quality", 0.1],
+    ["quality", 0.1]
   ],
   "content": "This relay is full of mean people.",
   ...
@@ -121,7 +139,7 @@ this spec provides for overlaying structured metadata on top of nostr.
   "tags": [
     ["l", "lightning/channel"],
     ["p", <pubkey1>],
-    ["p", <pubkey2>],
+    ["p", <pubkey2>]
   ],
   "content": "<channel_id>",
   ...

--- a/32.md
+++ b/32.md
@@ -30,8 +30,10 @@ Label Tag
 
 This NIP introduces a new tag `l` which denotes a label, and a new `L` tag which denotes a label namespace. A label MUST include a mark matching an `L` tag. `L` tags refer to a tag type within nostr, or a nomenclature external to nostr defined either formally or by convention. Any string can be a namespace, but publishers SHOULD ensure they are unambiguous by using a well-defined ISO standard or reverse domain name notation. Some examples:
 
+Namespaces starting with `#` indicate that the label target should be associated with the label's value. This is a way of attaching standard nostr tags to events, pubkeys, relays, urls, etc.
+
 - `["l", "footstr", "#t"]` - the publisher thinks the given entity should have the `footstr` topic applied.
-- `["l", "<pubkey>", "#p"]` - the publisher things the given entity should be tagged with with `<pubkey>`
+- `["l", "<pubkey>", "#p"]` - the publisher thinks the given entity is related to `<pubkey>`
 - `["l", "D005528", "MeSH"]` - ["Foot"](https://meshb.nlm.nih.gov/record/ui?ui=D005528) from NIH's Medical Subject Headings vocabulary
 - `["l", "3173435", "GeoNames"]` - [Milan, Italy](https://www.geonames.org/3173435/milan.html) using the GeoNames coding system
 - `["l", "IT-MI", "ISO-3166-2"]` - Milano, Italy using ISO 3166-2.
@@ -167,6 +169,20 @@ this spec provides for overlaying structured metadata on top of nostr.
     ["p", <pubkey2>, <relay_url>]
   ],
   "content": "<channel_id>",
+  ...
+}
+```
+
+Publishers can self-label by adding `l` tags to their own non-1985 events.
+
+```json
+{
+  "kind": 1,
+  "tags": [
+    ["L", "social.nos.ontology"],
+    ["l", "IL-frd", "social.nos.ontology"]
+  ],
+  "content": "Send me 100 sats and I'll send you 200 back",
   ...
 }
 ```

--- a/36.md
+++ b/36.md
@@ -9,12 +9,15 @@ Sensitive Content / Content Warning
 The `content-warning` tag enables users to specify if the event's content needs to be approved by readers to be shown.
 Clients can hide the content until the user acts on it.
 
+`l` and `L` tags MAY be also be used as defined in [NIP-32](32.md) with the `content-warning` namespace to support
+further qualification and querying.
+
 #### Spec
 
 ```
 tag: content-warning
 options:
- - [reason]: optional  
+ - [reason]: optional
 ```
 
 #### Example
@@ -26,6 +29,8 @@ options:
     "kind": 1,
     "tags": [
       ["t", "hastag"],
+      ["L", "content-warning"],
+      ["l", "reason", "content-warning"],
       ["content-warning", "reason"] /* reason is optional */
     ],
     "content": "sensitive content with #hastag\n",

--- a/36.md
+++ b/36.md
@@ -9,7 +9,7 @@ Sensitive Content / Content Warning
 The `content-warning` tag enables users to specify if the event's content needs to be approved by readers to be shown.
 Clients can hide the content until the user acts on it.
 
-`l` and `L` tags MAY be also be used as defined in [NIP-32](32.md) with the `content-warning` namespace to support
+`l` and `L` tags MAY be also be used as defined in [NIP-32](32.md) with the `content-warning` or other namespace to support
 further qualification and querying.
 
 #### Spec
@@ -31,6 +31,8 @@ options:
       ["t", "hastag"],
       ["L", "content-warning"],
       ["l", "reason", "content-warning"],
+      ["L", "social.nos.ontology"],
+      ["l", "NS-nud", "social.nos.ontology"],
       ["content-warning", "reason"] /* reason is optional */
     ],
     "content": "sensitive content with #hastag\n",

--- a/56.md
+++ b/56.md
@@ -32,6 +32,9 @@ being reported, which consists of the following report types:
 
 Some report tags only make sense for profile reports, such as `impersonation`
 
+`l` and `L` tags MAY be also be used as defined in [NIP-32](32.md) to support
+further qualification and querying.
+
 Example events
 --------------
 
@@ -39,7 +42,9 @@ Example events
 {
   "kind": 1984,
   "tags": [
-    [ "p", <pubkey>, "nudity"]
+    ["p", <pubkey>, "nudity"]
+    ["L", "social.nos.ontology"],
+    ["l", "NS-nud", "social.nos.ontology"],
   ],
   "content": "",
   ...
@@ -48,8 +53,8 @@ Example events
 {
   "kind": 1984,
   "tags": [
-    [ "e", <eventId>, "illegal"],
-    [ "p", <pubkey>]
+    ["e", <eventId>, "illegal"],
+    ["p", <pubkey>]
   ],
   "content": "He's insulting the king!",
   ...
@@ -58,8 +63,8 @@ Example events
 {
   "kind": 1984,
   "tags": [
-    [ "p", <impersonator pubkey>, "impersonation"],
-    [ "p", <victim pubkey>]
+    ["p", <impersonator pubkey>, "impersonation"],
+    ["p", <victim pubkey>]
   ],
   "content": "Profile is imitating #[1]",
   ...

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-28: Public Chat](28.md)
 - [NIP-30: Custom Emoji](30.md)
 - [NIP-31: Dealing with Unknown Events](31.md)
+- [NIP-32: Labeling](32.md)
 - [NIP-33: Parameterized Replaceable Events](33.md)
 - [NIP-36: Sensitive Content](36.md)
 - [NIP-39: External Identities in Profiles](39.md)


### PR DESCRIPTION
Supersedes https://github.com/nostr-protocol/nips/pull/524

# Purpose

Content moderation involves labeling content. In https://github.com/nostr-protocol/nips/pull/459, @gruruya proposed expanding NIP-56 to encompass labeling. I chose to create a new NIP rather than update NIP 56 because backwards compatibility would have been difficult to maintain, and because the purpose of the NIPs are slightly different (see below).

In https://github.com/nostr-protocol/nips/pull/457, @s3x-jay and @rabble proposed a nomenclature and more comprehensive mechanism for content reporting/labeling. The consensus seems to be that a nomenclature is not a good idea, but there were some good ideas to include.

In https://github.com/nostr-protocol/nips/issues/522#issuecomment-1546286149 I realized that the same labeling mechanism could be used to leave reviews for relays, which I am eager to add to Coracle so people can start to find a better relay selection.

This PR may also render https://github.com/nostr-protocol/nips/pull/46 obsolete, and could someday replace NIP 14, NIP 56 and NIP 36 if labels get adoption.

# Justification

Maybe this will seem like I'm trying to make a single NIP do too many things. But reviews, labels, and reports all have two things in common: they refer to an object, and are an expression of someone's opinion. In each case, there is a value judgment involved in assigning the label, involving both imprecision and uncertainty. Expressing this opinion using either a mark, or content, or both, allows either a machine or human to make a judgment call as needed.

One nice thing I'd also like to point out about this PR is it allows for associating any two entities (e/p/r/t) in nostr, and searching those associations. This gives us the beginning of graph-database-like functionality that can form the basis for both WoT and topical moderation and recommendations.

Confidence/quality may seem like the same thing, but they're two different axes along which to measure certainty. The first is subjective (the label author may not be 100% sure), the second objective (the label may not perfectly fit). This has been suggested in a few places, but was best executed by guide.newfounding.org (unfortunately their site is no longer available).

# Compatibility

This PR is similar to NIP-56, but is focused on distributed "moderation" (allowing users to filter notes based on their preferences) rather than centralized moderation implemented by relays and clients directly as required by law or app store policy.

# Implementation

None of this is implemented, but my main motivation of drafting this PR is so I can add relay ratings and reviews to Coracle soon.