### PR TITLE
3% Byte Reduction in a High Data Load

### DIFF
--- a/01.md
+++ b/01.md
@@ -18,7 +18,7 @@ The only object type that exists is the `event`, which has the following format 
 {
   "id": <32-bytes lowercase hex-encoded sha256 of the serialized event data>,
   "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>,
-  "created_at": <unix timestamp in seconds>,
+  "at": <unix timestamp in seconds>,
   "kind": <integer>,
   "tags": [
     ["e", <32-bytes hex of the id of another event>, <recommended relay URL>],
@@ -36,7 +36,7 @@ To obtain the `event.id`, we `sha256` the serialized event. The serialization is
 [
   0,
   <pubkey, as a (lowercase) hex string>,
-  <created_at, as a number>,
+  <at, as a number>,
   <kind, as a number>,
   <tags, as an array of arrays of non-null strings>,
   <content, as a string>


### PR DESCRIPTION
This Pull Request proposes a change in the Nostr Protocol to reduce the size of each transfer by approximately 3%. The change involves replacing the "created_at" parameter with "at" in the protocol.

The average size of a tweet in a similar protocol is estimated to be 280 bytes, which can be considered the average size of a transfer in the Nostr Protocol. Therefore, saving nearly 3% of bytes per transfer is significant.

This byte savings becomes even more crucial in a high data load scenario. As time goes by, the accumulation of transfers increases bandwidth requirements and resource usage. By implementing this change now, we can optimize the protocol's efficiency and reduce the burden on existing systems.

It is important to note that making changes to an established protocol becomes more challenging over time. As more implementations are developed and integrated with the Nostr Protocol, modifying it may require greater coordination and effort. Hence, it is urgent to address this improvement now to avoid future complications and ensure optimal protocol performance.

This Pull Request aims to initiate a discussion and thorough evaluation of the proposed change. We appreciate your feedback, suggestions, and additional contributions to enhance the efficiency and optimization of the Nostr Protocol.

Let's take action now to drive this improvement and ensure a more efficient and scalable protocol as it grows in adoption and usage.

We look forward to your review and feedback on this proposal!

Thank you for your attention and consideration.