### PR TITLE
NIP90 Job Result kinds

### DIFF
--- a/90.md
+++ b/90.md
@@ -16,11 +16,11 @@ This NIP reserves the range `65000-67000` for data vending machine use.
 | Kind | Description |
 | ---- | ----------- |
 | 65000 | Job feedback |
-| 66000 | Placeholder |
+| 66000 | **Placeholder* |
 | 65001-66000 | Job request kinds |
 | 66001-67000 | Job result kinds |
 
-[Appendix 2](#appendix-2-job-types) defines the job request and result types.
+[Appendix 2](#appendix-2-job-types) defines the job **Request** and **Result** types.
 
 ## Rationale
 Nostr can act as a marketplace for data processing, where users request jobs to be processed in certain ways (e.g., "speech-to-text", "summarization", etc.), but they don't necessarily care about "who" processes the data.
@@ -117,7 +117,7 @@ Service providers can give feedback about a job back to the customer.
 # Protocol Flow
 * Customer publishes a job request (e.g. `kind:65002` speech-to-text).
 * Service Providers can submit `kind:65000` job-feedback events (e.g. `payment-required`, `processing`, `error`, etc.).
-* Upon completion, the service provider publishes the result of the job with a `kind:66002` job-result event.
+* Upon completion, the service provider publishes the result of the job with the corresponding job-result event (e.g. `kind:66002` speech-to-text result).
 * At any point, if there is an `amount` pending to be paid as instructed by the service provider, the user can pay the included `bolt11` or zap the job result event the service provider has sent to the user
 
 `kind:65000` feedback and `kind:66001-67000` result events MAY include an `amount` tag, this can be interpreted as a suggestion to pay. Service Providers SHOULD use the `payment-required` feedback event to signal that a payment is required and no further actions will be performed until the payment is sent. Customers can always either pay the included `bolt11` invoice or zap the event requesting the payment and service providers should monitor for both if they choose to include a bolt11 invoice.

--- a/90.md
+++ b/90.md
@@ -11,15 +11,16 @@ This NIP defines the interaction between customers and Service Providers for per
 Money in, data out.
 
 ## Kinds
-This NIP reserves the range `65000-66000` for data vending machine use.
+This NIP reserves the range `65000-67000` for data vending machine use.
 
 | Kind | Description |
 | ---- | ----------- |
 | 65000 | Job feedback |
-| 65001 | Job result |
-| 65002-66000 | Job request kinds |
+| 66000 | Placeholder |
+| 65001-66000 | Job request kinds |
+| 66001-67000 | Job result kinds |
 
-[Appendix 2](#appendix-2-job-types) defines the job request types.
+[Appendix 2](#appendix-2-job-types) defines the job request and result types.
 
 ## Rationale
 Nostr can act as a marketplace for data processing, where users request jobs to be processed in certain ways (e.g., "speech-to-text", "summarization", etc.), but they don't necessarily care about "who" processes the data.
@@ -34,15 +35,15 @@ There are two actors in the workflow described in this NIP:
 # Event Kinds
 
 * `kind:65000`: job feedback
-* `kind:65001`: job result
-* `kind:65002`-`kind:66000`: job requests
+* `kind:65001`-`kind:66000`: job requests
+* `kind:66001`-`kind:67000`: job results
 
 ## Job request
 A request to have data processed, published by a customer. This event signals that an npub is interested in receiving the result of some kind of compute.
 
 ```json
 {
-    "kind": 65xxx, // kind in 65002-66000 range
+    "kind": 65xxx, // kind in 65001-66000 range
     "content": "",
     "tags": [
         [ "i", "<data>", "<input-type>", "<marker>", "<relay>" ],
@@ -80,7 +81,7 @@ Service providers publish job results, providing the output of the job result. T
 {
     "pubkey": "<service-provider pubkey>",
     "content": "<payload>",
-    "kind": 65001,
+    "kind": 66xxx, // kind in 66001-67000 range
     "tags": [
         [ "request", "<job-request>" ],
         [ "e", "<job-request-id>", "<relay-hint>" ],
@@ -116,15 +117,15 @@ Service providers can give feedback about a job back to the customer.
 # Protocol Flow
 * Customer publishes a job request (e.g. `kind:65002` speech-to-text).
 * Service Providers can submit `kind:65000` job-feedback events (e.g. `payment-required`, `processing`, `error`, etc.).
-* Upon completion, the service provider publishes the result of the job with a `kind:65001` job-result event.
+* Upon completion, the service provider publishes the result of the job with a `kind:66002` job-result event.
 * At any point, if there is an `amount` pending to be paid as instructed by the service provider, the user can pay the included `bolt11` or zap the job result event the service provider has sent to the user
 
-`kind:65000` and `kind:65001` events MAY include an `amount` tag, this can be interpreted as a suggestion to pay. Service Providers SHOULD use the `payment-required` feedback event to signal that a payment is required and no further actions will be performed until the payment is sent. Customers can always either pay the included `bolt11` invoice or zap the event requesting the payment and service providers should monitor for both if they choose to include a bolt11 invoice.
+`kind:65000` feedback and `kind:66001-67000` result events MAY include an `amount` tag, this can be interpreted as a suggestion to pay. Service Providers SHOULD use the `payment-required` feedback event to signal that a payment is required and no further actions will be performed until the payment is sent. Customers can always either pay the included `bolt11` invoice or zap the event requesting the payment and service providers should monitor for both if they choose to include a bolt11 invoice.
 
 ## Notes about the protocol flow
 The flow is deliberately ambiguous, allowing vast flexibility for the interaction between customers and service providers so that service providers can model their behavior based on their own decisions/perceptions of risk.
 
-Some service providers might choose to submit a `payment-required` as the first reaction before sending a `processing` or before delivering `kind:65001` results, some might choose to serve partial results for the job (e.g. as a sample), send a `payment-required` to deliver the rest of the results, and some service providers might choose to assess likelihood of payment based on an npub's past behavior and thus serve the job results before requesting payment for the best possible UX.
+Some service providers might choose to submit a `payment-required` as the first reaction before sending a `processing` or before delivering `kind:66001-67000` results, some might choose to serve partial results for the job (e.g. as a sample), send a `payment-required` to deliver the rest of the results, and some service providers might choose to assess likelihood of payment based on an npub's past behavior and thus serve the job results before requesting payment for the best possible UX.
 
 It's not up to this NIP to define how individual vending machines should choose to run their business.
 
@@ -191,7 +192,7 @@ Consult [Appendix 1: Example](#appendix-1-examples)'s [Summarization of a podcas
 
 * User zaps 100 sats to the `kind:65000` job-feedback
 
-### `kind:65001`: Job result + request for remaining payment
+### `kind:66002`: Job result + request for remaining payment
 ```json
 {
     "content": "blah blah blah",
@@ -224,7 +225,7 @@ User publishes event #1 and #2 together.
 }
 ```
 
-### `kind:65002`: Job Request #2: summarization of job #1's result
+### `kind:65003`: Job Request #2: summarization of job #1's result
 ```json
 {
     "id": "12346",
@@ -257,10 +258,10 @@ User publishes event #1 and #2 together.
 }
 ```
 
-### `kind:65001`: Job result
+### `kind:66004`: Job result of the note translation
 ```json
 {
-    "kind": 65001,
+    "kind": 66004,
     "content": "Che, que copado, boludo!",
     "tags": [
         ["e", "12346"],
@@ -314,7 +315,7 @@ User publishes event #1 and #2 together.
 ```json
 {
     "id": "126",
-    "kind": 65004,
+    "kind": 65005,
     "tags": [
         [ "i", "125", "job" ],
         [ "param", "prompt", "photorealistic" ],
@@ -329,7 +330,7 @@ User publishes event #1 and #2 together.
 ### `kind:65005`: Job request
 ```json
 {
-    "kind": 65004,
+    "kind": 65005,
     "tags": [
         [ "i", "Millions of vending machines, interconnected with tubes with eah other", "text" ],
         [ "param", "prompt", "photorealistic" ],
@@ -340,9 +341,12 @@ User publishes event #1 and #2 together.
 
 # Appendix 2: Job types
 
-This is a list of all the supported job requests.
+This is a list of all the supported job requests and results.
 
-## speech-to-text: `kind:65002`
+## speech-to-text: 
+`Request`: `kind:65002`
+
+`Result`: `kind:66002`
 
 ### params
 
@@ -352,18 +356,27 @@ This is a list of all the supported job requests.
 | `alignment`| opt  | word, segment, raw:  word-level, segment-level, or raw outputs |
 
 ## summarization: `kind:65003`
+`Request`: `kind:65003`
+
+`Result`: `kind:66003`
 
 | param     | req? | description   |
 |-----------|------|---------------|
 | `length`  | opt  | desired length |
 
 ## translation: `kind:65004`
+`Request`: `kind:65004`
+
+`Result`: `kind:66004`
 
 | param     | req? | description                                |
 |-----------|------|--------------------------------------------|
 | `lang`    | req  | desired language in BCP 47 format.         |
 
 ## image generation: `kind:65005`
+`Request`: `kind:65005`
+
+`Result`: `kind:66005`
 
 | param     | req? | description                                           |
 |-----------|------|-------------------------------------------------------|
@@ -371,6 +384,9 @@ This is a list of all the supported job requests.
 | `size`    | opt  | desired size of the image                             |
 
 ## event list generation: `kind:65006`
+`Request`: `kind:65006`
+
+`Result`: `kind:66006`
 
 Generates a list of event ids, (e.g. algorithmic feeds, spam-free notifications, trending topics)
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `20000`--`29999` | Ephemeral Events                 | [16](16.md) |
 | `30000`--`39999` | Parameterized Replaceable Events | [33](33.md) |
 | `65001`--`66000` | Job Requests                     | [90](90.md) |
-| `66001`--`67000` | Job Requests                     | [90](90.md) |
+| `66001`--`67000` | Job Results                      | [90](90.md) |
 
 ## Message types
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `31990` | Handler information        | [89](89.md) |
 | `34550` | Community Definition       | [72](72.md) |
 | `65000` | Job Feedback               | [90](90.md) |
-| `65001` | Job Result                 | [90](90.md) |
 
 ### Event Kind Ranges
 
@@ -138,7 +137,8 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `10000`--`19999` | Replaceable Events               | [16](16.md) |
 | `20000`--`29999` | Ephemeral Events                 | [16](16.md) |
 | `30000`--`39999` | Parameterized Replaceable Events | [33](33.md) |
-| `65002`--`66000` | Job Requests                     | [90](90.md) |
+| `65001`--`66000` | Job Requests                     | [90](90.md) |
+| `66001`--`67000` | Job Requests                     | [90](90.md) |
 
 ## Message types
 


### PR DESCRIPTION
Instead of using just `kind: 65001` for job result, assign a unique job-result kind to each job request. (discussed [here](https://github.com/nostr-protocol/nips/pull/682))

The proposal here uses `65001-66000` for job requests, and `66001-67000` for job results. This setup has low overhead when trying to figure out the job result kind of a corresponding request (simply add `1000` to the job request kind). 

Request `kind:65001` and result `kind:66001` is now vacant and should be assigned the next job type to reduce confusion. 

`66000` is vacant as well and reserved for future/special use

viewable [here](https://github.com/lnconsole/nips/blob/2x-kinds/90.md)