### PR TITLE
Add a naming convention of object keys for kind 0

### DIFF
--- a/01.md
+++ b/01.md
@@ -98,7 +98,7 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 
 ## Basic Event Kinds
 
-  - `0`: `set_metadata`: the `content` is set to a stringified JSON object `{name: <username>, about: <string>, picture: <url, string>}` describing the user who created the event. A relay may delete past `set_metadata` events once it gets a new one for the same pubkey.
+  - `0`: `set_metadata`: the `content` is set to a stringified JSON object `{name: <username>, about: <string>, picture: <url, string>}` describing the user who created the event. `snake_case` keys should be used for this object. A relay may delete past `set_metadata` events once it gets a new one for the same pubkey.
   - `1`: `text_note`: the `content` is set to the **plaintext** content of a note (anything the user wants to say). Content that must be parsed, such as Markdown and HTML, should not be used. Clients should also not parse content as those.
   - `2`: `recommend_server`: the `content` is set to the URL (e.g., `wss://somerelay.com`) of a relay the event creator wants to recommend to its followers.
 


### PR DESCRIPTION
Some clients use both of snake case and camel case keys in `kind 0`, such as `display_name` and `displayName`, causing confusion. Many clients conventionally use snake case keys, so make it explicit.