### PR TITLE
Allow array of filters in REQs

### DIFF
--- a/01.md
+++ b/01.md
@@ -52,7 +52,7 @@ Relays expose a websocket endpoint to which clients can connect.
 Clients can send 3 types of messages, which must be JSON arrays, according to the following patterns:
 
   * `["EVENT", <event JSON as defined above>]`, used to publish events.
-  * `["REQ", <subscription_id>, <filters JSON>...]`, used to request events and subscribe to new updates.
+  * `["REQ", <subscription_id>, [<filters JSON>...]]`, used to request events and subscribe to new updates.
   * `["CLOSE", <subscription_id>]`, used to stop previous subscriptions.
 
 `<subscription_id>` is an arbitrary, non-empty string of max length 64 chars, that should be used to represent a subscription.
@@ -80,7 +80,7 @@ The `ids` and `authors` lists contain lowercase hexadecimal strings, which may e
 
 All conditions of a filter that are specified must match for an event for it to pass the filter, i.e., multiple conditions are interpreted as `&&` conditions.
 
-A `REQ` message may contain multiple filters. In this case, events that match any of the filters are to be returned, i.e., multiple filters are to be interpreted as `||` conditions.
+A `REQ` message may contain multiple filters, which are ideally provided as a JSON array of filters or, alternatively, as a comma-separated list. In this case, events that match any of the filters are to be returned, i.e., multiple filters are to be interpreted as `||` conditions.
 
 The `limit` property of a filter is only valid for the initial query and can be ignored afterward. When `limit: n` is present it is assumed that the events returned in the initial query will be the latest `n` events. It is safe to return less events than `limit` specifies, but it is expected that relays do not return (much) more events than requested so clients don't get unnecessarily overwhelmed by data.
 

--- a/01.md
+++ b/01.md
@@ -66,8 +66,8 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
   "kinds": <a list of a kind numbers>,
   "#e": <a list of event ids that are referenced in an "e" tag>,
   "#p": <a list of pubkeys that are referenced in a "p" tag>,
-  "since": <an integer unix timestamp, events must be newer than this to pass>,
-  "until": <an integer unix timestamp, events must be older than this to pass>,
+  "since": <an integer unix timestamp in seconds, events must be newer than this to pass>,
+  "until": <an integer unix timestamp in seconds, events must be older than this to pass>,
   "limit": <maximum number of events to be returned in the initial query>
 }
 ```


### PR DESCRIPTION
I submit a proposal to allow a JSON array of filters in REQ messages. This is more intuitive than using a comma-separated list. Relays should still accept the latter format, to ensure backward compatibility.