### PR TITLE
Make NIP-51 useful again

### DIFF
--- a/51.md
+++ b/51.md
@@ -30,12 +30,12 @@ rely on them to augment the user profile or browsing experience.
 For example, _mute lists_ can contain the public keys of spammers and bad actors users don't want to see in
 their feeds or receive annoying notifications from.
 
-| name             | kind  | "d" tag         | description                                               | expected tag items                                |
-| ---              | ---   | ---             | ---                                                       | ---                                               |
-| Mute list        | 10000 |                 | things the user doesn't want to see in their feeds        | `"p"` (pubkeys), `"t"` (hashtags)                 |
-| Bookmarks list   | 30001 | `"bookmark"`    | things the user intends to save for the future            | `"e"` (kind:1 notes), `"a"` (kind:30023 articles) |
-| Pin list         | 30001 | `"pin"`         | events the user intends to showcase in their profile page | `"e"` (kind:1 notes)                              |
-| Communities list | 30001 | `"communities"` | [NIP-72](72.md) communities the user belongs to           | `"a"` (kind:34550 community definitions)          |
+| name             | kind  | description                                               | expected tag items                                |
+| ---              | ---   | ---                                                       | ---                                               |
+| Mute list        | 10000 | things the user doesn't want to see in their feeds        | `"p"` (pubkeys), `"t"` (hashtags)                 |
+| Pin list         | 10001 | events the user intends to showcase in their profile page | `"e"` (kind:1 notes)                              |
+| Bookmarks list   | 10003 | things the user intends to save for the future            | `"e"` (kind:1 notes), `"a"` (kind:30023 articles) |
+| Communities list | 10004 | [NIP-72](72.md) communities the user belongs to           | `"a"` (kind:34550 community definitions)          |
 
 ## Sets
 
@@ -59,11 +59,12 @@ Aside from their main identifier, the `"d"` tag, sets can optionally have a `"ti
 
 Some clients have used these lists in the past, but they should work on transitioning to the [standard formats](#standard-lists) above:
 
-- kind:30000 and `d` "mute"
-
-| kind  | "d" tag  | use instead            |
-| ---   | ---      | ---                    |
-| 30000 | `"mute"` | kind 10000 _mute list_ |
+| kind  | "d" tag         | use instead                   |
+| ---   | ---             | ---                           |
+| 30000 | `"mute"`        | kind 10000 _mute list_        |
+| 30001 | `"pin"`         | kind 10001 _pin list_         |
+| 30001 | `"bookmark"`    | kind 10003 _bookmarks list_   |
+| 30001 | `"communities"` | kind 10004 _communities list_ |
 
 ## Examples
 

--- a/51.md
+++ b/51.md
@@ -16,9 +16,41 @@ The kinds `30000` and `30001` have been reserved for generic lists. These must b
 
 ## Standard lists
 
-| name           | kind  | "d" tag        | description                                                                                   | expected tag items                                |
-| ---            | ---   | ---            | ---                                                                                           | ---                                               |
-| Muted list     | 30000 | `"mute"`       | things the user doesn't want to see in their feeds                                            | `"p"` (pubkeys), `"t"` (hashtags)                 |
-| Bookmarks list | 30001 | `"bookmark"`   | things the user intends to save for the future                                                | `"e"` (kind:1 notes), `"a"` (kind:30023 articles) |
-| Pin list       | 30001 | `"pin"`        | events the user intends to showcase in their profile page                                     | `"e"` (kind:1 notes)                              |
-| Relay sets     | 30002 | (user-defined) | user-defined relay groups the user can easily pick and choose from during variadic operations | `"relay"` (relay URLs)                            |
+| name             | kind  | "d" tag         | description                                                                                   | expected tag items                                |
+| ---              | ---   | ---             | ---                                                                                           | ---                                               |
+| Mute list       | 30000 | `"mute"`        | things the user doesn't want to see in their feeds                                            | `"p"` (pubkeys), `"t"` (hashtags)                 |
+| Bookmarks list   | 30001 | `"bookmark"`    | things the user intends to save for the future                                                | `"e"` (kind:1 notes), `"a"` (kind:30023 articles) |
+| Pin list         | 30001 | `"pin"`         | events the user intends to showcase in their profile page                                     | `"e"` (kind:1 notes)                              |
+| Communities list | 30001 | `"communities"` | [NIP-72](72.md) communities the user belongs to                                               | `"a"` (kind:34550 community definitions)          |
+| Relay sets       | 30002 | (user-defined)  | user-defined relay groups the user can easily pick and choose from during variadic operations | `"relay"` (relay URLs)                            |
+
+## Examples
+
+### A _Mute list_ with some public items and some encrypted items
+
+```json
+{
+  "id": "a92a316b75e44cfdc19986c634049158d4206fcc0b7b9c7ccbcdabe28beebcd0",
+  "pubkey": "854043ae8f1f97430ca8c1f1a090bdde6488bd5115c7a45307a2a212750ae4cb",
+  "created_at": 1699597889,
+  "kind": 30000,
+  "tags": [
+    ["d", "mute"],
+    ["p", "07caba282f76441955b695551c3c5c742e5b9202a3784780f8086fdcdc1da3a9"],
+    ["p", "a55c15f5e41d5aebd236eca5e0142789c5385703f1a7485aa4b38d94fd18dcc4"]
+  ],
+  "content": "TJob1dQrf2ndsmdbeGU+05HT5GMnBSx3fx8QdDY/g3NvCa7klfzgaQCmRZuo1d3WQjHDOjzSY1+MgTK5WjewFFumCcOZniWtOMSga9tJk1ky00tLoUUzyLnb1v9x95h/iT/KpkICJyAwUZ+LoJBUzLrK52wNTMt8M5jSLvCkRx8C0BmEwA/00pjOp4eRndy19H4WUUehhjfV2/VV/k4hMAjJ7Bb5Hp9xdmzmCLX9+64+MyeIQQjQAHPj8dkSsRahP7KS3MgMpjaF8nL48Bg5suZMxJayXGVp3BLtgRZx5z5nOk9xyrYk+71e2tnP9IDvSMkiSe76BcMct+m7kGVrRcavDI4n62goNNh25IpghT+a1OjjkpXt9me5wmaL7fxffV1pchdm+A7KJKIUU3kLC7QbUifF22EucRA9xiEyxETusNludBXN24O3llTbOy4vYFsq35BeZl4v1Cse7n2htZicVkItMz3wjzj1q1I1VqbnorNXFgllkRZn4/YXfTG/RMnoK/bDogRapOV+XToZ+IvsN0BqwKSUDx+ydKpci6htDRF2WDRkU+VQMqwM0CoLzy2H6A2cqyMMMD9SLRRzBg==?iv=S3rFeFr1gsYqmQA7bNnNTQ==",
+  "sig": "1173822c53261f8cffe7efbf43ba4a97a9198b3e402c2a1df130f42a8985a2d0d3430f4de350db184141e45ca844ab4e5364ea80f11d720e36357e1853dba6ca"
+}
+```
+
+## Encryption process pseudocode
+
+```scala
+val private_items = [
+  ["p", "07caba282f76441955b695551c3c5c742e5b9202a3784780f8086fdcdc1da3a9"],
+  ["a", "a55c15f5e41d5aebd236eca5e0142789c5385703f1a7485aa4b38d94fd18dcc4"],
+]
+val base64blob = nip04.encrypt(json.encode_to_string(private_items))
+event.content = base64blob
+```

--- a/51.md
+++ b/51.md
@@ -52,9 +52,9 @@ Aside from their main identifier, the `"d"` tag, sets can optionally have a `"ti
 
 | name          | kind  | description                                                                                   | expected tag items                                |
 | ---           | ---   | ---                                                                                           | ---                                               |
+| Follow sets   | 30000 | categorized groups of users a client may choose to check out in different circumstances       | `"p"` (pubkeys)                                   |
 | Relay sets    | 30002 | user-defined relay groups the user can easily pick and choose from during variadic operations | `"relay"` (relay URLs)                            |
 | Curation sets | 30004 | groups of articles picked by users as interesting and/or belonging to the same category       | `"a"` (kind:30023 articles), `"e"` (kind:1 notes) |
-| Follow sets   | 30005 | categorized groups of users a client may choose to check out in different circumstances       | `"p"` (pubkeys)                                   |
 
 ## Deprecated standard lists
 

--- a/51.md
+++ b/51.md
@@ -50,10 +50,11 @@ can be used by apps to showcase curations made by others tagged to different top
 Aside from their main identifier, the `"d"` tag, sets can optionally have a `"title"`, an `"image"` and a
 `"description"` tag that can be used to enhance their UI.
 
