### PR TITLE
NIP-315: User Statuses

### DIFF
--- a/315.md
+++ b/315.md
@@ -1,0 +1,60 @@
+
+NIP-315
+=======
+
+User Statuses
+--------------
+
+`draft` `optional` `author:jb55`
+
+## Abstract
+
+This NIP enables a way for users to share live statuses such as what music they are listening to, as well as what they are currently doing: work, play, out of office, etc.
+
+## Live Statuses
+
+A special event with `kind:30315` "User Status" is defined as an *optionally expiring* _parameterized replaceable event_, where the `d` tag represents the status type:
+
+For example:
+
+```js
+{
+  "kind": 30315,
+  "content": "Sign up for nostrasia!",
+  "tags": [
+    ["d", "general"],
+    ["r", "https://nostr.world"]
+  ],
+}
+
+{
+  "kind": 30315,
+  "content": "Intergalatic - Beastie Boys",
+  "tags": [
+    ["d", "music"],
+    ["r", "spotify:search:Intergalatic%20-%20Beastie%20Boys"],
+    ["expiration", "1692845589"]
+  ],
+}
+```
+
+Two common status types are defined: `general` and `music`. `general` represent general statuses: "Working", "Hiking", etc.
+
+`music` status events are for live streaming what you are currently listening to. The expiry of the `music` status should be when the track will stop playing.
+
+Any other status types can be used but they are not defined by this NIP.
+
+The status MAY include an `r`, `p`, `e` or `a` tag linking to a URL, profile, note, or parameterized replaceable event.
+
+# Client behavior
+
+Clients MAY display this next to the username on posts or profiles to provide live user status information.
+
+# Use Cases
+
+* Calendar nostr apps that update your general status when you're in a meeting
+* Nostr Nests that update your general status with a link to the nest when you join
+* Nostr music streaming services that update your music status when you're listening
+* Podcasting apps that update your music status when you're listening to a podcast, with a link for others to listen as well
+* Clients can use the system media player to update playing music status
+

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-94: File Metadata](94.md)
 - [NIP-98: HTTP Auth](98.md)
 - [NIP-99: Classified Listings](99.md)
+- [NIP-315: User Statuses](315.md)
 
 ## Event Kinds
 
@@ -113,6 +114,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `30024` | Draft Long-form Content    | [23](23.md) |
 | `30078` | Application-specific Data  | [78](78.md) |
 | `30311` | Live Event                 | [53](53.md) |
+| `30315` | User Statuses              | [315](315.md) |
 | `30402` | Classified Listing         | [99](99.md) |
 | `30403` | Draft Classified Listing   | [99](99.md) |
 | `31922` | Date-Based Calendar Event  | [52](52.md) |


### PR DESCRIPTION
This NIP enables a way for users to share live statuses such as what music they are listening to, as well as what they are currently doing: work, play, out of office, etc.

[315.md](https://github.com/jb55/nips/blob/user-statuses/315.md)