### PR TITLE
NIP-77 - Trust Clock

### DIFF
--- a/77.md
+++ b/77.md
@@ -28,15 +28,15 @@ relay hints in a month window.
 
 The client trusted relay list at the time in seconds,
 informed on the `at` query param, can be checked at
-"https://client.example/.well-known/nostr/nip77.json?get=relays&at=\<time-in-seconds\>":
+"https://client.example/.well-known/nostr/nip77.json?get=relays&at=<time-in-seconds\>":
 `{ relays: ["https://relay1.example", "https://relay2.example", "https://relay3.example"] }`.
 
 Clients can delegate trust by responding to
-"https://client.example/.well-known/nostr/nip77.json?get=relays&at=\<time-in-seconds\>"
+"https://client.example/.well-known/nostr/nip77.json?get=relays&at=<time-in-seconds\>"
 with: `{ delegated_to: "https://another.client" }`
 
 Now it is possible to ask relay to sign an `event.id` at
-"https://relay1.example/.well-known/nostr/nip77.json?get=now&event=\<percent-encoded-stringified-event-json>\"
+"https://relay1.example/.well-known/nostr/nip77.json?get=now&event=<percent-encoded-stringified-event-json\>"
 and at the other two relay routes.
 
 The relay will validate the event `id` and check if its `created_at` is near the current time.
@@ -44,7 +44,7 @@ The relay will validate the event `id` and check if its `created_at` is near the
 The response is a JSON `{ sig: "<signature>", pubkey: "<relay1pubkey>" }`.
 The signature uses the same Schnorr setup from NIP-01 to sign the received event `id`.
 
-There is also "https://relay1.example/.well-known/nostr/nip77.json?get=pubkey&at=\<time-in-seconds\>"
+There is also "https://relay1.example/.well-known/nostr/nip77.json?get=pubkey&at=<time-in-seconds\>"
 to check what was the canonical relay pubkey at the time: `{ pubkey: "<pubkey-at-that-time>" }`.
 That's why a relay should keep a log of all the pubkeys used for each time window.
 
@@ -77,7 +77,7 @@ can have overlapping relays that don't need to be repeated.
 ### Validation
 
 The signature can be validated with the pubkey from
-"https://relay1.example/.well-known/nostr/nip77.json?get=pubkey&at=\<event.created_at>".
+"https://relay1.example/.well-known/nostr/nip77.json?get=pubkey&at=<event.created_at\>".
 
 The client trusted relay list at the time can be checked at
-"https://client.example/.well-known/nostr/nip77.json?get=relays&at=\<event.created_at\>".
+"https://client.example/.well-known/nostr/nip77.json?get=relays&at=<event.created_at\>".

--- a/77.md
+++ b/77.md
@@ -9,7 +9,7 @@ Trust Clock
 ## What the Trust Clock Does?
 
 It creates an event's `created_at` proof scoped to a client.
-For more clients to trust the event's `created_at`, more `clock` tags
+For more clients to trust the event's `created_at`, more `relay` signarutes
 scoped to different clients are used.
 
 ## How to Use the Trust Clock?
@@ -26,41 +26,58 @@ The 3 most trusted relays by the client user base
 (relays that support this NIP) would be the 3 relay urls with more
 relay hints in a month window.
 
-The client trusted relay list at the time in milliseconds,
+The client trusted relay list at the time in seconds,
 informed on the `at` query param, can be checked at
-"https://client.example/.well-known/nostr/nip77.json?get=relays&at=\<time-in-ms\>":
+"https://client.example/.well-known/nostr/nip77.json?get=relays&at=\<time-in-seconds\>":
 `{ relays: ["https://relay1.example", "https://relay2.example", "https://relay3.example"] }`.
 
 Clients can delegate trust by responding to
-"https://client.example/.well-known/nostr/nip77.json?get=relays&at=\<time-in-ms\>"
+"https://client.example/.well-known/nostr/nip77.json?get=relays&at=\<time-in-seconds\>"
 with: `{ delegated_to: "https://another.client" }`
 
-Now it is possible to ask what time is it in milliseconds at
-"https://relay1.example/.well-known/nostr/nip77.json?get=now"
+Now it is possible to ask relay to sign an `event.id` at
+"https://relay1.example/.well-known/nostr/nip77.json?get=now&event=\<percent-encoded-stringified-event-json>\"
 and at the other two relay routes.
 
-The response is a JSON `{ now: ["<relay1pubkey>", "<time-in-ms>", "<signature>"] }`.
-The signature uses the same Schnorr setup from NIP-01 but the considered "id" is just the
-"\<time-in-ms\>" string.
+The relay will validate the event `id` and check if its `created_at` is near the current time.
 
-There is also "https://relay1.example/.well-known/nostr/nip77.json?get=pubkey&at=\<time-in-ms\>"
+The response is a JSON `{ sig: "<signature>", pubkey: "<relay1pubkey>" }`.
+The signature uses the same Schnorr setup from NIP-01 to sign the received event `id`.
+
+There is also "https://relay1.example/.well-known/nostr/nip77.json?get=pubkey&at=\<time-in-seconds\>"
 to check what was the canonical relay pubkey at the time: `{ pubkey: "<pubkey-at-that-time>" }`.
 That's why a relay should keep a log of all the pubkeys used for each time window.
 
