### PR TITLE
NIP-34: Media Attachments

### DIFF
--- a/34.md
+++ b/34.md
@@ -1,0 +1,47 @@
+NIP-34
+======
+
+Media Attachments
+-----------------
+
+`draft` `optional` `author:alexgleason`
+
+Media attachments may be added to events with the `"media"` tag, in the form:
+
+```
+["media", <url>, <data, optional>]
+```
+
+Where:
+
+- `<url>` is the URL of the media file.
+- `<data>` (optional) is a stringified JSON object containing metadata about the media file.
+
+### Data
+
+The `data` field may contain any of the keys listed as tags in [NIP-94](./94.md). For example, `["m", "image/png"]` would become `{"m": "image/png"}` in the `data` field.
+
+### Application behavior
+
+Clients will typically display media attachments as thumbnail previews, separate from the content of the event.
+
+Relays are not expected to index this tag.
+
+### Examples
+
+```json5
+{
+  "kind": 1,
+  "content": "Been goin hard on the Open Source Software.",
+  "tags": [
+    [
+      "media",
+      "https://media.gleasonator.com/074862413a7fe1d18a2bee0f626280c8f795b392e9400419cc34ca4f3cb560ee.png",
+      "{\"m\":\"image/png\",\"dim\":\"1342x704\",\"blurhash\":\"MnR3f,%M%2%MjZ~Wj@j[t7Rjs:ayfkj[WB\"}"
+    ]
+  ],
+  "pubkey": "79c2cae114ea28a981e7559b4fe7854a473521a8d22a66bbab9fa248eb820ff6",
+  "created_at": 1691091365,
+  // ...
+}
+```

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-30: Custom Emoji](30.md)
 - [NIP-31: Dealing with Unknown Events](31.md)
 - [NIP-32: Labeling](32.md)
+- [NIP-34: Media Attachments](34.md)
 - [NIP-36: Sensitive Content](36.md)
 - [NIP-38: User Statuses](38.md)
 - [NIP-39: External Identities in Profiles](39.md)
@@ -180,6 +181,7 @@ Please update these lists when proposing NIPs introducing new event kinds.
 | `image`           | image URL                            | dimensions in pixels | [23](23.md), [58](58.md) |
 | `lnurl`           | `bech32` encoded `lnurl`             | --                   | [57](57.md)              |
 | `location`        | location string                      | --                   | [52](52.md), [99](99.md) |
+| `media`           | media URL                            | media metadata       | [34](34.md)              |
 | `name`            | badge name                           | --                   | [58](58.md)              |
 | `nonce`           | random                               | --                   | [13](13.md)              |
 | `preimage`        | hash of `bolt11` invoice             | --                   | [57](57.md)              |


### PR DESCRIPTION
There is no good obvious way to add media attachments to events on Nostr.

Parsing media data from inline URLs is unacceptable, and the other proposed solutions (like adding query parameters to URLs) are also hacks. NIP-94 is not acceptable either because every attachment has to be a separate event. We need the ability to easily add media to a single event.

Nostr should just support media tags:

```
["media", "<url>", "<optional data>"]
```

Read NIP here: https://github.com/alexgleason/nips/blob/9f545ee94974cbd8ffec411196a90175e30f8a5a/34.md