### PR TITLE
NIP-01: add detailed description of since/until in filters

### DIFF
--- a/01.md
+++ b/01.md
@@ -78,6 +78,8 @@ Filter attributes containing lists (such as `ids`, `kinds`, or `#e`) are JSON ar
 
 The `ids` and `authors` lists contain lowercase hexadecimal strings, which may either be an exact 64-character match, or a prefix of the event value.  A prefix match is when the filter string is an exact string prefix of the event value.  The use of prefixes allows for more compact filters where a large number of values are queried, and can provide some privacy for clients that may not want to disclose the exact authors or events they are searching for.
 
+The `since` and `until` properties can be used to specify the time range of events returned in the subscription. If a filter includes the `since` property, events with `created_at` greater than or equal to `since` are considered to match the filter. The `until` property is similar except that `created_at` must be less than or equal to `until`. In short, an event matches a filter if `since <= created_at <= until` holds.
+
 All conditions of a filter that are specified must match for an event for it to pass the filter, i.e., multiple conditions are interpreted as `&&` conditions.
 
 A `REQ` message may contain multiple filters. In this case, events that match any of the filters are to be returned, i.e., multiple filters are to be interpreted as `||` conditions.


### PR DESCRIPTION
Discussions of the particular decision to standardize `since <= created_at <= until` (closed interval) is in #650.

Resolves #650 