### PR TITLE
NIP-XX - Nostr Token Login

### DIFF
--- a/26.md
+++ b/26.md
@@ -8,7 +8,7 @@ Delegated Event Signing
 
 This NIP defines how events can be delegated so that they can be signed by other keypairs.
 
-Another application of this proposal is to abstract away the use of the 'root' keypairs when interacting with clients. For example, a user could generate new keypairs for each client they wish to use and authorize those keypairs to generate events on behalf of their root pubkey, where the root keypair is stored in cold storage. 
+Another application of this proposal is to abstract away the use of the 'root' keypairs when interacting with clients. For example, a user could generate new keypairs for each client they wish to use and authorize those keypairs to generate events on behalf of their root pubkey, where the root keypair is stored in cold storage.
 
 #### Introducing the 'delegation' tag
 
@@ -39,10 +39,14 @@ The following fields and operators are supported in the above query string:
 1. `kind`
    -  *Operators*:
       -  `=${KIND_NUMBER}` - delegatee may only sign events of this kind
+      -  `=-${KIND_NUMBER}` - delegatee may sign events of any kind except this one
 2. `created_at`
    -  *Operators*:
       -  `<${TIMESTAMP}` - delegatee may only sign events created ***before*** the specified timestamp
       -  `>${TIMESTAMP}` - delegatee may only sign events created ***after*** the specified timestamp
+3. #{TAG[0]}
+   -  *Operators*:
+      -  `=${TAG[1]}` - delegatee may only sign events containing a tag array with TAG[0] name and TAG[1] value
 
 In order to create a single condition, you must use a supported field and operator. Multiple conditions can be used in a single query string, including on the same field. Conditions must be combined with `&`.
 
@@ -51,6 +55,7 @@ For example, the following condition strings are valid:
 - `kind=1&created_at<1675721813`
 - `kind=0&kind=1&created_at>1675721813`
 - `kind=1&created_at>1674777689&created_at<1675721813`
+- `kind=-5&#t=nostr&#t=nostrich`
 
 For the vast majority of use-cases, it is advisable that:
 1. Query strings should include a `created_at` ***after*** condition reflecting the current time, to prevent the delegatee from publishing historic notes on the delegator's behalf.

--- a/26.md
+++ b/26.md
@@ -60,6 +60,7 @@ For example, the following condition strings are valid:
 For the vast majority of use-cases, it is advisable that:
 1. Query strings should include a `created_at` ***after*** condition reflecting the current time, to prevent the delegatee from publishing historic notes on the delegator's behalf.
 2. Query strings should include a `created_at` ***before*** condition that is not empty and is not some extremely distant time in the future. If delegations are not limited in time scope, they expose similar security risks to simply using the root key for authentication.
+3. Query strings should not include kind 5 rights. Instead, consider using `z` tags (deletable by) conditions with both pubkeys, from delegatee and from delegator.
 
 #### Example
 
@@ -107,9 +108,37 @@ The event should be considered a valid delegation if the conditions are satisfie
 
 Clients should display the delegated note as if it was published directly by the delegator (8e0d3d3e).
 
+#### Revoking a Delegation
+
+It is highly recommended to use revocable NIP-26 delegations.
+
+##### Revocation Event
+
+Delegators may send a `kind: 1026` event with an `s` tag with the delegation string
+(the `nostr:delegation:<pubkey of publisher (delegatee)>:<conditions query string>` one).
+
+The event presence means the corresponding delegation has been revoked.
+
+It is recommended to add a [NIP-40](40.md) expiration tag to the event with the `created_at<` condition value, if present.
+
+##### Making a Revocable Delegation
+
+To make a delegation revocable, add one `rr` (revocation relay) param to the conditions query string with a percent-encoded relay url. Extra `rr` params are ignored.
+
+Add this, for example: `&rr=wss%3A%2F%recovation.relay.example`.
+
+A `kind: 1026` event should be sent to the revocation relay if the delegator wants to revoke the delegation.
 
 #### Relay & Client Support
 
 Relays should answer requests such as `["REQ", "", {"authors": ["A"]}]` by querying both the `pubkey` and delegation tags `[1]` value.
 
 Relays SHOULD allow the delegator (8e0d3d3e) to delete the events published by the delegatee (477318cf).
+
+Delegated events with `created_at` in the past MUST be rejected by relays. Such delegations are considered expired.
+An exception is made if the past event comes from a trusted bulk event importing feature.
+
+Relays receiving the delegated event with `rr` condition query param MUST check at the revocation relay
+if the delegation has been revoked, before saving the event.
+If a `kind: 1026` from the delegator with an `s` tag with a corresponding delegation string is present
+at the revocation relay, the received delegated event MUST NOT be saved.

--- a/xx.md
+++ b/xx.md
@@ -1,0 +1,34 @@
+NIP-XX
+======
+
+Nostr Token Login
+-----------------
+
+`draft` `optional` `author:arthurfranca`
+
+Defines a token to create a session to login without using the primary private key.
+
+It is shown to user as a `ntoken` [NIP-19](#19.md) entity.
+
+The token is usually created by the app trusted to store the user's private key.
+
+Then the user can paste the `ntoken` at other apps it wants to login.
+
+The `ntoken` entity encodes a disposable private key and [NIP-26](26.md)
+delegation tag entries, effectively delegating event signing rights from
+the user's private key to the disposable keypair for a configured time period.
+It should also encode relay(s) where one can find the user's metadata events.
+
+Clients supporting "Nostr Token Login" can use the disposable delegatee's
+private key and the delegation tag to freely sign events on behalf of the user's
+private key until the configured duration expires.
+
+## Recommended NIP-26 Setup
+
+It is advisable to give all but kind `5` (deletion) rights, require inserting
+`z` tags with both pubkeys (from delegatee and delegator) on events and
+limit `created_at` range between the current moment and 15h ahead.
+
+Example delegation condition string:
+
+`kind=-5&created_at>1695516361&created_at<1695570361&#z=<delegatee_pubkey>&#z=<delegator_pubkey>`

--- a/xx.md
+++ b/xx.md
@@ -26,9 +26,11 @@ private key until the configured duration expires.
 ## Recommended NIP-26 Setup
 
 It is advisable to give all but kind `5` (deletion) rights, require inserting
-`z` tags with both pubkeys (from delegatee and delegator) on events and
-limit `created_at` range between the current moment and 15h ahead.
+`z` tags (deletable by) with both pubkeys (from delegatee and delegator) on events and
+limit `created_at` range between the current moment and 15h ahead at most.
+
+It is highly recommended to use nostr tokens with revocable NIP-26 delegations (`rr` parameter).
 
 Example delegation condition string:
 
-`kind=-5&created_at>1695516361&created_at<1695570361&#z=<delegatee_pubkey>&#z=<delegator_pubkey>`
+`kind=-5&created_at>1695516361&created_at<1695570361&#z=<delegatee_pubkey>&#z=<delegator_pubkey>&rr=<percent_enconded_relay_url>`


### PR DESCRIPTION
The token (NIP-19 `ntoken`) will usually be created by the client trusted to store the user's private key.

The idea is that other clients should support user pasting their `ntoken` to login (creating a temporary session) instead of pasting their `nsec`.

I know NIP-26 was not intended for this because clients not supporting NIP-26 will be full of faceless users publishing stuff
but this is probably better than users pasting their nsec at every client they want to test.

Read [here](https://github.com/arthurfranca/nips/blob/token/xx.md)