### PR TITLE
Add recommended relays set

### DIFF
--- a/28.md
+++ b/28.md
@@ -24,7 +24,7 @@ Client-centric moderation gives client developers discretion over what types of 
 Create a public chat channel.
 
 In the channel creation `content` field, Client SHOULD include basic channel metadata (`name`, `about`, `picture` as specified in kind 41).
-In the channel creation `content` field, Client SHOULD include a list of recommended relays for using this chat.
+In the channel creation `tags` field, Client SHOULD include a list of recommended relays for using this chat.
 
 ```json
 {


### PR DESCRIPTION
The main chat creation message should include a list of relays where the chat is typically found.

In addition, when updating the metadata for a chat, the set can be changed (chat has moved)

This allows someone to follow a thread of a chat across relays, and it  helps preserve censorship resistance properties.