### PR TITLE
NIP-172: Moderated communities

### DIFF
--- a/172.md
+++ b/172.md
@@ -80,7 +80,7 @@ The post-approval event MUST include `a` tags of the communities the moderator i
 
 It's recommended that multiple moderators approve posts to avoid deleting them from the community when a moderator is removed from the owner's list. In case the full list of moderators must be rotated, the new moderator set must sign new approvals for posts in the past or the community will restart. The owner can also periodically copy and re-sign of each moderator's approval events to make sure posts don't dissapear with moderators. 
 
-Replaceable events can be submitted for approval in two ways: (i) by their `e` tag if moderators want to approve each individual change to the repleceable event or (ii) by the `a` tag if the moderator trusts the original post author to not modify the event beyond community rules. 
+Post Approvals of replaceable events can be created in three ways: (i) by tagging the replaceable event as an `e` tag if moderators want to approve each individual change to the repleceable event; (ii) by tagging the replaceable event as an `a` tag if the moderator authorizes the replaceable event author to make changes without additional approvals and (iii) by tagging the replaceable event with both its `e` and `a` tag which empowers clients to display the original and updated versions of the event, with appropriate remarks in the UI. Since relays are instructed to delete old versions of a replaceable event, the `.content` of an `e`-approval MUST have the specific version of the event or Clients might not be able to find that version of the content anywhere.
 
 Clients SHOULD evaluate any non-`34550:*` `a` tag as posts to be included in all `34550:*` `a` tags.  
 

--- a/172.md
+++ b/172.md
@@ -59,7 +59,7 @@ Community management clients MAY filter all mentions to a given `kind:34550` eve
 
 # Post Approval by moderators
 
