### PR TITLE
NIP-28: use parameterized replaceable event for channel metadata

### DIFF
--- a/28.md
+++ b/28.md
@@ -7,23 +7,24 @@ Public Chat
 
 `draft` `optional` `author:ChristopherDavid` `author:fiatjaf` `author:jb55` `author:Cameri`
 
-This NIP defines new event kinds for public chat channels, channel messages, and basic client-side moderation.
+This NIP defines new event kinds for public chat channels, channel messages, and basic client-side moderation:
 
-It reserves five event kinds (40-44) for immediate use:
-
-- `40 - channel create`
-- `41 - channel metadata`
-- `42 - channel message`
-- `43 - hide message`
-- `44 - mute user`
+- `40`: Channel Creation
+- `30041`: Channel Metadata
+- `42`: Channel Message
+- `43`: Hide Nessage
+- `44`: Mute User
 
 Client-centric moderation gives client developers discretion over what types of content they want included in their apps, while imposing no additional requirements on relays.
 
-## Kind 40: Create channel
+
+## Kind 40: Channel Creation
 
 Create a public chat channel.
 
-In the channel creation `content` field, Client SHOULD include basic channel metadata (`name`, `about`, `picture` as specified in kind 41).
+The `id` of a kind 40 event is regarded as an identifier of the channel by other public chat related event kinds.
+
+In the channel creation `content` field, Client SHOULD include basic channel metadata (`name`, `about`, `picture` as specified in kind 30041).
 
 ```json
 {
@@ -33,13 +34,11 @@ In the channel creation `content` field, Client SHOULD include basic channel met
 ```
 
 
-## Kind 41: Set channel metadata
+## Kind 30041: Channel Metadata
 
-Update a channel's public metadata.
+A parameterized replaceable event for updating a channel's public metadata.
 
-Clients and relays SHOULD handle kind 41 events similar to kind 33 replaceable events, where the information is used to update the metadata, without modifying the event id for the channel.  Only the most recent kind 41 is needed to be stored.
-
-Clients SHOULD ignore kind 41s from pubkeys other than the kind 40 pubkey.
+The value of "d" tag MUST be the `id` of the channel creation event for the channel to be updated. In addition, clients MAY use "e" tags to recommend a relay.
 
 Clients SHOULD support basic metadata fields:
 
@@ -49,24 +48,31 @@ Clients SHOULD support basic metadata fields:
 
 Clients MAY add additional metadata fields.
 
-Clients SHOULD use [NIP-10](10.md) marked "e" tags to recommend a relay.
+Clients SHOULD ignore kind 30041s from pubkeys other than the creator of the channel to be updated.
 
 ```json
 {
     "content": "{\"name\": \"Updated Demo Channel\", \"about\": \"Updating a test channel.\", \"picture\": \"https://placekitten.com/201/201\"}",
-    "tags": [["e", <channel_create_event_id>, <relay-url>]],
+    "tags": [
+        ["d", <kind_40_event_id>],
+        ["e", <kind_40_event_id>, <relay-url>],
+    ],
     ...
 }
 ```
 
+### Deprecation of kind 41 
 
-## Kind 42: Create channel message
+kind 41, formerly used to update channel metadata, is now deprecated in favor of kind 30041.
+
+
+## Kind 42: Channel Message
 
 Send a text message to a channel.
 
-Clients SHOULD use [NIP-10](10.md) marked "e" tags to recommend a relay and specify whether it is a reply or root message.
+Clients SHOULD use [NIP-10](10.md) marked `e` tags to recommend a relay and specify whether it is a reply or root message.
 
-Clients SHOULD append [NIP-10](10.md) "p" tags to replies.
+Clients SHOULD append [NIP-10](10.md) `p` tags to replies.
 
 Root message:
 
@@ -94,7 +100,7 @@ Reply to another message:
 ```
 
 
-## Kind 43: Hide message
+## Kind 43: Hide Message
 
 User no longer wants to see a certain message.
 
@@ -114,7 +120,7 @@ Clients MAY hide event 42s for other users other than the user who sent the even
 }
 ```
 
-## Kind 44: Mute user
+## Kind 44: Mute User
 
 User no longer wants to see messages from another user.
 


### PR DESCRIPTION
This PR proposes to migrate public channel metadata events (kind: 41) to parameterized replaceable events, allowing a single user to update metadata of multiple channels more naturally, in a backward compatible way.

cf. "Problem with Updating Channel Metadata" section in #754