### PR TITLE
Change kind of community post from 1 to 72

### DIFF
--- a/72.md
+++ b/72.md
@@ -48,7 +48,7 @@ Any Nostr event can be a post request. Clients MUST add the community's `a` tag 
   "id": "<32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>",
   "pubkey": "<32-bytes lowercase hex-encoded public key of the event creator>",
   "created_at": <Unix timestamp in seconds>,
-  "kind": 1,
+  "kind": 72,
   "tags": [
     ["a", "34550:<Community event author pubkey>:<d-identifier of the community>", "<Optional relay url>"],
   ],


### PR DESCRIPTION
This is a breaking change and we will all die, but hopefully it is minor enough that implementors can switch easily. And there are few enough implementations that it should be doable.

Also implementations can keep reading 1 and 72 simultaneously while creating just 72 from now on, maybe?

The thing is that having different kinds for different purposes is generally better.