### PR TITLE
Adds contributor images to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,3 +230,9 @@ mailing lists where you can work on NIPs before submitting them here:
 ## License
 
 All NIPs are public domain.
+
+## Contributors
+
+<a align="center" href="https://github.com/nostr-protocol/nips/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=nostr-protocol/nips" />
+</a>


### PR DESCRIPTION
Adds a cool viz with all contributors to the readme. 

Check it out at the end of the readme here: https://github.com/vitorpamplona/nips/tree/contrib

Related: 
- https://github.com/nostr-protocol/nips/issues/162
- https://github.com/nostr-protocol/nips/pull/883