### PR TITLE
NIP-88: Pay request spec for relays

### DIFF
--- a/88.md
+++ b/88.md
@@ -1,4 +1,4 @@
-NIP-XX
+NIP-88
 ======
 
 PAY Request

--- a/88.md
+++ b/88.md
@@ -6,21 +6,21 @@ PAY Request
 
 `draft` `optional`
 
-At any point, the relay can send a `PAY` request to a client with a BOLT 11 invoice, a description of what the user is purchasing by paying the invoice and a url for other options or more information. The Lightning invoice is the id of the request. 
+At any point, the relay can send a `PAY` request to a client with a BOLT 11 invoice, a description of what the user is purchasing by paying the invoice, and a URL for other options or more information. The Lightning invoice is the ID of the request.
 
 ```js
 [
   "PAY",
   "<BOLT 11 Invoice>",
-  "<Description>"	
+  "<Description>"
   "<Url for other plan options>"
 ]
 ```
 
-Supporting clients SHOULD display a popup or notification to describe the action needed and collect immediate response from the user: `pay` and keep using the relay, `dismiss` and stop using the relay or `more information` by navigating the user to the url. Clients SHOULD expect that the same request might be sent multiple times, if the user dismisses or pays the amount, the client SHOULD ignore following requests with the same invoice. 
+Supporting clients SHOULD display a popup or notification to describe the action needed and collect immediate response from the user: `pay` and keep using the relay, `dismiss` and stop using the relay, or `more information` by navigating the user to the URL. Clients SHOULD expect that the same request might be sent multiple times, if the user dismisses or pays the amount, the client SHOULD ignore following requests with the same invoice.
 
-Supporting relays SHOULD make sure the lightning invoice is the same for similar payment requests and minimize the number of times this request is sent to avoid annoying users with poorly-implemented clients. 
+Supporting relays SHOULD make sure the lightning invoice is the same for similar payment requests and minimize the number of times this request is sent to avoid annoying users with multiple popups.
 
 ### Motivation
 
-Paid relays often run into friction when renewing subscriptions or when upselling users to the next plan they have available. The API described here allows clie
+Paid relays often run into friction when renewing subscriptions or when upselling users to the next plan they have 

--- a/88.md
+++ b/88.md
@@ -1,0 +1,26 @@
+NIP-XX
+======
+
+PAY Request
+-----------
+
+`draft` `optional`
+
+At any point, the relay can send a `PAY` request to a client with a BOLT 11 invoice, a description of what the user is purchasing by paying the invoice and a url for other options or more information. The Lightning invoice is the id of the request. 
+
+```js
+[
+  "PAY",
+  "<BOLT 11 Invoice>",
+  "<Description>"	
+  "<Url for other plan options>"
+]
+```
+
+Supporting clients SHOULD display a popup or notification to describe the action needed and collect immediate response from the user: `pay` and keep using the relay, `dismiss` and stop using the relay or `more information` by navigating the user to the url. Clients SHOULD expect that the same request might be sent multiple times, if the user dismisses or pays the amount, the client SHOULD ignore following requests with the same invoice. 
+
+Supporting relays SHOULD make sure the lightning invoice is the same for similar payment requests and minimize the number of times this request is sent to avoid annoying users with poorly-implemented clients. 
+
+### Motivation
+
+Paid relays often run into friction when renewing subscriptions or when upselling users to the next plan they have available. The API described here allows clie

--- a/88.md
+++ b/88.md
@@ -23,4 +23,4 @@ Supporting relays SHOULD make sure the lightning invoice is the same for similar
 
 ### Motivation
 
-Paid relays often run into friction when renewing subscriptions or when upselling users to the next plan they have 
+Paid relays often run into friction when renewing subscriptions or when upselling users to the next plan they have available. The API described here allows clients to ease the subscription payment process on an as-needed basis. 


### PR DESCRIPTION
Paid relays often run into friction when renewing subscriptions or when upselling users to the next plan they have available. This PR allows relays to request payments on an as-needed basis. 

This has been implemented on inbox.nostr.wine and Amethyst. 

![](https://image.nostr.build/4811f5fd783b5e7f0972b7f097a88e5b31659be35748c4115f5f05a024b20529.jpg)

