### PR TITLE
NIP-01: Explicitly state that the `subscription_id` is treated per connection

### DIFF
--- a/01.md
+++ b/01.md
@@ -55,7 +55,7 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
   * `["REQ", <subscription_id>, <filters JSON>...]`, used to request events and subscribe to new updates.
   * `["CLOSE", <subscription_id>]`, used to stop previous subscriptions.
 
-`<subscription_id>` is an arbitrary, non-empty string of max length 64 chars, that should be used to represent a subscription.
+`<subscription_id>` is an arbitrary, non-empty string of max length 64 chars, that should be used to represent a subscription. Relays should manage `<subscription_id>`s independently for each WebSocket connection; even if `<subscrption_id>`s are the same string, they should be treated as different subscriptions for different connections.
 
 `<filters>` is a JSON object that determines what events will be sent in that subscription, it can have the following attributes:
 


### PR DESCRIPTION
I think it would be better to have it clearly stated to avoid confusion for new readers.

What do you think? And let me know if you have a better wording.