### PR TITLE
NIP-37: Language Tag

### DIFF
--- a/37.md
+++ b/37.md
@@ -1,0 +1,29 @@
+NIP-37
+======
+
+Language Tag
+------------
+
+`draft` `optional` `author:alexgleason`
+
+A `lang` tag may be added to text events to indicate the language of the text. The value of the tag MUST be a valid [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code.
+
+For example:
+
+```json
+["lang", "en"]
+```
+
+The language tag is a hint for automatic translations, as well as a tool for filtering by language. It is not a guarantee that the text is in the specified language. Some messages could contain text in multiple languages, text in a different language, or text in no language at all.
+
+### Client behavior
+
+Clients may append a `lang` tag based on the user's selection at the time of the post, or based on a user setting. If the user has not selected a language, the client should omit the `lang` tag.
+
+### Relay behavior
+
+Relays implementing this NIP should validate that the `lang` tag is a valid ISO 639-1 language code, and if so index the event so it can be requested with tag filters:
+
+```json
+["REQ", <subscription_id>, {"#lang": ["en"]}]
+```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-32: Labeling](32.md)
 - [NIP-33: Parameterized Replaceable Events](33.md)
 - [NIP-36: Sensitive Content](36.md)
+- [NIP-37: Language Tag](37.md)
 - [NIP-39: External Identities in Profiles](39.md)
 - [NIP-40: Expiration Timestamp](40.md)
 - [NIP-42: Authentication of clients to relays](42.md)
@@ -172,6 +173,7 @@ When experimenting with kinds, keep in mind the classification introduced by [NI
 | `emoji`           | shortcode                            | image URL            | [30](30.md)              |
 | `expiration`      | unix timestamp (string)              | --                   | [40](40.md)              |
 | `image`           | image URL                            | dimensions in pixels | [23](23.md), [58](58.md) |
+| `lang`            | language                             | --                   | [37](37.md)              |
 | `lnurl`           | `bech32` encoded `lnurl`             | --                   | [57](57.md)              |
 | `name`            | badge name                           | --                   | [58](58.md)              |
 | `nonce`           | random                               | --                   | [13](13.md)              |


### PR DESCRIPTION
Adds a `lang` tag for text events allowing users to specify their language.

NIP text here: https://github.com/alexgleason/nips/blob/dcb38b6e2301e149a2d592d1880bd3a6a7492f03/37.md