### PR TITLE
Clarify NIP-42 flow

### DIFF
--- a/42.md
+++ b/42.md
@@ -4,7 +4,7 @@ NIP-42
 Authentication of clients to relays
 -----------------------------------
 
-`draft` `optional` `author:Semisol` `author:fiatjaf`
+`draft` `optional` `author:Semisol` `author:fiatjaf` `author:arthurfranca` `author:staab`
 
 This NIP defines a way for clients to authenticate to relays by signing an ephemeral event.
 
@@ -56,7 +56,14 @@ Relays MUST exclude `kind: 22242` events from being broadcasted to any client.
 
 ## Protocol flow
 
-At any moment the relay may send an `AUTH` message to the client containing a challenge. After receiving that the client may decide to
+At any moment the relay may send an `AUTH` message to the client containing a challenge.
+
+If the relay `AUTH` message is in response to a client message that requires authentication, such as `REQ`/`EVENT`,
+the relay MUST wait for the client `AUTH` response before sending the corresponding `EOSE` or `OK` message.
+However, the relay SHOULD send a premature `EOSE` or failure `OK` message if the client doesn't respond within some time limit
+(3 minutes is a good default, considering users may take time to allow signing the `kind: 22242` event).
+
+After receiving the relay `AUTH` message, the client may decide to
 authenticate itself or not. The challenge is expected to be valid for the duration of the connection or until a next challenge is sent by
 the relay.
 


### PR DESCRIPTION
Previous discussion: #841 and #571 

Added a paragraph to NIP-42 explaining the expected flow when relay sends an AUTH in response to a client message that requires authentication. This is a important detail that wasn't guaranteed to be followed by relays. Because of that, clients couldn't rely on it.

It uses the relay "buffering" method @staab suggested.