### PR TITLE
Thread NIP

### DIFF
--- a/00.md
+++ b/00.md
@@ -8,9 +8,15 @@ Thread
 
 Defines a standard way to build and load threads.
 
+## Motivation
+
+- Avoid overloading `e`/`a` tag with meanings other than direct reference for disambiguation;
+- Enable fetching original post and reply events separately by making them different kinds;
+- Make original post editable but reference it by `id` to prevent referencing an unintended context
+
 ## Original Post
 
-The original post (OP) by default is a `kind:31111` event for social clients. It is similar to a `kind:1`
+The original post (OP) by default is a `kind:31111` event for microblogging clients. It is similar to a `kind:1`
 event because it allows just plaintext, but it is only used
 to start a thread, i.e. when not replying to another event.
 
@@ -35,7 +41,7 @@ Example:
 
 ## Reply
 
-A reply is a `kind:1` event, considering social clients. It can be another event kind for other use cases.
+A reply is a `kind:1` event, considering microblogging clients. It can be another event kind for other use cases.
 
 It MUST have an `o` tag referencing the OP's `id`, with a required recommended relay (where the OP was found).
 


### PR DESCRIPTION
It tries to fix thread building and loading with better rules to follow instead of NIP-10 ones.

[Read here](https://github.com/arthurfranca/nips/blob/thread/00.md)


This would only work with major client owners cooperation. Maybe its the last chance to fix this.