### PR TITLE
Add "s" tag to reactions

### DIFF
--- a/25.md
+++ b/25.md
@@ -30,9 +30,11 @@ reacting to. This allows users to be notified of reactions to posts they were
 mentioned in. Including the `e` tags enables clients to pull all the reactions
 associated with individual posts or all the posts in a thread.
 
-The last `e` tag MUST be the `id` of the note that is being reacted to. 
+The last `e` tag MUST be the `id` of the note that is being reacted to.
 
 The last `p` tag MUST be the `pubkey` of the event being reacted to.
+
+One `s` tag MUST be added with either '+' value for positive/unknown sentiment or '-' for negative sentiment.
 
 The reaction event MAY include a `k` tag with the stringified kind number
 of the reacted event as its value.
@@ -41,11 +43,12 @@ Example code
 
 ```swift
 func make_like_event(pubkey: String, privkey: String, liked: NostrEvent) -> NostrEvent {
-    var tags: [[String]] = liked.tags.filter { 
-    	tag in tag.count >= 2 && (tag[0] == "e" || tag[0] == "p") 
+    var tags: [[String]] = liked.tags.filter {
+    	tag in tag.count >= 2 && (tag[0] == "e" || tag[0] == "p")
     }
     tags.append(["e", liked.id])
     tags.append(["p", liked.pubkey])
+    tags.append(["s", "+"])
     tags.append(["k", liked.kind])
     let ev = NostrEvent(content: "+", pubkey: pubkey, kind: 7, tags: tags)
     ev.calculate_id()
@@ -66,7 +69,10 @@ content as an emoji if shortcode is specified.
   "kind": 7,
   "content": ":soapbox:",
   "tags": [
-    ["emoji", "soapbox", "https://gleasonator.com/emoji/Gleasonator/soapbox.png"]
+    ["emoji", "soapbox", "https://gleasonator.com/emoji/Gleasonator/soapbox.png"],
+    ["e", "5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36"],
+    ["p", "f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca"],
+    ["s", "+"]
   ],
   "pubkey": "79c2cae114ea28a981e7559b4fe7854a473521a8d22a66bbab9fa248eb820ff6",
   "created_at": 1682790000


### PR DESCRIPTION
One `s` tag is set to reactions with "+" (positive or unknown sentiment, in case of some emojis) or "-" (negative sentiment) value.
This allows for using NIP-45 to count likes and dislikes separately.