### PR TITLE
added nodestr to nip07 providers

### DIFF
--- a/07.md
+++ b/07.md
@@ -34,3 +34,4 @@ async window.nostr.nip04.decrypt(pubkey, ciphertext): string // takes ciphertext
 - [TokenPocket](https://www.tokenpocket.pro/) (Android, IOS, Chrome and derivatives)
 - [Nostrmo](https://github.com/haorendashu/nostrmo_faq#download) (Android, IOS)
 - [Spring Browser](https://spring.site) (Android)
+- [nodestr](https://github.com/lightning-digital-entertainment/nodestr) (NodeJS polyfill)


### PR DESCRIPTION
We started a library that implements window.nostr methods and polyfills them inside NodeJS.

While Node is certainly less limited when it comes to key-handling than a browser is, having this polyfill allows code that relies on nip07 to run on node environments too. It will also enable more complex key setups for developers and users, as we  implement more signing methods, like nip46, encrypted keyfiles etc.