-An user can use the response to prove its event's `created_at` is near the
-Trust Clock time, using atleat 2 `now` tags from the same set of relays a client trusts:
+An user can use the response to prove its event's `created_at` is legit according to
+relays, using atleast 2 signatures from the same set of relays a client trusts.
+It should place the proof at an extra `clock` field like this:
 
 ```
-["clock", "https://client.example", "https://relay1.example", "<time-in-ms>", "<signature>"],
-["clock", "https://client.example", "https://relay3.example", "<time-in-ms>", "<signature>"]
+{
+  "id": ...,
+  "kind": ...,
+  // ... all regular event fields,
+  clock: {
+    c: ["https://client.example"], // clients to check trusted relay set
+    s: [ // relays and corresponding signatures
+      ["https://relay1.example", "<signature1>"]
+      ["https://relay3.example", "<signature3>"]
+    ]
+  }
+}
 ```
+
+Relays receiving this event should store the event and the extra `clock` field.
+
+The `clock.c` field can have multiple clients. It serves the purpose of claiming what
+are the clients that will trust the relay signatures.
+If using multiple clients' relay sets, the `clock.s` field
+can have overlapping relays that don't need to be repeated.
 
 ### Validation
 
-The time used in `clock` tags shouldn't diverge more than 30 seconds.
-
 The signature can be validated with the pubkey from
-"https://relay1.example/.well-known/nostr/nip77.json?get=pubkey&at=\<time-in-ms\>".
+"https://relay1.example/.well-known/nostr/nip77.json?get=pubkey&at=\<event.created_at>".
 
 The client trusted relay list at the time can be checked at
-"https://client.example/.well-known/nostr/nip77.json?get=relays&at=\<time-in-ms\>".
+"https://client.example/.well-known/nostr/nip77.json?get=relays&at=\<event.created_at\>".

--- a/77.md
+++ b/77.md
@@ -1,0 +1,66 @@
+NIP-77
+======
+
+Trust Clock
+-----------
+
+`draft` `optional` `author:arthurfranca` `author:melvincarvalho`
+
+## What the Trust Clock Does?
+
+It creates an event's `created_at` proof scoped to a client.
+For more clients to trust the event's `created_at`, more `clock` tags
+scoped to different clients are used.
+
+## How to Use the Trust Clock?
+
+A client first picks three relays to trust as a clock for a period
+such as a month window. The client should keep
+a log of all the trusted relay sets for each time window.
+
+One way of selecting trusted relays is as follows:
+a client collects relay hints from some of the events
+its users fetch, excluding encrypted ones. Relays hints are
+relay urls present in `e`, `p`, `a` or `relay` tags.
+The 3 most trusted relays by the client user base
+(relays that support this NIP) would be the 3 relay urls with more
+relay hints in a month window.
+
+The client trusted relay list at the time in milliseconds,
+informed on the `at` query param, can be checked at
+"https://client.example/.well-known/nostr/nip77.json?get=relays&at=\<time-in-ms\>":
+`{ relays: ["https://relay1.example", "https://relay2.example", "https://relay3.example"] }`.
+
+Clients can delegate trust by responding to
+"https://client.example/.well-known/nostr/nip77.json?get=relays&at=\<time-in-ms\>"
+with: `{ delegated_to: "https://another.client" }`
+
+Now it is possible to ask what time is it in milliseconds at
+"https://relay1.example/.well-known/nostr/nip77.json?get=now"
+and at the other two relay routes.
+
+The response is a JSON `{ now: ["<relay1pubkey>", "<time-in-ms>", "<signature>"] }`.
+The signature uses the same Schnorr setup from NIP-01 but the considered "id" is just the
+"\<time-in-ms\>" string.
+
+There is also "https://relay1.example/.well-known/nostr/nip77.json?get=pubkey&at=\<time-in-ms\>"
+to check what was the canonical relay pubkey at the time: `{ pubkey: "<pubkey-at-that-time>" }`.
+That's why a relay should keep a log of all the pubkeys used for each time window.
+
+An user can use the response to prove its event's `created_at` is near the
+Trust Clock time, using atleat 2 `now` tags from the same set of relays a client trusts:
+
+```
+["clock", "https://client.example", "https://relay1.example", "<time-in-ms>", "<signature>"],
+["clock", "https://client.example", "https://relay3.example", "<time-in-ms>", "<signature>"]
+```
+
+### Validation
+
+The time used in `clock` tags shouldn't diverge more than 30 seconds.
+
+The signature can be validated with the pubkey from
+"https://relay1.example/.well-known/nostr/nip77.json?get=pubkey&at=\<time-in-ms\>".
+
+The client trusted relay list at the time can be checked at
+"https://client.example/.well-known/nostr/nip77.json?get=relays&at=\<time-in-ms\>".


### PR DESCRIPTION
[Read here](https://github.com/arthurfranca/nips/blob/trust-clock/77.md)

I was just reading @melvincarvalho's thoughts at telegram group on verifiable timestamps based on relay infrastructure
and then started writing this NIP and put him as author without talking to him.

It would be an alternative to NIP-03 (OpenTimestamps Attestations for Events) without using blockchain.

Can you tell me if it makes sense or is it just impossible gibberish?