### PR TITLE
65: trim trailing slashes from relay URIs

### DIFF
--- a/65.md
+++ b/65.md
@@ -59,3 +59,5 @@ This NIP allows Clients to connect directly with the most up-to-date relay set f
 4. DMs SHOULD only be broadcasted to the author's WRITE relays and to the receiver's READ relays to keep maximum privacy. 
 
 5. If a relay signals support for this NIP in their [NIP-11](11.md) document that means they're willing to accept kind 10002 events from a broad range of users, not only their paying customers or whitelisted group.
+
+6. Clients SHOULD trim trailing slashes (`/`) from relay URIs to canonicalize connections.


### PR DESCRIPTION
This is intended to address the issue of some clients duplicating connections due to trailing slashes in the relay URI.