### PR TITLE
NIP-101 HTTP REST API

### DIFF
--- a/101.md
+++ b/101.md
@@ -15,7 +15,7 @@ GET `/api/event`
 Tags should be passed as query paramaters
 `/api/req?ids=id1,id2,id3&authors=pk1&since=0`
 
-Clients should return the events in a JSON array, not dissimilar from how it's done over websockets
+Relays should return the events in a JSON array, not dissimilar from how it's done over websockets
 ```json
 [
     event1,

--- a/101.md
+++ b/101.md
@@ -1,0 +1,42 @@
+NIP-101
+======
+
+Standard HTTP REST API for Relays
+-------------------------------
+
+`draft` `optional` `author:jacany`
+
+This NIP defines the structure for a standard REST API to be implemented by relays. This is to ensure compatibility between different relay implementations and the clients accessing them.
+
+## Reading Events
+
+GET `/api/event`
+
+Tags should be passed as query paramaters
+`/api/req?ids=id1,id2,id3&authors=pk1&since=0`
+
+Clients should return the events in a JSON array, not dissimilar from how it's done over websockets
+```json
+[
+    event1,
+    event2,
+    event3,
+    event4
+]
+```
+
+## Publish Events
+
+PUT `/api/event`
+
+Clients should attach an `application/json` payload as an array containing events to publish.
+```json
+[
+    event1,
+    event2
+]
+```
+
+Relays must verify the event's signature and it's JSON validity when the data is recieved.
+
+Relays should return a `201 Created` if both checks pass the event is stored and processed, if not the server should return a `400 Bad Request` with a description of the error.


### PR DESCRIPTION
This NIP outlines a REST API to be implemented by Relays. This is being standardized to ensure compatibility between various relay implementations.
This NIP is useful for example if you simply need to publish or receive events from the command line, GitHub Actions, etc where opening a websocket connection is complex.