### PR TITLE
NIP-75: Zap Goals

### DIFF
--- a/75.md
+++ b/75.md
@@ -1,0 +1,76 @@
+# NIP-75
+
+## Zap Goals
+
+`draft` `optional` `author:verbiricha`
+
+This NIP defines an event for creating fundraising goals. Users can contribute funds towards the goal by zapping the goal event.
+
+## Nostr Event
+
+A `kind:9041` event is used.
+
+The `.content` contains a human-readable description of the goal.
+
+The following tags are defined as REQUIRED.
+
+- `amount` - target amount in milisats.
+- `relays` - a list of relays the zaps to this goal will be sent to and tallied from.
+
+Example event:
+
+```json
+{
+  "kind": 9041,
+  "tags": [
+    ["relays", "wss://alicerelay.example.com", "wss://bobrelay.example.com", ...],
+    ["amount", "210000"],
+  ],
+  "content": "Nostrasia travel expenses",
+  ...other fields
+```
+
+The following tags are OPTIONAL.
+
+- `closed_at` - timestamp for determining which zaps are included in the tally. Zap receipts published after the `closed_at` timestamp SHOULD NOT count towards the goal progress.
+
+```json
+{
+  "kind": 9041,
+  "tags": [
+    ["relays", "wss://alicerelay.example.com", "wss://bobrelay.example.com", ...],
+    ["amount", "210000"],
+    ["closed_at", "<unix timestamp in seconds>"],
+  ],
+  "content": "Nostrasia travel expenses",
+  ...other fields
+```
+
+The goal MAY include an `r` or `a` tag linking to a URL or parameterized replaceable event.
+
+The goal MAY include multiple beneficiary pubkeys by specifying [`zap` tags](57.md#appendix-g-zap-tag-on-other-events).
+
+Parameterized replaceable events can link to a goal by using a `goal` tag specifying the event id and an optional relay hint.
+
+```json
+{
+  "kind": 3XXXX,
+  "tags": [
+    ...
+    ["goal", "<event id>", "<Relay URL (optional)>"],
+  ],
+  ...other fields
+```
+
+## Client behavior
+
+Clients MAY display funding goals on user profiles.
+
+When zapping a goal event, clients MUST include the relays in the `relays` tag of the goal event in the zap request `relays` tag.
+
+When zapping a parameterized replaceable event with a `goal` tag, clients SHOULD tag the goal event id in the `e` tag of the zap request.
+
+## Use cases
+
+- Fundraising clients
+- Adding funding goals to events such as long form posts, badges or live streams

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-58: Badges](58.md)
 - [NIP-65: Relay List Metadata](65.md)
 - [NIP-72: Moderated Communities](72.md)
+- [NIP-75: Zap Goals](75.md)
 - [NIP-78: Application-specific data](78.md)
 - [NIP-89: Recommended Application Handlers](89.md)
 - [NIP-94: File Metadata](94.md)
@@ -93,6 +94,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `1984`  | Reporting                  | [56](56.md) |
 | `1985`  | Label                      | [32](32.md) |
 | `4550`  | Community Post Approval    | [72](72.md) |
+| `9041`  | Zap Goal                   | [75](75.md) |
 | `9734`  | Zap Request                | [57](57.md) |
 | `9735`  | Zap                        | [57](57.md) |
 | `10000` | Mute List                  | [51](51.md) |
@@ -177,6 +179,7 @@ Please update these lists when proposing NIPs introducing new event kinds.
 | `description`     | invoice description                  | --                   | [57](57.md)              |
 | `emoji`           | shortcode, image URL                 | --                   | [30](30.md)              |
 | `expiration`      | unix timestamp (string)              | --                   | [40](40.md)              |
+| `goal`            | event id (hex)                       | relay URL            | [75](75.md)              |
 | `image`           | image URL                            | dimensions in pixels | [23](23.md), [58](58.md) |
 | `lnurl`           | `bech32` encoded `lnurl`             | --                   | [57](57.md)              |
 | `location`        | location string                      | --                   | [52](52.md), [99](99.md) |


### PR DESCRIPTION
Introduces a new event kind for fundraising goals using zaps. Users can contribute funds towards the goal by zapping the goal event.

Read: https://github.com/nostr-protocol/nips/blob/goals/75.md

## Client implementations

- [Goals](https://goals-silk.vercel.app/) ([source code](https://git.v0l.io/verbiricha/goals))
- [Zap.stream](https://zap.stream) ([source code](https://git.v0l.io/Kieran/stream))
- [Snort](https://snort.social) ([source code](https://git.v0l.io/Kieran/snort))