### PR TITLE
Corrected a typo, issue #584

### DIFF
--- a/01.md
+++ b/01.md
@@ -16,7 +16,7 @@ The only object type that exists is the `event`, which has the following format 
 
 ```json
 {
-  "id": <32-bytes lowercase hex-encoded sha256 of the serialized event data>
+  "id": <32-bytes lowercase hex-encoded sha256 of the serialized event data>,
   "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>,
   "created_at": <unix timestamp in seconds>,
   "kind": <integer>,


### PR DESCRIPTION
Add a ',' between the 'id' and 'pubkey' elements in the JSON event in 01.md.