### PR TITLE
NIP-94: Add optional 'download' flag

### DIFF
--- a/94.md
+++ b/94.md
@@ -21,6 +21,7 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
 * `magnet` (optional) URI to magnet file
 * `i` (optional) torrent infohash
 * `blurhash`(optional) the [blurhash](https://github.com/woltapp/blurhash) to show while the file is being loaded by the client
+* `download` expresses that this file is intended to be presented as a download link, rather than played inline. Client's may choose to ignore this.
 
 ```json
 {
@@ -37,7 +38,8 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
     ["dim", <size of file in pixels>],
     ["magnet",<magnet URI> ],
     ["i",<torrent infohash>],
-    ["blurhash", <value>]
+    ["blurhash", <value>],
+    ["download", <boolean>]
   ],
   "content": <description>,
   "sig": <64-bytes hex of the signature of the sha256 hash of the serialized event data, which is the same as the "id" field>


### PR DESCRIPTION
In Stemstr, we have notes that present the same audio file as both a downloadable wav file and a streamable m3u8. We would like other clients to know that the wav is meant to be downloaded and the m3u8 is meant to be played inline.

The proposed change is adding a "download" flag to NIP-94 to signal this intent.