### PR TITLE
find tag by name

### DIFF
--- a/01.md
+++ b/01.md
@@ -118,6 +118,7 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
   "authors": <a list of lowercase pubkeys, the pubkey of an event must be one of these>,
   "kinds": <a list of a kind numbers>,
   "#<single-letter (a-zA-Z)>": <a list of tag values, for #e — a list of event ids, for #p — a list of event pubkeys etc>,
+  "#": <a list of tag names>,
   "since": <an integer unix timestamp in seconds, events must be newer than this to pass>,
   "until": <an integer unix timestamp in seconds, events must be older than this to pass>,
   "limit": <maximum number of events relays SHOULD return in the initial query>


### PR DESCRIPTION
If `#` is given for filters, REQ returns a result containing all of the list of tag names have that follow.

motivation: current specification can not find events only that have `g` tag.