### PR TITLE
Draft for NIP-73 meetup communities

### DIFF
--- a/73.md
+++ b/73.md
@@ -80,7 +80,6 @@ In addition to the fields mentioned in NIP-52 there is also the following:
 
 - an additional "g" tag formatted as the city g tags above. ie. Alpha2:City Name. This makes it possible to search by city. 
 - an ["L" , "kind"] and ["l", "meetup", "kind"] tag so that these evnts can be differentiated from those that don'e have a community associated with them
-- an "e" tag referencing the associated community.
 - an optional "brief" tag, for a short description of the event
 
 This gives us:

--- a/73.md
+++ b/73.md
@@ -1,0 +1,166 @@
+NIP-73
+======
+
+Location Based Communities (Meetup Style)
+------------------------------------
+
+`draft` `optional` `author:brighton_btc`
+
+The purpose of this NIP is to create location based communities that allow for some light moderation, leverage NIP-52 time based calendar events for the creation of in-person meetup events, NIP-51 lists for membership and moderation, and NIP-28 for community chat.
+
+# Community creation event:
+New communities are created with a `Kind:1037` event. This event acts as an anchor point for other event kinds associated with the community
+
+```json
+{
+  "content": <Optional description>,
+  "created_at": <Unix timestamp in seconds>,
+  "id": <32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>,
+  "kind": 1037,
+  "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>
+}
+```
+
+# Community metadata:
+
+Community metadata can be created or updated with a `Kind:30037` event. It should use the ID of the associated `Kind:1037` as its `d` tag.
+
+```json
+{
+  "content": <description of community, markdown formatted>,
+  "created_at": <Unix timestamp in seconds>,
+  "id": <32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>,
+  "kind": 30037,
+  "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>,
+  "tags": [
+    ["title", <Community name>],
+    ["d", <UID, ID of the associated 1037 event  >],
+    ["image", <optional image URL>],
+    ["g", <geohash>, "geohash"],
+    ["g", <Alpha2 Country Code:City Name>, "city"], // eg "GB:Brighton"
+    ["t", <string>] // can be multiple t tags
+  ]
+}
+
+```
+
+# Following communities
+
+Users follow communities by adding the `Kind:1037` (Community creation event) id as an `e` tag to a `Kind:10037` event. 
+
+Users can also add extra metadata, such as location `g` tags, to this event. This enables clients to build in discoverability options for their users.
+
+```json
+{
+  "content": <User status>, // optional
+  "created_at": <Unix timestamp in seconds>,
+  "id": <32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>,
+  "kind": 10037,
+  "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>,
+  "tags": [
+    ["e", <id of an associated 1037 event>],
+    ["e", <another id of an associated 1037 event>],
+    // etc...
+
+    // Suggested optional tags:
+    ["locationStatus", <living | visiting>],
+    ["g", <Alpha2:City>, "city"], // eg "GB:Brighton"
+    ["t", <topic 1>],
+    ["t", <topic 2>]
+    // etc...
+  ]
+}
+```
+
+# Time-Based Calendar Event (NIP-52):
+
+The owner of a community can create `Kind:31923` calendar events to represent location based, in person, meetup events. It's `d` tag should be the ID of the associated `Kind:1037` event.
+
+In addition to the fields mentioned in NIP-52 there is also the following:
+
+- an additional "g" tag formatted as the city g tags above. ie. Alpha2:City Name. This makes it possible to search by city. 
+- an ["L" , "kind"] and ["l", "meetup", "kind"] tag so that these evnts can be differentiated from those that don'e have a community associated with them
+- an "e" tag referencing the associated community.
+- an optional "brief" tag, for a short description of the event
+
+This gives us:
+
+```json
+{
+  "content": <markdown formatted event description>,
+  "created_at": <Unix timestamp in seconds>,
+  "id": <32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>,
+  "kind": 31923,
+  "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>,
+  "tags": [
+    ["d", <UID, ID of the associated 1037 event  >],
+
+    ["name", <name of calendar event>],
+
+    // Dates
+    ["start", <Unix timestamp in seconds>],
+    ["end", <Unix timestamp in seconds>],
+
+    // Location
+    ["location", "<location>"],
+    ["g", <geohash>, "geohash"],
+    ["g", <Alpha2:City>, "city"],
+
+    // Hashtags
+    ["t", "<tag>"],
+    ["t", "<tag>"],
+    
+    // addition fields
+    ["brief", <brief description>],
+    ["e", <id of the associated 1037 event>],
+    ["L", "kind" ],
+    ["l", "meetup", "kind"],
+    
+  ]
+}
+```
+
+# RSVPing to community events
+
+See NIP-52 `Kind:31925` events
+
+# Community moderation
+
+A user can be considered as one of 3 levels by a community: follower, member, or muted.
+
+- **Member** - Is following the community (community ID exists in the users `Kind:10037` list) AND the users hex public key exists in the community's `Kind:30000` member list.
+- **Follower** - Is following the community (community ID exists in the users `Kind:10037` list) BUT the users hex public key DOESN'T exist in the community's `Kind:30000` member list.
+- **Muted** - Is following the community (community ID exists in the users `Kind:10037` list) AND the users hex public key exists in the community's `Kind:30000` block list. 
+
+The community owner manages 2 `Kind:30000` (NIP-51) lists, one for members, one for muted/blocked users. The member event should include a `d` tag that mirrors the ID of the associated `Kind:1037`, and the muted list should be the `Kind:1037` with `:blocked` appended.
+
+### Member list
+
+```json
+
+"kind": 30000,
+  "tags": [
+    ["d", <UID, ID of the associated 1037 event  >],
+    ["p", "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"],
+    ["p", "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245"],
+    // ...etc.
+  ]
+```
+
+### Muted list
+
+```json
+
+"kind": 30000,
+  "tags": [
+    ["d", <UID, ID of the associated 1037 event  > + ":blocked"],
+    ["p", "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"],
+    ["p", "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245"],
+    // ...etc.
+  ]
+```
+
+
+# Community Chat
+
+Community chat can be implemented using NIP-28. The `Kind:40` chat creation event should include include an `e` tag that references the community `Kind:1037` event. Chat can be moderated as described above in the Community moderation section.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-58: Badges](58.md)
 - [NIP-65: Relay List Metadata](65.md)
 - [NIP-72: Moderated Communities](72.md)
