### PR TITLE
NIP-91: Bech32 URL Query

### DIFF
--- a/91.md
+++ b/91.md
@@ -1,0 +1,56 @@
+NIP-91
+======
+
+Bech32 URL Query
+----------------
+
+`draft` `optional` `author:tyiu`
+
+This specification enables a client on any platform to replace a bespoke URL that routes to a Nostr entity on different web client to instead route internally to its own presentation of that same entity in its own client if it is supported.
+
+It is similar in intent to the [NIP-21](21.md) `nostr:` URI scheme to enable maximum interoperability and openness in the network. However, this specification is mainly for `HTTP`/`HTTPS` where shared links from bespoke web clients might not follow the `nostr:` URI scheme and because modern web browsers do not support the `nostr:` URI scheme yet.
+
+## Rationale
+
+Each web client can have its own bespoke URL to display a Nostr entity. For example:
+* https://snort.social/p/npub1yaul8k059377u9lsu67de7y637w4jtgeuwcmh5n7788l6xnlnrgs3tvjmf
+* https://snort.social/e/nevent1qqs2u9n02ftcmrgnhyenyyu0sl8t8dr7tu94t398r24dkcp0kn9taqsppemhxue69uhkummn9ekx7mp0z2jws2
+* https://coracle.social/people/npub1yaul8k059377u9lsu67de7y637w4jtgeuwcmh5n7788l6xnlnrgs3tvjmf/notes
+* https://primal.net/tyiu
+* https://primal.net/profile/npub1yaul8k059377u9lsu67de7y637w4jtgeuwcmh5n7788l6xnlnrgs3tvjmf
+* https://primal.net/thread/note14ctx75jh3kx38wfnxgfclp7wkw68uhct2hz2wx42mdszldx2h6pq8x7dwk
+
+When a different client displays a URL in this format and the user wants to navigate to it, it forces the user to leave their current client, which makes for a poor user experience. The ideal experience should be keeping the user in the same client to view the Nostr entity instead if it is supported.
+
+## URL query with Bech32-encoded entity
+
+Web clients MAY create URLs with a `nostr` query parameter that indicates the [NIP-19](19.md) Bech32-encoded entity that it represents.
+
+The query parameter can be either:
+1. The main way that the web client determines how to route to the entity, or
+2. Complementary to the web client's bespoke URL path routing pattern.
+
+This specification intentionally does not specify which of the two options a web client should support.
+
+A different client on any platform parsing this URL MAY identify the `nostr` URL query and MAY replace the original URL in order to route to the internal representation of the same entity instead.
+
+## URL Format
+
+```
+https://path/to/site?nostr=<bech32>
+```
+
+## Examples
+
+* https://snort.social?nostr=npub1yaul8k059377u9lsu67de7y637w4jtgeuwcmh5n7788l6xnlnrgs3tvjmf
+* https://snort.social?nostr=nevent1qqs2u9n02ftcmrgnhyenyyu0sl8t8dr7tu94t398r24dkcp0kn9taqsppemhxue69uhkummn9ekx7mp0z2jws2
+* https://coracle.social?nostr=npub1yaul8k059377u9lsu67de7y637w4jtgeuwcmh5n7788l6xnlnrgs3tvjmf
+* https://primal.net/tyiu?nostr=npub1yaul8k059377u9lsu67de7y637w4jtgeuwcmh5n7788l6xnlnrgs3tvjmf
+* https://primal.net?nostr=npub1yaul8k059377u9lsu67de7y637w4jtgeuwcmh5n7788l6xnlnrgs3tvjmf
+* https://primal.net?nostr=note14ctx75jh3kx38wfnxgfclp7wkw68uhct2hz2wx42mdszldx2h6pq8x7dwk
+
+An iOS client like Damus MAY choose to replace these URLs with an internal URI scheme so that it routes to its own representation of the same entities to avoid the user leaving the client to see them.
+* `damus:p:2779f3d9f42c7dee17f0e6bcdcf89a8f9d592d19e3b1bbd27ef1cffd1a7f98d1`
+* `damus:nostr:npub1yaul8k059377u9lsu67de7y637w4jtgeuwcmh5n7788l6xnlnrgs3tvjmf`
+* `damus:nostr:nevent1qqs2u9n02ftcmrgnhyenyyu0sl8t8dr7tu94t398r24dkcp0kn9taqsppemhxue69uhkummn9ekx7mp0z2jws2`
+* `damus:nostr:note14ctx75jh3kx38wfnxgfclp7wkw68uhct2hz2wx42mdszldx2h6pq8x7dwk`

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-65: Relay List Metadata](65.md)
 - [NIP-78: Application-specific data](78.md)
 - [NIP-89: Recommended Application Handlers](89.md)
+- [NIP-91: Bech32 URL Query](91.md)
 - [NIP-94: File Metadata](94.md)
 
 ## Event Kinds


### PR DESCRIPTION
This specification enables a client on any platform to replace a bespoke URL that routes to a Nostr entity on different web client to instead route internally to its own presentation of that same entity in its own client if it is supported.

It is similar in intent to the [NIP-21](21.md) `nostr:` URI scheme to enable maximum interoperability and openness in the network. However, this specification is mainly for `HTTP`/`HTTPS` where shared links from bespoke web clients might not follow the `nostr:` URI scheme and because modern web browsers do not support the `nostr:` URI scheme yet.