### PR TITLE
NIP-11: add `"restricted_writes"` limitation

### DIFF
--- a/11.md
+++ b/11.md
@@ -79,6 +79,7 @@ are rejected or fail immediately.
     "min_pow_difficulty": 30,
     "auth_required": true,
     "payment_required": true,
+    "restricted_writes": true,
     "created_at_lower_limit": 31536000,
     "created_at_upper_limit": 3
   },
@@ -123,6 +124,9 @@ to happen before a new connection may perform any other action.
 Even if set to False, authentication may be required for specific actions.
 
 - `payment_required`: this relay requires payment before a new connection may perform any action.
+
+- `restricted_writes`: this relay requires some kind of condition to be fulfilled in order to
+accept events (not necessarily, but including `payment_required` and `min_pow_difficulty`).
 
 - `created_at_lower_limit`: 'created_at' lower limit as defined in [NIP-22](22.md)
 

--- a/11.md
+++ b/11.md
@@ -127,6 +127,9 @@ Even if set to False, authentication may be required for specific actions.
 
 - `restricted_writes`: this relay requires some kind of condition to be fulfilled in order to
 accept events (not necessarily, but including `payment_required` and `min_pow_difficulty`).
+This should only be set to `true` when users are expected to know the relay policy before trying
+to write to it -- like belonging to a special pubkey-based whitelist or writing only events of
+a specific niche kind or content. Normal anti-spam heuristics, for example, do not qualify.
 
 - `created_at_lower_limit`: 'created_at' lower limit as defined in [NIP-22](22.md)
 


### PR DESCRIPTION
Because relays may have other kinds of arbitrary restrictions that are not `payment_required`.