### PR TITLE
add nip-24: extra metadata fields

### DIFF
--- a/24.md
+++ b/24.md
@@ -1,0 +1,24 @@
+NIP-24
+======
+
+Extra metadata fields and tags
+------------------------------
+
+`draft` `optional` `author:fiatjaf`
+
+This NIP defines extra optional fields added to events.
+
+kind 0
+======
+
+These are extra fields not specified in NIP-01 that may be present in the stringified JSON of metadata events:
+
+  - `display_name`: a bigger name with richer characters than `name`. Implementations should fallback to `name` when this is not available.
+  - `website`: a web URL related in any way to the event author.
+
+tags
+====
+
+These tags may be present in multiple event kinds. Whenever a different meaning is not specified by some more specific NIP, they have the following meanings:
+
+  - `r`: a web URL the event is referring to in some way

--- a/24.md
+++ b/24.md
@@ -15,6 +15,14 @@ These are extra fields not specified in NIP-01 that may be present in the string
 
   - `display_name`: a bigger name with richer characters than `name`. Implementations should fallback to `name` when this is not available.
   - `website`: a web URL related in any way to the event author.
+  - `banner`: an URL to a wide (~1024x768) picture to be optionally displayed in the background of a profile screen.
+
+### Deprecated fields
+
+These are fields that should be ignored or removed when found in the wild:
+
+  - `displayName`: use `display_name` instead.
+  - `username`: use `name` instead.
 
 tags
 ====


### PR DESCRIPTION
Because Nostr won't survive if all clients have to keep checking for `displayName`, `handle`, `username` and whatever else is in there.

https://github.com/nostr-protocol/nips/blob/extra/24.md

Motivation: https://njump.me/nevent1qqs9pt0ghyzzq7p6pqajnlvjgr7n9tyhy0vhpuyhgvdrd6y5r50n90cppemhxue69uhkummn9ekx7mp0qyghwumn8ghj7mn0wd68ytnhd9hx2tcar0mnt