### PR TITLE
update nip-57 zap receipt spec to include 'a' tag

### DIFF
--- a/57.md
+++ b/57.md
@@ -128,7 +128,7 @@ The following should be true of the `zap receipt` event:
 
 - The `content` SHOULD be empty.
 - The `created_at` date SHOULD be set to the invoice `paid_at` date for idempotency.
-- `tags` MUST include the `p` tag AND optional `e` tag from the `zap request`.
+- `tags` MUST include the `p` tag AND optional `e` tag from the `zap request` AND optional `a` tag from the `zap request`.
 - The `zap receipt` MUST have a `bolt11` tag containing the description hash bolt11 invoice.
 - The `zap receipt` MUST contain a `description` tag which is the JSON-encoded invoice description.
 - `SHA256(description)` MUST match the description hash in the bolt11 invoice.


### PR DESCRIPTION
@verbiricha [reached out letting us know SN's zapper wasn't including `a` tags in the zap receipt.](https://snort.social/e/nevent1qqsx2gxs8e6jk9mzwvwyuw6u2y863acewy2pqg0dn5hhzqed4rxj0asu7e8e8)

Figured it should be added to the spec for future zappers.