### PR TITLE
using multiple independent kinds for community-scoped events

### DIFF
--- a/72.md
+++ b/72.md
@@ -14,7 +14,6 @@ The goal of this NIP is to create moderator-approved public communities around a
 
 ```json
 {
-  "created_at": <Unix timestamp in seconds>,
   "kind": 34550,
   "tags": [
     ["d", "<community-d-identifier>"],
@@ -40,11 +39,23 @@ The goal of this NIP is to create moderator-approved public communities around a
 
 # New Post Request
 
-Any Nostr event can be submitted to a community by anyone for approval. Clients MUST add the community's `a` tag to the new post event in order to be presented for the moderator's approval.
+A "post request" is an event that can be published by anyone with the intention to be displayed inside a community. Moderators will be notified of this request and decide about approving it or not. Only after approval these posts will be displayed inside the communities.
+
+Event kinds defined in other NIPs can be supported inside communities, but here we defined kind translations for them such that they don't get confused with events published outside communities.
+
+| Community-scoped Kind | Description                    | Original Kind | Original NIP |
+| ---                   | ---                            | ---           | ---          |
+| 11                    | Community post                 | 1             | 1            |
+| 10500                 | Community-scoped user metadata | 0             | 1            |
+| 10501                 | Community-scoped follow list   | 3             | 2            |
+| 4548                  | Community file metadata        | 1063          | 94           |
+| 30500                 | Community long-form article    | 23            | 23           |
+
+So, for example, in order to publish a "text note" (`kind:1`) inside a community one must use the `kind:11` instead.
 
 ```json
 {
-  "kind": 4549,
+  "kind": 11,
   "tags": [
     ["a", "34550:<community event author pubkey>:<community-d-identifier>", "<optional-relay-url>"],
   ],
@@ -52,8 +63,6 @@ Any Nostr event can be submitted to a community by anyone for approval. Clients 
   ...
 }
 ```
-
-Community management clients MAY filter all mentions to a given `kind:34550` event and request moderators to approve each submission. Moderators MAY delete his/her approval of a post at any time using event deletions (See [NIP-09](09.md)).
 
 # Post Approval by moderators
 
@@ -99,13 +108,3 @@ The following filter displays the approved posts.
 ```
 
 Clients MAY hide approvals by blocked moderators at the user's request.
-
-# Other kinds of Community-scoped Events
-
-Clients MAY decide to support multiple other kinds to be published for consumption only inside a specific community. These kinds follow the same structure defined for them in other NIPs, but with a different kind number:
-
-| Community-scoped Kind   | Original Kind   | Original NIP   |
-| ----------------------- | --------------- | -------------- |
-| 4549                    | 1               | 1              |
-| 30500                   | 23              | 23             |
-| 10500                   | 0               | 1              |

--- a/72.md
+++ b/72.md
@@ -44,7 +44,7 @@ Any Nostr event can be submitted to a community by anyone for approval. Clients 
 
 ```json
 {
-  "kind": 1,
+  "kind": 4549,
   "tags": [
     ["a", "34550:<community event author pubkey>:<community-d-identifier>", "<optional-relay-url>"],
   ],
@@ -99,3 +99,13 @@ The following filter displays the approved posts.
 ```
 
 Clients MAY hide approvals by blocked moderators at the user's request.
+
+# Other kinds of Community-scoped Events
+
+Clients MAY decide to support multiple other kinds to be published for consumption only inside a specific community. These kinds follow the same structure defined for them in other NIPs, but with a different kind number:
+
+| Community-scoped Kind   | Original Kind   | Original NIP   |
+| ----------------------- | --------------- | -------------- |
+| 4549                    | 1               | 1              |
+| 30500                   | 23              | 23             |
+| 10500                   | 0               | 1              |


### PR DESCRIPTION
Hopefully this supersedes https://github.com/nostr-protocol/nips/pull/753.

Adds a table of new possible kinds that can be published inside communities:

| Community-scoped Kind | Description                    | Original Kind | Original NIP |
| ---                   | ---                            | ---           | ---          |
| 4549                  | Community post                 | 1             | 1            |
| 10500                 | Community-scoped user metadata | 0             | 1            |
| 10501                 | Community-scoped follow list   | 3             | 2            |
| 4548                  | Community file metadata        | 1063          | 94           |
| 30500                 | Community long-form article    | 23            | 23           |

## Justification

**Why not use a single event kind with a tag indicating what other kind this event refers to (as in #743)?**

Why not have a single event kind in the entirety of Nostr and just use tags for everything? The answer is that kinds are a simple way for clients to scope what they want to handle and what they don't want to handle. They can query just what they want and that's it.

**But they can query for only the tags they want!**

Yes, but this is less efficient querying, and for what reason? For nothing.

**But I want FLEXIBILITY**

I know, programmers have this natural desire to want flexibility, but in the context of a protocol that wants to remain simple and open, flexibility is actually a heavy tax on everybody. It is much better for the health of us all if we can agree to a standard and hardcode that standard into our apps by consulting a central table of rules while in the process of writing code -- instead of having everything be dynamic and handled at runtime by the clients. Incidentally this also makes apps 0.001% faster and events 0.1% smaller (numbers made up).

The idea is that whenever someone wants to support a new event kind inside communities they come here and add a new row to the table and that's it.

@vivganes @lovvtide @vitorpamplona @mikedilger @hzrd149 @arthurfranca @reyamir
