### PR TITLE
The shortest private messages NIP (Simplex)

### DIFF
--- a/lol.md
+++ b/lol.md
@@ -1,0 +1,13 @@
+NIP-lol
+=======
+
+Truly Private Messages
+----------------------
+
+`draft` `optional` `author:lol` 
+
+This NIP defines how to send and receive direct messages privately.
+
+## Specification
+
+Just use [Simplex](https://github.com/simplex-chat/simplexmq).


### PR DESCRIPTION
This PR is (only somewhat of) a joke.

NIP4 is an elegant hack for somewhat private messages, but its design has many flaws in the details. There have been numerous proposed patches and workarounds to make NIP4 slightly less bad.

Maybe, we don't have to write a new standard this time?

[Simplex](https://github.com/simplex-chat/simplexmq) seems to be a private messaging protocol that takes care of many thread vectors, and it's "smart client, dumb relay" architecture design is even similar to nostr.

Maybe all that's needed in this repo, is a reference to the simplex protocol?

Simplex Website: https://simplex.chat/

Simplex Client: https://github.com/simplex-chat/simplex-chat

Simplex Messaging Protocol (the crypto magic, could maybe be used with nostr relays too): https://github.com/simplex-chat/simplexmq/blob/master/protocol/simplex-messaging.md

Simplex Architecture Overview: [https://github.com/simplex-chat/simplexmq/blob/stable/protocol/overview-](https://github.com/simplex-chat/simplexmq/blob/stable/protocol/overview-tjr.md)