### PR TITLE
For improved SEO of web clients, add canonical tag to NIPs 23 and 52.

### DIFF
--- a/23.md
+++ b/23.md
@@ -28,6 +28,7 @@ Other metadata fields can be added as tags to the event as necessary. Here we st
 - `"image"`, for a URL pointing to an image to be shown along with the title
 - `"summary"`, for the article summary
 - `"published_at"`, for the timestamp in unix seconds (stringified) of the first time the article was published
+- `"canonical"`, for the canonical url of the article. Web clients SHOULD include the `<link rel="canonical" href="URL_HERE" />` tag when returning a persistent page for the article.
 
 ### Editability
 
@@ -55,6 +56,7 @@ References to other Nostr notes, articles or profiles must be made according to 
     ["t", "placeholder"],
     ["e", "b3e392b11f5d4f28321cedd09303a748acfd0487aea5a7450b3481c60b6e4f87", "wss://relay.example.com"],
     ["a", "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum", "wss://relay.nostr.org"]
+    ["canonical", "https://example.com/preferred-url-here/"],
   ],
   "pubkey": "...",
   "id": "..."

--- a/52.md
+++ b/52.md
@@ -30,6 +30,7 @@ The list of tags are as follows:
 * `start` (required) inclusive start date in ISO 8601 format (YYYY-MM-DD). Must be less than `end`, if it exists.
 * `end` (optional) exclusive end date in ISO 8601 format (YYYY-MM-DD). If omitted, the calendar event ends on the same date as `start`.
 * `location` (optional) location of the calendar event. e.g. address, GPS coordinates, meeting room name, link to video call
+* `canonical` (optional) canonical url of the event. Web clients SHOULD include the `<link rel="canonical" href="URL_HERE" />` tag when returning a persistent page for the event.
 * `g` (optional) [geohash](https://en.wikipedia.org/wiki/Geohash) to associate calendar event with a searchable physical location
 * `p` (optional, repeated) 32-bytes hex pubkey of a participant, optional recommended relay URL, and participant's role in the meeting
 * `t` (optional, repeated) hashtag to categorize calendar event
@@ -66,6 +67,9 @@ The list of tags are as follows:
     // Reference links
     ["r", "<url>"],
     ["r", "<url>"]
+
+    // Canonical URL
+    ["canonical", "<url>"],
   ]
 }
 ```
@@ -88,6 +92,7 @@ The list of tags are as follows:
 * `start_tzid` (optional) time zone of the start timestamp, as defined by the IANA Time Zone Database. e.g., `America/Costa_Rica`
 * `end_tzid` (optional) time zone of the end timestamp, as defined by the IANA Time Zone Database. e.g., `America/Costa_Rica`. If omitted and `start_tzid` is provided, the time zone of the end timestamp is the same as the start timestamp.
 * `location` (optional) location of the calendar event. e.g. address, GPS coordinates, meeting room name, link to video call
+* `canonical` (optional) canonical url of the event. Web clients SHOULD include the `<link rel="canonical" href="URL_HERE" />` tag when returning a persistent page for the event.
 * `g` (optional) [geohash](https://en.wikipedia.org/wiki/Geohash) to associate calendar event with a searchable physical location
 * `p` (optional, repeated) 32-bytes hex pubkey of a participant, optional recommended relay URL, and participant's role in the meeting
 * `t` (optional, repeated) hashtag to categorize calendar event
@@ -127,6 +132,9 @@ The list of tags are as follows:
     // Reference links
     ["r", "<url>"],
     ["r", "<url>"]
+
+    // Canonical URL
+    ["canonical", "<url>"],
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Please update these lists when proposing NIPs introducing new event kinds.
 | `t`               | hashtag                              | --                   |                                       |
 | `amount`          | millisatoshis, stringified           | --                   | [57](57.md)                           |
 | `bolt11`          | `bolt11` invoice                     | --                   | [57](57.md)                           |
+| `canonical`       | canonical url                        | --                   | [23](23.md), [52](52.md)              |
 | `challenge`       | challenge string                     | --                   | [42](42.md)                           |
 | `content-warning` | reason                               | --                   | [36](36.md)                           |
 | `delegation`      | pubkey, conditions, delegation token | --                   | [26](26.md)                           |


### PR DESCRIPTION
When displaying Long-form Content (NIP-23) and Calendar Events (NIP-52) on web clients, there is a risk that search engines will penalize these web clients (and the original publisher of the article) due to the "duplicate content penalty". 

A simple way around this is for Nostr events to include a `canonical` tag with a single url. Then web clients can easily add the `<link rel="canonical" href="URL_HERE" />` tag to their web pages when displaying a persistent page for an article or calendar event. This shouldn't be used when displaying lots of articles or calendar events in a list, of course, just when there's a page that displays the article or calendar event by itself or as the top-most parent of the thread.

The `r` tag is insufficient for this as there could be multiple `r` tags, and they're meant to display links within the article, not necessarily the canonical url of the article itself. To mix them together would be confusing.