### PR TITLE
Private Event

### DIFF
--- a/102.md
+++ b/102.md
@@ -68,10 +68,19 @@ Note that **this is not the user's private key**, but a disposable one.
 Similar to DMs, the disposable or the author private key can decrypt the
 referenced event content.
 
-Note that only the author of the event referenced in the config array
-can set the disposable private key.
+Note that only the **author** of the event referenced in the config array
+can set the disposable private key when publishing private events.
 
-### Example
+The author must have previously added the disposable private key,
+if applicable (if the referenced event is to be encrypted),
+to the referenced event (or events, in case of `u` indentifier)
+inside a NIP-44 encrypted `privkey` tag next to the encrypted `p` tags.
+
+The author will need it for the configuration array when publishing
+a private event in reply to their own previous private event.
+Other users won't need it when replying.
+
+### Configuration Array Example
 
 `["a", "<nip_51_list_address>", "<disposable_privkey>"]`
 
@@ -82,7 +91,13 @@ attach to these private events an extra `config` attribute namespaced
 in the `private` key holding the "configuration array"
 **without** the "disposable privkey" array item.
 
-This is important to build client interfaces that enable configuration array editing features
+Instead of the "disposable privkey" array item it must always add the author of
+the event referenced in the config (their pubkey). The author will use it to check if
+their referenced event holds a `privkey` tag (inside the encrypted `.content`)
+it may need to privately reply to their own previous private event.
+
+The extra field is important to build client interfaces that enable
+configuration array editing features
 and to allow replying in [Private Threads](#private-threads).
 
 Example of a returned event:
@@ -94,7 +109,7 @@ Example of a returned event:
   // ...other event fields
   sig: ...,
   private: {
-    config: ["a", "<nip_51_list_address>"]
+    config: ["a", "<nip_51_list_address>", "<nip_51_list_author_PUBKEY>"]
   }
 }
 ```
@@ -102,35 +117,26 @@ Example of a returned event:
 ### Private Threads
 
 Private replies work by publishing the reply event using a `PRIVATE_EVENT` message
-with the same config array identifier found in the `private.config` field
-attached to the root message's by relays or, for example, inside a chat creation event.
+with the same config array identifier found in the extra `private.config` field
+attached to the root message by relays or, for example,
+attached to a chat creation/metadata.
 
-Remember that only the author of the event referenced in the config array
+Remember that only the **author** of the event referenced in the config array
 can and will set the disposable private key in `PRIVATE_EVENT` messages,
 if applicable (if the referenced event is encrypted),
-be them for publishing replies or any other event.
+be them for publishing private replies or any other private event.
 
 **Important**: `Relays` must be aware that if it's not the author of the encrypted event
 referenced in the config array the one who is publishing the private event,
-the `PRIVATE_EVENT` message will not carry a "disposable private key" in the config array.
+the `PRIVATE_EVENT` message will **not** carry a "disposable private key" in the config array.
 
-## Error Handling
+## OK Messages
 
 When a relay receives a `PRIVATE_EVENT` message
 with a configuration array referencing a missing event it should reply with
-a failure `OK` message:
+a failure NIP-01 `OK` message:
 
 `["OK", "b1a649ebe8...", false, 'missing-reference: missing referenced event']`
-
-When a relay receives a `PRIVATE_EVENT` message
-with a configuration array referencing
-an event with no `p` tags and no "disposable privkey"
-was informed by the referenced event author in the current
-or previous `PRIVATE_EVENT` messages
-(meaning the relay can't decrypt the referenced event content in search for `p` tags),
-the relay should send a failure `OK` message:
-
-`["OK", "b1a649ebe8...", false, 'incomplete-reference: no "p" tags found in the referenced event']`
 
 If successful, it should send a success OK message:
 

--- a/102.md
+++ b/102.md
@@ -133,11 +133,19 @@ the `PRIVATE_EVENT` message will **not** carry a "disposable private key" in the
 ## OK Messages
 
 When a relay receives a `PRIVATE_EVENT` message
-with a configuration array referencing a missing event it should reply with
+with a configuration array referencing a missing event it must reply with
 a failure NIP-01 `OK` message:
 
-`["OK", "b1a649ebe8...", false, 'missing-reference: missing referenced event']`
+`["OK", "b1a649ebe8...", false, "missing-reference: missing referenced event"]`
 
-If successful, it should send a success OK message:
+If successful, it must send a success OK message:
 
 `["OK", "b1a649ebe8...", true, ""]`
+
+Considering (parameterized) replaceable events, if a new private version is published, it deletes and replaces the older private (or public) event version.
+
+However, a new **public** replaceable event version (published with a regular
+`EVENT` message) MUST NOT replace a previous **private** event version
+and the relay must reply with a failure `OK` message:
+
+`["OK", "b1a649ebe8...", false, "cant-replace-private: can't replace private event"]`

--- a/102.md
+++ b/102.md
@@ -22,8 +22,13 @@ has a configuration array as an extra argument:
 
 `["PRIVATE_EVENT", {<event JSON>}, [<configuration array>]]`
 
+The event author must be authenticated using NIP-43
+before sending the message.
+
 The message can be sent more than once by the event author
 to change the configuration array.
+
+If the configuration array is absent or empty, the event becomes public.
 
 ## Access Control
 
@@ -31,31 +36,59 @@ The private event can be accessed by its `author`, by a `pubkey`
 referenced in the configuration array or by `pubkeys` inside the
 event referenced in the configuration array as `p` tags.
 
-The user fetches events as usual with NIP-01 `REQ` message. Only allowed users authenticated to the relay using NIP-43 will
+The user fetches events as usual with NIP-01 `REQ` message.
+Only allowed users authenticated to the relay using NIP-43 will
 receive private events that match the filters.
 
 ## Configuration Array
 
 The config array has atleast two items. The first is the identifier type and the second is the identifier value.
 
-The identifier type can be `p`, `e` or `a`.
+The identifier type can be `p`, `e`, `a` or `u`.
 
 When `p`, the referenced pubkey value is allowed to access the private event.
+For example, useful for DMs.
 
 Identifier value for `e` and `a` types may be any event that contains `p`
 tags. These `p` tags are the users allowed to access the private event.
-
 For example `e` and `a` can be a list or a group
 creation/metadata event that contains `p` tags (both encrypted or not).
 The event should be sent to the used relay.
 
+Identifier value for `u` types may reference any unbounded list with each
+item holding one `p` tag, allowing, for example, for the creation of private
+feeds meant to be read only by an unbounded number of paying subscribers.
+
 Optionally, there is a third configuration array value with
-a private key that can decrypt the `e` or `a` event referenced
-as the second item using [NIP-44](44.md). Note that **this is not
-the user private key**, but a disposable one. Similar to DMs,
-the disposable or the author private key can decrypt the
+a private key that can decrypt the `e` or `a` event (or `u` list events)
+referenced as the second item using [NIP-44](44.md).
+Note that **this is not the user private key**, but a disposable one.
+Similar to DMs, the disposable or the author private key can decrypt the
 referenced event content.
 
 ### Example
 
 `["a", "<nip_51_list_address>", "<disposable_privkey>"]`
+
+## Extra Event Field
+
+When requesting events, if the requesting user is **author** of some of them,
+and they were previously configured as **private**, these events should include an extra
+`config` attribute namespaced in the `nip102` key holding the "configuration array"
+(including the "disposable" privkey, if applicable).
+
+This is important to build client interfaces that enable configuration array editing features.
+
+Example of a returned event:
+
+```
+{
+  id: ...,
+  kind: 1,
+  // ...other event fields
+  sig: ...,
+  nip102: {
+    config: ["a", "<nip_51_list_address>"]
+  }
+}
+```

--- a/102.md
+++ b/102.md
@@ -13,15 +13,14 @@ This NIP defines a new client to relay message to send private events.
 A private event has the same format of a regular event but it
 is expected to be fetched just by allowed pubkeys. The relay is
 trusted to use [NIP-43](43.md) to restrict access to the private
-event. It MUST have a `private` tag as explained in the
-[Private Threads](#private-threads) section.
+event.
 
 ## Message
 
 The message is similar to the [NIP-01](01.md) `EVENT` message but
 has a configuration array as an extra argument:
 
-`["PRIVATE_EVENT", {<event JSON>}, [<configuration array>]]`
+`["PRIVATE_EVENT", {<event_JSON>}, [<configuration_array>]]`
 
 The event author must be authenticated using NIP-43
 before sending the message.
@@ -57,7 +56,7 @@ creation/metadata event that contains `p` tags (both encrypted or not).
 The referenced event must be previously sent to the used relay.
 
 Identifier value for `u` types may reference any unbounded list with each
-item holding one `p` tag, allowing, for example, for the creation of private
+item holding atleast one `p` tag, allowing, for example, for the creation of private
 feeds meant to be read only by an unbounded number of paying subscribers.
 The referenced unbounded list must have atleast one of its items previously
 sent to the used relay.
@@ -65,28 +64,55 @@ sent to the used relay.
 Optionally, there is a third configuration array value with
 a private key that can decrypt the `e` or `a` event (or `u` list events)
 referenced as the second item using [NIP-44](44.md).
-Note that **this is not the user private key**, but a disposable one.
+Note that **this is not the user's private key**, but a disposable one.
 Similar to DMs, the disposable or the author private key can decrypt the
 referenced event content.
+
+Note that only the author of the event referenced in the config array
+can set the disposable private key.
 
 ### Example
 
 `["a", "<nip_51_list_address>", "<disposable_privkey>"]`
 
-## Private Threads
+## Extra Event Field
 
-Private replies work by referencing the same config array identifier of the root message.
-This is available at the root messages's `private` tag,
-**without** the "disposable privkey" array item. For example:
+When requesting events, if some of them are private, the `relay` MUST
+attach to these private events an extra `config` attribute namespaced
+in the `private` key holding the "configuration array"
+**without** the "disposable privkey" array item.
 
-`["private", "a", "<nip_51_list_address>"]`
+This is important to build client interfaces that enable configuration array editing features
+and to allow replying in [Private Threads](#private-threads).
 
-The reply itself MUST also have the same `private` tag to help with further replies.
+Example of a returned event:
 
-**Important**: `Relays` receiving a `PRIVATE_EVENT` message without a "disposable privkey", should
-check first if the "disposable privkey" it may have already received in a past `PRIVATE_EVENT`
-message still works to decrypt the referenced event content. If that is the case, it should keep using
-that key even though the current `PRIVATE_EVENT` message doesn't inform a key.
+```
+{
+  id: ...,
+  kind: 1,
+  // ...other event fields
+  sig: ...,
+  private: {
+    config: ["a", "<nip_51_list_address>"]
+  }
+}
+```
+
+### Private Threads
+
+Private replies work by publishing the reply event using a `PRIVATE_EVENT` message
+with the same config array identifier found in the `private.config` field
+attached to the root message's by relays or, for example, inside a chat creation event.
+
+Remember that only the author of the event referenced in the config array
+can and will set the disposable private key in `PRIVATE_EVENT` messages,
+if applicable (if the referenced event is encrypted),
+be them for publishing replies or any other event.
+
+**Important**: `Relays` must be aware that if it's not the author of the encrypted event
+referenced in the config array the one who is publishing the private event,
+the `PRIVATE_EVENT` message will not carry a "disposable private key" in the config array.
 
 ## Error Handling
 
@@ -99,8 +125,13 @@ a failure `OK` message:
 When a relay receives a `PRIVATE_EVENT` message
 with a configuration array referencing
 an event with no `p` tags and no "disposable privkey"
-was informed in the current or previous `PRIVATE_EVENT` messages
+was informed by the referenced event author in the current
+or previous `PRIVATE_EVENT` messages
 (meaning the relay can't decrypt the referenced event content in search for `p` tags),
 the relay should send a failure `OK` message:
 
 `["OK", "b1a649ebe8...", false, 'incomplete-reference: no "p" tags found in the referenced event']`
+
+If successful, it should send a success OK message:
+
+`["OK", "b1a649ebe8...", true, ""]`

--- a/102.md
+++ b/102.md
@@ -1,0 +1,61 @@
+NIP-102
+=======
+
+Private Event
+-------------
+
+`draft` `optional` `author:arthurfranca`
+
+This NIP defines a new client to relay message to send private events.
+
+## Private Event
+
+A private event has the same format of a regular event but it
+is expected to be fetched just by allowed pubkeys. The relay is
+trusted to use [NIP-43](43.md) to restrict access to the private
+event.
+
+## Message
+
+The message is similar to the [NIP-01](01.md) `EVENT` message but
+has a configuration array as an extra argument:
+
+`["PRIVATE_EVENT", {<event JSON>}, [<configuration array>]]`
+
+The message can be sent more than once by the event author
+to change the configuration array.
+
+## Access Control
+
+The private event can be accessed by its `author`, by a `pubkey`
+referenced in the configuration array or by `pubkeys` inside the
+event referenced in the configuration array as `p` tags.
+
+The user fetches events as usual with NIP-01 `REQ` message. Only allowed users authenticated to the relay using NIP-43 will
+receive private events that match the filters.
+
+## Configuration Array
+
+The config array has atleast two items. The first is the identifier type and the second is the identifier value.
+
+The identifier type can be `p`, `e` or `a`.
+
+When `p`, the referenced pubkey value is allowed to access the private event.
+
+Identifier value for `e` and `a` types may be any event that contains `p`
+tags. These `p` tags are the users allowed to access the private event.
+
+For example `e` and `a` can be a list or a group
+creation/metadata event that contains `p` tags (both encrypted or not).
+The event should be sent to the used relay.
+
+Optionally, there is a third configuration array value with
+a private key that can decrypt the `e` or `a` event referenced
+as the second item using [NIP-44](44.md). Note that **this is not
+the user private key**, but a disposable one. Similar to DMs,
+the disposable or the author private key can decrypt the
+referenced event content.
+
+### Example
+
+`["a", "<nip_51_list_address>", "<disposable_privkey>"]`

--- a/102.md
+++ b/102.md
@@ -13,7 +13,8 @@ This NIP defines a new client to relay message to send private events.
 A private event has the same format of a regular event but it
 is expected to be fetched just by allowed pubkeys. The relay is
 trusted to use [NIP-43](43.md) to restrict access to the private
-event.
+event. It MUST have a `private` tag as explained in the
+[Private Threads](#private-threads) section.
 
 ## Message
 
@@ -70,25 +71,34 @@ referenced event content.
 
 `["a", "<nip_51_list_address>", "<disposable_privkey>"]`
 
-## Extra Event Field
+## Private Threads
 
-When requesting events, if the requesting user is **author** of some of them,
-and they were previously configured as **private**, these events should include an extra
-`config` attribute namespaced in the `nip102` key holding the "configuration array"
-(including the "disposable" privkey, if applicable).
+Private replies work by referencing the same config array identifier of the root message.
+This is available at the root messages's `private` tag,
+**without** the "disposable privkey" array item. For example:
 
-This is important to build client interfaces that enable configuration array editing features.
+`["private", "a", "<nip_51_list_address>"]`
 
-Example of a returned event:
+The reply itself MUST also have the same `private` tag to help with further replies.
 
-```
-{
-  id: ...,
-  kind: 1,
-  // ...other event fields
-  sig: ...,
-  nip102: {
-    config: ["a", "<nip_51_list_address>"]
-  }
-}
-```
+**Important**: `Relays` receiving a `PRIVATE_EVENT` message without a "disposable privkey", should
+check first if the "disposable privkey" it may have already received in a past `PRIVATE_EVENT`
+message still works to decrypt the referenced event content. If that is the case, it should keep using
+that key even though the current `PRIVATE_EVENT` message doesn't inform a key.
+
+## Error Handling
+
+When a relay receives a `PRIVATE_EVENT` message
+with a configuration array referencing a missing event it should reply with
+a failure `OK` message:
+
+`["OK", "b1a649ebe8...", false, 'missing-reference: missing referenced event']`
+
+When a relay receives a `PRIVATE_EVENT` message
+with a configuration array referencing
+an event with no `p` tags and no "disposable privkey"
+was informed in the current or previous `PRIVATE_EVENT` messages
+(meaning the relay can't decrypt the referenced event content in search for `p` tags),
+the relay should send a failure `OK` message:
+
+`["OK", "b1a649ebe8...", false, 'incomplete-reference: no "p" tags found in the referenced event']`

--- a/102.md
+++ b/102.md
@@ -54,11 +54,13 @@ Identifier value for `e` and `a` types may be any event that contains `p`
 tags. These `p` tags are the users allowed to access the private event.
 For example `e` and `a` can be a list or a group
 creation/metadata event that contains `p` tags (both encrypted or not).
-The event should be sent to the used relay.
+The referenced event must be previously sent to the used relay.
 
 Identifier value for `u` types may reference any unbounded list with each
 item holding one `p` tag, allowing, for example, for the creation of private
 feeds meant to be read only by an unbounded number of paying subscribers.
+The referenced unbounded list must have atleast one of its items previously
+sent to the used relay.
 
 Optionally, there is a third configuration array value with
 a private key that can decrypt the `e` or `a` event (or `u` list events)

--- a/65.md
+++ b/65.md
@@ -10,6 +10,8 @@ Defines a replaceable event using `kind:10002` to advertise preferred relays for
 
 The event MUST include a list of `r` tags with relay URIs and a `read` or `write` marker. If the marker is omitted, the relay is used for both purposes.
 
+A `nip102` sub-marker may be used to signal to clients what write relays to use for [NIP-102](102.md).
+
 The `.content` is not used.
 
 ```json
