### PR TITLE
NIP-46: Add target POW difficulty when signing events

### DIFF
--- a/46.md
+++ b/46.md
@@ -66,7 +66,9 @@ These are mandatory methods the remote signer app MUST implement:
   - params []
   - result `pubkey` 
 - **sign_event**
-  - params [`event`]
+  - params [`event`, `options`]
+  - options
+    - `pow` minimum proof-of-work difficulty
   - result `event_with_signature` 
 
 #### optional

--- a/46.md
+++ b/46.md
@@ -67,8 +67,8 @@ These are mandatory methods the remote signer app MUST implement:
   - result `pubkey` 
 - **sign_event**
   - params [`event`, `options`]
-  - options
-    - `pow` minimum proof-of-work difficulty
+    - `options` (object, optional)
+      - `pow` target proof-of-work difficulty for the signed event
   - result `event_with_signature` 
 
 #### optional


### PR DESCRIPTION
When using Nostr Connect, it makes the most sense to negotiate proof-of-work requirements for signed events within the NIP-46 request itself.

This MR adds a `options` object to the `sign_event` method. So far it supports only one option, `pow` which is the target proof-of-work difficulty for the signed event.

(Marked as a draft because I have not actually implemented this yet.)