### PR TITLE
Add nip for key sharing

### DIFF
--- a/86.md
+++ b/86.md
@@ -1,0 +1,51 @@
+NIP-86
+=======
+
+Shared Keys
+-----------
+
+`draft` `optional` `author:staab` `author:earonesty` `author:vitorpamplona` `author:water783`
+
+A shared key allows key holders to encrypt and decrypt messages to all other key holders. A shared key is issued by a single pubkey (the `admin`) who has sole authority to issue invitations and key rotations.
+
+This NIP relies on [NIP 59](./59.md) for event wrapping.
+
+## Key Sharing
+
+Keys are shared via a `kind 24` rumor sealed by the `admin` key, wrapped using the shared key, and addressed to each recipient individually. The rumor MUST have a single `shared_key` tag containing the shared private key.
+
+```json
+{
+  "kind": 24,
+  "content": "Just a regular key rotation",
+  "tags": [["shared_key", "<new shared key>"]],
+}
+```
+
+## Key Rotation
+
+To rotate the shared key, the `admin` must publish a new `kind 24` rumor as described above. A `grace_period` tag MAY be included on the rumor indicating how many seconds after the new event's `created_at` timestamp previous keys are valid. This invalidates previous keys and replaces them with a new shared key.
+
+An `expiration` tag (defined by NIP-40) MAY be included on the wrapper to support a weak form of forward secrecy (weak, since it relies on relays to delete the event). This can reduce the impact of a member's private key being leaked, which could otherwise expose old shared keys and messages addressed to those keys.
+
+## Using the Shared Key
+
+Anyone holding the shared key may privately post events of any kind as a rumor sealed by their own key, and signed by the shared key.
+
+# Other Notes
+
+## Admin key vulnerabilities
+
+Since ultimate control of the group lies with the holder of the admin key, the security of this key is paramount. Leakage of this key would result in complete compromise of the group, as well as the doxxing of all members who have posted to the group. Management of this key is up to the group admin, but should be taken seriously.
+
+An ideal solution would be to use an air-gapped signing mechanism to publish events, viable since the group admin need not publish often except to rotate shared keys. Also viable would be to manage key access using an nsec bunker.
+
+## Shared key vulnerabilities
+
+Any member of the group can implicitly invite new members to the group, since they have the private key (although this would have to happen out-of-band, since the private key is stored in a `rumor`). Any member of a group can dox other members by publishing their wrapped messages. Any member of the group can spam the group, or otherwise DOS the group. Any member can post anonymously to the group by sealing their messages with an alternative or ephemeral key.
+
+If any single member leaks the shared secret, all messages can then be decrypted by others until the next key rotation. The use of optional frequent forward secrecy rotation events can mitigate these attacks, provided the server is compliant with the expiration times.
+
+## Replaceable events
+
+Wrapped replaceable events can't be de-duplicated by relays. Clients SHOULD perform this deduplication manually, keeping the most recent version.


### PR DESCRIPTION
This PR adds a simple scheme for sharing keys, including simple rotation that supports weak forward secrecy. This is a prerequisite to #875.