### PR TITLE
Fix Alby description in NIP-07

### DIFF
--- a/07.md
+++ b/07.md
@@ -26,7 +26,7 @@ async window.nostr.nip04.decrypt(pubkey, ciphertext): string // takes ciphertext
 
 - [horse](https://github.com/fiatjaf/horse) (Chrome and derivatives)
 - [nos2x](https://github.com/fiatjaf/nos2x) (Chrome and derivatives)
-- [Alby](https://getalby.com) (Chrome and derivatives, Firefox, Safari)
+- [Alby](https://getalby.com) (Chrome and derivatives, Firefox)
 - [Blockcore](https://www.blockcore.net/wallet) (Chrome and derivatives)
 - [nos2x-fox](https://diegogurpegui.com/nos2x-fox/) (Firefox)
 - [Flamingo](https://www.getflamingo.org/) (Chrome and derivatives)


### PR DESCRIPTION
Currently Alby does not support Safari.

https://github.com/getAlby/lightning-browser-extension#browser-support

> Alby supports
> - All Chromium based browsers - Chrome, Edge, Opera, Brave etc.
> - Firefox
> - more coming soon...