### PR TITLE
Remove label annotations from NIP 32

### DIFF
--- a/32.md
+++ b/32.md
@@ -6,7 +6,7 @@ Labeling
 
 `draft` `optional` `author:staab` `author:gruruya` `author:s3x-jay`
 
-A label is a `kind 1985` event that is used to label other entities. This supports a number of use cases, from distributed moderation and content recommendations to reviews and ratings.
+A label is a `kind 1985` event that is used to label other entities. This supports a number of use cases, including distributed moderation, collection management, license assignment, and content classification.
 
 Label Target
 ----
@@ -41,16 +41,6 @@ MAY be used when the label content is provided by an end user.
 `l` and `L` tags MAY be added to other event kinds to support self-reporting. For events
 with a kind other than 1985, labels refer to the event itself.
 
-Label Annotations
------
-
-A label tag MAY include a 4th positional element detailing extra metadata about the label in question. This string
-should be a json-encoded object. Any key MAY be used, but the following are recommended:
-
-- `quality` may have a value of 0 to 1. This allows for an absolute, granular scale that can be represented in any way (5 stars, color scale, etc).
-- `confidence` may have a value of 0 to 1. This indicates the certainty which the author has about their rating.
-- `context` may be an array of urls (including NIP-21 urls) indicating other context that should be considered when interpreting labels.
-
 Content
 -------
 
@@ -83,8 +73,9 @@ A review of a relay.
   "kind": 1985,
   "tags": [
     ["L", "com.example.ontology"],
-    ["l", "relay/review", "com.example.ontology", "{\"quality\": 0.1}"],
-    ["r", <relay_url>]
+    ["l", "relay/review", "com.example.ontology"],
+    ["r", <relay_url>],
+    ["rating", "0.1"]
   ],
   "content": "This relay is full of mean people.",
   ...


### PR DESCRIPTION
I added label annotations to NIP 32 in order to support reviews as a use case. This was a mistake for the following reasons:

- It adds a 4th positional argument, which is too many
- That argument is json-encoded and therefore way too open-ended
- The suggested keys for the json object were poorly defined (especially context)

Most importantly, giving labels a `value` field transforms labels into a key-value store. This makes this NIP applicable to many more use cases (like reviews), but is a very poor fit for them. Adding a regular tag to the even can cover many of them orthogonal to NIP 32. For the rest, a different data structure should be used.

For those of you wondering why I left the `L` tag in and mandatory, they're important for the following reasons:

- `L` tags make it possible to query only the `l` tags with the meaning you want, and all labels within the namespace without knowing them in advance.
- `L` is required, with `ugc` being the default namespace so that ugc-only labels can still be queried. If we ever get REQ functionality for "doesn't have tag", we can make `L` optional.

@Gruruya @s3x-jay @rabble