### PR TITLE
"c" for content-type

### DIFF
--- a/01.md
+++ b/01.md
@@ -99,7 +99,7 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 ## Basic Event Kinds
 
   - `0`: `set_metadata`: the `content` is set to a stringified JSON object `{name: <username>, about: <string>, picture: <url, string>}` describing the user who created the event. A relay may delete past `set_metadata` events once it gets a new one for the same pubkey.
-  - `1`: `text_note`: the `content` is set to the plaintext content of a note (anything the user wants to say). Do not use Markdown! Clients should not have to guess how to interpret content like `[]()`. Set MIME content-type to `"c"` tag if the note should be displayed as Markdown or HTML.
+  - `1`: `text_note`: the `content` is set to the plaintext content of a note (anything the user wants to say). Do not use Markdown! Clients should not have to guess how to interpret content like `[]()`. Set MIME content-type to `"c"` tag if the note should be displayed as Markdown or HTML. Default content-type MUST be text/plain.
   - `2`: `recommend_server`: the `content` is set to the URL (e.g., `wss://somerelay.com`) of a relay the event creator wants to recommend to its followers.
 
 A relay may choose to treat different message kinds differently, and it may or may not choose to have a default way to handle kinds it doesn't know about.

--- a/01.md
+++ b/01.md
@@ -99,7 +99,7 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 ## Basic Event Kinds
 
   - `0`: `set_metadata`: the `content` is set to a stringified JSON object `{name: <username>, about: <string>, picture: <url, string>}` describing the user who created the event. A relay may delete past `set_metadata` events once it gets a new one for the same pubkey.
-  - `1`: `text_note`: the `content` is set to the plaintext content of a note (anything the user wants to say). Do not use Markdown! Clients should not have to guess how to interpret content like `[]()`. Use different event kinds for parsable content.
+  - `1`: `text_note`: the `content` is set to the plaintext content of a note (anything the user wants to say). Do not use Markdown! Clients should not have to guess how to interpret content like `[]()`. Set MIME content-type to `"c"` tag if the note should be displayed as Markdown or HTML.
   - `2`: `recommend_server`: the `content` is set to the URL (e.g., `wss://somerelay.com`) of a relay the event creator wants to recommend to its followers.
 
 A relay may choose to treat different message kinds differently, and it may or may not choose to have a default way to handle kinds it doesn't know about.

--- a/01.md
+++ b/01.md
@@ -99,7 +99,7 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 ## Basic Event Kinds
 
   - `0`: `set_metadata`: the `content` is set to a stringified JSON object `{name: <username>, about: <string>, picture: <url, string>}` describing the user who created the event. A relay may delete past `set_metadata` events once it gets a new one for the same pubkey.
-  - `1`: `text_note`: the `content` is set to the plaintext content of a note (anything the user wants to say). Do not use Markdown! Clients should not have to guess how to interpret content like `[]()`. Set MIME content-type to `"c"` tag if the note should be displayed as Markdown or HTML. Default content-type MUST be text/plain.
+  - `1`: `text_note`: the `content` is set to the plaintext content of a note (anything the user wants to say). Do not use Markdown! Clients should not have to guess how to interpret content like `[]()`. Set MIME content-type to `"c"` tag if the note should be displayed as Markdown or HTML. Default content-type MUST be text/plain. At the least, clients SHOULD NOT render or guess the content without looking this content-type. If client does not support the specified content-type, it's better to give up rendering.
   - `2`: `recommend_server`: the `content` is set to the URL (e.g., `wss://somerelay.com`) of a relay the event creator wants to recommend to its followers.
 
 A relay may choose to treat different message kinds differently, and it may or may not choose to have a default way to handle kinds it doesn't know about.


### PR DESCRIPTION
Currently nostr has clients that interpret content as Markdown or HTML on their own.

* Snort as Markdown
* Satelite as HTML with sanitizer
* Primal as HTML with sanitizer

Rendering with HTML is wrong since the santizer might not work correctly in all clients. Satelite and Primal drops following content after `<script>` tag.

![image](https://github.com/nostr-protocol/nips/assets/10111/61e7c1c5-f4c2-4546-b7de-10a42cba1283)

It is different between Snort and others. Snort displays `<g>`  or `&lt;g&gt;` as we can see. (`<g>` OMG)

![image](https://github.com/nostr-protocol/nips/assets/10111/e83426fc-1583-4aa7-a026-d635a4607323)

![image](https://github.com/nostr-protocol/nips/assets/10111/2c0e5209-fe21-40b7-a2be-a149ca46851e)

So we should add way to specify content-type. Client does not need to guess the content, and it can give up rendering