-| name                  | kind  | description                                                                                   | expected tag items                                |
-| ---                   | ---   | ---                                                                                           | ---                                               |
-| Relay sets            | 30002 | user-defined relay groups the user can easily pick and choose from during variadic operations | `"relay"` (relay URLs)                            |
-| Article Curation sets | 30004 | groups of articles picked by users as interesting and/or belonging to the same category       | `"a"` (kind:30023 articles), `"e"` (kind:1 notes) |
+| name          | kind  | description                                                                                   | expected tag items                                |
+| ---           | ---   | ---                                                                                           | ---                                               |
+| Relay sets    | 30002 | user-defined relay groups the user can easily pick and choose from during variadic operations | `"relay"` (relay URLs)                            |
+| Curation sets | 30004 | groups of articles picked by users as interesting and/or belonging to the same category       | `"a"` (kind:30023 articles), `"e"` (kind:1 notes) |
+| Follow sets   | 30005 | categorized groups of users a client may choose to check out in different circumstances       | `"p"` (pubkeys)                                   |
 
 ## Deprecated standard lists
 

--- a/51.md
+++ b/51.md
@@ -47,8 +47,7 @@ For example, _relay sets_ can be displayed in a dropdown UI to give users the op
 relays they will publish an event or from which relays they will read the replies to an event; _curation sets_
 can be used by apps to showcase curations made by others tagged to different topics.
 
-Aside from their main identifier, the `"d"` tag, sets can optionally have a `"name"`, a `"picture"` and an
-`"about"` tag that can be used to enhance their UI.
+Aside from their main identifier, the `"d"` tag, sets can optionally have a `"title"`, an `"image"` and a `"description"` tags that can be used to enhance their UI.
 
 | name          | kind  | description                                                                                  | expected tag items                                                                |
 | ---           | ---   | ---                                                                                          | ---                                                                               |

--- a/51.md
+++ b/51.md
@@ -18,9 +18,6 @@ stored in the `.content`.
 
 ### Generic lists
 
-The kind `30001` has been reserved for generic lists. These must be accompanied by a `d` tag identifying the
-list, but these have no standard meaning and are generally client-specific (except in the standard cases
-specified below).
 
 ## Standard lists
 

--- a/51.md
+++ b/51.md
@@ -34,6 +34,7 @@ their feeds or receive annoying notifications from.
 | Public chats   | 10005 | [NIP-28](28.md) chat channels the user is in                | `"e"` (kind:40 community definitions)                                             |
 | Blocked relays | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                            |
 | Search relays  | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                            |
+| Interests      | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a" (kind:30015 interest set)`                              |
 | Emojis         | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                  |
 
 ## Sets
@@ -55,6 +56,7 @@ Aside from their main identifier, the `"d"` tag, sets can optionally have a `"na
 | Relay sets    | 30002 | user-defined relay groups the user can easily pick and choose from during various operations | `"relay"` (relay URLs)                                                            |
 | Bookmark sets | 30003 | user-defined bookmarks categories , for when bookmarks must be in labeled separate groups    | `"e"` (kind:1 notes), `"a"` (kind:30023 articles), `"t"` (hashtags), `"r" (URLs)` |
 | Curation sets | 30004 | groups of articles picked by users as interesting and/or belonging to the same category      | `"a"` (kind:30023 articles), `"e"` (kind:1 notes)                                 |
+| Interest sets | 30015 | interest topics represented by a bunch of "hashtags"                                         | `"t"` (hashtags)                                                                  |
 | Emoji sets    | 30030 | categorized emoji groups                                                                     | `"emoji"` (see [NIP-30](30.md))                                                   |
 
 ## Deprecated standard lists

--- a/51.md
+++ b/51.md
@@ -6,148 +6,19 @@ Lists
 
 `draft` `optional` `author:fiatjaf` `author:arcbtc` `author:monlovesmango` `author:eskema` `author:gzuuus`
 
-A "list" event is defined as having a list of public and/or private tags. Public tags will be listed in the event `tags`. Private tags will be encrypted in the event `content`. Encryption for private tags will use [NIP-04 - Encrypted Direct Message](04.md) encryption, using the list author's private and public key for the shared secret. A distinct event kind should be used for each list type created.
+This NIP defines lists of things that users can create. Lists can contain references to anything, and these references can be **public** or **private**.
 
-If a list should only be defined once per user (like the "mute" list) the list is declared as a _replaceable event_. These lists may be referred to as "replaceable lists". Otherwise, the list is a _parameterized replaceable event_ and the list name will be used as the `d` tag. These lists may be referred to as "parameterized replaceable lists".
+Public items in a list are specified in the event `tags` array, while private items are specified in a JSON array that mimics the structure of the event `tags` array, but stringified and encrypted using the same scheme from [NIP-04](04.md) (the shared key is computed using the author's public and private key) and stored in the `.content`.
 
-## Replaceable List Event Example
+## Generic lists
 
-Lets say a user wants to create a 'Mute' list and has keys:
-```
-priv: fb505c65d4df950f5d28c9e4d285ee12ffaf315deef1fc24e3c7cd1e7e35f2b1
-pub: b1a5c93edcc8d586566fde53a20bdb50049a97b15483cb763854e57016e0fa3d
-```
-The user wants to publicly include these users:
+The kinds `30000` and `30001` have been reserved for generic lists. These must be accompanied by a `d` tag identifying the list, but these are generally client-specific, except in the standard cases specified below.
 
-```json
-["p", "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"],
-["p", "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245"]
-```
-and privately include these users (below is the JSON that would be encrypted and placed in the event content):
+## Standard lists
 
-```json
-[
-    ["p", "9ec7a778167afb1d30c4833de9322da0c08ba71a69e1911d5578d3144bb56437"],
-    ["p", "8c0da4862130283ff9e67d889df264177a508974e2feb96de139804ea66d6168"]
-]
-```
-
-Then the user would create a 'Mute' list event like below:
-
-```json
-{
-  "kind": 10000,
-  "tags": [
-    ["p", "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"],
-    ["p", "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245"],
-  ],
-  "content": "VezuSvWak++ASjFMRqBPWS3mK5pZ0vRLL325iuIL4S+r8n9z+DuMau5vMElz1tGC/UqCDmbzE2kwplafaFo/FnIZMdEj4pdxgptyBV1ifZpH3TEF6OMjEtqbYRRqnxgIXsuOSXaerWgpi0pm+raHQPseoELQI/SZ1cvtFqEUCXdXpa5AYaSd+quEuthAEw7V1jP+5TDRCEC8jiLosBVhCtaPpLcrm8HydMYJ2XB6Ixs=?iv=/rtV49RFm0XyFEwG62Eo9A==",
-  ...other fields
-}
-```
-
-
-## Parameterized Replaceable List Event Example
-
-Lets say a user wants to create a 'Categorized People' list of `nostr` people and has keys:
-```
-priv: fb505c65d4df950f5d28c9e4d285ee12ffaf315deef1fc24e3c7cd1e7e35f2b1
-pub: b1a5c93edcc8d586566fde53a20bdb50049a97b15483cb763854e57016e0fa3d
-```
-The user wants to publicly include these users:
-
-```json
-["p", "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"],
-["p", "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245"]
-```
-and privately include these users (below is the JSON that would be encrypted and placed in the event content):
-
-```json
-[
-    ["p", "9ec7a778167afb1d30c4833de9322da0c08ba71a69e1911d5578d3144bb56437"],
-    ["p", "8c0da4862130283ff9e67d889df264177a508974e2feb96de139804ea66d6168"]
-]
-```
-
-Then the user would create a 'Categorized People' list event like below:
-
-```json
-{
-  "kind": 30000,
-  "tags": [
-    ["d", "nostr"],
-    ["p", "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"],
-    ["p", "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245"],
-  ],
-  "content": "VezuSvWak++ASjFMRqBPWS3mK5pZ0vRLL325iuIL4S+r8n9z+DuMau5vMElz1tGC/UqCDmbzE2kwplafaFo/FnIZMdEj4pdxgptyBV1ifZpH3TEF6OMjEtqbYRRqnxgIXsuOSXaerWgpi0pm+raHQPseoELQI/SZ1cvtFqEUCXdXpa5AYaSd+quEuthAEw7V1jP+5TDRCEC8jiLosBVhCtaPpLcrm8HydMYJ2XB6Ixs=?iv=/rtV49RFm0XyFEwG62Eo9A==",
-  ...other fields
-}
-```
-
-Lets say a user wants to create a 'Categorized Bookmarks' list of `bookmarks` and has keys:
-```
-priv: fb505c65d4df950f5d28c9e4d285ee12ffaf315deef1fc24e3c7cd1e7e35f2b1
-pub: b1a5c93edcc8d586566fde53a20bdb50049a97b15483cb763854e57016e0fa3d
-```
-The user wants to publicly include these bookmarks:
-
-```json
-["e", "5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36", "wss://nostr.example.com"],
-["a", "30023:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:abcd", "wss://nostr.example.com"],
-["r", "https://github.com/nostr-protocol/nostr", "Nostr repository"],
-```
-and privately include these bookmarks (below is the JSON that would be encrypted and placed in the event content):
-
-```json
-[
-    ["r", "https://my-private.bookmark", "My private bookmark"],
-    ["a", "30001:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:abcd", "wss://nostr.example.com"],
-]
-```
-
-Then the user would create a 'Categorized Bookmarks' list event like below:
-
-```json
-{
-  "kind": 30001,
-  "tags": [
-    ["d", "bookmarks"],
-    ["e", "5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36", "wss://nostr.example.com"],
-    ["a", "30023:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:abcd", "wss://nostr.example.com"],
-    ["r", "https://github.com/nostr-protocol/nostr", "Nostr repository"],
-  ],
-  "content": "y3AyaLJfnmYr9x9Od9o4aYrmL9+Ynmsim5y2ONrU0urOTq+V81CyAthQ2mUOWE9xwGgrizhY7ILdQwWhy6FK0sA33GHtC0egUJw1zIdknPe7BZjznD570yk/8RXYgGyDKdexME+RMYykrnYFxq1+y/h00kmJg4u+Gpn+ZjmVhNYxl9b+TiBOAXG9UxnK/H0AmUqDpcldn6+j1/AiStwYZhD1UZ3jzDIk2qcCDy7MlGnYhSP+kNmG+2b0T/D1L0Z7?iv=PGJJfPE84gacAh7T0e6duQ==",
-  ...other fields
-}
-```
-
-## List Event Kinds
-
-| kind   | list type               |
-| ------ | ----------------------- |
-| 10000  | Mute                    |
-| 10001  | Pin                     |
-| 30000  | Categorized People      |
-| 30001  | Categorized Bookmarks   |
-| 30002  | Categorized Relay Sets  |
-
-
-### Mute List
-
-An event with kind `10000` is defined as a replaceable list event for listing content a user wants to mute. Any standardized tag can be included in a Mute List.
-
-### Pin List
-
-An event with kind `10001` is defined as a replaceable list event for listing content a user wants to pin. Any standardized tag can be included in a Pin List.
-
-### Categorized People List
-
-An event with kind `30000` is defined as a parameterized replaceable list event for categorizing people. The 'd' parameter for this event holds the category name of the list. The tags included in these lists MUST follow the format of kind 3 events as defined in [NIP-02 - Contact List and Petnames](02.md).
-
-### Categorized Bookmarks List
-
-An event of kind `30001` is defined as a parameterized replaceable list event for categorizing bookmarks. The 'd' parameter for this event holds the category name of the list. The bookmark lists may contain metadata tags such as 'title', 'image', 'summary' as defined in [NIP-23 - Long-form Content](23.md). Any standardized tag can be included in a Categorized Bookmark List.
-
-### Categorized Relay Set
-
-An event of kind `30002` is defined as a parameterized replaceable list event for categorizing relays. The 'd' parameter for this event holds the category name of the list. The relays lists may contain metadata tags such as 'title', 'image', 'summary' as defined in [NIP-23 - Long-form Content](23.md). These sets can be used by clients in order to determine which relays to query in different scenarios.
+| name           | kind  | "d" tag        | description                                                                                   | expected tag items                                |
+| ---            | ---   | ---            | ---                                                                                           | ---                                               |
+| Muted list     | 30000 | `"mute"`       | things the user doesn't want to see in their feeds                                            | `"p"` (pubkeys), `"t"` (hashtags)                 |
+| Bookmarks list | 30001 | `"bookmark"`   | things the user intends to save for the future                                                | `"e"` (kind:1 notes), `"a"` (kind:30023 articles) |
+| Pin list       | 30001 | `"pin"`        | events the user intends to showcase in their profile page                                     | `"e"` (kind:1 notes)                              |
+| Relay sets     | 30002 | (user-defined) | user-defined relay groups the user can easily pick and choose from during variadic operations | `"relay"` (relay URLs)                            |

--- a/51.md
+++ b/51.md
@@ -24,7 +24,7 @@ For example, _mute lists_ can contain the public keys of spammers and bad actors
 | Pinned notes   | 10001 | events the user intends to showcase in their profile page   | `"e"` (kind:1 notes)                                                              |
 | Bookmarks      | 10003 | uncategorized, "global" list of things a user wants to save | `"e"` (kind:1 notes), `"a"` (kind:30023 articles), `"t"` (hashtags), `"r" (URLs)` |
 | Communities    | 10004 | [NIP-72](72.md) communities the user belongs to             | `"a"` (kind:34550 community definitions)                                          |
-| Public chats   | 10005 | [NIP-28](28.md) chat channels the user is in                | `"e"` (kind:40 community definitions)                                             |
+| Public chats   | 10005 | [NIP-28](28.md) chat channels the user is in                | `"e"` (kind:40 channel definitions)                                             |
 | Blocked relays | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                            |
 | Search relays  | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                            |
 | Interests      | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a" (kind:30015 interest set)`                              |