-The post-approval event SHOULD include a stringified `new post request` event inside the `.content` of the approval ([NIP-18-style](18.md)).
+The post-approval event MUST include `a` tags of the communities the moderator is posting into (one or more), the `e` tag of the post and `p` tag of the author of the post (for approval notificaitons). The event SHOULD also include the stringified `post request` event inside the `.content` ([NIP-18-style](18.md)) and a `k` tag with the original post's event kind to allow filtering of approved posts by kind.
 
 ```js
 {

--- a/172.md
+++ b/172.md
@@ -1,0 +1,85 @@
+NIP-172
+=======
+
+Moderated Communities (Reddit Style)
+------------------------------------
+
+`draft` `optional` `author:vitorpamplona`
+
+The goal of this NIP is to create moderator-approved public communities arount a topic. It defines the replaceable event `34550` to define the community and the current list of moderators/administrators. Users that want to post into to the community, simply tag any Nostr event with an `a` tag. Moderators the issue an approval event `34551` that links the community with the new post. 
+
+# Community definition
+
+Kind 34550 should include any field that helps define the community and the set of moderators. 
+
+```js
+{
+  "id": "<32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>",
+  "pubkey": "<32-bytes lowercase hex-encoded public key of the event creator>",
+  "created_at": "<Unix timestamp in seconds>",
+  "kind": "34550",
+  "tags": [
+    ["d", "<community_name>"],
+	["description", "<community_description>"],
+
+    // moderators
+    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"]
+	["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"]
+	["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"]
+  ]
+}
+```
+
+# New Post Request
+
+Any Nostr event can be a post request. Clients should simply add the community's `a` tag to be presented for the moderator's approval. 
+
+```js
+{
+  "id": "<32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>",
+  "pubkey": "<32-bytes lowercase hex-encoded public key of the event creator>",
+  "created_at": "<Unix timestamp in seconds>",
+  "kind": "1",
+  "tags": [
+    ["a", "34550:<community event author pubkey>:<d-identifier of the community>", "<optional relay url>"],
+  ], 
+  "content": "<my content>"
+}
+```
+
+Community management clients can filter all mentions to the kind-34550 event and request moderators to approve each submission. The same moderator can remove his/her approval of the post at anytime. 
+
+# Post Approval by moderators
+
+The post approval includes a stringified `new post request` event inside the content's of the approval (NIP-18-style). 
+
+```js
+{
+  "id": "<32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>",
+  "pubkey": "<32-bytes lowercase hex-encoded public key of the event creator>",
+  "created_at": "<Unix timestamp in seconds>",
+  "kind": "34551",
+  "tags": [
+    ["a", "34550:<community event author pubkey>:<d-identifier of the community>", "<optional relay url>"],
+	["e", "<Post Request ID>", "<optional relay url>"],
+	["p", "<Post Request Author ID>", "<optional relay url>"],
+  ], 
+  "content": "{ <New Post Request JSON> }"
+}
+```
+
+It's recommended that multiple moderators approve posts to avoid unapproving them when a given moderator is removed from the owner's list. In case the full list of moderators must be rotated, the new moderator set must sign post approvals for the past post or the community will restart. 
+
+# Displaying
+
+Community clients can display posts that have been approved by at least 1 moderator or by the community owner. 
+
+The following filter displays the approved posts. 
+
+```js
+{
+  "authors": ["<author>", "moderator1", "moderator2", "moderator3", ...],
+  "kinds": 34551,
+  "#a": ["34550:<community event author pubkey>:<d-identifier of the community>"],
+}
+```

--- a/172.md
+++ b/172.md
@@ -21,9 +21,9 @@ Kind 34550 should include any field that helps define the community and the set 
   "tags": [
     ["d", "<community_name>"],
     ["description", "<community_description>"],
-	["image",  "<communityimagen>", "WidthxHeight"]
+    ["image",  "<community_image>", "WidthxHeight"],
 	
-	//.. other tags relevant to defining the community
+    //.. other tags relevant to defining the community
 
     // moderators
     ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"],

--- a/172.md
+++ b/172.md
@@ -8,9 +8,9 @@ Moderated Communities (Reddit Style)
 
 The goal of this NIP is to create moderator-approved public communities around a topic. It defines the replaceable event `kind:34550` to define the community and the current list of moderators/administrators. Users that want to post into the community, simply tag any Nostr event with the community's `a` tag (See [NIP-33](33.md)). Moderators issue an approval event `kind:4550` that links the community with the new post.
 
-# Community definition
+# Community Definition
 
-`Kind:34550` should include any field that helps define the community and the set of moderators.
+`Kind:34550` SHOULD include any field that helps define the community and the set of moderators.
 
 ```js
 {
@@ -19,9 +19,9 @@ The goal of this NIP is to create moderator-approved public communities around a
   "created_at": "<Unix timestamp in seconds>",
   "kind": 34550,
   "tags": [
-    ["d", "<Community_name>"],
-    ["description", "<Community_description>"],
-    ["image", "<Community_image_url>", "<Width>x<Height>"],
+    ["d", "<Community name>"],
+    ["description", "<Community description>"],
+    ["image", "<Community image url>", "<Width>x<Height>"],
 	
     //.. other tags relevant to defining the community
 
@@ -40,7 +40,7 @@ The goal of this NIP is to create moderator-approved public communities around a
 
 # New Post Request
 
-Any Nostr event can be a post request. Clients should simply add the community's `a` tag to be presented for the moderator's approval.
+Any Nostr event can be a post request. Clients MUST add the community's `a` tag to the new post event in order to be presented for the moderator's approval.
 
 ```js
 {
@@ -55,11 +55,11 @@ Any Nostr event can be a post request. Clients should simply add the community's
 }
 ```
 
-Community management clients can filter all mentions to a given `kind:34550` event and request moderators to approve each submission. The same moderator can delete his/her approval of the post at any time using event deletions (See [NIP-09](09.md)).
+Community management clients MAY filter all mentions to a given `kind:34550` event and request moderators to approve each submission. Moderators MAY delete his/her approval of a post at any time using event deletions (See [NIP-09](09.md)).
 
 # Post Approval by moderators
 
-The post-approval event includes a stringified `new post request` event inside the `.content` of the approval ([NIP-18-style](18.md)).
+The post-approval event SHOULD include a stringified `new post request` event inside the `.content` of the approval ([NIP-18-style](18.md)).
 
 ```js
 {
@@ -81,14 +81,16 @@ It's recommended that multiple moderators approve posts to avoid deleting them f
 
 # Displaying
 
-Community clients can display posts that have been approved by at least 1 moderator or by the community owner.
+Community clients SHOULD display posts that have been approved by at least 1 moderator or by the community owner.
 
 The following filter displays the approved posts.
 
 ```js
 {
-  "authors": ["<Author>", "<Moderator1>", "<Moderator2>", "<Moderator3>", ...],
+  "authors": ["<Author pubkey>", "<Moderator1 pubkey>", "<Moderator2 pubkey>", "<Moderator3 pubkey>", ...],
   "kinds": [4550],
   "#a": ["34550:<Community event author pubkey>:<d-identifier of the community>"],
 }
 ```
+
+Clients MAY hide approvals by blocked moderators at the user's request. 

--- a/172.md
+++ b/172.md
@@ -79,6 +79,10 @@ The post-approval event MUST include `a` tags of the communities the moderator i
 
 It's recommended that multiple moderators approve posts to avoid deleting them from the community when a moderator is removed from the owner's list. In case the full list of moderators must be rotated, the new moderator set must sign new approvals for posts in the past or the community will restart. The owner can also periodically copy and re-sign of each moderator's approval events to make sure posts don't dissapear with moderators. 
 
+Replaceable events can be submitted for approval in two ways: (i) by their `e` tag if moderators want to approve each individual change to the repleceable event or (ii) by the `a` tag if the moderator trusts the original post author to not modify the event beyond community rules. 
+
+Clients SHOULD evaluate any non-`34550:*` `a` tag as posts to be included in all `34550:*` `a` tags.  
+
 # Displaying
 
 Community clients SHOULD display posts that have been approved by at least 1 moderator or by the community owner.

--- a/172.md
+++ b/172.md
@@ -10,7 +10,7 @@ The goal of this NIP is to create moderator-approved public communities around a
 
 # Community Definition
 
-`Kind:34550` SHOULD include any field that helps define the community and the set of moderators.
+`Kind:34550` SHOULD include any field that helps define the community and the set of moderators. `relay` tags MAY be used to describe the preferred relay to download requests and approvals. 
 
 ```js
 {
@@ -30,9 +30,10 @@ The goal of this NIP is to create moderator-approved public communities around a
     ["p", "<32-bytes hex of a pubkey2>", "<optional recommended relay URL>", "moderator"],
     ["p", "<32-bytes hex of a pubkey3>", "<optional recommended relay URL>", "moderator"],
 	
-    // relays used by the community 
+    // relays used by the community (w/optional marker)
     ["relay", "<relay hosting author kind 0>", "author"],
-    ["relay", "<relay where to post requests to and fetch approvals from>"], 
+    ["relay", "<relay where to send and receive requests>", "requests"], 
+    ["relay", "<relay where to send and receive approvals>", "approvals"],
     ["relay", "<relay where to post requests to and fetch approvals from>"]
   ]
 }

--- a/172.md
+++ b/172.md
@@ -77,7 +77,7 @@ The post-approval event includes a stringified `new post request` event inside t
 }
 ```
 
-It's recommended that multiple moderators approve posts to avoid unapproving them when a given moderator is removed from the owner's list. In case the full list of moderators must be rotated, the new moderator set must sign new approvals for posts in the past or the community will restart. The owner can also periodically copies of each moderator's approval events. 
+It's recommended that multiple moderators approve posts to avoid deleting them from the community when a moderator is removed from the owner's list. In case the full list of moderators must be rotated, the new moderator set must sign new approvals for posts in the past or the community will restart. The owner can also periodically copy and re-sign of each moderator's approval events to make sure posts don't dissapear with moderators. 
 
 # Displaying
 
@@ -88,7 +88,7 @@ The following filter displays the approved posts.
 ```js
 {
   "authors": ["<author>", "moderator1", "moderator2", "moderator3", ...],
-  "kinds": ["4550"],
+  "kinds": [4550],
   "#a": ["34550:<community event author pubkey>:<d-identifier of the community>"],
 }
 ```

--- a/172.md
+++ b/172.md
@@ -47,7 +47,7 @@ Any Nostr event can be a post request. Clients should simply add the community's
   "id": "<32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>",
   "pubkey": "<32-bytes lowercase hex-encoded public key of the event creator>",
   "created_at": "<Unix timestamp in seconds>",
-  "kind": "1",
+  "kind": 1,
   "tags": [
     ["a", "34550:<community event author pubkey>:<d-identifier of the community>", "<optional relay url>"],
   ], 

--- a/172.md
+++ b/172.md
@@ -30,7 +30,7 @@ Kind 34550 should include any field that helps define the community and the set 
     ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"],
     ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"],
 	
-	// relays used by the community 
+    // relays used by the community 
     ["relay", "<relay hosting author kind 0>", "author"],
     ["relay", "<relay where to post requests to and fetch approvals from>"], 
     ["relay", "<relay where to post requests to and fetch approvals from>"]

--- a/172.md
+++ b/172.md
@@ -55,7 +55,7 @@ Any Nostr event can be a post request. Clients should simply add the community's
 }
 ```
 
