### PR TITLE
Improved readability of nip 65; added 'dm'

### DIFF
--- a/65.md
+++ b/65.md
@@ -6,29 +6,37 @@ Relay List Metadata
 
 `draft` `optional` `author:mikedilger`
 
-A special replaceable event meaning "Relay List Metadata" is defined as an event with kind `10002` having a list of `r` tags, one for each relay the author uses to either read or write to.
+A special replaceable event meaning "Relay List Metadata" is defined as an event with kind `10002` having a list of `r` tags, one for each relay the author either writes events to, or reads events from.
 
-The primary purpose of this relay list is to advertise to others, not for configuring one's client.
+The primary purpose of this relay list is to advertise to others, so people know where to find the author's events and where to send events they want the author to read. It is not intended for configuring one's clients.
 
 The `content` is not used and SHOULD be an empty string.
 
-The `r` tags can have a second parameter as either `read` or `write`. If it is omitted, it means the author uses the relay for both purposes.
+The `r` tags can have a second parameter as either `write`, `read`, or `dm`. If it is omitted, it means the author uses the relay for both `write` and `read` purposes.
 
 Clients SHOULD, as with all replaceable events, use only the most recent kind-10002 event they can find.
 
-### The meaning of read and write
+### The meaning of write
 
-Write relays are for events that are intended for anybody (e.g. your followers). Read relays are for events that address a particular person.
+Relays tagged with "write" are relays that the author publishes events to. These are events intended for anybody (e.g. your followers). To follow someone, seek their events at their "write" relay(s).
 
 Clients SHOULD write feed-related events created by their user to their user's write relays.
 
 Clients SHOULD read feed-related events created by another from at least some of that other person's write relays. Explicitly, they SHOULD NOT expect them to be available at their user's read relays. It SHOULD NOT be presumed that the user's read relays coincide with the write relays of the people the user follows.
 
-Clients SHOULD read events that tag their user from their user's read relays.
+Clients SHOULD presume that if their user has a pubkey in their ContactList (kind 3) that it is because they wish to see that author's feed-related events, which would be found at that persons "write" relays. But clients MAY presume otherwise.
+
+### The meaning of read
+
+Relays tagged with "read" are relays that the author searches for mentions of them on. This is a mechanism for addressing an event to a particular person, such as when you p-tag them or DM them.
 
 Clients SHOULD write events that tag a person to at least some of that person's read relays. Explicitly, they SHOULD NOT expect that person will pick them up from their user's write relays. It SHOULD NOT be presumed that the user's write relays coincide with the read relays of the person being tagged.
 
-Clients SHOULD presume that if their user has a pubkey in their ContactList (kind 3) that it is because they wish to see that author's feed-related events. But clients MAY presume otherwise.
+Clients SHOULD read events that tag their user from their user's read relays.
+
+### The meaning of dm
+
+Relays tagged with "dm" have the same meaning as "read" but are preferred by the user for DMs (for example, someone may use a more secure relay that only ingests events and doesn't serve events for receiving DMs on).
 
 ### Motivation
 


### PR DESCRIPTION
I'm trying to improve readability based on Vitor's comment:

nostr:nevent1qqst758ewh386ua0snv3pm0scsn2uys68xek8v73zz47d5ak094z9gcppemhxue69uhkummn9ekx7mp0qy08wumn8ghj7mn0wd68yttsw43zuam9d3kx7unyv4ezumn9wshszyrhwden5te0dehhxarj9ekk7mf0qy2hwumn8ghj7mn0wd68ytn00p68ytnyv4mz7qg3waehxw309ahx7um5wgh8w6twv5hszymhwden5te0danxvcmgv95kutnsw43z7qg4waehxw309aex2mrp0yhxgctdw4eju6t09uq3vamnwvaz7tmjv4kxz7fwd4hhxarj9ec82c30qythwumn8ghj7un9d3shjtnwdaehgu3wvfskuep0qy2hwumn8ghj7un9d3shjtnwdaehgu3wvfnj74pnq9m

````
I have been wanting to code it on Amethyst but the NIP text is too cryptic right now. I can barely get my head around it. 
````

I also took the opportunity to add the 'dm' relay.  Nobody is using that yet, so we could wait to merge until someone is if that is thought to be appropriate.