### PR TITLE
Adding encryption NIP-90 Data Vending Machine

### DIFF
--- a/90.md
+++ b/90.md
@@ -91,7 +91,7 @@ This param data will be encrypted and added to the `content` field and `p` tag s
 "content": "BE2Y4xvS6HIY7TozIgbEl3sAHkdZoXyLRRkZv4fLPh3R7LtviLKAJM5qpkC7D6VtMbgIt4iNcMpLtpo...",
     "tags": [
         [`p`, `04f74530a6ede6b24731b976b8e78fb449ea61f40ff10e3d869a3030c4edc91f`],
-        [ `param`, `encrypted`, true]
+        [`encrypted`]
     ]
 
 
@@ -124,6 +124,23 @@ Service providers publish job results, providing the output of the job result. T
 ## Encrypted Output
 
 If the request has encrypted params, then output should be encrypted and placed in  `content` field with `p` tag. If the output is encrypted, then avoid including `i` tag with input-data as clear text. 
+Add a tag encrypted to mark the output content as `encrypted`
+```json
+{
+    "pubkey": "<service-provider pubkey>",
+    "content": "<encrypted payload>",
+    "kind": 6xxx,
+    "tags": [
+        [ "request", "<job-request>" ],
+        [ "e", "<job-request-id>", "<relay-hint>" ],
+        [ "p", "<customer's-pubkey>" ],
+        [ "amount", "requested-payment-amount", "<optional-bolt11>" ],
+        [`encrypted`]
+
+    ]
+}
+```
+ 
 
 ## Job feedback
 Service providers can give feedback about a job back to the customer.

--- a/90.md
+++ b/90.md
@@ -79,8 +79,8 @@ If the user wants to keep the input parameters a secret, they can encrypt the `i
     [ "param", "temperature", "0.5" ],
     [ "param", "top-k", "50" ],
     [ "param", "top-p", "0.7" ],
-    [ "param", "frequency_penalty", "1" ],
-    [ "param", "output", "encrypted"]
+    [ "param", "frequency_penalty", "1" ]
+    
 ]
 
 ```
