### PR TITLE
NIP-30: clarify the character set allowed in emoji shortcodes

### DIFF
--- a/30.md
+++ b/30.md
@@ -14,7 +14,7 @@ Custom emoji may be added to **kind 0** and **kind 1** events by including one o
 
 Where:
 
-- `<shortcode>` is a name given for the emoji, which MUST be comprised of only alphanumeric characters.
+- `<shortcode>` is a name given for the emoji, which MUST be comprised of only alphanumeric characters and underscores.
 - `<image-url>` is a URL to the corresponding image file of the emoji.
 
 For each emoji tag, clients should parse emoji shortcodes (aka "emojify") like `:shortcode:` in the event to display custom emoji.


### PR DESCRIPTION
The term "only alphanumeric characters" is somewhat ambiguous. It would mean both of:
- only letters of the alphabet and numbers. (i.e. `/[a-zA-Z0-9]/`)
- only letters of the alphabet, numbers, and *some* punctuation marks.

If the term is intended to mean the former, it seems **too restrictive**.  In particular, underscores ( _ ) are widely used in emoji shortcodes in chat platforms like Slack, Discord, and many ActivityPub implementations. I think that there is no reason to prohibit the use of underscores (at least).

If the term is intended to mean the latter, it could be lead to **ambiguity and misinterpretation**.  Exactly what characters are included in "*some* punctuation marks" ?  This should be clarified.

Based on the above, I've decided to add the least amount of clarification to the NIP-30.

