### PR TITLE
Clarify character case of m tag value

### DIFF
--- a/94.md
+++ b/94.md
@@ -13,7 +13,7 @@ The purpose of this NIP is to allow an organization and classification of shared
 This NIP specifies the use of the `1063` event type, having in `content` a description of the file content, and a list of tags described below:
 
 * `url` the url to download the file
-* `m` a string indicating the data type of the file. The MIME types format must be used (https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types), and they should be lowercase.
+* `m` a string indicating the data type of the file. The [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) format must be used, and they should be lowercase.
 * `"aes-256-gcm"` (optional)  key and nonce for AES-GCM encryption with tagSize always 128bits
 * `x` containing the SHA-256 hexencoded string of the file.
 * `size` (optional) size of file in bytes

--- a/94.md
+++ b/94.md
@@ -13,7 +13,7 @@ The purpose of this NIP is to allow an organization and classification of shared
 This NIP specifies the use of the `1063` event type, having in `content` a description of the file content, and a list of tags described below:
 
 * `url` the url to download the file
-* `m` a string indicating the data type of the file. The MIME types format must be used (https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)
+* `m` a string indicating the data type of the file. The MIME types format must be used (https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types), and they should be lowercase.
 * `"aes-256-gcm"` (optional)  key and nonce for AES-GCM encryption with tagSize always 128bits
 * `x` containing the SHA-256 hexencoded string of the file.
 * `size` (optional) size of file in bytes


### PR DESCRIPTION
Clarifying case sensitivity is useful for filtering events.

I think this change does not negatively impact existing implementations using `m` tag.