### PR TITLE
NIP-42 - Allow client to ask for the challenge

### DIFF
--- a/42.md
+++ b/42.md
@@ -28,7 +28,13 @@ to authenticate. When sent by relays, the message is of the following form:
 ["AUTH", <challenge-string>]
 ```
 
-And, when sent by clients, of the following form:
+And, when sent by clients, in two forms. If requesting the challenge string, as follows:
+
+```json
+["AUTH"]
+```
+
+If responding to the relay `AUTH` message, in the following form:
 
 ```json
 ["AUTH", <signed-event-json>]
@@ -57,7 +63,11 @@ authenticate itself or not. The challenge is expected to be valid for the durati
 the relay.
 
 The client may send an auth message right before performing an action for which it knows authentication will be required -- for example, right
-before requesting `kind: 4` chat messages --, or it may do right on connection start or at some other moment it deems best. The authentication
+before requesting `kind: 4` chat messages --, or it may do right on connection start or at some other moment it deems best.
+
+If the client expects to use a restricted relay feature but the relay hasn't sent the challenge yet, the client can request it by sending an `AUTH` message without the second array element.
+
+The authentication
 is expected to last for the duration of the WebSocket connection.
 
 Upon receiving a message from an unauthenticated user it can't fulfill without authentication, a relay may choose to notify the client. For


### PR DESCRIPTION
On previous discussions we came to the conclusion that it wasn't desirable for clients to auto-authenticate blindly upon receiving relay `AUTH` messages, for privacy reasons.

Considering requesting DMs as a feature example that clients would be willing to authenticate for, it is desirable to previously request the challenge string, when the client knows the relay supports NIP-42 (by checking NIP-11), before requesting DMs.