### PR TITLE
NIP-99 use a tags pointing to Badge Definition events for access control

### DIFF
--- a/99.md
+++ b/99.md
@@ -48,6 +48,9 @@ The following tags, used for structured metadata, are standardized and SHOULD be
 Other standard tags that might be useful.
 
 - `"g"`, a geohash for more precise location
+- `"a"`, one or more a tags referencing kind `30009` Badge Definition events (NIP-58)
+
+When `"a"` tags refering kind `30009` events exist, a client CAN verify a user has been awarded all the respective badges before granting access to the product or service defined by the classified listing event.
 
 ## Example Event
 
@@ -73,7 +76,7 @@ Other standard tags that might be useful.
     ],
     [
       "a",
-      "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum",
+      "30009:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:coolkids-membersbadge",
       "wss://relay.nostr.org"
     ]
   ],


### PR DESCRIPTION
When 'a' tags referring Badge Definition events (kind 30009) are added, a client application CAN CHOOSE to verify the user has been awarded all respective badges before granting access to the product / service defined by the Classified Listing event.

Use Cases:
Requiring a "not-a-robot" badge to access a community group.
Requiring a "supporter" badge to gain early access to client features.
Presenting a "paid membership" badge to unlock access to one or more paid relays.

Creation of classified listing event with 'a' tags, and verification of badges (determining eligibility) implemented in [nostr-access-control](https://github.com/neilck/nostr-access-control) library.

Source code of application showing how to integrate this library is available at [nac-demo-app](https://github.com/neilck/nac-demo-app).