### PR TITLE
Key Change - NIP-76

### DIFF
--- a/76.md
+++ b/76.md
@@ -1,0 +1,75 @@
+NIP-76
+======
+
+Key Change
+----------
+
+`draft` `optional` `author:arthurfranca`
+
+An user can setup a backup keypair to change to if the original key is compromised.
+
+## How-to
+
+An user generates two keypairs, the original and the backup one.
+
+The original private key signs a kind `1076` event using a Trust Clock (NIP-77)
+scoped to clients it cares the most and both `p` and `z` ("deletable by" tag - NIP-09)
+tags set to the backup pubkey:
+
+```
+{
+  "id": "<kind-1076-event-id>"
+  "pubkey": "<original-pubkey>",
+  "kind": 1076,
+  "tags": [
+    ["p", "<backup-pubkey>"],
+    ["z", "<backup-pubkey>"]
+  ],
+  "content": "",
+  "created_at": "<now>",
+  "sig": "<signature>",
+  "clock": {
+    "c": [
+      "https://my-client.example",
+      "https://popular1.client",
+      "https://popular2.client"
+    ],
+    "s": [
+      ["https://relay1.example", "<signature1>"],
+      ["https://relay2.example", "<signature1>"],
+      ["https://relay3.example", "<signature3>"],
+      ["https://relay4.example", "<signature1>"]
+    ]
+  }
+}
+```
+
+The `z` tag makes sure a hacker holding the original private key can't
+delete the event.
+
+To keep disk space usage to a minimum, relays SHOULD block such events
+if it has already saved a kind `1076` event from the same author,
+because the presence of more than one event of this kind from the same pubkey
+is a sign that the key is compromised.
+
+The user's client broadcasts the event to all relays it knows about.
+
+Now clients that trust two of the `clock.s` relay clocks or that
+delegate clock trust to any of the clients listed at `clock.c`
+(checking if the delegation is using the right relay set
+according to NIP-77)
+will consider this event the oldest one of its kind.
+
+In a compromised original key scenario, the backup private key broadcasts
+a kind `1077` event with a `p` tag set to the original pubkey.
+
+A friend's client subscribes to kind `1077` events
+with the `p` tag set to its own friends' pubkeys.
+
+Upon receiving a kind `1077` event, the client proceeds to fetching kind `1076`
+events from some relays (not just one) and uses the clocks it trusts
+to decide what is the oldest `1076` event (or if it is the only one)
+and if the oldest (or only) one has the kind `1077` event author as `p` tag.
+
+If it is the case, it automatically follows the backup pubkey and unfollows
+the original one.


### PR DESCRIPTION
Read text [here](https://github.com/arthurfranca/nips/blob/key-change/76.md)

It explores the draft Trust Clock NIP-77 and NIP-09's `z` (deletable by) tag addition to setup a key rotation scheme.