### PR TITLE
Update 18.md for reposting parameterized replaceable events

### DIFF
--- a/18.md
+++ b/18.md
@@ -19,6 +19,10 @@ to indicate where it can be fetched.
 The repost SHOULD include a `p` tag with the `pubkey` of the event being
 reposted.
 
+## Reposting Parameterized Replaceable Events
+
+When reposting events of kind `30000 <= n < 40000`, a parameterised replaceable event as defined by [NIP-33](https://github.com/nostr-protocol/nips/blob/master/33.md), the repost SHOULD also include an `a` tag with fields `<kind>:<pubkey>:<d-identifier>`  and `relay-url`. This allows the most recent version of the parameterised event to be retrieved even if the original event is no longer available.
+
 ## Quote Reposts
 
 Quote reposts are `kind 1` events with an embedded `e` tag (see [NIP-08](08.md) and [NIP-27](27.md)).


### PR DESCRIPTION
Reposting is a key mechanism that allows for the discovery of quality content. Therefore, I believe it would be beneficial to apply the repost feature to NIP-23 long-form articles as well.



