### PR TITLE
Regular Event as Custom App Data for CRDT applications

### DIFF
--- a/1078.md
+++ b/1078.md
@@ -1,2 +1,19 @@
-# Customized Application Data, but as a regular events
-Everything is the same as NIP78, except it's a regular event kind 1078 so that replays don't remove the old event.
+# NIP-1078
+
+## Arbitrary custom app data
+`draft` `optional` `author:BlowaterNostr`
+
+## Nostr event
+
+This NIP specifies the use of event kind `1078` which is almost identical to 30078 except that it's not a replacible event.
+
+## Some use cases
+The reason to not having a 30078 is that some clients want to implement local state changes as CRDTs, meaning support cumulative and associative mutations.
+
+Meaning the order of applying operations doesn't change the final result as long as the same set of operations are applied.
+
+For example, in [Blowater](https://blowater.deno.dev), Pin/Unpin Contacts is implemented as regular events to achieve better consistency.
+
+Event set [`Pin Npub X`, `Unpin NpubX`, `Pin Npub Y`] will result in a pin list of `[Y]` no matter how the order is shifted.
+
+Many other operations are best implemented as CRDTs as well.

--- a/1078.md
+++ b/1078.md
@@ -1,0 +1,2 @@
+# Customized Application Data, but as a regular events
+Everything is the same as NIP78, except it's a regular event kind 1078 so that replays don't remove the old event.


### PR DESCRIPTION
CRDT stands for Conflict-free replicated data type and it's a good way to implement a distributed system for high eventual consistency, high availability and network partition tolerance.

Having custom app data as regular events instead of replaceable events is a critical step towards CRDT over Nostr.