### PR TITLE
Remove all NIP authors

### DIFF
--- a/01.md
+++ b/01.md
@@ -4,7 +4,7 @@ NIP-01
 Basic protocol flow description
 -------------------------------
 
-`draft` `mandatory` `author:fiatjaf` `author:distbit` `author:scsibug` `author:kukks` `author:jb55` `author:semisol` `author:cameri` `author:Giszmo`
+`draft` `mandatory`
 
 This NIP defines the basic protocol that should be implemented by everybody. New NIPs may add new optional (or mandatory) fields and messages and features to the structures and flows described here.
 

--- a/02.md
+++ b/02.md
@@ -4,7 +4,7 @@ NIP-02
 Contact List and Petnames
 -------------------------
 
-`final` `optional` `author:fiatjaf` `author:arcbtc`
+`final` `optional`
 
 A special event with kind `3`, meaning "contact list" is defined as having a list of `p` tags, one for each of the followed/known profiles one is following.
 

--- a/03.md
+++ b/03.md
@@ -4,7 +4,7 @@ NIP-03
 OpenTimestamps Attestations for Events
 --------------------------------------
 
-`draft` `optional` `author:fiatjaf` `author:constant`
+`draft` `optional`
 
 This NIP defines an event with `kind:1040` that can contain an [OpenTimestamps](https://opentimestamps.org/) proof for any other event:
 

--- a/04.md
+++ b/04.md
@@ -4,7 +4,7 @@ NIP-04
 Encrypted Direct Message
 ------------------------
 
-`final` `optional` `author:arcbtc`
+`final` `optional`
 
 A special event with kind `4`, meaning "encrypted direct message". It is supposed to have the following attributes:
 

--- a/05.md
+++ b/05.md
@@ -4,7 +4,7 @@ NIP-05
 Mapping Nostr keys to DNS-based internet identifiers
 ----------------------------------------------------
 
-`final` `optional` `author:fiatjaf` `author:mikedilger`
+`final` `optional`
 
 On events of kind `0` (`metadata`) one can specify the key `"nip05"` with an [internet identifier](https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1) (an email-like address) as the value. Although there is a link to a very liberal "internet identifier" specification above, NIP-05 assumes the `<local-part>` part will be restricted to the characters `a-z0-9-_.`, case-insensitive.
 

--- a/06.md
+++ b/06.md
@@ -4,7 +4,7 @@ NIP-06
 Basic key derivation from mnemonic seed phrase
 ----------------------------------------------
 
-`draft` `optional` `author:fiatjaf`
+`draft` `optional`
 
 [BIP39](https://bips.xyz/39) is used to generate mnemonic seed words and derive a binary seed from them.
 

--- a/07.md
+++ b/07.md
@@ -4,7 +4,7 @@ NIP-07
 `window.nostr` capability for web browsers
 ------------------------------------------
 
-`draft` `optional` `author:fiatjaf`
+`draft` `optional`
 
 The `window.nostr` object may be made available by web browsers or extensions and websites or web-apps may make use of it after checking its availability.
 

--- a/08.md
+++ b/08.md
@@ -6,7 +6,7 @@ NIP-08
 Handling Mentions
 -----------------
 
-`final` `unrecommended` `optional` `author:fiatjaf` `author:scsibug`
+`final` `unrecommended` `optional`
 
 This document standardizes the treatment given by clients of inline mentions of other events and pubkeys inside the content of `text_note`s.
 

--- a/09.md
+++ b/09.md
@@ -4,7 +4,7 @@ NIP-09
 Event Deletion
 --------------
 
-`draft` `optional` `author:scsibug`
+`draft` `optional`
 
 A special event with kind `5`, meaning "deletion" is defined as having a list of one or more `e` tags, each referencing an event the author is requesting to be deleted.
 

--- a/10.md
+++ b/10.md
@@ -5,7 +5,7 @@ NIP-10
 On "e" and "p" tags in Text Events (kind 1).
 --------------------------------------------
 
-`draft` `optional` `author:unclebobmartin`
+`draft` `optional`
 
 ## Abstract
 This NIP describes how to use "e" and "p" tags in text events, especially those that are replies to other text events.  It helps clients thread the replies into a tree rooted at the original event.

--- a/11.md
+++ b/11.md
@@ -4,7 +4,7 @@ NIP-11
 Relay Information Document
 ---------------------------
 
-`draft` `optional` `author:scsibug` `author:doc-hex` `author:cameri`
+`draft` `optional`
 
 Relays may provide server metadata to clients to inform them of capabilities, administrative contacts, and various server attributes.  This is made available as a JSON document over HTTP, on the same URI as the relay's websocket.
 

--- a/12.md
+++ b/12.md
@@ -4,6 +4,6 @@ NIP-12
 Generic Tag Queries
 -------------------
 
-`final` `mandatory` `author:scsibug` `author:fiatjaf`
+`final` `mandatory`
 
 Moved to [NIP-01](01.md).

--- a/13.md
+++ b/13.md
@@ -4,7 +4,7 @@ NIP-13
 Proof of Work
 -------------
 
-`draft` `optional` `author:jb55` `author:cameri`
+`draft` `optional`
 
 This NIP defines a way to generate and interpret Proof of Work for nostr notes. Proof of Work (PoW) is a way to add a proof of computational work to a note. This is a bearer proof that all relays and clients can universally validate with a small amount of code. This proof can be used as a means of spam deterrence.
 

--- a/14.md
+++ b/14.md
@@ -4,7 +4,7 @@ NIP-14
 Subject tag in Text events
 --------------------------
 
-`draft` `optional` `author:unclebobmartin`
+`draft` `optional`
 
 This NIP defines the use of the "subject" tag in text (kind: 1) events.  
 (implemented in more-speech)

--- a/15.md
+++ b/15.md
@@ -4,7 +4,7 @@ NIP-15
 Nostr Marketplace (for resilient marketplaces)
 -----------------------------------
 
-`draft` `optional` `author:fiatjaf` `author:benarc`  `author:motorina0` `author:talvasconcelos`
+`draft` `optional` 
 
 > Based on https://github.com/lnbits/Diagon-Alley
 

--- a/16.md
+++ b/16.md
@@ -4,6 +4,6 @@ NIP-16
 Event Treatment
 ---------------
 
-`final` `mandatory` `author:Semisol`
+`final` `mandatory`
 
 Moved to [NIP-01](01.md).

--- a/18.md
+++ b/18.md
@@ -4,7 +4,7 @@ NIP-18
 Reposts
 -------
 
-`draft` `optional` `author:jb55` `author:fiatjaf` `author:arthurfranca`
+`draft` `optional`
 
 A repost is a `kind 6` event that is used to signal to followers
 that a `kind 1` text note is worth reading.

--- a/19.md
+++ b/19.md
@@ -4,7 +4,7 @@ NIP-19
 bech32-encoded entities
 -----------------------
 
-`draft` `optional` `author:jb55` `author:fiatjaf` `author:Semisol`
+`draft` `optional`
 
 This NIP standardizes bech32-formatted strings that can be used to display keys, ids and other information in clients. These formats are not meant to be used anywhere in the core protocol, they are only meant for displaying to users, copy-pasting, sharing, rendering QR codes and inputting data.
 

--- a/20.md
+++ b/20.md
@@ -4,6 +4,6 @@ NIP-20
 Command Results
 ---------------
 
-`final` `mandatory` `author:jb55`
+`final` `mandatory`
 
 Moved to [NIP-01](01.md).

--- a/21.md
+++ b/21.md
@@ -4,7 +4,7 @@ NIP-21
 `nostr:` URI scheme
 -------------------
 
-`draft` `optional` `author:fiatjaf`
+`draft` `optional`
 
 This NIP standardizes the usage of a common URI scheme for maximum interoperability and openness in the network.
 

--- a/22.md
+++ b/22.md
@@ -4,7 +4,7 @@ NIP-22
 Event `created_at` Limits
 -------------------------
 
-`draft` `optional` `author:jeffthibault` `author:Giszmo`
+`draft` `optional`
 
 Relays may define both upper and lower limits within which they will consider an event's `created_at` to be acceptable. Both the upper and lower limits MUST be unix timestamps in seconds as defined in [NIP-01](01.md).
 

--- a/23.md
+++ b/23.md
@@ -4,7 +4,7 @@ NIP-23
 Long-form Content
 -----------------
 
-`draft` `optional` `author:fiatjaf`
+`draft` `optional`
 
 This NIP defines `kind:30023` (a _parameterized replaceable event_) for long-form text content, generally referred to as "articles" or "blog posts". `kind:30024` has the same structure as `kind:30023` and is used to save long form drafts.
 

--- a/24.md
+++ b/24.md
@@ -4,7 +4,7 @@ NIP-24
 Extra metadata fields and tags
 ------------------------------
 
-`draft` `optional` `author:fiatjaf`
+`draft` `optional`
 
 This NIP defines extra optional fields added to events.
 

--- a/25.md
+++ b/25.md
@@ -5,7 +5,7 @@ NIP-25
 Reactions
 ---------
 
-`draft` `optional` `author:jb55`
+`draft` `optional`
 
 A reaction is a `kind 7` event that is used to react to other events.
 

--- a/26.md
+++ b/26.md
@@ -4,7 +4,7 @@ NIP-26
 Delegated Event Signing
 -----
 
-`draft` `optional` `author:markharding` `author:minds`
+`draft` `optional`
 
 This NIP defines how events can be delegated so that they can be signed by other keypairs.
 

--- a/27.md
+++ b/27.md
@@ -4,7 +4,7 @@ NIP-27
 Text Note References
 --------------------
 
-`draft` `optional` `author:arthurfranca` `author:hodlbod` `author:fiatjaf`
+`draft` `optional`
 
 This document standardizes the treatment given by clients of inline references of other events and profiles inside the `.content` of any event that has readable text in its `.content` (such as kinds 1 and 30023).
 

--- a/28.md
+++ b/28.md
@@ -5,7 +5,7 @@ NIP-28
 Public Chat
 -----------
 
-`draft` `optional` `author:ChristopherDavid` `author:fiatjaf` `author:jb55` `author:Cameri`
+`draft` `optional`
 
 This NIP defines new event kinds for public chat channels, channel messages, and basic client-side moderation.
 

--- a/30.md
+++ b/30.md
@@ -4,7 +4,7 @@ NIP-30
 Custom Emoji
 ------------
 
-`draft` `optional` `author:alexgleason`
+`draft` `optional`
 
 Custom emoji may be added to **kind 0** and **kind 1** events by including one or more `"emoji"` tags, in the form:
 

--- a/31.md
+++ b/31.md
@@ -4,7 +4,7 @@ NIP-31
 Dealing with unknown event kinds
 --------------------------------
 
-`draft` `optional` `author:pablof7z` `author:fiatjaf`
+`draft` `optional`
 
 When creating a new custom event kind that is part of a custom protocol and isn't meant to be read as text (like `kind:1`), clients should use an `alt` tag to write a short human-readable plaintext summary of what that event is about.
 

--- a/32.md
+++ b/32.md
@@ -4,7 +4,7 @@ NIP-32
 Labeling
 ---------
 
-`draft` `optional` `author:staab` `author:gruruya` `author:s3x-jay`
+`draft` `optional`
 
 A label is a `kind 1985` event that is used to label other entities. This supports a number of use cases,
 including distributed moderation, collection management, license assignment, and content classification.

--- a/33.md
+++ b/33.md
@@ -4,6 +4,6 @@ NIP-33
 Parameterized Replaceable Events
 --------------------------------
 
-`final` `mandatory` `author:Semisol` `author:Kukks` `author:Cameri` `author:Giszmo`
+`final` `mandatory`
 
 Moved to [NIP-01](01.md).

--- a/36.md
+++ b/36.md
@@ -4,7 +4,7 @@ NIP-36
 Sensitive Content / Content Warning
 -----------------------------------
 
-`draft` `optional` `author:fernandolguevara`
+`draft` `optional`
 
 The `content-warning` tag enables users to specify if the event's content needs to be approved by readers to be shown.
 Clients can hide the content until the user acts on it.

--- a/38.md
+++ b/38.md
@@ -5,7 +5,7 @@ NIP-38
 User Statuses
 --------------
 
-`draft` `optional` `author:jb55`
+`draft` `optional`
 
 ## Abstract
 

--- a/39.md
+++ b/39.md
@@ -4,7 +4,7 @@ NIP-39
 External Identities in Profiles
 -------------------------------
 
-`draft` `optional` `author:pseudozach` `author:Semisol`
+`draft` `optional`
 
 ## Abstract
 

--- a/40.md
+++ b/40.md
@@ -4,7 +4,7 @@ NIP-40
 Expiration Timestamp
 -----------------------------------
 
-`draft` `optional` `author:0xtlt`
+`draft` `optional`
 
 The `expiration` tag enables users to specify a unix timestamp at which the message SHOULD be considered expired (by relays and clients) and SHOULD be deleted by relays.
 

--- a/42.md
+++ b/42.md
@@ -4,7 +4,7 @@ NIP-42
 Authentication of clients to relays
 -----------------------------------
 
-`draft` `optional` `author:Semisol` `author:fiatjaf`
+`draft` `optional`
 
 This NIP defines a way for clients to authenticate to relays by signing an ephemeral event.
 

--- a/45.md
+++ b/45.md
@@ -4,7 +4,7 @@ NIP-45
 Event Counts
 --------------
 
-`draft` `optional` `author:staab`
+`draft` `optional`
 
 Relays may support the verb `COUNT`, which provides a mechanism for obtaining event counts.
 

--- a/46.md
+++ b/46.md
@@ -4,7 +4,7 @@ NIP-46
 Nostr Connect
 ------------------------
 
-`draft` `optional` `author:tiero` `author:giowe` `author:vforvalerio87`
+`draft` `optional`
 
 ## Rationale
 

--- a/47.md
+++ b/47.md
@@ -4,7 +4,7 @@ NIP-47
 Nostr Wallet Connect
 --------------------
 
-`draft` `optional` `author:kiwiidb` `author:bumi` `author:semisol` `author:vitorpamplona`
+`draft` `optional`
 
 ## Rationale
 

--- a/48.md
+++ b/48.md
@@ -4,7 +4,7 @@ NIP-48
 Proxy Tags
 ----------
 
-`draft` `optional` `author:alexgleason`
+`draft` `optional`
 
 Nostr events bridged from other protocols such as ActivityPub can link back to the source object by including a `"proxy"` tag, in the form:
 

--- a/50.md
+++ b/50.md
@@ -4,7 +4,7 @@ NIP-50
 Search Capability
 -----------------
 
-`draft` `optional` `author:brugeman` `author:mikedilger` `author:fiatjaf`
+`draft` `optional`
 
 ## Abstract
 

--- a/51.md
+++ b/51.md
@@ -4,7 +4,7 @@ NIP-51
 Lists
 -----
 
-`draft` `optional` `author:fiatjaf` `author:arcbtc` `author:monlovesmango` `author:eskema` `author:gzuuus`
+`draft` `optional`
 
 A "list" event is defined as having a list of public and/or private tags. Public tags will be listed in the event `tags`. Private tags will be encrypted in the event `content`. Encryption for private tags will use [NIP-04 - Encrypted Direct Message](04.md) encryption, using the list author's private and public key for the shared secret. A distinct event kind should be used for each list type created.
 

--- a/52.md
+++ b/52.md
@@ -4,7 +4,7 @@ NIP-52
 Calendar Events
 ---------------
 
-`draft` `optional` `author:tyiu`
+`draft` `optional`
 
 This specification defines calendar events representing an occurrence at a specific moment or between moments. These calendar events are _parameterized replaceable_ and deletable per [NIP-09](09.md).
 

--- a/53.md
+++ b/53.md
@@ -4,7 +4,7 @@ NIP-53
 Live Activities
 ---------------
 
-`draft` `optional` `author:vitorpamplona` `author:v0l`
+`draft` `optional`
 
 ## Abstract
 

--- a/56.md
+++ b/56.md
@@ -5,7 +5,7 @@ NIP-56
 Reporting
 ---------
 
-`draft` `optional` `author:jb55`
+`draft` `optional`
 
 A report is a `kind 1984` note that is used to report other notes for spam,
 illegal and explicit content.

--- a/57.md
+++ b/57.md
@@ -4,7 +4,7 @@ NIP-57
 Lightning Zaps
 --------------
 
-`draft` `optional` `author:jb55` `author:kieran`
+`draft` `optional`
 
 This NIP defines two new event types for recording lightning payments between users. `9734` is a `zap request`, representing a payer's request to a recipient's lightning wallet for an invoice. `9735` is a `zap receipt`, representing the confirmation by the recipient's lightning wallet that the invoice issued in response to a `zap request` has been paid.
 

--- a/58.md
+++ b/58.md
@@ -4,7 +4,7 @@ NIP-58
 Badges
 ------
 
-`draft` `optional` `author:cameri`
+`draft` `optional`
 
 Three special events are used to define, award and display badges in
 user profiles:

--- a/65.md
+++ b/65.md
@@ -4,7 +4,7 @@ NIP-65
 Relay List Metadata
 -------------------
 
-`draft` `optional` `author:mikedilger` `author:vitorpamplona`
+`draft` `optional`
 
 Defines a replaceable event using `kind:10002` to advertise preferred relays for discovering a user's content and receiving fresh content from others.
 

--- a/72.md
+++ b/72.md
@@ -4,7 +4,7 @@ NIP-72
 Moderated Communities (Reddit Style)
 ------------------------------------
 
-`draft` `optional` `author:vitorpamplona` `author:arthurfranca`
+`draft` `optional`
 
 The goal of this NIP is to create moderator-approved public communities around a topic. It defines the replaceable event `kind:34550` to define the community and the current list of moderators/administrators. Users that want to post into the community, simply tag any Nostr event with the community's `a` tag. Moderators issue an approval event `kind:4550` that links the community with the new post.
 

--- a/75.md
+++ b/75.md
@@ -2,7 +2,7 @@
 
 ## Zap Goals
 
-`draft` `optional` `author:verbiricha`
+`draft` `optional`
 
 This NIP defines an event for creating fundraising goals. Users can contribute funds towards the goal by zapping the goal event.
 

--- a/78.md
+++ b/78.md
@@ -4,7 +4,7 @@ NIP-78
 Arbitrary custom app data
 -------------------------
 
-`draft` `optional` `author:sandwich` `author:fiatjaf`
+`draft` `optional`
 
 The goal of this NIP is to enable [remoteStorage](https://remotestorage.io/)-like capabilities for custom applications that do not care about interoperability.
 

--- a/84.md
+++ b/84.md
@@ -4,7 +4,7 @@ NIP-84
 Highlights
 ----------
 
-`draft` `optional` `author:pablof7z`
+`draft` `optional`
 
 This NIP defines `kind:9802`, a "highlight" event, to signal content a user finds valuable.
 

--- a/89.md
+++ b/89.md
@@ -4,7 +4,7 @@ NIP-89
 Recommended Application Handlers
 --------------------------------
 
-`draft` `optional` `author:pablof7z`
+`draft` `optional`
 
 This NIP describes `kind:31989` and `kind:31990`: a way to discover applications that can handle unknown event-kinds.
 

--- a/90.md
+++ b/90.md
@@ -4,7 +4,7 @@ NIP-90
 Data Vending Machine
 --------------------
 
-`draft` `optional` `author:pablof7z` `author:dontbelievethehype`
+`draft` `optional`
 
 This NIP defines the interaction between customers and Service Providers for performing on-demand computation.
 

--- a/94.md
+++ b/94.md
@@ -4,7 +4,7 @@ NIP-94
 File Metadata
 -------------
 
-`draft` `optional` `author:frbitten` `author:kieran` `author:lovvtide` `author:fiatjaf` `author:staab`
+`draft` `optional`
 
 The purpose of this NIP is to allow an organization and classification of shared files. So that relays can filter and organize in any way that is of interest. With that, multiple types of filesharing clients can be created. NIP-94 support is not expected to be implemented by "social" clients that deal with kind:1 notes or by longform clients that deal with kind:30023 articles.
 

--- a/98.md
+++ b/98.md
@@ -4,7 +4,7 @@ NIP-98
 HTTP Auth
 -------------------------
 
-`draft` `optional` `author:kieran` `author:melvincarvalho`
+`draft` `optional`
 
 This NIP defines an ephemeral event used to authorize requests to HTTP servers using nostr events.
 

--- a/99.md
+++ b/99.md
@@ -2,7 +2,7 @@
 
 ## Classified Listings
 
-`draft` `optional` `author:erskingardner`
+`draft` `optional`
 
 This NIP defines `kind:30402`: a parameterized replaceable event to describe classified listings that list any arbitrary product, service, or other thing for sale or offer and includes enough structured metadata to make them useful.
 


### PR DESCRIPTION
I don't know if this is a good idea, but it might be. Let me know.

I think having people's names in NIPs cause others to be afraid of proposing changes or additions to them, and also NIPs are all so heavily modified by everybody, either directly or indirectly, that these names end up not really reflecting reality at all.