-Community management clients can filter all mentions of the `kind:34550` event and request moderators to approve each submission. The same moderator can remove his/her approval of the post at any time.
+Community management clients can filter all mentions to a given `kind:34550` event and request moderators to approve each submission. The same moderator can delete his/her approval of the post at any time using event deletions (See [NIP-09](09.md)).
 
 # Post Approval by moderators
 

--- a/172.md
+++ b/172.md
@@ -4,7 +4,7 @@ NIP-172
 Moderated Communities (Reddit Style)
 ------------------------------------
 
-`draft` `optional` `author:vitorpamplona`
+`draft` `optional` `author:vitorpamplona` `author:arthurfranca`
 
 The goal of this NIP is to create moderator-approved public communities around a topic. It defines the replaceable event `34550` to define the community and the current list of moderators/administrators. Users that want to post into the community, simply tag any Nostr event with an `a` tag. Moderators issue an approval event `4550` that links the community with the new post.
 

--- a/172.md
+++ b/172.md
@@ -17,7 +17,7 @@ Kind 34550 should include any field that helps define the community and the set 
   "id": "<32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>",
   "pubkey": "<32-bytes lowercase hex-encoded public key of the event creator>",
   "created_at": "<Unix timestamp in seconds>",
-  "kind": "34550",
+  "kind": 34550,
   "tags": [
     ["d", "<community_name>"],
     ["description", "<community_description>"],

--- a/172.md
+++ b/172.md
@@ -71,6 +71,7 @@ The post-approval event includes a stringified `new post request` event inside t
     ["a", "34550:<community event author pubkey>:<d-identifier of the community>", "<optional relay url>"],
     ["e", "<Post Request ID>", "<optional relay url>"],
     ["p", "<Post Request Author ID>", "<optional relay url>"],
+    ["k", "<New Post Request kind>"],
   ], 
   "content": "{ <New Post Request JSON> }"
 }