@@ -19,6 +21,7 @@ The `.content` is not used.
     ["r", "wss://alicerelay.example.com"],
     ["r", "wss://brando-relay.com"],
     ["r", "wss://expensive-relay.example2.com", "write"],
+    ["r", "wss://nip102-enabled-relay.example.com", "write", "nip102"],
     ["r", "wss://nostr-relay.example.com", "read"],
   ],
   "content": "",
@@ -31,31 +34,31 @@ This NIP doesn't fully replace relay lists that are designed to configure a clie
 
 When seeking events **from** a user, Clients SHOULD use the WRITE relays of the user's `kind:10002`
 
-When seeking events **about** a user, where the user was tagged, Clients SHOULD use the READ relays of the user's `kind:10002` 
+When seeking events **about** a user, where the user was tagged, Clients SHOULD use the READ relays of the user's `kind:10002`
 
 When broadcasting an event, Clients SHOULD:
 
 - Broadcast the event to the WRITE relays of the author
-- Broadcast the event all READ relays of each tagged user. 
+- Broadcast the event all READ relays of each tagged user.
 
 ## Motivation
 
-The old model of using a fixed relay list per user centralizes in large relay operators: 
+The old model of using a fixed relay list per user centralizes in large relay operators:
 
   - Most users submit their posts to the same highly popular relays, aiming to achieve greater visibility among a broader audience.
   - Many users are pulling events from a large number of relays in order to get more data at the expense of duplication
   - Events are being copied between relays, oftentimes to many different relays
