### PR TITLE
Minor edit: specify the unit of the filters' date attributes (seconds)

### DIFF
--- a/01.md
+++ b/01.md
@@ -66,8 +66,8 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
   "kinds": <a list of a kind numbers>,
   "#e": <a list of event ids that are referenced in an "e" tag>,
   "#p": <a list of pubkeys that are referenced in a "p" tag>,
-  "since": <an integer unix timestamp, events must be newer than this to pass>,
-  "until": <an integer unix timestamp, events must be older than this to pass>,
+  "since": <an integer unix timestamp in seconds, events must be newer than this to pass>,
+  "until": <an integer unix timestamp in seconds, events must be older than this to pass>,
   "limit": <maximum number of events to be returned in the initial query>
 }
 ```


### PR DESCRIPTION
Minor edit, for clarification: The time unit for all date attributes in the filters (since, until) is in seconds.