### PR TITLE
Adds hashtag, url and event follows to Contact List

### DIFF
--- a/02.md
+++ b/02.md
@@ -6,7 +6,7 @@ Contact List and Petnames
 
 `final` `optional` `author:fiatjaf` `author:arcbtc`
 
-A special event with kind `3`, meaning "contact list" is defined as having a list of `p`, `t`, `e` or `a` tags, one for each of the profiles, hashtags and other events such as communities or chats one is following.
+A special event with kind `3`, meaning "contact list" is defined as having a list of `p`, `t`, `r`, `e` or `a` tags, one for each of the profiles, hashtags and other events such as communities or chats one is following.
 
 Each `p` tag entry should contain the key for the profile, a relay URL where events from that key can be found (can be set to an empty string if not needed), and a local name (or "petname") for that profile (can also be set to an empty string or not provided), i.e., `["p", <32-bytes hex key>, <main relay URL>, <petname>]`. The `content` can be anything and should be ignored.
 
@@ -20,6 +20,7 @@ For example:
     ["p", "14aeb..8dad4", "wss://bobrelay.com/nostr", "bob"],
     ["p", "612ae..e610f", "ws://carolrelay.com/ws", "carol"], 
 	["t", "intro"] // hashtag
+	["r", "http://mywebsite.com"] // url follows
 	["a", "34550:3f770d65d3a764a9c5cb503ae123e62ec7598ad035d836e2a810f3877a745b24:android", "ws://carolrelay.com/ws"] // Android community
 	["e", "25e5c82273a271cb1a840d0060391a0bf4965cafeb029d5ab55350b418953fbb", "ws://carolrelay.com/ws"] // Nostr Public Chat kind:40 Creation Event
   ],

--- a/02.md
+++ b/02.md
@@ -9,6 +9,8 @@ Contact List and Petnames
 A special event with kind `3`, meaning "contact list" is defined as having a list of `p`, `t`, `r`, `e` or `a` tags, one for each of the profiles, hashtags and other events such as communities or chats one is following.
 
 Each `p` tag entry should contain the key for the profile, a relay URL where events from that key can be found (can be set to an empty string if not needed), and a local name (or "petname") for that profile (can also be set to an empty string or not provided), i.e., `["p", <32-bytes hex key>, <main relay URL>, <petname>]`. The `content` can be anything and should be ignored.
+	
+Clients are not expected to support all types of follows, but MUST not delete unsupported tags when updating the contact list. 
 
 For example:
 

--- a/02.md
+++ b/02.md
@@ -21,10 +21,10 @@ For example:
     ["p", "91cf9..4e5ca", "wss://alicerelay.com/", "alice"],
     ["p", "14aeb..8dad4", "wss://bobrelay.com/nostr", "bob"],
     ["p", "612ae..e610f", "ws://carolrelay.com/ws", "carol"], 
-	["t", "intro"] // hashtag
-	["r", "http://mywebsite.com"] // url follows
-	["a", "34550:3f770d65d3a764a9c5cb503ae123e62ec7598ad035d836e2a810f3877a745b24:android", "ws://carolrelay.com/ws"] // Android kind:34550 moderated community
-	["e", "25e5c82273a271cb1a840d0060391a0bf4965cafeb029d5ab55350b418953fbb", "ws://carolrelay.com/ws"] // Nostr Public Chat kind:40 Creation Event
+    ["t", "intro"] // hashtag
+    ["r", "http://mywebsite.com"] // url follows
+    ["a", "34550:3f770d65d3a764a9c5cb503ae123e62ec7598ad035d836e2a810f3877a745b24:android", "ws://carolrelay.com/ws"] // Android kind:34550 moderated community
+    ["e", "25e5c82273a271cb1a840d0060391a0bf4965cafeb029d5ab55350b418953fbb", "ws://carolrelay.com/ws"] // Nostr Public Chat kind:40 Creation Event
   ],
   "content": "",
   ...other fields

--- a/02.md
+++ b/02.md
@@ -21,7 +21,7 @@ For example:
     ["p", "612ae..e610f", "ws://carolrelay.com/ws", "carol"], 
 	["t", "intro"] // hashtag
 	["r", "http://mywebsite.com"] // url follows
-	["a", "34550:3f770d65d3a764a9c5cb503ae123e62ec7598ad035d836e2a810f3877a745b24:android", "ws://carolrelay.com/ws"] // Android community
+	["a", "34550:3f770d65d3a764a9c5cb503ae123e62ec7598ad035d836e2a810f3877a745b24:android", "ws://carolrelay.com/ws"] // Android kind:34550 moderated community
 	["e", "25e5c82273a271cb1a840d0060391a0bf4965cafeb029d5ab55350b418953fbb", "ws://carolrelay.com/ws"] // Nostr Public Chat kind:40 Creation Event
   ],
   "content": "",

--- a/02.md
+++ b/02.md
@@ -6,19 +6,22 @@ Contact List and Petnames
 
 `final` `optional` `author:fiatjaf` `author:arcbtc`
 
-A special event with kind `3`, meaning "contact list" is defined as having a list of `p` tags, one for each of the followed/known profiles one is following.
+A special event with kind `3`, meaning "contact list" is defined as having a list of `p`, `t`, `e` or `a` tags, one for each of the profiles, hashtags and other events such as communities or chats one is following.
 
-Each tag entry should contain the key for the profile, a relay URL where events from that key can be found (can be set to an empty string if not needed), and a local name (or "petname") for that profile (can also be set to an empty string or not provided), i.e., `["p", <32-bytes hex key>, <main relay URL>, <petname>]`. The `content` can be anything and should be ignored.
+Each `p` tag entry should contain the key for the profile, a relay URL where events from that key can be found (can be set to an empty string if not needed), and a local name (or "petname") for that profile (can also be set to an empty string or not provided), i.e., `["p", <32-bytes hex key>, <main relay URL>, <petname>]`. The `content` can be anything and should be ignored.
 
 For example:
 
-```json
+```js
 {
   "kind": 3,
   "tags": [
     ["p", "91cf9..4e5ca", "wss://alicerelay.com/", "alice"],
     ["p", "14aeb..8dad4", "wss://bobrelay.com/nostr", "bob"],
-    ["p", "612ae..e610f", "ws://carolrelay.com/ws", "carol"]
+    ["p", "612ae..e610f", "ws://carolrelay.com/ws", "carol"], 
+	["t", "intro"] // hashtag
+	["a", "34550:3f770d65d3a764a9c5cb503ae123e62ec7598ad035d836e2a810f3877a745b24:android", "ws://carolrelay.com/ws"] // Android community
+	["e", "25e5c82273a271cb1a840d0060391a0bf4965cafeb029d5ab55350b418953fbb", "ws://carolrelay.com/ws"] // Nostr Public Chat kind:40 Creation Event
   ],
   "content": "",
   ...other fields


### PR DESCRIPTION
This PR updates the guidance of the contact list to account for the new additions by clients. In the last months, we have seen an expansion of the meaning of "contact" as a PubKey, hashtag, URL, event id or `a` tag the user has reviewed and wishes to either follow or simply mark as a reviewed/trusted pointer (to help identify impersonations of a person or community). These additions seem to be accepted as practice by now. 