-  
-This NIP allows Clients to connect directly with the most up-to-date relay set from each individual user, eliminating the need of broadcasting events to popular relays. 
+
+This NIP allows Clients to connect directly with the most up-to-date relay set from each individual user, eliminating the need of broadcasting events to popular relays.
 
 ## Final Considerations
 
-1. Clients SHOULD guide users to keep `kind:10002` lists small (2-4 relays). 
+1. Clients SHOULD guide users to keep `kind:10002` lists small (2-4 relays).
 
-2. Clients SHOULD spread an author's `kind:10002` events to as many relays as viable. 
+2. Clients SHOULD spread an author's `kind:10002` events to as many relays as viable.
 
 3. `kind:10002` events should primarily be used to advertise the user's preferred relays to others. A user's own client may use other heuristics for selecting relays for fetching data.
 
-4. DMs SHOULD only be broadcasted to the author's WRITE relays and to the receiver's READ relays to keep maximum privacy. 
+4. DMs SHOULD only be broadcasted to the author's WRITE relays and to the receiver's READ relays to keep maximum privacy.
 
 5. If a relay signals support for this NIP in their [NIP-11](11.md) document that means they're willing to accept kind 10002 events from a broad range of users, not only their paying customers or whitelisted group.


### PR DESCRIPTION
Considering DMs and gift wraps, it bothers me the downgrade to DX because a client can't anymore filter by:
- kind (no "k" tag added to the gift wrap)
- author (random author)
- created_at window (implementations using random past created_at up to 1 week)
- id (real id is inside gift wrap)
- and maybe by receipient tag (alias "p" tag instead of the real one)

Here I propose trusting author/created_at/"k"or kind/"p" (and other one-letter tags) metadata to relays, introducing a new client-to-relay message.

The NIP suggests NIP-43 usage because NIP-42 slows down event fetching with awkward flow.

Read text [here](https://github.com/arthurfranca/nips/blob/private/102.md)

