### PR TITLE
NIP-100

### DIFF
--- a/100.md
+++ b/100.md
@@ -10,4 +10,5 @@ This document standardizes the default network port for Nostr relays, each relay
 
 # motivation
 
-This standard can help developers for selecting a default port. also users know a `nostr://` url probably is on port `4444` and the relay nodes don't need to provide port by default when providing IP address.
+This standard can help developers for selecting a default port. also users know a `nostr:` url probably is on port `4444` and the relay nodes don't need to provide port by default when providing IP address.
+Clients also can consider it as default port.

--- a/100.md
+++ b/100.md
@@ -1,0 +1,13 @@
+NIP-100
+======
+
+Default Relay Port Standard
+-----------------
+
+`optional` `author:kehiy` `author:melvincarvalho`
+
+This document standardizes the default network port for Nostr relays, each relay can serve it services on `4444` port as default.
+
+# motivation
+
+This standard can help developers for selecting a default port. also users know a `nostr://` url probably is on port `4444` and the relay nodes don't need to provide port by default when providing IP address.


### PR DESCRIPTION
This NIP specifies a default port for relay nodes.

> NOTE: The reason for choosing port 444 is it's open and not used, also some relay implementations use it now.

@melvincarvalho