### PR TITLE
Update 02.md

### DIFF
--- a/02.md
+++ b/02.md
@@ -25,7 +25,7 @@ For example:
 }
 ```
 
-Every new contact list that gets published overwrites the past ones, so it should contain all entries. Relays and clients SHOULD delete past contact lists as soon as they receive a new one.
+Every new contact list that gets published overwrites the past ones, so it should contain all entries. Relays and clients SHOULD delete past contact lists as soon as they one with a later creation date as declared by the "created_at" field.
 
 ## Uses
 


### PR DESCRIPTION
This clarifies what field should be used to determine "newer" contact lists as there is no mention of the "created_at" field in this document at all.

If this is incorrect, then I think it proves that more clarification is needed.