### PR TITLE
Addition to NIP-36: Specifying kind for Content with content-warning

### DIFF
--- a/36.md
+++ b/36.md
@@ -9,6 +9,11 @@ Sensitive Content / Content Warning
 The `content-warning` tag enables users to specify if the event's content needs to be approved by readers to be shown.
 Clients can hide the content until the user acts on it.
 
+For content utilizing the `content-warning` tag, it is recommended to use `kind 18` to appropriately categorize such events.
+This recommendation is grounded in the fact that using the usual `kind 1` could lead to inappropriate display of sensitive
+content by clients not compliant with NIP-36. By distinguishing with `kind 18`, it helps to avoid such confusion and ensures
+better adherence to `content-warning` tag.
+
 `l` and `L` tags MAY be also be used as defined in [NIP-32](32.md) with the `content-warning` or other namespace to support
 further qualification and querying.
 
@@ -26,7 +31,7 @@ options:
 {
     "pubkey": "<pub-key>",
     "created_at": 1000000000,
-    "kind": 1,
+    "kind": 18,
     "tags": [
       ["t", "hastag"],
       ["L", "content-warning"],

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `7`           | Reaction                   | [25](25.md) |
 | `8`           | Badge Award                | [58](58.md) |
 | `16`          | Generic Repost             | [18](18.md) |
+| `18`          | Sensitive Content          | [36](36.md) |
 | `40`          | Channel Creation           | [28](28.md) |
 | `41`          | Channel Metadata           | [28](28.md) |
 | `42`          | Channel Message            | [28](28.md) |


### PR DESCRIPTION
In the context of NIP-36 regarding the content-warning tag, it is advised that when posting content that requires a content warning, the kind attribute of the event should be set to 18 instead of 1. This adjustment ensures that the nature of the content is appropriately categorized and handled by clients adhering to the Nostr protocol specifications. The use of kind 18 specifically designates the content as requiring a warning, which aligns with the intent of NIP-36 to offer users control over the visibility of sensitive content.