--- a/51.md
+++ b/51.md
@@ -6,35 +6,64 @@ Lists
 
 `draft` `optional` `author:fiatjaf` `author:arcbtc` `author:monlovesmango` `author:eskema` `author:gzuuus`
 
-This NIP defines lists of things that users can create. Lists can contain references to anything, and these references can be **public** or **private**.
+This NIP defines lists of things that users can create. Lists can contain references to anything, and these
+references can be **public** or **private**.
 
-Public items in a list are specified in the event `tags` array, while private items are specified in a JSON array that mimics the structure of the event `tags` array, but stringified and encrypted using the same scheme from [NIP-04](04.md) (the shared key is computed using the author's public and private key) and stored in the `.content`.
+Public items in a list are specified in the event `tags` array, while private items are specified in a JSON
+array that mimics the structure of the event `tags` array, but stringified and encrypted using the same
+scheme from [NIP-04](04.md) (the shared key is computed using the author's public and private key) and
+stored in the `.content`.
 
-## Generic lists
+## Types of lists
 
-The kinds `30000` and `30001` have been reserved for generic lists. These must be accompanied by a `d` tag identifying the list, but these are generally client-specific, except in the standard cases specified below.
+### Generic lists
 
-### Standard lists
+The kind `30001` has been reserved for generic lists. These must be accompanied by a `d` tag identifying the
+list, but these have no standard meaning and are generally client-specific (except in the standard cases
+specified below).
 
-These are some standards that emerged in the wild:
+## Standard lists
+
+Users are expected to have a single list of each of these types. They have special meaning and clients may
+rely on them to augment the user profile or browsing experience.
+
+For example, _mute lists_ can contain the public keys of spammers and bad actors users don't want to see in
+their feeds or receive annoying notifications from.
 
 | name             | kind  | "d" tag         | description                                               | expected tag items                                |
 | ---              | ---   | ---             | ---                                                       | ---                                               |
-| Mute list        | 30000 | `"mute"`        | things the user doesn't want to see in their feeds        | `"p"` (pubkeys), `"t"` (hashtags)                 |
+| Mute list        | 10000 |                 | things the user doesn't want to see in their feeds        | `"p"` (pubkeys), `"t"` (hashtags)                 |
 | Bookmarks list   | 30001 | `"bookmark"`    | things the user intends to save for the future            | `"e"` (kind:1 notes), `"a"` (kind:30023 articles) |
 | Pin list         | 30001 | `"pin"`         | events the user intends to showcase in their profile page | `"e"` (kind:1 notes)                              |
 | Communities list | 30001 | `"communities"` | [NIP-72](72.md) communities the user belongs to           | `"a"` (kind:34550 community definitions)          |
 
 ## Sets
 
-Sets are lists with well-defined meaning and purpose and user-assigned `d` tags meant to be displayed in the UI. For example, _relay sets_ can be displayed in a dropdown UI to give users the option to switch to which relays they will publish an event or from which relays they will read the replies to an event; or _curation sets_ can be used by apps to showcase curations made by others tagged to different topics.
+Sets are lists with well-defined meaning that can enhance the functionality and the UI of clients that rely
+on them. Unlike standard lists, users are expected to have more than one set of each kind, therefore each of
+them must be assigned a different `"d"` identifier.
 
-Aside from their main identifier, the `"d"` tag, sets can optionally have a `"title"`, an `"image"` and a `"description"` tag that can be used to enhance their UI.
+For example, _relay sets_ can be displayed in a dropdown UI to give users the option to switch to which
+relays they will publish an event or from which relays they will read the replies to an event; _curation sets_
+can be used by apps to showcase curations made by others tagged to different topics.
 
-| name                  | kind  | description                                                                                   | expected tag items          |
-| ---                   | ---   | ---                                                                                           | ---                         |
-| Relay sets            | 30002 | user-defined relay groups the user can easily pick and choose from during variadic operations | `"relay"` (relay URLs)      |
-| Article Curation sets | 30003 | groups of articles picked by users as interesting and/or belonging to the same category       | `"a"` (kind:30023 articles) |
+Aside from their main identifier, the `"d"` tag, sets can optionally have a `"title"`, an `"image"` and a
+`"description"` tag that can be used to enhance their UI.
+
+| name                  | kind  | description                                                                                   | expected tag items                                |
+| ---                   | ---   | ---                                                                                           | ---                                               |
+| Relay sets            | 30002 | user-defined relay groups the user can easily pick and choose from during variadic operations | `"relay"` (relay URLs)                            |
+| Article Curation sets | 30004 | groups of articles picked by users as interesting and/or belonging to the same category       | `"a"` (kind:30023 articles), `"e"` (kind:1 notes) |
+
+## Deprecated standard lists
+
+Some clients have used these lists in the past, but they should work on transitioning to the [standard formats](#standard-lists) above:
+
+- kind:30000 and `d` "mute"
+
+| kind  | "d" tag  | use instead            |
+| ---   | ---      | ---                    |
+| 30000 | `"mute"` | kind 10000 _mute list_ |
 
 ## Examples
 
@@ -45,14 +74,75 @@ Aside from their main identifier, the `"d"` tag, sets can optionally have a `"ti
   "id": "a92a316b75e44cfdc19986c634049158d4206fcc0b7b9c7ccbcdabe28beebcd0",
   "pubkey": "854043ae8f1f97430ca8c1f1a090bdde6488bd5115c7a45307a2a212750ae4cb",
   "created_at": 1699597889,
-  "kind": 30000,
+  "kind": 10000,
   "tags": [
-    ["d", "mute"],
     ["p", "07caba282f76441955b695551c3c5c742e5b9202a3784780f8086fdcdc1da3a9"],
     ["p", "a55c15f5e41d5aebd236eca5e0142789c5385703f1a7485aa4b38d94fd18dcc4"]
   ],
   "content": "TJob1dQrf2ndsmdbeGU+05HT5GMnBSx3fx8QdDY/g3NvCa7klfzgaQCmRZuo1d3WQjHDOjzSY1+MgTK5WjewFFumCcOZniWtOMSga9tJk1ky00tLoUUzyLnb1v9x95h/iT/KpkICJyAwUZ+LoJBUzLrK52wNTMt8M5jSLvCkRx8C0BmEwA/00pjOp4eRndy19H4WUUehhjfV2/VV/k4hMAjJ7Bb5Hp9xdmzmCLX9+64+MyeIQQjQAHPj8dkSsRahP7KS3MgMpjaF8nL48Bg5suZMxJayXGVp3BLtgRZx5z5nOk9xyrYk+71e2tnP9IDvSMkiSe76BcMct+m7kGVrRcavDI4n62goNNh25IpghT+a1OjjkpXt9me5wmaL7fxffV1pchdm+A7KJKIUU3kLC7QbUifF22EucRA9xiEyxETusNludBXN24O3llTbOy4vYFsq35BeZl4v1Cse7n2htZicVkItMz3wjzj1q1I1VqbnorNXFgllkRZn4/YXfTG/RMnoK/bDogRapOV+XToZ+IvsN0BqwKSUDx+ydKpci6htDRF2WDRkU+VQMqwM0CoLzy2H6A2cqyMMMD9SLRRzBg==?iv=S3rFeFr1gsYqmQA7bNnNTQ==",
   "sig": "1173822c53261f8cffe7efbf43ba4a97a9198b3e402c2a1df130f42a8985a2d0d3430f4de350db184141e45ca844ab4e5364ea80f11d720e36357e1853dba6ca"
+}
+```
+
+### A _communities list_ with just public items
+
+```json
+{
+  "id": "da6b18c5452b5a60bf49588fc13ae4d1a047519c13e49a77b3184e6188c7bb1c",
+  "pubkey": "83fd07de9b763334cc9d46f2785c2558e6c2eabfe7d0c6ec214667cbaec50d47",
+  "created_at": 1689082210,
+  "kind": 30001,
+  "tags": [
+    [
+      "d",
+      "communities"
+    ],
+    [
+      "a",
+      "34550:83fd07de9b763334cc9d46f2785c2558e6c2eabfe7d0c6ec214667cbaec50d47:meme"
+    ],
+    [
+      "a",
+      "34550:b9a537523bba2fcdae857d90d8a760de4f2139c9f90d986f747ce7d0ec0d173d:NoBullshitBitcoin"
+    ]
+  ],
+  "content": "",
+  "sig": "e400cc8bf24955243137e4456b22142fdff400a7950cf0b0ac2ee86ed78671e2fddf9a9b40c77ccf8397f9c21d608b3fab3678ff13713fc3f97a4394cf766079"
+}
+```
+
+### A _curation set_ of articles and notes about yaks
+
+```
+{
+  "id": "567b41fc9060c758c4216fe5f8d3df7c57daad7ae757fa4606f0c39d4dd220ef",
+  "pubkey": "d6dc95542e18b8b7aec2f14610f55c335abebec76f3db9e58c254661d0593a0c",
+  "created_at": 1695327657,
+  "kind": 30004,
+  "tags": [
+    [
+      "d",
+      "jvdy9i4"
+    ],
+    [
+      "title",
+      "Yaks"
+    ],
+    [
+      "summary",
+      "The domestic yak, also known as the Tartary ox, grunting ox, or hairy cattle, is a species of long-haired domesticated cattle found throughout the Himalayan region of the Indian subcontinent, the Tibetan Plateau, Gilgit-Baltistan, Tajikistan and as far north as Mongolia and Siberia."
+    ],
+    [
+      "image",
+      "https://cdn.britannica.com/40/188540-050-9AC748DE/Yak-Himalayas-Nepal.jpg"
+    ],
+    ["a", "30023:26dc95542e18b8b7aec2f14610f55c335abebec76f3db9e58c254661d0593a0c:95ODQzw3ajNoZ8SyMDOzQ"],
+    ["a", "30023:54af95542e18b8b7aec2f14610f55c335abebec76f3db9e58c254661d0593a0c:1-MYP8dAhramH9J5gJWKx"],
+    ["a", "30023:f8fe95542e18b8b7aec2f14610f55c335abebec76f3db9e58c254661d0593a0c:D2Tbd38bGrFvU0bIbvSMt"],
+    ["e", "d78ba0d5dce22bfff9db0a9e996c9ef27e2c91051de0c4e1da340e0326b4941e"]
+  ],
+  "content": "",
+  "sig": "a9a4e2192eede77e6c9d24ddfab95ba3ff7c03fbd07ad011fff245abea431fb4d3787c2d04aad001cb039cb8de91d83ce30e9a94f82ac3c5a2372aa1294a96bd"
 }
 ```
 

--- a/51.md
+++ b/51.md
@@ -25,16 +25,16 @@ browsing experience.
 For example, _mute lists_ can contain the public keys of spammers and bad actors users don't want to see in
 their feeds or receive annoying notifications from.
 
-| name           | kind  | description                                               | expected tag items                                                              |
-| ---            | ---   | ---                                                       | ---                                                                             |
-| Mute list      | 10000 | things the user doesn't want to see in their feeds        | `"p"` (pubkeys), `"t"` (hashtags), `"word"` (lowercase string), `"e"` (threads) |
-| Pinned notes   | 10001 | events the user intends to showcase in their profile page | `"e"` (kind:1 notes)                                                            |
-| Bookmarks      | 10003 | things the user intends to save for the future            | `"e"` (kind:1 notes), `"a"` (kind:30023 articles)                               |
-| Communities    | 10004 | [NIP-72](72.md) communities the user belongs to           | `"a"` (kind:34550 community definitions)                                        |
-| Public chats   | 10005 | [NIP-28](28.md) chat channels the user is in              | `"e"` (kind:40 community definitions)                                           |
-| Blocked relays | 10006 | relays clients should never connect to                    | `"relay"` (relay URLs)                                                          |
-| Search relays  | 10007 | relays clients should use when performing search queries  | `"relay"` (relay URLs)                                                          |
-| Emojis         | 10030 | user preferred emojis and pointers to emoji sets          | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                |
+| name           | kind  | description                                                 | expected tag items                                                                |
+| ---            | ---   | ---                                                         | ---                                                                               |
+| Mute list      | 10000 | things the user doesn't want to see in their feeds          | `"p"` (pubkeys), `"t"` (hashtags), `"word"` (lowercase string), `"e"` (threads)   |
+| Pinned notes   | 10001 | events the user intends to showcase in their profile page   | `"e"` (kind:1 notes)                                                              |
+| Bookmarks      | 10003 | uncategorized, "global" list of things a user wants to save | `"e"` (kind:1 notes), `"a"` (kind:30023 articles), `"t"` (hashtags), `"r" (URLs)` |
+| Communities    | 10004 | [NIP-72](72.md) communities the user belongs to             | `"a"` (kind:34550 community definitions)                                          |
+| Public chats   | 10005 | [NIP-28](28.md) chat channels the user is in                | `"e"` (kind:40 community definitions)                                             |
+| Blocked relays | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                            |
+| Search relays  | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                            |
+| Emojis         | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                  |
 
 ## Sets
 
@@ -49,12 +49,13 @@ can be used by apps to showcase curations made by others tagged to different top
 Aside from their main identifier, the `"d"` tag, sets can optionally have a `"name"`, a `"picture"` and an
 `"about"` tag that can be used to enhance their UI.
 
-| name          | kind  | description                                                                                   | expected tag items                                |
-| ---           | ---   | ---                                                                                           | ---                                               |
-| Follow sets   | 30000 | categorized groups of users a client may choose to check out in different circumstances       | `"p"` (pubkeys)                                   |
-| Relay sets    | 30002 | user-defined relay groups the user can easily pick and choose from during variadic operations | `"relay"` (relay URLs)                            |
-| Curation sets | 30004 | groups of articles picked by users as interesting and/or belonging to the same category       | `"a"` (kind:30023 articles), `"e"` (kind:1 notes) |
-| Emoji sets    | 30030 | categorized emoji groups                                                                      | `"emoji"` (see [NIP-30](30.md))                   |
+| name          | kind  | description                                                                                  | expected tag items                                                                |
+| ---           | ---   | ---                                                                                          | ---                                                                               |
+| Follow sets   | 30000 | categorized groups of users a client may choose to check out in different circumstances      | `"p"` (pubkeys)                                                                   |
+| Relay sets    | 30002 | user-defined relay groups the user can easily pick and choose from during various operations | `"relay"` (relay URLs)                                                            |
+| Bookmark sets | 30003 | user-defined bookmarks categories , for when bookmarks must be in labeled separate groups    | `"e"` (kind:1 notes), `"a"` (kind:30023 articles), `"t"` (hashtags), `"r" (URLs)` |
+| Curation sets | 30004 | groups of articles picked by users as interesting and/or belonging to the same category      | `"a"` (kind:30023 articles), `"e"` (kind:1 notes)                                 |
+| Emoji sets    | 30030 | categorized emoji groups                                                                     | `"emoji"` (see [NIP-30](30.md))                                                   |
 
 ## Deprecated standard lists
 

--- a/51.md
+++ b/51.md
@@ -14,19 +14,31 @@ Public items in a list are specified in the event `tags` array, while private it
 
 The kinds `30000` and `30001` have been reserved for generic lists. These must be accompanied by a `d` tag identifying the list, but these are generally client-specific, except in the standard cases specified below.
 
-## Standard lists
+### Standard lists
 
-| name             | kind  | "d" tag         | description                                                                                   | expected tag items                                |
-| ---              | ---   | ---             | ---                                                                                           | ---                                               |
-| Mute list       | 30000 | `"mute"`        | things the user doesn't want to see in their feeds                                            | `"p"` (pubkeys), `"t"` (hashtags)                 |
-| Bookmarks list   | 30001 | `"bookmark"`    | things the user intends to save for the future                                                | `"e"` (kind:1 notes), `"a"` (kind:30023 articles) |
-| Pin list         | 30001 | `"pin"`         | events the user intends to showcase in their profile page                                     | `"e"` (kind:1 notes)                              |
-| Communities list | 30001 | `"communities"` | [NIP-72](72.md) communities the user belongs to                                               | `"a"` (kind:34550 community definitions)          |
-| Relay sets       | 30002 | (user-defined)  | user-defined relay groups the user can easily pick and choose from during variadic operations | `"relay"` (relay URLs)                            |
+These are some standards that emerged in the wild:
+
+| name             | kind  | "d" tag         | description                                               | expected tag items                                |
+| ---              | ---   | ---             | ---                                                       | ---                                               |
+| Mute list        | 30000 | `"mute"`        | things the user doesn't want to see in their feeds        | `"p"` (pubkeys), `"t"` (hashtags)                 |
+| Bookmarks list   | 30001 | `"bookmark"`    | things the user intends to save for the future            | `"e"` (kind:1 notes), `"a"` (kind:30023 articles) |
+| Pin list         | 30001 | `"pin"`         | events the user intends to showcase in their profile page | `"e"` (kind:1 notes)                              |
+| Communities list | 30001 | `"communities"` | [NIP-72](72.md) communities the user belongs to           | `"a"` (kind:34550 community definitions)          |
+
+## Sets
+
+Sets are lists with well-defined meaning and purpose and user-assigned `d` tags meant to be displayed in the UI. For example, _relay sets_ can be displayed in a dropdown UI to give users the option to switch to which relays they will publish an event or from which relays they will read the replies to an event; or _curation sets_ can be used by apps to showcase curations made by others tagged to different topics.
+
+Aside from their main identifier, the `"d"` tag, sets can optionally have a `"title"`, an `"image"` and a `"description"` tag that can be used to enhance their UI.
+
+| name                  | kind  | description                                                                                   | expected tag items          |
+| ---                   | ---   | ---                                                                                           | ---                         |
+| Relay sets            | 30002 | user-defined relay groups the user can easily pick and choose from during variadic operations | `"relay"` (relay URLs)      |
+| Article Curation sets | 30003 | groups of articles picked by users as interesting and/or belonging to the same category       | `"a"` (kind:30023 articles) |
 
 ## Examples
 
-### A _Mute list_ with some public items and some encrypted items
+### A _mute list_ with some public items and some encrypted items
 
 ```json
 {

--- a/51.md
+++ b/51.md
@@ -86,33 +86,6 @@ Some clients have used these lists in the past, but they should work on transiti
 }
 ```
 
-### A _communities list_ with just public items
-
-```json
-{
-  "id": "da6b18c5452b5a60bf49588fc13ae4d1a047519c13e49a77b3184e6188c7bb1c",
-  "pubkey": "83fd07de9b763334cc9d46f2785c2558e6c2eabfe7d0c6ec214667cbaec50d47",
-  "created_at": 1689082210,
-  "kind": 30001,
-  "tags": [
-    [
-      "d",
-      "communities"
-    ],
-    [
-      "a",
-      "34550:83fd07de9b763334cc9d46f2785c2558e6c2eabfe7d0c6ec214667cbaec50d47:meme"
-    ],
-    [
-      "a",
-      "34550:b9a537523bba2fcdae857d90d8a760de4f2139c9f90d986f747ce7d0ec0d173d:NoBullshitBitcoin"
-    ]
-  ],
-  "content": "",
-  "sig": "e400cc8bf24955243137e4456b22142fdff400a7950cf0b0ac2ee86ed78671e2fddf9a9b40c77ccf8397f9c21d608b3fab3678ff13713fc3f97a4394cf766079"
-}
-```
-
 ### A _curation set_ of articles and notes about yaks
 
 ```

--- a/51.md
+++ b/51.md
@@ -16,9 +16,6 @@ stored in the `.content`.
 
 ## Types of lists
 
-### Generic lists
-
-
 ## Standard lists
 
 Standard lists use non-parameterized replaceable events, meaning users may only have a single list
@@ -28,12 +25,16 @@ browsing experience.
 For example, _mute lists_ can contain the public keys of spammers and bad actors users don't want to see in
 their feeds or receive annoying notifications from.
 
-| name             | kind  | description                                               | expected tag items                                |
-| ---              | ---   | ---                                                       | ---                                               |
-| Mute list        | 10000 | things the user doesn't want to see in their feeds        | `"p"` (pubkeys), `"t"` (hashtags)                 |
-| Pin list         | 10001 | events the user intends to showcase in their profile page | `"e"` (kind:1 notes)                              |
-| Bookmarks list   | 10003 | things the user intends to save for the future            | `"e"` (kind:1 notes), `"a"` (kind:30023 articles) |
-| Communities list | 10004 | [NIP-72](72.md) communities the user belongs to           | `"a"` (kind:34550 community definitions)          |
+| name           | kind  | description                                               | expected tag items                                                              |
+| ---            | ---   | ---                                                       | ---                                                                             |
+| Mute list      | 10000 | things the user doesn't want to see in their feeds        | `"p"` (pubkeys), `"t"` (hashtags), `"word"` (lowercase string), `"e"` (threads) |
+| Pinned notes   | 10001 | events the user intends to showcase in their profile page | `"e"` (kind:1 notes)                                                            |
+| Bookmarks      | 10003 | things the user intends to save for the future            | `"e"` (kind:1 notes), `"a"` (kind:30023 articles)                               |
+| Communities    | 10004 | [NIP-72](72.md) communities the user belongs to           | `"a"` (kind:34550 community definitions)                                        |
+| Public chats   | 10005 | [NIP-28](28.md) chat channels the user is in              | `"e"` (kind:40 community definitions)                                           |
+| Blocked relays | 10006 | relays clients should never connect to                    | `"relay"` (relay URLs)                                                          |
+| Search relays  | 10007 | relays clients should use when performing search queries  | `"relay"` (relay URLs)                                                          |
+| Emojis         | 10030 | user preferred emojis and pointers to emoji sets          | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                |
 
 ## Sets
 
@@ -45,18 +46,19 @@ For example, _relay sets_ can be displayed in a dropdown UI to give users the op
 relays they will publish an event or from which relays they will read the replies to an event; _curation sets_
 can be used by apps to showcase curations made by others tagged to different topics.
 
-Aside from their main identifier, the `"d"` tag, sets can optionally have a `"title"`, an `"image"` and a
-`"description"` tag that can be used to enhance their UI.
+Aside from their main identifier, the `"d"` tag, sets can optionally have a `"name"`, a `"picture"` and an
+`"about"` tag that can be used to enhance their UI.
 
 | name          | kind  | description                                                                                   | expected tag items                                |
 | ---           | ---   | ---                                                                                           | ---                                               |
 | Follow sets   | 30000 | categorized groups of users a client may choose to check out in different circumstances       | `"p"` (pubkeys)                                   |
 | Relay sets    | 30002 | user-defined relay groups the user can easily pick and choose from during variadic operations | `"relay"` (relay URLs)                            |
 | Curation sets | 30004 | groups of articles picked by users as interesting and/or belonging to the same category       | `"a"` (kind:30023 articles), `"e"` (kind:1 notes) |
+| Emoji sets    | 30030 | categorized emoji groups                                                                      | `"emoji"` (see [NIP-30](30.md))                   |
 
 ## Deprecated standard lists
 
-Some clients have used these lists in the past, but they should work on transitioning to the [standard formats](#standard-lists) above:
+Some clients have used these lists in the past, but they should work on transitioning to the [standard formats](#standard-lists) above.
 
 | kind  | "d" tag         | use instead                   |
 | ---   | ---             | ---                           |
@@ -93,22 +95,10 @@ Some clients have used these lists in the past, but they should work on transiti
   "created_at": 1695327657,
   "kind": 30004,
   "tags": [
-    [
-      "d",
-      "jvdy9i4"
-    ],
-    [
-      "title",
-      "Yaks"
-    ],
-    [
-      "summary",
-      "The domestic yak, also known as the Tartary ox, grunting ox, or hairy cattle, is a species of long-haired domesticated cattle found throughout the Himalayan region of the Indian subcontinent, the Tibetan Plateau, Gilgit-Baltistan, Tajikistan and as far north as Mongolia and Siberia."
-    ],
-    [
-      "image",
-      "https://cdn.britannica.com/40/188540-050-9AC748DE/Yak-Himalayas-Nepal.jpg"
-    ],
+    ["d", "jvdy9i4"],
+    ["name", "Yaks"],
+    ["picture", "https://cdn.britannica.com/40/188540-050-9AC748DE/Yak-Himalayas-Nepal.jpg"],
+    ["about", "The domestic yak, also known as the Tartary ox, grunting ox, or hairy cattle, is a species of long-haired domesticated cattle found throughout the Himalayan region of the Indian subcontinent, the Tibetan Plateau, Gilgit-Baltistan, Tajikistan and as far north as Mongolia and Siberia."],
     ["a", "30023:26dc95542e18b8b7aec2f14610f55c335abebec76f3db9e58c254661d0593a0c:95ODQzw3ajNoZ8SyMDOzQ"],
     ["a", "30023:54af95542e18b8b7aec2f14610f55c335abebec76f3db9e58c254661d0593a0c:1-MYP8dAhramH9J5gJWKx"],
     ["a", "30023:f8fe95542e18b8b7aec2f14610f55c335abebec76f3db9e58c254661d0593a0c:D2Tbd38bGrFvU0bIbvSMt"],

--- a/51.md
+++ b/51.md
@@ -21,8 +21,9 @@ stored in the `.content`.
 
 ## Standard lists
 
-Users are expected to have a single list of each of these types. They have special meaning and clients may
-rely on them to augment the user profile or browsing experience.
+Standard lists use non-parameterized replaceable events, meaning users may only have a single list
+of each kind. They have special meaning and clients may rely on them to augment a user's profile or
+browsing experience.
 
 For example, _mute lists_ can contain the public keys of spammers and bad actors users don't want to see in
 their feeds or receive annoying notifications from.

--- a/51.md
+++ b/51.md
@@ -6,24 +6,17 @@ Lists
 
 `draft` `optional` `author:fiatjaf` `author:arcbtc` `author:monlovesmango` `author:eskema` `author:gzuuus`
 
-This NIP defines lists of things that users can create. Lists can contain references to anything, and these
-references can be **public** or **private**.
+This NIP defines lists of things that users can create. Lists can contain references to anything, and these references can be **public** or **private**.
 
-Public items in a list are specified in the event `tags` array, while private items are specified in a JSON
-array that mimics the structure of the event `tags` array, but stringified and encrypted using the same
-scheme from [NIP-04](04.md) (the shared key is computed using the author's public and private key) and
-stored in the `.content`.
+Public items in a list are specified in the event `tags` array, while private items are specified in a JSON array that mimics the structure of the event `tags` array, but stringified and encrypted using the same scheme from [NIP-04](04.md) (the shared key is computed using the author's public and private key) and stored in the `.content`.
 
 ## Types of lists
 
 ## Standard lists
 
-Standard lists use non-parameterized replaceable events, meaning users may only have a single list
-of each kind. They have special meaning and clients may rely on them to augment a user's profile or
-browsing experience.
+Standard lists use non-parameterized replaceable events, meaning users may only have a single list of each kind. They have special meaning and clients may rely on them to augment a user's profile or browsing experience.
 
-For example, _mute lists_ can contain the public keys of spammers and bad actors users don't want to see in
-their feeds or receive annoying notifications from.
+For example, _mute lists_ can contain the public keys of spammers and bad actors users don't want to see in their feeds or receive annoying notifications from.
 
 | name           | kind  | description                                                 | expected tag items                                                                |
 | ---            | ---   | ---                                                         | ---                                                                               |
@@ -39,13 +32,9 @@ their feeds or receive annoying notifications from.
 
 ## Sets
 
-Sets are lists with well-defined meaning that can enhance the functionality and the UI of clients that rely
-on them. Unlike standard lists, users are expected to have more than one set of each kind, therefore each of
-them must be assigned a different `"d"` identifier.
+Sets are lists with well-defined meaning that can enhance the functionality and the UI of clients that rely on them. Unlike standard lists, users are expected to have more than one set of each kind, therefore each of them must be assigned a different `"d"` identifier.
 
-For example, _relay sets_ can be displayed in a dropdown UI to give users the option to switch to which
-relays they will publish an event or from which relays they will read the replies to an event; _curation sets_
-can be used by apps to showcase curations made by others tagged to different topics.
+For example, _relay sets_ can be displayed in a dropdown UI to give users the option to switch to which relays they will publish an event or from which relays they will read the replies to an event; _curation sets_ can be used by apps to showcase curations made by others tagged to different topics.
 
 Aside from their main identifier, the `"d"` tag, sets can optionally have a `"title"`, an `"image"` and a `"description"` tags that can be used to enhance their UI.
 

--- a/README.md
+++ b/README.md
@@ -74,66 +74,65 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-99: Classified Listings](99.md)
 
 ## Event Kinds
-| kind          | description                | NIP         |
-| ------------- | -------------------------- | ----------- |
-| `0`           | Metadata                   | [1](01.md)  |
-| `1`           | Short Text Note            | [1](01.md)  |
-| `2`           | Recommend Relay            |             |
-| `3`           | Contacts                   | [2](02.md)  |
-| `4`           | Encrypted Direct Messages  | [4](04.md)  |
-| `5`           | Event Deletion             | [9](09.md)  |
-| `6`           | Repost                     | [18](18.md) |
-| `7`           | Reaction                   | [25](25.md) |
-| `8`           | Badge Award                | [58](58.md) |
-| `16`          | Generic Repost             | [18](18.md) |
-| `40`          | Channel Creation           | [28](28.md) |
-| `41`          | Channel Metadata           | [28](28.md) |
-| `42`          | Channel Message            | [28](28.md) |
-| `43`          | Channel Hide Message       | [28](28.md) |
-| `44`          | Channel Mute User          | [28](28.md) |
-| `1063`        | File Metadata              | [94](94.md) |
-| `1311`        | Live Chat Message          | [53](53.md) |
-| `1040`        | OpenTimestamps             | [03](03.md) |
+| kind          | description                | NIP                                                              |
+| ------------- | -------------------------- | -----------                                                      |
+| `0`           | Metadata                   | [1](01.md)                                                       |
+| `1`           | Short Text Note            | [1](01.md)                                                       |
+| `2`           | Recommend Relay            |                                                                  |
+| `3`           | Contacts                   | [2](02.md)                                                       |
+| `4`           | Encrypted Direct Messages  | [4](04.md)                                                       |
+| `5`           | Event Deletion             | [9](09.md)                                                       |
+| `6`           | Repost                     | [18](18.md)                                                      |
+| `7`           | Reaction                   | [25](25.md)                                                      |
+| `8`           | Badge Award                | [58](58.md)                                                      |
+| `16`          | Generic Repost             | [18](18.md)                                                      |
+| `40`          | Channel Creation           | [28](28.md)                                                      |
+| `41`          | Channel Metadata           | [28](28.md)                                                      |
+| `42`          | Channel Message            | [28](28.md)                                                      |
+| `43`          | Channel Hide Message       | [28](28.md)                                                      |
+| `44`          | Channel Mute User          | [28](28.md)                                                      |
+| `1063`        | File Metadata              | [94](94.md)                                                      |
+| `1311`        | Live Chat Message          | [53](53.md)                                                      |
+| `1040`        | OpenTimestamps             | [03](03.md)                                                      |
 | `1971`        | Problem Tracker            | [1971](https://github.com/nostrocket/NIPS/blob/main/Problems.md) |
-| `1984`        | Reporting                  | [56](56.md) |
-| `1985`        | Label                      | [32](32.md) |
-| `4550`        | Community Post Approval    | [72](72.md) |
-| `5000`-`5999` | Job Request                | [90](90.md) |
-| `6000`-`6999` | Job Result                 | [90](90.md) |
-| `7000`        | Job Feedback               | [90](90.md) |
-| `9041`        | Zap Goal                   | [75](75.md) |
-| `9734`        | Zap Request                | [57](57.md) |
-| `9735`        | Zap                        | [57](57.md) |
-| `9802`        | Highlights                 | [84](84.md) |
-| `10000`       | Mute List                  | [51](51.md) |
-| `10001`       | Pin List                   | [51](51.md) |
-| `10002`       | Relay List Metadata        | [65](65.md) |
-| `13194`       | Wallet Info                | [47](47.md) |
-| `22242`       | Client Authentication      | [42](42.md) |
-| `23194`       | Wallet Request             | [47](47.md) |
-| `23195`       | Wallet Response            | [47](47.md) |
-| `24133`       | Nostr Connect              | [46](46.md) |
-| `27235`       | HTTP Auth                  | [98](98.md) |
-| `30000`       | Categorized People List    | [51](51.md) |
-| `30001`       | Categorized Bookmark List  | [51](51.md) |
-| `30008`       | Profile Badges             | [58](58.md) |
-| `30009`       | Badge Definition           | [58](58.md) |
-| `30017`       | Create or update a stall   | [15](15.md) |
-| `30018`       | Create or update a product | [15](15.md) |
-| `30023`       | Long-form Content          | [23](23.md) |
-| `30024`       | Draft Long-form Content    | [23](23.md) |
-| `30078`       | Application-specific Data  | [78](78.md) |
-| `30311`       | Live Event                 | [53](53.md) |
-| `30315`       | User Statuses              | [38](38.md) |
-| `30402`       | Classified Listing         | [99](99.md) |
-| `30403`       | Draft Classified Listing   | [99](99.md) |
-| `31922`       | Date-Based Calendar Event  | [52](52.md) |
-| `31923`       | Time-Based Calendar Event  | [52](52.md) |
-| `31924`       | Calendar                   | [52](52.md) |
-| `31925`       | Calendar Event RSVP        | [52](52.md) |
-| `31989`       | Handler recommendation     | [89](89.md) |
-| `31990`       | Handler information        | [89](89.md) |
-| `34550`       | Community Definition       | [72](72.md) |
+| `1984`        | Reporting                  | [56](56.md)                                                      |
+| `1985`        | Label                      | [32](32.md)                                                      |
+| `4550`        | Community Post Approval    | [72](72.md)                                                      |
+| `5000`-`5999` | Job Request                | [90](90.md)                                                      |
+| `6000`-`6999` | Job Result                 | [90](90.md)                                                      |
+| `7000`        | Job Feedback               | [90](90.md)                                                      |
+| `9041`        | Zap Goal                   | [75](75.md)                                                      |
+| `9734`        | Zap Request                | [57](57.md)                                                      |
+| `9735`        | Zap                        | [57](57.md)                                                      |
+| `9802`        | Highlights                 | [84](84.md)                                                      |
+| `10002`       | Relay List Metadata        | [65](65.md)                                                      |
+| `13194`       | Wallet Info                | [47](47.md)                                                      |
+| `22242`       | Client Authentication      | [42](42.md)                                                      |
+| `23194`       | Wallet Request             | [47](47.md)                                                      |
+| `23195`       | Wallet Response            | [47](47.md)                                                      |
+| `24133`       | Nostr Connect              | [46](46.md)                                                      |
+| `27235`       | HTTP Auth                  | [98](98.md)                                                      |
+| `30000`       | People List                | [51](51.md)                                                      |
+| `30001`       | Things List                | [51](51.md)                                                      |
+| `30002`       | Relay Set                  | [51](51.md)                                                      |
+| `30008`       | Profile Badges             | [58](58.md)                                                      |
+| `30009`       | Badge Definition           | [58](58.md)                                                      |
+| `30017`       | Create or update a stall   | [15](15.md)                                                      |
+| `30018`       | Create or update a product | [15](15.md)                                                      |
+| `30023`       | Long-form Content          | [23](23.md)                                                      |
+| `30024`       | Draft Long-form Content    | [23](23.md)                                                      |
+| `30078`       | Application-specific Data  | [78](78.md)                                                      |
+| `30311`       | Live Event                 | [53](53.md)                                                      |
+| `30315`       | User Statuses              | [38](38.md)                                                      |
+| `30402`       | Classified Listing         | [99](99.md)                                                      |
+| `30403`       | Draft Classified Listing   | [99](99.md)                                                      |
+| `31922`       | Date-Based Calendar Event  | [52](52.md)                                                      |
+| `31923`       | Time-Based Calendar Event  | [52](52.md)                                                      |
+| `31924`       | Calendar                   | [52](52.md)                                                      |
+| `31925`       | Calendar Event RSVP        | [52](52.md)                                                      |
+| `31989`       | Handler recommendation     | [89](89.md)                                                      |
+| `31990`       | Handler information        | [89](89.md)                                                      |
+| `34550`       | Community Definition       | [72](72.md)                                                      |
 
 ## Message types
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `10005`       | Public chats list          | [51](51.md)                        |
 | `10006`       | Blocked relays list        | [51](51.md)                        |
 | `10007`       | Search relays list         | [51](51.md)                        |
+| `10015`       | Interests list             | [51](51.md)                        |
 | `10030`       | User emoji list            | [51](51.md)                        |
 | `13194`       | Wallet Info                | [47](47.md)                        |
 | `22242`       | Client Authentication      | [42](42.md)                        |
@@ -127,6 +128,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `30004`       | Curation sets              | [51](51.md)                        |
 | `30008`       | Profile Badges             | [58](58.md)                        |
 | `30009`       | Badge Definition           | [58](58.md)                        |
+| `30015`       | Interest sets              | [51](51.md)                        |
 | `30030`       | Emoji sets                 | [51](51.md)                        |
 | `30017`       | Create or update a stall   | [15](15.md)                        |
 | `30018`       | Create or update a product | [15](15.md)                        |

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `30000`       | Follow sets                | [51](51.md)                        |
 | `30001`       | Generic lists              | [51](51.md)                        |
 | `30002`       | Relay sets                 | [51](51.md)                        |
+| `30003`       | Bookmark sets              | [51](51.md)                        |
 | `30004`       | Curation sets              | [51](51.md)                        |
 | `30008`       | Profile Badges             | [58](58.md)                        |
 | `30009`       | Badge Definition           | [58](58.md)                        |

--- a/README.md
+++ b/README.md
@@ -105,8 +105,11 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `9734`        | Zap Request                | [57](57.md)                        |
 | `9735`        | Zap                        | [57](57.md)                        |
 | `9802`        | Highlights                 | [84](84.md)                        |
-| `10000`       | Mute list                  | [65](65.md)                        |
+| `10000`       | Mute list                  | [51](51.md)                        |
+| `10001`       | Pin list                   | [51](51.md)                        |
 | `10002`       | Relay List Metadata        | [65](65.md)                        |
+| `10003`       | Bookmark list              | [51](51.md)                        |
+| `10004`       | Communities list           | [51](51.md)                        |
 | `13194`       | Wallet Info                | [47](47.md)                        |
 | `22242`       | Client Authentication      | [42](42.md)                        |
 | `23194`       | Wallet Request             | [47](47.md)                        |

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `30001`       | Generic lists              | [51](51.md)                        |
 | `30002`       | Relay sets                 | [51](51.md)                        |
 | `30004`       | Curation sets              | [51](51.md)                        |
+| `30005`       | Follow sets                | [51](51.md)                        |
 | `30008`       | Profile Badges             | [58](58.md)                        |
 | `30009`       | Badge Definition           | [58](58.md)                        |
 | `30017`       | Create or update a stall   | [15](15.md)                        |

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `10002`       | Relay List Metadata        | [65](65.md)                        |
 | `10003`       | Bookmark list              | [51](51.md)                        |
 | `10004`       | Communities list           | [51](51.md)                        |
+| `10005`       | Public chats list          | [51](51.md)                        |
+| `10006`       | Blocked relays list        | [51](51.md)                        |
+| `10007`       | Search relays list         | [51](51.md)                        |
+| `10030`       | User emoji list            | [51](51.md)                        |
 | `13194`       | Wallet Info                | [47](47.md)                        |
 | `22242`       | Client Authentication      | [42](42.md)                        |
 | `23194`       | Wallet Request             | [47](47.md)                        |
@@ -122,6 +126,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `30004`       | Curation sets              | [51](51.md)                        |
 | `30008`       | Profile Badges             | [58](58.md)                        |
 | `30009`       | Badge Definition           | [58](58.md)                        |
+| `30030`       | Emoji sets                 | [51](51.md)                        |
 | `30017`       | Create or update a stall   | [15](15.md)                        |
 | `30018`       | Create or update a product | [15](15.md)                        |
 | `30023`       | Long-form Content          | [23](23.md)                        |

--- a/README.md
+++ b/README.md
@@ -74,65 +74,68 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-99: Classified Listings](99.md)
 
 ## Event Kinds
-| kind          | description                | NIP                                                              |
-| ------------- | -------------------------- | -----------                                                      |
-| `0`           | Metadata                   | [1](01.md)                                                       |
-| `1`           | Short Text Note            | [1](01.md)                                                       |
-| `2`           | Recommend Relay            |                                                                  |
-| `3`           | Contacts                   | [2](02.md)                                                       |
-| `4`           | Encrypted Direct Messages  | [4](04.md)                                                       |
-| `5`           | Event Deletion             | [9](09.md)                                                       |
-| `6`           | Repost                     | [18](18.md)                                                      |
-| `7`           | Reaction                   | [25](25.md)                                                      |
-| `8`           | Badge Award                | [58](58.md)                                                      |
-| `16`          | Generic Repost             | [18](18.md)                                                      |
-| `40`          | Channel Creation           | [28](28.md)                                                      |
-| `41`          | Channel Metadata           | [28](28.md)                                                      |
-| `42`          | Channel Message            | [28](28.md)                                                      |
-| `43`          | Channel Hide Message       | [28](28.md)                                                      |
-| `44`          | Channel Mute User          | [28](28.md)                                                      |
-| `1063`        | File Metadata              | [94](94.md)                                                      |
-| `1311`        | Live Chat Message          | [53](53.md)                                                      |
-| `1040`        | OpenTimestamps             | [03](03.md)                                                      |
-| `1971`        | Problem Tracker            | [1971](https://github.com/nostrocket/NIPS/blob/main/Problems.md) |
-| `1984`        | Reporting                  | [56](56.md)                                                      |
-| `1985`        | Label                      | [32](32.md)                                                      |
-| `4550`        | Community Post Approval    | [72](72.md)                                                      |
-| `5000`-`5999` | Job Request                | [90](90.md)                                                      |
-| `6000`-`6999` | Job Result                 | [90](90.md)                                                      |
-| `7000`        | Job Feedback               | [90](90.md)                                                      |
-| `9041`        | Zap Goal                   | [75](75.md)                                                      |
-| `9734`        | Zap Request                | [57](57.md)                                                      |
-| `9735`        | Zap                        | [57](57.md)                                                      |
-| `9802`        | Highlights                 | [84](84.md)                                                      |
-| `10002`       | Relay List Metadata        | [65](65.md)                                                      |
-| `13194`       | Wallet Info                | [47](47.md)                                                      |
-| `22242`       | Client Authentication      | [42](42.md)                                                      |
-| `23194`       | Wallet Request             | [47](47.md)                                                      |
-| `23195`       | Wallet Response            | [47](47.md)                                                      |
-| `24133`       | Nostr Connect              | [46](46.md)                                                      |
-| `27235`       | HTTP Auth                  | [98](98.md)                                                      |
-| `30000`       | People List                | [51](51.md)                                                      |
-| `30001`       | Things List                | [51](51.md)                                                      |
-| `30002`       | Relay Set                  | [51](51.md)                                                      |
-| `30008`       | Profile Badges             | [58](58.md)                                                      |
-| `30009`       | Badge Definition           | [58](58.md)                                                      |
-| `30017`       | Create or update a stall   | [15](15.md)                                                      |
-| `30018`       | Create or update a product | [15](15.md)                                                      |
-| `30023`       | Long-form Content          | [23](23.md)                                                      |
-| `30024`       | Draft Long-form Content    | [23](23.md)                                                      |
-| `30078`       | Application-specific Data  | [78](78.md)                                                      |
-| `30311`       | Live Event                 | [53](53.md)                                                      |
-| `30315`       | User Statuses              | [38](38.md)                                                      |
-| `30402`       | Classified Listing         | [99](99.md)                                                      |
-| `30403`       | Draft Classified Listing   | [99](99.md)                                                      |
-| `31922`       | Date-Based Calendar Event  | [52](52.md)                                                      |
-| `31923`       | Time-Based Calendar Event  | [52](52.md)                                                      |
-| `31924`       | Calendar                   | [52](52.md)                                                      |
-| `31925`       | Calendar Event RSVP        | [52](52.md)                                                      |
-| `31989`       | Handler recommendation     | [89](89.md)                                                      |
-| `31990`       | Handler information        | [89](89.md)                                                      |
-| `34550`       | Community Definition       | [72](72.md)                                                      |
+| kind          | description                | NIP                                |
+| ------------- | -------------------------- | -----------                        |
+| `0`           | Metadata                   | [1](01.md)                         |
+| `1`           | Short Text Note            | [1](01.md)                         |
+| `2`           | Recommend Relay            |                                    |
+| `3`           | Contacts                   | [2](02.md)                         |
+| `4`           | Encrypted Direct Messages  | [4](04.md)                         |
+| `5`           | Event Deletion             | [9](09.md)                         |
+| `6`           | Repost                     | [18](18.md)                        |
+| `7`           | Reaction                   | [25](25.md)                        |
+| `8`           | Badge Award                | [58](58.md)                        |
+| `16`          | Generic Repost             | [18](18.md)                        |
+| `40`          | Channel Creation           | [28](28.md)                        |
+| `41`          | Channel Metadata           | [28](28.md)                        |
+| `42`          | Channel Message            | [28](28.md)                        |
+| `43`          | Channel Hide Message       | [28](28.md)                        |
+| `44`          | Channel Mute User          | [28](28.md)                        |
+| `1063`        | File Metadata              | [94](94.md)                        |
+| `1311`        | Live Chat Message          | [53](53.md)                        |
+| `1040`        | OpenTimestamps             | [03](03.md)                        |
+| `1971`        | Problem Tracker            | [nostrocket-1971][nostrocket-1971] |
+| `1984`        | Reporting                  | [56](56.md)                        |
+| `1985`        | Label                      | [32](32.md)                        |
+| `4550`        | Community Post Approval    | [72](72.md)                        |
+| `5000`-`5999` | Job Request                | [90](90.md)                        |
+| `6000`-`6999` | Job Result                 | [90](90.md)                        |
+| `7000`        | Job Feedback               | [90](90.md)                        |
+| `9041`        | Zap Goal                   | [75](75.md)                        |
+| `9734`        | Zap Request                | [57](57.md)                        |
+| `9735`        | Zap                        | [57](57.md)                        |
+| `9802`        | Highlights                 | [84](84.md)                        |
+| `10000`       | Mute list                  | [65](65.md)                        |
+| `10002`       | Relay List Metadata        | [65](65.md)                        |
+| `13194`       | Wallet Info                | [47](47.md)                        |
+| `22242`       | Client Authentication      | [42](42.md)                        |
+| `23194`       | Wallet Request             | [47](47.md)                        |
+| `23195`       | Wallet Response            | [47](47.md)                        |
+| `24133`       | Nostr Connect              | [46](46.md)                        |
+| `27235`       | HTTP Auth                  | [98](98.md)                        |
+| `30001`       | Generic lists              | [51](51.md)                        |
+| `30002`       | Relay sets                 | [51](51.md)                        |
+| `30004`       | Curation sets              | [51](51.md)                        |
+| `30008`       | Profile Badges             | [58](58.md)                        |
+| `30009`       | Badge Definition           | [58](58.md)                        |
+| `30017`       | Create or update a stall   | [15](15.md)                        |
+| `30018`       | Create or update a product | [15](15.md)                        |
+| `30023`       | Long-form Content          | [23](23.md)                        |
+| `30024`       | Draft Long-form Content    | [23](23.md)                        |
+| `30078`       | Application-specific Data  | [78](78.md)                        |
+| `30311`       | Live Event                 | [53](53.md)                        |
+| `30315`       | User Statuses              | [38](38.md)                        |
+| `30402`       | Classified Listing         | [99](99.md)                        |
+| `30403`       | Draft Classified Listing   | [99](99.md)                        |
+| `31922`       | Date-Based Calendar Event  | [52](52.md)                        |
+| `31923`       | Time-Based Calendar Event  | [52](52.md)                        |
+| `31924`       | Calendar                   | [52](52.md)                        |
+| `31925`       | Calendar Event RSVP        | [52](52.md)                        |
+| `31989`       | Handler recommendation     | [89](89.md)                        |
+| `31990`       | Handler information        | [89](89.md)                        |
+| `34550`       | Community Definition       | [72](72.md)                        |
+
+[nostrocket-1971]: https://github.com/nostrocket/NIPS/blob/main/Problems.md
 
 ## Message types
 

--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `23195`       | Wallet Response            | [47](47.md)                        |
 | `24133`       | Nostr Connect              | [46](46.md)                        |
 | `27235`       | HTTP Auth                  | [98](98.md)                        |
+| `30000`       | Follow sets                | [51](51.md)                        |
 | `30001`       | Generic lists              | [51](51.md)                        |
 | `30002`       | Relay sets                 | [51](51.md)                        |
 | `30004`       | Curation sets              | [51](51.md)                        |
-| `30005`       | Follow sets                | [51](51.md)                        |
 | `30008`       | Profile Badges             | [58](58.md)                        |
 | `30009`       | Badge Definition           | [58](58.md)                        |
 | `30017`       | Create or update a stall   | [15](15.md)                        |


### PR DESCRIPTION
https://github.com/nostr-protocol/nips/blob/save-nip-51/51.md

This NIP was a mess and wasn't being followed and there were many wild standards not documented. We should try to agree and actually follow some standards.

Also I've simplified the format to display some clearly defined simple tables so it's easier for people to add more stuff here.

We should stick to the 1xxxx range going forward for lists with standard meaning for which users are only expected to have one, 30001 for random lists and new 3xxxx lists for lists with standard meaning for which users are expected to have more than one.

---

**Update:**

This actually turned out to be a big movement involving tons of client developers in rehabilitating NIP-51, writing down old standards, creating new ones and cleaning up some mess from the past.