--- a/172.md
+++ b/172.md
@@ -6,7 +6,7 @@ Moderated Communities (Reddit Style)
 
 `draft` `optional` `author:vitorpamplona`
 
-The goal of this NIP is to create moderator-approved public communities around a topic. It defines the replaceable event `34550` to define the community and the current list of moderators/administrators. Users that want to post into the community, simply tag any Nostr event with an `a` tag. Moderators issue an approval event `34551` that links the community with the new post.
+The goal of this NIP is to create moderator-approved public communities around a topic. It defines the replaceable event `34550` to define the community and the current list of moderators/administrators. Users that want to post into the community, simply tag any Nostr event with an `a` tag. Moderators issue an approval event `4550` that links the community with the new post.
 
 # Community definition
 
@@ -66,7 +66,7 @@ The post-approval event includes a stringified `new post request` event inside t
   "id": "<32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>",
   "pubkey": "<32-bytes lowercase hex-encoded public key of the event creator>",
   "created_at": "<Unix timestamp in seconds>",
-  "kind": "34551",
+  "kind": "4550",
   "tags": [
     ["a", "34550:<community event author pubkey>:<d-identifier of the community>", "<optional relay url>"],
     ["e", "<Post Request ID>", "<optional relay url>"],
@@ -77,7 +77,7 @@ The post-approval event includes a stringified `new post request` event inside t
 }
 ```
 
-It's recommended that multiple moderators approve posts to avoid unapproving them when a given moderator is removed from the owner's list. In case the full list of moderators must be rotated, the new moderator set must sign post-approvals for posts in the past or the community will restart.
+It's recommended that multiple moderators approve posts to avoid unapproving them when a given moderator is removed from the owner's list. In case the full list of moderators must be rotated, the new moderator set must sign new approvals for posts in the past or the community will restart. The owner can also periodically copies of each moderator's approval events. 
 
 # Displaying
 
@@ -88,7 +88,7 @@ The following filter displays the approved posts.
 ```js
 {
   "authors": ["<author>", "moderator1", "moderator2", "moderator3", ...],
-  "kinds": 34551,
+  "kinds": ["4550"],
   "#a": ["34550:<community event author pubkey>:<d-identifier of the community>"],
 }
 ```

--- a/172.md
+++ b/172.md
@@ -6,11 +6,11 @@ Moderated Communities (Reddit Style)
 
 `draft` `optional` `author:vitorpamplona`
 
-The goal of this NIP is to create moderator-approved public communities arount a topic. It defines the replaceable event `34550` to define the community and the current list of moderators/administrators. Users that want to post into to the community, simply tag any Nostr event with an `a` tag. Moderators the issue an approval event `34551` that links the community with the new post. 
+The goal of this NIP is to create moderator-approved public communities around a topic. It defines the replaceable event `34550` to define the community and the current list of moderators/administrators. Users that want to post into the community, simply tag any Nostr event with an `a` tag. Moderators issue an approval event `34551` that links the community with the new post.
 
 # Community definition
 
-Kind 34550 should include any field that helps define the community and the set of moderators. 
+Kind 34550 should include any field that helps define the community and the set of moderators.
 
 ```js
 {
@@ -32,7 +32,7 @@ Kind 34550 should include any field that helps define the community and the set 
 
 # New Post Request
 
-Any Nostr event can be a post request. Clients should simply add the community's `a` tag to be presented for the moderator's approval. 
+Any Nostr event can be a post request. Clients should simply add the community's `a` tag to be presented for the moderator's approval.
 
 ```js
 {
@@ -47,11 +47,11 @@ Any Nostr event can be a post request. Clients should simply add the community's
 }
 ```
 
-Community management clients can filter all mentions to the kind-34550 event and request moderators to approve each submission. The same moderator can remove his/her approval of the post at anytime. 
+Community management clients can filter all mentions of the kind-34550 event and request moderators to approve each submission. The same moderator can remove his/her approval of the post at any time.
 
 # Post Approval by moderators
 
-The post approval includes a stringified `new post request` event inside the content's of the approval (NIP-18-style). 
+The post-approval event includes a stringified `new post request` event inside the content of the approval (NIP-18-style).
 
 ```js
 {
@@ -68,13 +68,13 @@ The post approval includes a stringified `new post request` event inside the con
 }
 ```
 
-It's recommended that multiple moderators approve posts to avoid unapproving them when a given moderator is removed from the owner's list. In case the full list of moderators must be rotated, the new moderator set must sign post approvals for the past post or the community will restart. 
+It's recommended that multiple moderators approve posts to avoid unapproving them when a given moderator is removed from the owner's list. In case the full list of moderators must be rotated, the new moderator set must sign post-approvals for posts in the past or the community will restart.
 
 # Displaying
 
-Community clients can display posts that have been approved by at least 1 moderator or by the community owner. 
+Community clients can display posts that have been approved by at least 1 moderator or by the community owner.
 
-The following filter displays the approved posts. 
+The following filter displays the approved posts.
 
 ```js
 {

--- a/172.md
+++ b/172.md
@@ -20,12 +20,12 @@ Kind 34550 should include any field that helps define the community and the set 
   "kind": "34550",
   "tags": [
     ["d", "<community_name>"],
-	["description", "<community_description>"],
+    ["description", "<community_description>"],
 
     // moderators
     ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"]
-	["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"]
-	["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"]
+    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"]
+    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"]
   ]
 }
 ```
@@ -61,8 +61,8 @@ The post-approval event includes a stringified `new post request` event inside t
   "kind": "34551",
   "tags": [
     ["a", "34550:<community event author pubkey>:<d-identifier of the community>", "<optional relay url>"],
-	["e", "<Post Request ID>", "<optional relay url>"],
-	["p", "<Post Request Author ID>", "<optional relay url>"],
+    ["e", "<Post Request ID>", "<optional relay url>"],
+    ["p", "<Post Request Author ID>", "<optional relay url>"],
   ], 
   "content": "{ <New Post Request JSON> }"
 }

