### PR TITLE
Change wording to imply that reactions can target any event

### DIFF
--- a/25.md
+++ b/25.md
@@ -7,7 +7,7 @@ Reactions
 
 `draft` `optional` `author:jb55`
 
-A reaction is a `kind 7` event that is used to react to other `kind 1` text notes.
+A reaction is a `kind 7` event that is used to react to other events.
 
 The generic reaction, represented by the `content` set to a `+` string, SHOULD
 be interpreted as a "like" or "upvote".
@@ -34,6 +34,9 @@ The last `e` tag MUST be the `id` of the note that is being reacted to.
 
 The last `p` tag MUST be the `pubkey` of the event being reacted to.
 
+The reaction event SHOULD include a `k` tag with the stringified kind number
+of the reacted event as its value.
+
 Example code
 
 ```swift
@@ -43,6 +46,7 @@ func make_like_event(pubkey: String, privkey: String, liked: NostrEvent) -> Nost
     }
     tags.append(["e", liked.id])
     tags.append(["p", liked.pubkey])
+    tags.append(["k", liked.kind])
     let ev = NostrEvent(content: "+", pubkey: pubkey, kind: 7, tags: tags)
     ev.calculate_id()
     ev.sign(privkey: privkey)
@@ -70,13 +74,3 @@ content as an emoji if shortcode is specified.
 ```
 
 The content can be set only one `:shortcode:`. And emoji tag should be one.
-
-Generic Reactions
------------------
-
-Since `kind 7` reactions are reserved for `kind 1` contents, we use `kind 17`
-as a "generic reaction", that can include any kind of event inside other than
-`kind 1`.
-
-`kind 17` reactions SHOULD contain a `k` tag with the stringified kind number
-of the reacted event as its value.

--- a/25.md
+++ b/25.md
@@ -7,7 +7,7 @@ Reactions
 
 `draft` `optional` `author:jb55`
 
-A reaction is a `kind 7` note that is used to react to other notes.
+A reaction is a `kind 7` event that is used to react to other `kind 1` text notes.
 
 The generic reaction, represented by the `content` set to a `+` string, SHOULD
 be interpreted as a "like" or "upvote".
