### PR TITLE
NIP-47 Optional Secret

### DIFF
--- a/47.md
+++ b/47.md
@@ -83,12 +83,14 @@ If the command was successful, the `error` field must be null.
 The **wallet service** generates this connection URI with protocol `nostr+walletconnect:` and base path it's hex-encoded `pubkey` with the following query string parameters: 
 
 - `relay` Required. URL of the relay where the **wallet service** is connected and will be listening for events. May be more than one.
-- `secret` Required. 32-byte randomly generated hex encoded string. The **client** MUST use this to sign events and encrypt payloads when communicating with the **wallet service**.
+- `secret` Recommended. 32-byte randomly generated hex encoded string. The **client** MUST use this if present to sign events and encrypt payloads when communicating with the **wallet service**.
     - Authorization does not require passing keys back and forth.
     - The user can have different keys for different applications. Keys can be revoked and created at will and have arbitrary constraints (eg. budgets).
     - The key is harder to leak since it is not shown to the user and backed up.
     - It improves privacy because the user's main key would not be linked to their payments.
 - `lud16` Recommended. A lightning address that clients can use to automatically setup the `lud16` field on the user's profile if they have none configured.
+
+The **client** MAY generate a 32-byte random secret and store it and uses this secret when it wants to perform an action. The corresponding public key must be passed to the **wallet service** to allow it to authorize the **client**. The **client** MUST only use this secret if the wallet service does not return a different secret to the client.
 
 The **client** should then store this connection and use it when the user wants to perform actions like paying an invoice. Due to this NIP using ephemeral events, it is recommended to pick relays that do not close connections on inactivity to not drop events.
 


### PR DESCRIPTION
I think `secret` can be optional here.

Reasoning / Use case: 

This can be used for more than just traditional nostr clients. A service provider may have their own secured private key or HSM to sign events with that they prefer to use when requesting money from a user's lightning wallet. This would be more secure than having the user copy paste private keys that they are allowing to withdraw money.

On the wallet side, the UX would be whenever a NWC profile is being created, the wallet should allow the user to paste the public key of the service provider or auto generate one. 

Existing nostr clients may not want to change anything but it would add some benefits with more lightning wallet integrations.

CC other NWC peeps: @benthecarman @bumi @rolznz 