+- [NIP-73: Meetup Communities](73.md)
 - [NIP-75: Zap Goals](75.md)
 - [NIP-78: Application-specific data](78.md)
 - [NIP-89: Recommended Application Handlers](89.md)
@@ -90,6 +91,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `42`    | Channel Message            | [28](28.md) |
 | `43`    | Channel Hide Message       | [28](28.md) |
 | `44`    | Channel Mute User          | [28](28.md) |
+| `1037`  | Meetup Community Creation  | [73](73.md) |
 | `1063`  | File Metadata              | [94](94.md) |
 | `1311`  | Live Chat Message          | [53](53.md) |
 | `1040`  | OpenTimestamps             | [03](03.md) |
@@ -102,6 +104,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `10000` | Mute List                  | [51](51.md) |
 | `10001` | Pin List                   | [51](51.md) |
 | `10002` | Relay List Metadata        | [65](65.md) |
+| `10037` | Meetup Community Metadata  | [73](73.md) |
 | `13194` | Wallet Info                | [47](47.md) |
 | `22242` | Client Authentication      | [42](42.md) |
 | `23194` | Wallet Request             | [47](47.md) |
@@ -116,6 +119,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `30018` | Create or update a product | [15](15.md) |
 | `30023` | Long-form Content          | [23](23.md) |
 | `30024` | Draft Long-form Content    | [23](23.md) |
+| `30037` | Meetup Follow List         | [73](73.md) |
 | `30078` | Application-specific Data  | [78](78.md) |
 | `30311` | Live Event                 | [53](53.md) |
 | `30315` | User Statuses              | [38](38.md) |


### PR DESCRIPTION
This is a draft proposal for Meetup style location based communities. 

For a working example this is currently implemented at https://www.inmytown.social/ (https://github.com/BrightonBTC/inmytown.social).

The idea is to have communities similar to those on Meetup .com, and introduces 3 new kinds to achieve this. One for community creation, One for community metadata, and one for community follow lists. The rest of the functionality is provided by existing NIPs. NIP-52 for location and time based meetup events, NIP-28 for community chat, and NIP-51 person lists to manage membership.