--- a/172.md
+++ b/172.md
@@ -21,11 +21,19 @@ Kind 34550 should include any field that helps define the community and the set 
   "tags": [
     ["d", "<community_name>"],
     ["description", "<community_description>"],
+	["image",  "<communityimagen>", "WidthxHeight"]
+	
+	//.. other tags relevant to defining the community
 
     // moderators
-    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"]
-    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"]
-    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"]
+    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"],
+    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"],
+    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"],
+	
+	// relays used by the community 
+    ["relay", "<relay hosting author kind 0>", "author"],
+    ["relay", "<relay where to post requests to and fetch approvals from>"], 
+    ["relay", "<relay where to post requests to and fetch approvals from>"]
   ]
 }
 ```
@@ -51,7 +59,7 @@ Community management clients can filter all mentions of the kind-34550 event and
 
 # Post Approval by moderators
 
-The post-approval event includes a stringified `new post request` event inside the content of the approval (NIP-18-style).
+The post-approval event includes a stringified `new post request` event inside the `.content` of the approval (NIP-18-style).
 
 ```js
 {

--- a/172.md
+++ b/172.md
@@ -6,11 +6,11 @@ Moderated Communities (Reddit Style)
 
 `draft` `optional` `author:vitorpamplona` `author:arthurfranca`
 
-The goal of this NIP is to create moderator-approved public communities around a topic. It defines the replaceable event `34550` to define the community and the current list of moderators/administrators. Users that want to post into the community, simply tag any Nostr event with an `a` tag. Moderators issue an approval event `4550` that links the community with the new post.
+The goal of this NIP is to create moderator-approved public communities around a topic. It defines the replaceable event `kind:34550` to define the community and the current list of moderators/administrators. Users that want to post into the community, simply tag any Nostr event with the community's `a` tag (See [NIP-33](33.md)). Moderators issue an approval event `kind:4550` that links the community with the new post.
 
 # Community definition
 
-Kind 34550 should include any field that helps define the community and the set of moderators.
+`Kind:34550` should include any field that helps define the community and the set of moderators.
 
 ```js
 {
@@ -19,16 +19,16 @@ Kind 34550 should include any field that helps define the community and the set 
   "created_at": "<Unix timestamp in seconds>",
   "kind": 34550,
   "tags": [
-    ["d", "<community_name>"],
-    ["description", "<community_description>"],
-    ["image",  "<community_image>", "WidthxHeight"],
+    ["d", "<Community_name>"],
+    ["description", "<Community_description>"],
+    ["image", "<Community_image_url>", "<Width>x<Height>"],
 	
     //.. other tags relevant to defining the community
 
     // moderators
-    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"],
-    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"],
-    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "moderator"],
+    ["p", "<32-bytes hex of a pubkey1>", "<optional recommended relay URL>", "moderator"],
+    ["p", "<32-bytes hex of a pubkey2>", "<optional recommended relay URL>", "moderator"],
+    ["p", "<32-bytes hex of a pubkey3>", "<optional recommended relay URL>", "moderator"],
 	
     // relays used by the community 
     ["relay", "<relay hosting author kind 0>", "author"],
@@ -49,17 +49,17 @@ Any Nostr event can be a post request. Clients should simply add the community's
   "created_at": "<Unix timestamp in seconds>",
   "kind": 1,
   "tags": [
-    ["a", "34550:<community event author pubkey>:<d-identifier of the community>", "<optional relay url>"],
+    ["a", "34550:<Community event author pubkey>:<d-identifier of the community>", "<Optional relay url>"],
   ], 
-  "content": "<my content>"
+  "content": "<My content>"
 }
 ```
 
-Community management clients can filter all mentions of the kind-34550 event and request moderators to approve each submission. The same moderator can remove his/her approval of the post at any time.
+Community management clients can filter all mentions of the `kind:34550` event and request moderators to approve each submission. The same moderator can remove his/her approval of the post at any time.
 
 # Post Approval by moderators
 
-The post-approval event includes a stringified `new post request` event inside the `.content` of the approval (NIP-18-style).
+The post-approval event includes a stringified `new post request` event inside the `.content` of the approval ([NIP-18-style](18.md)).
 
 ```js
 {
@@ -68,12 +68,12 @@ The post-approval event includes a stringified `new post request` event inside t
   "created_at": "<Unix timestamp in seconds>",
   "kind": "4550",
   "tags": [
-    ["a", "34550:<community event author pubkey>:<d-identifier of the community>", "<optional relay url>"],
-    ["e", "<Post Request ID>", "<optional relay url>"],
-    ["p", "<Post Request Author ID>", "<optional relay url>"],
+    ["a", "34550:<Community event author pubkey>:<d-identifier of the community>", "<Optional relay url>"],
+    ["e", "<Post Request ID>", "<Optional relay url>"],
+    ["p", "<Post Request Author ID>", "<Optional relay url>"],
     ["k", "<New Post Request kind>"],
   ], 
-  "content": "{ <New Post Request JSON> }"
+  "content": "<New Post Request JSON>"
 }
 ```
 
@@ -87,8 +87,8 @@ The following filter displays the approved posts.
 
 ```js
 {
-  "authors": ["<author>", "moderator1", "moderator2", "moderator3", ...],
+  "authors": ["<Author>", "<Moderator1>", "<Moderator2>", "<Moderator3>", ...],
   "kinds": [4550],
-  "#a": ["34550:<community event author pubkey>:<d-identifier of the community>"],
+  "#a": ["34550:<Community event author pubkey>:<d-identifier of the community>"],
 }
 ```


### PR DESCRIPTION
The goal of this NIP is to create moderator-approved public communities around a topic and provide a simple solution to Reddit clients that might want to come into Nostr. 

Let the best curators win. 

Read it [here](https://github.com/vitorpamplona/nips/blob/moderated-communities/172.md)