### PR TITLE
Add context for limiting `before` timestamp

### DIFF
--- a/26.md
+++ b/26.md
@@ -52,7 +52,9 @@ For example, the following condition strings are valid:
 - `kind=0&kind=1&created_at>1675721813`
 - `kind=1&created_at>1674777689&created_at<1675721813`
 
-For the vast majority of use-cases, it is advisable that query strings should include a `created_at` ***after*** condition reflecting the current time, to prevent the delegatee from publishing historic notes on the delegator's behalf.
+For the vast majority of use-cases, it is advisable that:
+1. Query strings should include a `created_at` ***after*** condition reflecting the current time, to prevent the delegatee from publishing historic notes on the delegator's behalf.
+2. Query strings should include a `created_at` ***before*** condition that is not empty and is not some extremely distant time in the future. If delegations are not limited in time scope, they expose similar security risks to simply using the root key for authentication.
 
 #### Example
 


### PR DESCRIPTION
In the current form of the NIP, there is no recommendation against infinite duration delegated keys. If a user were to create a delegated key with no end timestamp (or one very far in the future) it would be granting similar permissions in most cases to the root key and providing very little real-word security improvement.

While it's hard to come up with a recommended timeframe as it's a personal decision, we *should* recommend people at least include an ending timestamp for the delegation so it will be unusable at some point if compromised.