### PR TITLE
Specify replacement behaviour when replaceable events have the same timestamp

### DIFF
--- a/16.md
+++ b/16.md
@@ -20,6 +20,8 @@ Upon a replaceable event with a newer timestamp than the currently known latest 
 effectively replacing what gets returned when querying for
 `author:kind` tuples.
 
+If two events have the same timestamp, the event with the lowest id (first in lexical order) SHOULD be retained, and the other discarded.
+
 Ephemeral Events
 ----------------
 An *ephemeral event* is defined as an event with a kind `20000 <= n < 30000`.

--- a/33.md
+++ b/33.md
@@ -18,6 +18,8 @@ replaceable event with the same kind, author and first `d` tag value being recei
 SHOULD be discarded, effectively replacing what gets returned when querying for
 `author:kind:d-tag` tuples.
 
+If two events have the same timestamp, the event with the lowest id (first in lexical order) SHOULD be retained, and the other discarded.
+
 A missing or a `d` tag with no value should be interpreted equivalent to a `d` tag with the
 value as an empty string. Events from the same author with any of the following `tags`
 replace each other:


### PR DESCRIPTION
- This is so that relays can converge on a deterministic sets of events, no matter the order they were received
- Otherwise, clients or relays that sync their sets of events could continually retransmit events they think are missing on the other side, wasting bandwidth