### PR TITLE
NIP-57 - Zap Proofs / Partially complete zap receipts

### DIFF
--- a/57.md
+++ b/57.md
@@ -178,6 +178,30 @@ When an event includes a `zap` tag, clients SHOULD calculate the lnurl pay reque
 }
 ```
 
+### Appendix H: Partially Complete Zap Receipt
+
+LNURL Servers SHOULD return a Partially complete Zap Receipt together with the payment request in step 6. This allows clients to republish the receipt to "proof" a payment has been made, even when the LNURL server fails or refuses to publish the Zap receipt. In order to stop a client from publishing the receipt without ever paying the invoice, the LNURL server removes the value of the preimage-tag before sending it back in the response, making the receipt an invalid event until the paying client has paid the invoice to discover the preimage themselves. 
+
+Example `Partially complete zap receipt`:
+
+```json
+{
+    "id": "67b48a14fb66c60c8f9070bdeb37afdfcc3d08ad01989460448e4081eddda446",
+    "pubkey": "9630f464cca6a5147aa8a35f0bcdd3ce485324e732fd39e09233b1d848238f31",
+    "created_at": 1674164545,
+    "kind": 9735,
+    "tags": [
+      ["p", "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245"],
+      ["e", "3624762a1274dd9636e0c552b53086d70bc88c165bc4dc0f9e836a1eaf86c3b8"],
+      ["bolt11", "lnbc10u1p3unwfusp5t9r3yymhpfqculx78u027lxspgxcr2n2987mx2j55nnfs95nxnzqpp5jmrh92pfld78spqs78v9euf2385t83uvpwk9ldrlvf6ch7tpascqhp5zvkrmemgth3tufcvflmzjzfvjt023nazlhljz2n9hattj4f8jq8qxqyjw5qcqpjrzjqtc4fc44feggv7065fqe5m4ytjarg3repr5j9el35xhmtfexc42yczarjuqqfzqqqqqqqqlgqqqqqqgq9q9qxpqysgq079nkq507a5tw7xgttmj4u990j7wfggtrasah5gd4ywfr2pjcn29383tphp4t48gquelz9z78p4cq7ml3nrrphw5w6eckhjwmhezhnqpy6gyf0"],
+      ["description", "{\"pubkey\":\"32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245\",\"content\":\"\",\"id\":\"d9cc14d50fcb8c27539aacf776882942c1a11ea4472f8cdec1dea82fab66279d\",\"created_at\":1674164539,\"sig\":\"77127f636577e9029276be060332ea565deaf89ff215a494ccff16ae3f757065e2bc59b2e8c113dd407917a010b3abd36c8d7ad84c0e3ab7dab3a0b0caa9835d\",\"kind\":9734,\"tags\":[[\"e\",\"3624762a1274dd9636e0c552b53086d70bc88c165bc4dc0f9e836a1eaf86c3b8\"],[\"p\",\"32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245\"],[\"relays\",\"wss://relay.damus.io\",\"wss://nostr-relay.wlvs.space\",\"wss://nostr.fmt.wiz.biz\",\"wss://relay.nostr.bg\",\"wss://nostr.oxtr.dev\",\"wss://nostr.v0l.io\",\"wss://brb.io\",\"wss://nostr.bitcoiner.social\",\"ws://monad.jb55.com:8080\",\"wss://relay.snort.social\"]]}"],
+      ["preimage", ""]
+    ],
+    "content": "",
+    "sig": "b0a3c5c984ceb777ac455b2f659505df51585d5fd97a0ec1fdb5f3347d392080d4b420240434a3afd909207195dac1e2f7e3df26ba862a45afd8bfe101c2b1cc"
+  }
+```
+
 ## Future Work
 
 Zaps can be extended to be more private by encrypting `zap request` notes to the target user, but for simplicity it has been left out of this initial draft.


### PR DESCRIPTION
Todays zap flow puts a lot of trust in the Zap Provider publishing the zap receipt. There is pretty much no way to proof a zap has been sent, when the provider refuses or fails to publish the receipt (even a preimage wont help you here). In order to enable a broader zap-based ecosystem this needs to change.

This PR propses a fairly simply addition to the Zap flow in which the provider sends a incomplete Zap Receipt along with the payment requests that can be completed and published by the sender only after the preimage has been revealed.

Instead of modifying the Zap Receipt, the provider could also encrypt it using the preimage and send it along, but it feels like this adds too much complexity on both sides.

This is marked as draft because it propbably is not mature enough yet and needs feedback.