### PR TITLE
Add values to NIP 32

### DIFF
--- a/85.md
+++ b/85.md
@@ -1,0 +1,80 @@
+NIP-85
+======
+
+Semantic Tuples
+--------------
+
+`draft` `optional` `author:staab`
+
+A semantic tuple is a tag whose values are a tuple of `value`, `key`, and an optional `namespace`. This format is similar to NIP 32 labels, but are semantically different. While labels are values that can be applied to targets per se, triples are value/key doubles or value/key/namespace triples.
+
+This NIP introduces two new tags which MAY be applied to any event:
+
+- `v` is a value that relays should index
+- `value` is a value that relays should not index
+
+An event with `kind 1986` MAY be used if no other kind is appropriate.
+
+In any given tuple:
+
+- `value` can be any string. If the domain of values is large, the "value" tag SHOULD be used instead of the "v" tag so relays don't have to index values that won't be used in a filter.
+- `key` can be any string. It MAY be a `label` as defined by NIP 32.
+- `namespace` is optional, and can be any string. It MAY be a `namespace` as defined by NIP 32.
+
+Example events
+--------------
+
+An RDF triple.
+
+```json
+{
+  "kind": 1986,
+  "tags": [
+    ["v", "http://example.name#BobSmith12", "http://xmlns.com/foaf/0.1/knows", "http://example.name#JohnDoe34"]
+  ],
+}
+```
+
+An RDF triple with NIP 32 labels for indexing.
+
+```json
+{
+  "kind": 1986,
+  "tags": [
+    ["L", "http://example.name#JohnDoe34"],
+    ["l", "http://xmlns.com/foaf/0.1/knows", "http://example.name#JohnDoe34"],
+    ["v", "http://example.name#BobSmith12", "http://xmlns.com/foaf/0.1/knows", "http://example.name#JohnDoe34"]
+  ],
+}
+```
+
+A relay review with rating metadata.
+
+```json
+{
+  "kind": 1985,
+  "content": "This relay is fast!",
+  "tags": [
+    ["L", "review"],
+    ["l", "relay", "review"],
+    ["v", "+", "rating/sentiment", "review"],
+    ["value", "0.9", "rating/quality", "review"],
+    ["value", "1", "rating/confidence", "review"],
+    ["r", <relay_url>]
+  ],
+}
+```
+
+A kind 1 post with additional metadata about the subject of the post.
+
+```json
+{
+  "kind": 1,
+  "content": "Just bought a new car, check it out https://example.com/my-car.png",
+  "tags": [
+    ["v", "Ford", "make"],
+    ["v", "Pinto", "model"],
+    ["v", "1972", "year"]
+  ],
+}
+```


### PR DESCRIPTION
This PR adds values back in to NIP 32 (@fiatjaf is going to hate me for it).

The problems with the old version of label values were:

- Not indexable
- Value object keys were not well defined
- Gross json in tag position 4

The approach used here supports indexing values (if relays want to support it), without losing the ability to assign values to individual labels or use multiple namespaces in a single event.

@s3x-jay @sroertgen @rodant

Keeping this a draft until it's implemented as per the usual process.