@@ -90,8 +90,8 @@ This param data will be encrypted and added to the `content` field and `p` tag s
 ```
 "content": "BE2Y4xvS6HIY7TozIgbEl3sAHkdZoXyLRRkZv4fLPh3R7LtviLKAJM5qpkC7D6VtMbgIt4iNcMpLtpo...",
     "tags": [
-        [`p`, `04f74530a6ede6b24731b976b8e78fb449ea61f40ff10e3d869a3030c4edc91f`]
-
+        [`p`, `04f74530a6ede6b24731b976b8e78fb449ea61f40ff10e3d869a3030c4edc91f`],
+        [ `param`, `encrypted`, true]
     ]
 
 
@@ -120,6 +120,10 @@ Service providers publish job results, providing the output of the job result. T
 * `request`: The job request event stringified-JSON.
 * `amount`: millisats that the Service Provider is requesting to be paid. An optional third value can be a bolt11 invoice.
 * `i`: The original input(s) specified in the request.
+
+## Encrypted Output
+
+If the request has encrypted params, then output should be encrypted and placed in  `content` field with `p` tag. If the output is encrypted, then avoid including `i` tag with input-data as clear text. 
 
 ## Job feedback
 Service providers can give feedback about a job back to the customer.

--- a/90.md
+++ b/90.md
@@ -73,7 +73,7 @@ If the user wants to keep the input parameters a secret, they can encrypt the `i
 
 ```json
 [
-    [ "i", "what is the capital of France? ", "prompt" ],
+    [ "i", "what is the capital of France? ", "text" ],
     [ "param", "model", "LLaMA-2" ],
     [ "param", "max_tokens", "512" ],
     [ "param", "temperature", "0.5" ],

--- a/90.md
+++ b/90.md
@@ -67,6 +67,37 @@ All tags are optional.
 * `relays`: List of relays where Service Providers SHOULD publish responses to
 * `p`: Service Providers the customer is interested in. Other SPs MIGHT still choose to process the job
 
+## Encrypted Params 
+
+If the user wants to keep the input parameters a secret, they can encrypt the `i` and `param` tags with the service provider's 'p' tag and add it to the content field. The user also indicates whether the output should be encrypted or not as one of the parameters.
+
+```json
+[
+    [ "i", "what is the capital of France? ", "prompt" ],
+    [ "param", "model", "LLaMA-2" ],
+    [ "param", "max_tokens", "512" ],
+    [ "param", "temperature", "0.5" ],
+    [ "param", "top-k", "50" ],
+    [ "param", "top-p", "0.7" ],
+    [ "param", "frequency_penalty", "1" ],
+    [ "param", "output", "encrypted"]
+]
+
+```
+
+This param data will be encrypted and added to the `content` field and `p` tag should be present 
+
+```
+"content": "BE2Y4xvS6HIY7TozIgbEl3sAHkdZoXyLRRkZv4fLPh3R7LtviLKAJM5qpkC7D6VtMbgIt4iNcMpLtpo...",
+    "tags": [
+        [`p`, `04f74530a6ede6b24731b976b8e78fb449ea61f40ff10e3d869a3030c4edc91f`]
+
+    ]
+
+
+```
+
+
 ## Job result (`kind:6000-6999`)
 
 Service providers publish job results, providing the output of the job result. They should tag the original job request event id as well as the customer's pubkey.
@@ -109,6 +140,8 @@ Service providers can give feedback about a job back to the customer.
 * `content`: Either empty or a job-result (e.g. for partial-result samples)
 * `amount` tag: as defined in the [Job Result](#job-result) section.
 * `status` tag: Service Providers SHOULD indicate what this feedback status refers to. [Appendix 1](#appendix-1-job-feedback-status) defines status. Extra human-readable information can be added as an extra argument.
+
+* NOTE: If the input params requires input to be encryped, then `content` field will have encrypted payload with `p` tag as key.
 
 ### Job feedback status
 

--- a/90.md
+++ b/90.md
@@ -69,7 +69,7 @@ All tags are optional.
 
 ## Encrypted Params 
 
-If the user wants to keep the input parameters a secret, they can encrypt the `i` and `param` tags with the service provider's 'p' tag and add it to the content field. The user also indicates whether the output should be encrypted or not as one of the parameters.
+If the user wants to keep the input parameters a secret, they can encrypt the `i` and `param` tags with the service provider's 'p' tag and add it to the content field. Add a tag `encrypted` as tags. Encryption for private tags will use [NIP-04 - Encrypted Direct Message encryption](https://github.com/nostr-protocol/nips/blob/master/04.md), using the user's private and service provider's public key for the shared secret
 
 ```json
 [
@@ -90,8 +90,8 @@ This param data will be encrypted and added to the `content` field and `p` tag s
 ```
 "content": "BE2Y4xvS6HIY7TozIgbEl3sAHkdZoXyLRRkZv4fLPh3R7LtviLKAJM5qpkC7D6VtMbgIt4iNcMpLtpo...",
     "tags": [
-        [`p`, `04f74530a6ede6b24731b976b8e78fb449ea61f40ff10e3d869a3030c4edc91f`],
-        [`encrypted`]
+        ["p", "04f74530a6ede6b24731b976b8e78fb449ea61f40ff10e3d869a3030c4edc91f"],
+        ["encrypted"]
     ]
 
 
@@ -123,7 +123,7 @@ Service providers publish job results, providing the output of the job result. T
 
 ## Encrypted Output
 
-If the request has encrypted params, then output should be encrypted and placed in  `content` field with `p` tag. If the output is encrypted, then avoid including `i` tag with input-data as clear text. 
+If the request has encrypted params, then output should be encrypted and placed in  `content` field. If the output is encrypted, then avoid including `i` tag with input-data as clear text. 
 Add a tag encrypted to mark the output content as `encrypted`
 ```json
 {
@@ -135,7 +135,7 @@ Add a tag encrypted to mark the output content as `encrypted`
         [ "e", "<job-request-id>", "<relay-hint>" ],
         [ "p", "<customer's-pubkey>" ],
         [ "amount", "requested-payment-amount", "<optional-bolt11>" ],
-        [`encrypted`]
+        ["encrypted"]
 
     ]
 }


### PR DESCRIPTION
We are not able to implement NIP-90 without encrypting the generative AI parameters and results. Currently the users are using kind 4 event to communicate with AI agents. This is not useful since kind 4 events are not visible within the DVM eco system. The change requested follows the same logic as NIP-51 where the private lists are encrypted and stored on the content field. 

link to changes: https://github.com/starbackr-dev/nips/blob/patch-2/90.md

