### PR TITLE
Nip 51 extended kind 30001

### DIFF
--- a/51.md
+++ b/51.md
@@ -84,6 +84,43 @@ Then the user would create a 'Categorized People' list event like below:
 }
 ```
 
+Lets say a user wants to create a 'Categorized Bookmarks' list of `bookmarks` and has keys:
+```
+priv: fb505c65d4df950f5d28c9e4d285ee12ffaf315deef1fc24e3c7cd1e7e35f2b1
+pub: b1a5c93edcc8d586566fde53a20bdb50049a97b15483cb763854e57016e0fa3d
+```
+The user wants to publicly include these bookmarks:
+
+```json
+["e", "5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36", "wss://nostr.example.com"],
+["a", "30023:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:abcd", "wss://nostr.example.com"],
+["r", "https://github.com/nostr-protocol/nostr", "Nostr repository"],
+```
+and privately include these bookmarks (below is the JSON that would be encrypted and placed in the event content):
+
+```json
+[
+    ["r", "https://my-private.bookmark", "My private bookmark"],
+    ["a", "30001:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:abcd", "wss://nostr.example.com"],
+]
+```
+
+Then the user would create a 'Categorized Bookmarks' list event like below:
+
+```json
+{
+  "kind": 30001,
+  "tags": [
+    ["d", "bookmarks"],
+    ["e", "5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36", "wss://nostr.example.com"],
+    ["a", "30023:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:abcd", "wss://nostr.example.com"],
+    ["r", "https://github.com/nostr-protocol/nostr", "Nostr repository"],
+  ],
+  "content": "y3AyaLJfnmYr9x9Od9o4aYrmL9+Ynmsim5y2ONrU0urOTq+V81CyAthQ2mUOWE9xwGgrizhY7ILdQwWhy6FK0sA33GHtC0egUJw1zIdknPe7BZjznD570yk/8RXYgGyDKdexME+RMYykrnYFxq1+y/h00kmJg4u+Gpn+ZjmVhNYxl9b+TiBOAXG9UxnK/H0AmUqDpcldn6+j1/AiStwYZhD1UZ3jzDIk2qcCDy7MlGnYhSP+kNmG+2b0T/D1L0Z7?iv=PGJJfPE84gacAh7T0e6duQ==",
+  ...other fields
+}
+```
+
 ## List Event Kinds
 
 | kind   | list type               |
@@ -92,7 +129,7 @@ Then the user would create a 'Categorized People' list event like below:
 | 10001  | Pin                     |
 | 30000  | Categorized People      |
 | 30001  | Categorized Bookmarks   |
-| 30303  | Categorized Reference List   |
+
 
 ### Mute List
 
@@ -108,8 +145,4 @@ An event with kind `30000` is defined as a parameterized replaceable list event 
 
 ### Categorized Bookmarks List
 
-An event with kind `30001` is defined as a parameterized replaceable list event for categorizing bookmarks. The 'd' parameter for this event holds the category name of the list. Any standardized tag can be included in a Categorized Bookmarks List.
-
-### Categorized Reference List
-  
-An event with kind `30303` is defined as a parameterized replaceable list event for categorizing user references. The 'd' parameter of this event holds the category name of the list. The reference lists may have metadata tags such as 'title', 'image', 'summary' as defined in [NIP-23 - Long-form Content](23.md) . Items in these lists are `r` tags, and follow the schema of Kind 3 events as defined in [NIP-02 - Contact List and Petnames](02.md). Each `r` tag entry should contain the 'reference URL' and the 'description', `["r", <reference URL>, <description>]`. Any standard tag can be included in a reference list.
+An event of kind `30001` is defined as a parameterised replaceable list event for categorizing bookmarks. The `d' parameter for this event holds the category name of the list. The bookmark lists may contain metadata tags such as 'title', 'image', 'summary' as defined in [NIP-23 - Long-form Content](23.md). The tags included in these lists MUST follow the schema of event tags as defined in [NIP-01 - Basic protocol flow description](01.md). Any standardized tag can be included in a Categorized Bookmark List.