@@ -70,3 +70,13 @@ content as an emoji if shortcode is specified.
 ```
 
 The content can be set only one `:shortcode:`. And emoji tag should be one.
+
+Generic Reactions
+-----------------
+
+Since `kind 7` reactions are reserved for `kind 1` contents, we use `kind 17`
+as a "generic reaction", that can include any kind of event inside other than
+`kind 1`.
+
+`kind 17` reactions SHOULD contain a `k` tag with the stringified kind number
+of the reacted event as its value.

--- a/25.md
+++ b/25.md
@@ -34,7 +34,7 @@ The last `e` tag MUST be the `id` of the note that is being reacted to.
 
 The last `p` tag MUST be the `pubkey` of the event being reacted to.
 
-The reaction event SHOULD include a `k` tag with the stringified kind number
+The reaction event MAY include a `k` tag with the stringified kind number
 of the reacted event as its value.
 
 Example code

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `7`     | Reaction                   | [25](25.md) |
 | `8`     | Badge Award                | [58](58.md) |
 | `16`    | Generic Repost             | [18](18.md) |
+| `17`    | Generic Reaction           | [25](25.md) |
 | `40`    | Channel Creation           | [28](28.md) |
 | `41`    | Channel Metadata           | [28](28.md) |
 | `42`    | Channel Message            | [28](28.md) |
@@ -156,47 +157,47 @@ Please update these lists when proposing NIPs introducing new event kinds.
 
 ## Standardized Tags
 
-| name              | value                                | other parameters     | NIP                      |
-| ----------------- | ------------------------------------ | -------------------- | ------------------------ |
-| `e`               | event id (hex)                       | relay URL, marker    | [01](01.md), [10](10.md) |
-| `p`               | pubkey (hex)                         | relay URL, petname   | [01](01.md), [02](02.md) |
-| `a`               | coordinates to an event              | relay URL            | [01](01.md)              |
-| `d`               | identifier                           | --                   | [01](01.md)              |
-| `alt`             | summary                              | --                   | [31](31.md)              |
-| `g`               | geohash                              | --                   | [52](52.md)              |
-| `i`               | identity                             | proof                | [39](39.md)              |
-| `k`               | kind number (string)                 | --                   | [18](18.md), [72](72.md) |
-| `l`               | label, label namespace               | annotations          | [32](32.md)              |
-| `L`               | label namespace                      | --                   | [32](32.md)              |
-| `m`               | MIME type                            | --                   | [94](94.md)              |
-| `r`               | a reference (URL, etc)               | petname              |                          |
-| `r`               | relay url                            | marker               | [65](65.md)              |
-| `t`               | hashtag                              | --                   |                          |
-| `amount`          | millisatoshis, stringified           | --                   | [57](57.md)              |
-| `bolt11`          | `bolt11` invoice                     | --                   | [57](57.md)              |
-| `challenge`       | challenge string                     | --                   | [42](42.md)              |
-| `content-warning` | reason                               | --                   | [36](36.md)              |
-| `delegation`      | pubkey, conditions, delegation token | --                   | [26](26.md)              |
-| `description`     | invoice/badge description            | --                   | [57](57.md), [58](58.md) |
-| `emoji`           | shortcode, image URL                 | --                   | [30](30.md)              |
-| `expiration`      | unix timestamp (string)              | --                   | [40](40.md)              |
-| `goal`            | event id (hex)                       | relay URL            | [75](75.md)              |
-| `image`           | image URL                            | dimensions in pixels | [23](23.md), [58](58.md) |
-| `lnurl`           | `bech32` encoded `lnurl`             | --                   | [57](57.md)              |
-| `location`        | location string                      | --                   | [52](52.md), [99](99.md) |
-| `name`            | badge name                           | --                   | [58](58.md)              |
-| `nonce`           | random                               | --                   | [13](13.md)              |
-| `preimage`        | hash of `bolt11` invoice             | --                   | [57](57.md)              |
-| `price`           | price                                | currency, frequency  | [99](99.md)              |
-| `proxy`           | external ID                          | protocol             | [48](48.md)              |
-| `published_at`    | unix timestamp (string)              | --                   | [23](23.md)              |
-| `relay`           | relay url                            | --                   | [42](42.md)              |
-| `relays`          | relay list                           | --                   | [57](57.md)              |
-| `subject`         | subject                              | --                   | [14](14.md)              |
-| `summary`         | article summary                      | --                   | [23](23.md)              |
-| `thumb`           | badge thumbnail                      | dimensions in pixels | [58](58.md)              |
-| `title`           | article title                        | --                   | [23](23.md)              |
-| `zap`             | pubkey (hex), relay URL              | weight               | [57](57.md)              |
+| name              | value                                | other parameters     | NIP                                   |
+| ----------------- | ------------------------------------ | -------------------- | ------------------------------------- |
+| `e`               | event id (hex)                       | relay URL, marker    | [01](01.md), [10](10.md)              |
+| `p`               | pubkey (hex)                         | relay URL, petname   | [01](01.md), [02](02.md)              |
+| `a`               | coordinates to an event              | relay URL            | [01](01.md)                           |
+| `d`               | identifier                           | --                   | [01](01.md)                           |
+| `alt`             | summary                              | --                   | [31](31.md)                           |
+| `g`               | geohash                              | --                   | [52](52.md)                           |
+| `i`               | identity                             | proof                | [39](39.md)                           |
+| `k`               | kind number (string)                 | --                   | [18](18.md), [25](25.md), [72](72.md) |
+| `l`               | label, label namespace               | annotations          | [32](32.md)                           |
+| `L`               | label namespace                      | --                   | [32](32.md)                           |
+| `m`               | MIME type                            | --                   | [94](94.md)                           |
+| `r`               | a reference (URL, etc)               | petname              |                                       |
+| `r`               | relay url                            | marker               | [65](65.md)                           |
+| `t`               | hashtag                              | --                   |                                       |
+| `amount`          | millisatoshis, stringified           | --                   | [57](57.md)                           |
+| `bolt11`          | `bolt11` invoice                     | --                   | [57](57.md)                           |
+| `challenge`       | challenge string                     | --                   | [42](42.md)                           |
+| `content-warning` | reason                               | --                   | [36](36.md)                           |
+| `delegation`      | pubkey, conditions, delegation token | --                   | [26](26.md)                           |
+| `description`     | invoice/badge description            | --                   | [57](57.md), [58](58.md)              |
+| `emoji`           | shortcode, image URL                 | --                   | [30](30.md)                           |
+| `expiration`      | unix timestamp (string)              | --                   | [40](40.md)                           |
+| `goal`            | event id (hex)                       | relay URL            | [75](75.md)                           |
+| `image`           | image URL                            | dimensions in pixels | [23](23.md), [58](58.md)              |
+| `lnurl`           | `bech32` encoded `lnurl`             | --                   | [57](57.md)                           |
+| `location`        | location string                      | --                   | [52](52.md), [99](99.md)              |
+| `name`            | badge name                           | --                   | [58](58.md)                           |
+| `nonce`           | random                               | --                   | [13](13.md)                           |
+| `preimage`        | hash of `bolt11` invoice             | --                   | [57](57.md)                           |
+| `price`           | price                                | currency, frequency  | [99](99.md)                           |
+| `proxy`           | external ID                          | protocol             | [48](48.md)                           |
+| `published_at`    | unix timestamp (string)              | --                   | [23](23.md)                           |
+| `relay`           | relay url                            | --                   | [42](42.md)                           |
+| `relays`          | relay list                           | --                   | [57](57.md)                           |
+| `subject`         | subject                              | --                   | [14](14.md)                           |
+| `summary`         | article summary                      | --                   | [23](23.md)                           |
+| `thumb`           | badge thumbnail                      | dimensions in pixels | [58](58.md)                           |
+| `title`           | article title                        | --                   | [23](23.md)                           |
+| `zap`             | pubkey (hex), relay URL              | weight               | [57](57.md)                           |
 
 ## Criteria for acceptance of NIPs
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `7`     | Reaction                   | [25](25.md) |
 | `8`     | Badge Award                | [58](58.md) |
 | `16`    | Generic Repost             | [18](18.md) |
-| `17`    | Generic Reaction           | [25](25.md) |
 | `40`    | Channel Creation           | [28](28.md) |
 | `41`    | Channel Metadata           | [28](28.md) |
 | `42`    | Channel Message            | [28](28.md) |


### PR DESCRIPTION
- Define "generic reactions" (`kind 17`) in the same way as "generic reposts" (`kind 16`)
  - #610
- Any clients reacting only to `kind 1` events will not need additional support, and clients reacting to events other than `kind 1` events will be able to handle the kind they want.

I am developing a client for Public Chat ([NIP-28](28.md)) that can react to `kind 42` events.  
However, it is causing troubles for other clients that only handle `kind 1` events.  
In addition, I only want to handle reactions to `kind 42` events.  
So I want to use generic reactions containing the `k` tag.  
