### PR TITLE
NIP-110: MIT license

### DIFF
--- a/110.md
+++ b/110.md
@@ -1,0 +1,63 @@
+NIP-110
+=======
+
+MIT License
+-----------
+
+`draft` `optional` `author:degenrocket`
+
+This NIP defines how to add an MIT license to Nostr events.
+
+### Problem
+
+Currently, the Nostr ecosystem is growing in a very friendly environment, but once the environment will change to hostile, relays and clients can face legal responsibilities for distributing the copyright-protected content.
+
+At the moment of writing, a user who signs a Nostr event doesn't give an explicit permission for his content to be distributed without any restriction.
+
+### Solution
+
+The easiest solution for this problem is to add an MIT license to each signed event in accordance with the [SPASM](https://github.com/degenrocket/spasm) specification.
+
+Then relays and clients can check whether events have an MIT license and choose whether to display/distribute such events or not.
+
+While adding a dedicated license field (`"license":"MIT"`) would be ideal, the easiest solution with backwards-compatibility is to add a license as a tag.
+
+```js
+tags: [
+  [
+    "license",
+    "MIT"
+  ]
+]
+```
+
+### Implementation
+
+Here is an example of adding an MIT license to each Nostr event as a tag.
+
+```js
+let nostrEvent = {
+  kind: 1,
+  created_at: Math.floor(Date.now() / 1000),
+  tags: [
+    [
+      "spasm_version",
+      "1.0.0"
+    ],
+    [
+      "spasm_target",
+      "0xbd934a01dc3bd9bb183bda807d35e61accf7396c527b8a3d029c20c00b294cf029997be953772da32483b077eea856e6bafcae7a2aff95ae572af25dd3e204a71b"
+    ],
+    [
+      "spasm_action",
+      "reply"
+    ],
+    [
+      "license",
+      "MIT"
+    ]
+  ],
+  content: "not your keys, not your words",
+  pubkey: "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9",
+}
+```


### PR DESCRIPTION
This NIP defines how to add an MIT license to Nostr events in order to protect relays and clients from potential legal responsibilities for distributing the copyright-protected content.

Currently implemented at [DegenRocket](https://degenrocket.space) and [SimplifiedPrivacy](https://vid.simplifiedprivacy.com).