### PR TITLE
Clarify NIP-57 Appendix G purpose

### DIFF
--- a/57.md
+++ b/57.md
@@ -168,7 +168,7 @@ A client can retrieve `zap receipt`s on events and pubkeys using a NIP-01 filter
 
 ### Appendix G: `zap` tag on zapped event
 
-When an event includes a `zap` tag, clients SHOULD calculate the lnurl pay request based on it's value instead of the profile's field. An optional third argument on the tag specifies the type of value, either `lud06` or `lud16`.
+When an event includes a `zap` tag, clients wishing to zap it SHOULD calculate the lnurl pay request based on it's value instead of the author's profile field. An optional third argument on the tag specifies the type of value, either `lud06` or `lud16`.
 
 ```json
 {


### PR DESCRIPTION
It took me 5 minutes before I realized what the 'zap' tag on an event was for.  I thought maybe people were indicating zap receipt data, which confused me because tags are signed and events are zapped after they are created so the tags cannot change.

These few words would have saved me the confusion.