### PR TITLE
Adds Zap splits to NIP-57

### DIFF
--- a/57.md
+++ b/57.md
@@ -173,9 +173,9 @@ When an event includes one or more `zap` tags, clients SHOULD calculate the lnur
 ```json
 {
     "tags": [
-		[ "zap", "LNURL..", "lud06", 10 ],  // 10%
+        [ "zap", "LNURL..", "lud06", 10 ],  // 10%
         [ "zap", "pablo@f7z.io", "lud16", 65 ], // 65%
-		[ "zap", "460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c", "pubkey", 25 ] // 25%
+        [ "zap", "460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c", "pubkey", 25 ] // 25%
     ]
 }
 ```

--- a/57.md
+++ b/57.md
@@ -180,7 +180,7 @@ When an event includes one or more `zap` tags, clients SHOULD calculate the lnur
 }
 ```
 
-When the hex code is used, clients MAY inform the user the zap split configuration in the note. 
+Clients MAY display the zap split configuration in the note.
 
 ## Future Work
 

--- a/57.md
+++ b/57.md
@@ -168,15 +168,19 @@ A client can retrieve `zap receipt`s on events and pubkeys using a NIP-01 filter
 
 ### Appendix G: `zap` tag on zapped event
 
-When an event includes a `zap` tag, clients SHOULD calculate the lnurl pay request based on it's value instead of the profile's field. An optional third argument on the tag specifies the type of value, either `lud06` or `lud16`.
+When an event includes one or more `zap` tags, clients SHOULD calculate the lnurl pay request based on their value instead of the profile's field. The tag's second argument is a `lud06` address, `lud16` identifier or `hex` string of the receiver's pub key. An optional third argument specifies the type of the previous value: `lud06`, `lud16` or `pubkey`. An optional fourth parameter specifies the weight (a generalization of a percentage) assigned to the respective receiver. Clients should parse all weights, calculate a sum, and then a percentage to each member. If weights are not present, CLIENTS should equally divide the zap amount to all zap receivers. If weights are only partially present, receivers without a weight should not be zapped (`weight = 0`).
 
 ```json
 {
     "tags": [
-        [ "zap", "pablo@f7z.io", "lud16" ]
+		[ "zap", "LNURL..", "lud06", 10 ],  // 10%
+        [ "zap", "pablo@f7z.io", "lud16", 65 ], // 65%
+		[ "zap", "460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c", "pubkey", 25 ] // 25%
     ]
 }
 ```
+
+When the hex code is used, clients MAY inform the user the zap split configuration in the note. 
 
 ## Future Work
 


### PR DESCRIPTION
1. Changes NIP-57's `zap` tag in events from one to many 
2. Adds an optional percentage for each zap receiver. 
3. Adds dynamic resolution of the lightning address of the receiver by `zap` tagging with pubkey
4. Adds the suggestion to clients to display the Zap split on the screen. 