### PR TITLE
Update NIP-10 including definitions for "a" tags

### DIFF
--- a/10.md
+++ b/10.md
@@ -37,8 +37,8 @@ They are citings from this event.  `root-id` and `reply-id` are as above.
 
 >This scheme is deprecated because it creates ambiguities that are difficult, or impossible to resolve when an event references another but is not a reply.
 
-## Marked "e" tags (PREFERRED)
-`["e", <event-id>, <relay-url>, <marker>]`
+## Marked "e" and "a" tags (PREFERRED)
+`["e", <event-id>, <relay-url>, <marker>]` (or `["a", <event-id>, <relay-url>, <marker>]` for replaceable events)
 
 Where:
 
@@ -48,7 +48,7 @@ Where:
 
 Those marked with `"reply"` denote the id of the reply event being responded to.  Those marked with `"root"` denote the root id of the reply thread being responded to. For top level replies (those replying directly to the root event), only the `"root"` marker should be used. Those marked with `"mention"` denote a quoted or reposted event id.
 
-A direct reply to the root of a thread should have a single marked "e" tag of type "root".
+A direct reply to the root of a thread should have a single marked `"e"` tag (or `"a"` tag if it is a replaceable event) of type `"root"`.
 
 >This scheme is preferred because it allows events to mention others without confusing them with `<reply-id>` or `<root-id>`.
 

--- a/10.md
+++ b/10.md
@@ -2,13 +2,13 @@ NIP-10
 ======
 
 
-On "e" and "p" tags in Text Events (kind 1).
+On "e", "a" and "p" tags in Text Events (kind 1).
 --------------------------------------------
 
 `draft` `optional` `author:unclebobmartin`
 
 ## Abstract
-This NIP describes how to use "e" and "p" tags in text events, especially those that are replies to other text events.  It helps clients thread the replies into a tree rooted at the original event.
+This NIP describes how to use "e", "a" and "p" tags in text events, especially those that are replies to other text events.  It helps clients thread the replies into a tree rooted at the original event.
 
 ## Positional "e" tags (DEPRECATED)
 >This scheme is in common use; but should be considered deprecated.


### PR DESCRIPTION
Clients will use NIP-10 as reference to implement replies and will only look for `e` tags, ignoring `a` tags for both displaying content and properly tagging notes.

For example, comments in [habla.news](https://habla.news) (via [zapthreads](https://github.com/fr4nzap/zapthreads)), which essentially are replies to a kind 30023 parameterized replaceable event, will not be treated as replies in "kind 1" clients.

This has repeatedly generated confusion; a reply to an Habla.news article will show up as a root-less, context-less comment in most kind 1 clients because they ignore the `a` tag.

NIP-01 defines the `p`, `e` and `a` tags so NIP-10 should follow.