### PR TITLE
Clarify that Whitespace is allowed in Content Field for Event Serialization

### DIFF
--- a/01.md
+++ b/01.md
@@ -29,7 +29,7 @@ The only object type that exists is the `event`, which has the following format 
 }
 ```
 
-To obtain the `event.id`, we `sha256` the serialized event. The serialization is done over the UTF-8 JSON-serialized string (with no white space or line breaks) of the following structure:
+To obtain the `event.id`, we `sha256` the serialized event. The serialization is done over the UTF-8 JSON-serialized string (with no white space or line breaks) of the following structure. Note that the `<content>`field may include whitespace and line breaks.
 
 ```json
 [
@@ -41,6 +41,7 @@ To obtain the `event.id`, we `sha256` the serialized event. The serialization is
   <content, as a string>
 ]
 ```
+
 
 ### Tags
 


### PR DESCRIPTION
This would make NIP-01 more clear and ease implementation.