### PR TITLE
Remove NIP 45 COUNT

### DIFF
--- a/45.md
+++ b/45.md
@@ -1,3 +1,5 @@
+> __Warning__  `unrecommended`: deprecated
+
 NIP-45
 ======
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-40: Expiration Timestamp](40.md)
 - [NIP-42: Authentication of clients to relays](42.md)
 - [NIP-44: Versioned Encryption](44.md)
-- [NIP-45: Counting results](45.md)
+- [NIP-45: Counting results](45.md) --- **unrecommended**: deprecated
 - [NIP-46: Nostr Connect](46.md)
 - [NIP-47: Wallet Connect](47.md)
 - [NIP-48: Proxy Tags](48.md)


### PR DESCRIPTION
- No non-defunct relay implementations that I'm aware of
- No active client implementations that I'm aware of (coracle has some code but doesn't use it)
- There's no way to accurately reconcile counts between multiple relays
- Increases complexity of relay implementations
- Better handled outside relays (via centralized service or DVM)
- I was the original author of COUNT