### PR TITLE
Add preview and caption tags to nip94

### DIFF
--- a/94.md
+++ b/94.md
@@ -15,7 +15,8 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
 * `url` the url to download the file
 * `m` a string indicating the data type of the file. The [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) format must be used, and they should be lowercase.
 * `"aes-256-gcm"` (optional)  key and nonce for AES-GCM encryption with tagSize always 128bits
-* `x` containing the SHA-256 hexencoded string of the file.
+* `x` containing the SHA-256 hexencoded string of the **original** file before any server transformations
+* `xx` containing the SHA-256 hexencoded string of the **transformed** file after any server transformations
 * `size` (optional) size of file in bytes
 * `dim` (optional) size of file in pixels in the form `<width>x<height>`
 * `magnet` (optional) URI to magnet file
@@ -37,6 +38,7 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
     ["aes-256-gcm",<key>, <iv>],
     ["m", <MIME type>],
     ["x",<Hash SHA-256>],
+    ["xx",<Hash SHA-256>],
     ["size", <size of file in bytes>],
     ["dim", <size of file in pixels>],
     ["magnet",<magnet URI> ],

--- a/94.md
+++ b/94.md
@@ -16,7 +16,7 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
 * `m` a string indicating the data type of the file. The [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) format must be used, and they should be lowercase.
 * `"aes-256-gcm"` (optional)  key and nonce for AES-GCM encryption with tagSize always 128bits
 * `x` containing the SHA-256 hexencoded string of the **transformed** file after any server transformations
-* `xx` containing the SHA-256 hexencoded string of the **original** file before any server transformations
+* `ox` containing the SHA-256 hexencoded string of the **original** file before any server transformations
 * `size` (optional) size of file in bytes
 * `dim` (optional) size of file in pixels in the form `<width>x<height>`
 * `magnet` (optional) URI to magnet file
@@ -38,7 +38,7 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
     ["aes-256-gcm",<key>, <iv>],
     ["m", <MIME type>],
     ["x",<Hash SHA-256>],
-    ["xx",<Hash SHA-256>],
+    ["ox",<Hash SHA-256>],
     ["size", <size of file in bytes>],
     ["dim", <size of file in pixels>],
     ["magnet",<magnet URI> ],

--- a/94.md
+++ b/94.md
@@ -21,7 +21,9 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
 * `magnet` (optional) URI to magnet file
 * `i` (optional) torrent infohash
 * `blurhash`(optional) the [blurhash](https://github.com/woltapp/blurhash) to show while the file is being loaded by the client
-* `preview` (optional) shorter file variant such as thumbnail, blurred image or text excerpt
+* `thumb` (optional) url of thumbnail with same aspect ratio
+* `image` (optional) url of preview image with same dimensions
+* `summary` (optional) text excerpt
 * `alt` (optional) description for accessibility
 
 ```json
@@ -40,7 +42,9 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
     ["magnet",<magnet URI> ],
     ["i",<torrent infohash>],
     ["blurhash", <value>],
-    ["preview", <preview url/text>, <MIME type>],
+    ["thumb", <string with thumbnail URI>],
+    ["image", <string with preview URI>],
+    ["summary", <excerpt>],
     ["alt", <description>]
   ],
   "content": <caption>,

--- a/94.md
+++ b/94.md
@@ -15,8 +15,8 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
 * `url` the url to download the file
 * `m` a string indicating the data type of the file. The [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) format must be used, and they should be lowercase.
 * `"aes-256-gcm"` (optional)  key and nonce for AES-GCM encryption with tagSize always 128bits
-* `x` containing the SHA-256 hexencoded string of the **original** file before any server transformations
-* `xx` containing the SHA-256 hexencoded string of the **transformed** file after any server transformations
+* `x` containing the SHA-256 hexencoded string of the **transformed** file after any server transformations
+* `xx` containing the SHA-256 hexencoded string of the **original** file before any server transformations
 * `size` (optional) size of file in bytes
 * `dim` (optional) size of file in pixels in the form `<width>x<height>`
 * `magnet` (optional) URI to magnet file

--- a/94.md
+++ b/94.md
@@ -22,7 +22,7 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
 * `i` (optional) torrent infohash
 * `blurhash`(optional) the [blurhash](https://github.com/woltapp/blurhash) to show while the file is being loaded by the client
 * `preview` (optional) shorter file variant such as thumbnail, blurred image or text excerpt
-* `caption` (optional) loose description not meant for accessibility
+* `alt` (optional) description for accessibility
 
 ```json
 {
@@ -41,9 +41,9 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
     ["i",<torrent infohash>],
     ["blurhash", <value>],
     ["preview", <preview url/text>, <MIME type>],
-    ["caption", <string with loose description>]
+    ["alt", <description>]
   ],
-  "content": <description>,
+  "content": <caption>,
   "sig": <64-bytes hex of the signature of the sha256 hash of the serialized event data, which is the same as the "id" field>
 }
 ```

--- a/94.md
+++ b/94.md
@@ -21,6 +21,8 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
 * `magnet` (optional) URI to magnet file
 * `i` (optional) torrent infohash
 * `blurhash`(optional) the [blurhash](https://github.com/woltapp/blurhash) to show while the file is being loaded by the client
+* `preview` (optional) shorter file variant such as thumbnail, blurred image or text excerpt
+* `caption` (optional) loose description not meant for accessibility
 
 ```json
 {
@@ -37,7 +39,9 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
     ["dim", <size of file in pixels>],
     ["magnet",<magnet URI> ],
     ["i",<torrent infohash>],
-    ["blurhash", <value>]
+    ["blurhash", <value>],
+    ["preview", <preview url/text>, <MIME type>],
+    ["caption", <string with loose description>]
   ],
   "content": <description>,
   "sig": <64-bytes hex of the signature of the sha256 hash of the serialized event data, which is the same as the "id" field>

--- a/94.md
+++ b/94.md
@@ -15,8 +15,7 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
 * `url` the url to download the file
 * `m` a string indicating the data type of the file. The [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) format must be used, and they should be lowercase.
 * `"aes-256-gcm"` (optional)  key and nonce for AES-GCM encryption with tagSize always 128bits
-* `x` containing the SHA-256 hexencoded string of the **transformed** file after any server transformations
-* `ox` containing the SHA-256 hexencoded string of the **original** file before any server transformations
+* `x` containing the SHA-256 hexencoded string of the file.
 * `size` (optional) size of file in bytes
 * `dim` (optional) size of file in pixels in the form `<width>x<height>`
 * `magnet` (optional) URI to magnet file
@@ -38,7 +37,6 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
     ["aes-256-gcm",<key>, <iv>],
     ["m", <MIME type>],
     ["x",<Hash SHA-256>],
-    ["ox",<Hash SHA-256>],
     ["size", <size of file in bytes>],
     ["dim", <size of file in pixels>],
     ["magnet",<magnet URI> ],


### PR DESCRIPTION
Updated NIP [here](https://github.com/arthurfranca/nips/blob/94-tags/94.md)

`preview` for thumbnails or preview text
`caption` for a loose description (as nip94 `content` is currently being used by Amethyst as alt text for accessibility)

The `caption` makes it possible to use nip94 in a media gallery without using another kind (using a `t` tag to differentiate the event from a non-media-gallery one).