--- a/51.md
+++ b/51.md
@@ -145,4 +145,4 @@ An event with kind `30000` is defined as a parameterized replaceable list event 
 
 ### Categorized Bookmarks List
 
-An event of kind `30001` is defined as a parameterised replaceable list event for categorizing bookmarks. The `d' parameter for this event holds the category name of the list. The bookmark lists may contain metadata tags such as 'title', 'image', 'summary' as defined in [NIP-23 - Long-form Content](23.md). The tags included in these lists MUST follow the schema of event tags as defined in [NIP-01 - Basic protocol flow description](01.md). Any standardized tag can be included in a Categorized Bookmark List.
+An event of kind `30001` is defined as a parameterized replaceable list event for categorizing bookmarks. The 'd' parameter for this event holds the category name of the list. The bookmark lists may contain metadata tags such as 'title', 'image', 'summary' as defined in [NIP-23 - Long-form Content](23.md). Any standardized tag can be included in a Categorized Bookmark List.

--- a/51.md
+++ b/51.md
@@ -4,7 +4,7 @@ NIP-51
 Lists
 -----
 
-`draft` `optional` `author:fiatjaf` `author:arcbtc` `author:monlovesmango` `author:eskema`
+`draft` `optional` `author:fiatjaf` `author:arcbtc` `author:monlovesmango` `author:eskema` `author:gzuuus`
 
 A "list" event is defined as having a list of public and/or private tags. Public tags will be listed in the event `tags`. Private tags will be encrypted in the event `content`. Encryption for private tags will use [NIP-04 - Encrypted Direct Message](04.md) encryption, using the list author's private and public key for the shared secret. A distinct event kind should be used for each list type created.
 
@@ -92,6 +92,7 @@ Then the user would create a 'Categorized People' list event like below:
 | 10001  | Pin                     |
 | 30000  | Categorized People      |
 | 30001  | Categorized Bookmarks   |
+| 30303  | Categorized Reference List   |
 
 ### Mute List
 
@@ -108,3 +109,7 @@ An event with kind `30000` is defined as a parameterized replaceable list event 
 ### Categorized Bookmarks List
 
 An event with kind `30001` is defined as a parameterized replaceable list event for categorizing bookmarks. The 'd' parameter for this event holds the category name of the list. Any standardized tag can be included in a Categorized Bookmarks List.
+
+### Categorized Reference List
+  
+An event with kind `30303` is defined as a parameterized replaceable list event for categorizing user references. The 'd' parameter of this event holds the category name of the list. The reference lists may have metadata tags such as 'title', 'image', 'summary' as defined in [NIP-23 - Long-form Content](23.md) . Items in these lists are `r` tags, and follow the schema of Kind 3 events as defined in [NIP-02 - Contact List and Petnames](02.md). Each `r` tag entry should contain the 'reference URL' and the 'description', `["r", <reference URL>, <description>]`. Any standard tag can be included in a reference list.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Please update these lists when proposing NIPs introducing new event kinds.
 | `k`               | kind number (string)                 | --                   | [18](18.md), [72](72.md) |
 | `l`               | label, label namespace               | annotations          | [32](32.md)              |
 | `L`               | label namespace                      | --                   | [32](32.md)              |
-| `r`               | a reference (URL, etc)               | --                   |                          |
+| `r`               | a reference (URL, etc)               | petname              |                          |
 | `r`               | relay url                            | marker               | [65](65.md)              |
 | `t`               | hashtag                              | --                   |                          |
 | `amount`          | millisatoshis, stringified           | --                   | [57](57.md)              |


### PR DESCRIPTION
In order to standardize the new kind `30303`used in the nostree client, the content of nip 51 is extended to include the new kind and its definition. It is not really a big change in the nip, as I have tried to follow the previous standards. I hope I have expressed it as well as possible and would appreciate any feedback. 
Cheers