### PR TITLE
Clarify sort order when specified limit

### DIFF
--- a/01.md
+++ b/01.md
@@ -84,7 +84,7 @@ All conditions of a filter that are specified must match for an event for it to 
 
 A `REQ` message may contain multiple filters. In this case, events that match any of the filters are to be returned, i.e., multiple filters are to be interpreted as `||` conditions.
 
-The `limit` property of a filter is only valid for the initial query and can be ignored afterward. When `limit: n` is present it is assumed that the events returned in the initial query will be the latest `n` events. It is safe to return less events than `limit` specifies, but it is expected that relays do not return (much) more events than requested so clients don't get unnecessarily overwhelmed by data.
+The `limit` property of a filter is only valid for the initial query and can be ignored afterward. When `limit: n` is present it is assumed that the events returned in the initial query will be the last `n` events ordered by the `created_at`. It is safe to return less events than `limit` specifies, but it is expected that relays do not return (much) more events than requested so clients don't get unnecessarily overwhelmed by data.
 
 ### From relay to client: sending events and notices
 


### PR DESCRIPTION
From reading #579, #663 and the implementation of major relays, it seems that the descending order of the `created_at` is a common understanding, so this PR clarified it.