### PR TITLE
Add PRE exception to NIP-22

### DIFF
--- a/22.md
+++ b/22.md
@@ -7,6 +7,7 @@ Event `created_at` Limits
 `draft` `optional` `author:jeffthibault` `author:Giszmo`
 
 Relays may define both upper and lower limits within which they will consider an event's `created_at` to be acceptable. Both the upper and lower limits MUST be unix timestamps in seconds as defined in [NIP-01](01.md).
+However, [Parameterized Replaceable Events](33.md) should be allowed to have `created_at` value far back in the past so as not to disturb its sort order.
 
 If a relay supports this NIP, the relay SHOULD send the client a [NIP-20](20.md) command result saying the event was not stored for the `created_at` timestamp not being within the permitted limits.
 

--- a/33.md
+++ b/33.md
@@ -13,7 +13,8 @@ Implementation
 The value of a tag can be any string and is defined as the first parameter of a tag after the tag name.
 
 A *parameterized replaceable event* is defined as an event with a kind `30000 <= n < 40000`.
-Upon a parameterized replaceable event with a newer timestamp than the currently known latest
+Upon a parameterized replaceable event with a newer timestamp (informed at the `updated_at` tag, if present,
+of else at the `created_at` field) than the currently known latest
 replaceable event with the same kind, author and first `d` tag value being received, the old event
 SHOULD be discarded, effectively replacing what gets returned when querying for
 `author:kind:d-tag` tuples.


### PR DESCRIPTION
This is considering Parameterized Replaceable Events (PREs) can choose to keep the same `created_at` value like [in this example](https://github.com/nostr-protocol/nips/pull/662#issuecomment-1638356069) to mantain the correct sort order.

Such PREs, like in the mentioned example, can commit to a convention of adding the created_at value to the "d" tag so that if values don't match, the event can be considered invalid by clients, just like an event with wrong signature.