### PR TITLE
NIP-24: Rich Text Note

### DIFF
--- a/24.md
+++ b/24.md
@@ -1,0 +1,56 @@
+NIP-24
+======
+
+Rich Text Note
+--------------
+
+`draft` `optional` `author:AsaiToshiya`
+
+This NIP defines kinds for a "rich text note" such as HTML and Markdown that are primarily displayed in "social" clients.
+
+Events with these kinds are basically the same as kind `1` but with different the `content`.
+
+## Event Kinds
+
+| kind   | type     |
+| ------ | -------- |
+| `1011` | HTML     |
+| `1012` | Markdown |
+
+### HTML
+
+This type of event uses kind `1011`.
+
+The `content` should be written in HTML. And it can include references to other events using [NIP-21](21.md).
+
+Example event:
+
+```json
+{
+  "kind": 1011,
+  "content": "Lorem <b>ipsum</b> nostr:note1fntxtkcy9pjwucqwa9mddn7v03wwwsu9j330jj350nvhpky2tuaspk6nqc",
+  ...other fields the same as kind 1
+}
+```
+
+### Markdown
+
+This type of event uses kind `1012`.
+
+The `content` should be written in Markdown. And it can include references to other events using [NIP-21](21.md).
+
+As mentioned in the introduction, this differs from [NIP-23](23.md) in that it expects to be displayed in "social" clients.
+
+Example event:
+
+```json
+{
+  "kind": 1012,
+  "content": "Lorem **ipsum** nostr:note1fntxtkcy9pjwucqwa9mddn7v03wwwsu9j330jj350nvhpky2tuaspk6nqc",
+  ...other fields the same as kind 1
+}
+```
+
+## Security Warning
+
+Clients displaying events of this NIP must prevent cross-site scripting (XSS) attacks.


### PR DESCRIPTION
This NIP defines kinds for a "rich text note" such as HTML and Markdown that are primarily displayed in "social" clients.

Read [here](https://github.com/AsaiToshiya/nips/blob/nip-24-rich-text-note/24.md).

Related: #589