### PR TITLE
`CLOSED` messages for relays that want to reject REQs and NIP-42 `AUTH` integration

### DIFF
--- a/01.md
+++ b/01.md
@@ -145,6 +145,7 @@ Relays can send 4 types of messages, which must also be JSON arrays, according t
   * `["EVENT", <subscription_id>, <event JSON as defined above>]`, used to send events requested by clients.
   * `["OK", <event_id>, <true|false>, <message>]`, used to indicate acceptance or denial of an `EVENT` message.
   * `["EOSE", <subscription_id>]`, used to indicate the _end of stored events_ and the beginning of events newly received in real-time.
+  * `["CLOSED", <subscription_id>, <message>]`, used to indicate that a subscription was ended on the server side.
   * `["NOTICE", <message>]`, used to send human-readable error messages or other things to clients.
 
 This NIP defines no rules for how `NOTICE` messages should be sent or treated.
@@ -161,3 +162,9 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
   * `["OK", "b1a649ebe8...", false, "invalid: event creation date is too far off from the current time. Is your system clock in sync?"]`
   * `["OK", "b1a649ebe8...", false, "pow: difficulty 26 is less than 30"]`
   * `["OK", "b1a649ebe8...", false, "error: could not connect to the database"]`
+- `CLOSED` messages MUST be sent when the relay in response to a `REQ` when the relay refuses to fulfill it. It can also be sent when a relay decides to kill a subscription on its side before a client has disconnected or sent a `CLOSE`. This message uses the same pattern of `OK` messages with the machine-readable prefix and human-readable message. The standardized machine-readable prefixes are: `duplicate`, `unsupported` and `error` for when none of that fits. Some examples:
+
+  * `["CLOSED", "sub1", "duplicate: sub1 already opened"]`
+  * `["CLOSED", "sub1", "unsupported: filter contains unknown elements"]`
+  * `["CLOSED", "sub1", "error: could not connect to the database"]`
+  * `["CLOSED", "sub1", "error: shutting down idle subscription"]`

--- a/01.md
+++ b/01.md
@@ -151,20 +151,19 @@ Relays can send 4 types of messages, which must also be JSON arrays, according t
 This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 
 - `EVENT` messages MUST be sent only with a subscription ID related to a subscription previously initiated by the client (using the `REQ` message above).
-- `OK` messages MUST be sent in response to `EVENT` messages received from clients, they must have the 3rd parameter set to `true` when an event has been accepted by the relay, `false` otherwise. The 4th parameter MUST always be present, but MAY be an empty string when the 3rd is `true`, otherwise it MUST be a string formed by a machine-readable single-word prefix followed by a `:` and then a human-readable message. The standardized machine-readable prefixes are: `duplicate`, `pow`, `blocked`, `rate-limited`, `invalid`, and `error` for when none of that fits. Some examples:
-
+- `OK` messages MUST be sent in response to `EVENT` messages received from clients, they must have the 3rd parameter set to `true` when an event has been accepted by the relay, `false` otherwise. The 4th parameter MUST always be present, but MAY be an empty string when the 3rd is `true`, otherwise it MUST be a string formed by a machine-readable single-word prefix followed by a `:` and then a human-readable message. Some examples:
   * `["OK", "b1a649ebe8...", true, ""]`
   * `["OK", "b1a649ebe8...", true, "pow: difficulty 25>=24"]`
   * `["OK", "b1a649ebe8...", true, "duplicate: already have this event"]`
   * `["OK", "b1a649ebe8...", false, "blocked: you are banned from posting here"]`
   * `["OK", "b1a649ebe8...", false, "blocked: please register your pubkey at https://my-expensive-relay.example.com"]`
   * `["OK", "b1a649ebe8...", false, "rate-limited: slow down there chief"]`
-  * `["OK", "b1a649ebe8...", false, "invalid: event creation date is too far off from the current time. Is your system clock in sync?"]`
+  * `["OK", "b1a649ebe8...", false, "invalid: event creation date is too far off from the current time"]`
   * `["OK", "b1a649ebe8...", false, "pow: difficulty 26 is less than 30"]`
   * `["OK", "b1a649ebe8...", false, "error: could not connect to the database"]`
-- `CLOSED` messages MUST be sent in response to a `REQ` when the relay refuses to fulfill it. It can also be sent when a relay decides to kill a subscription on its side before a client has disconnected or sent a `CLOSE`. This message uses the same pattern of `OK` messages with the machine-readable prefix and human-readable message. The standardized machine-readable prefixes are: `duplicate`, `unsupported` and `error` for when none of that fits. Some examples:
-
+- `CLOSED` messages MUST be sent in response to a `REQ` when the relay refuses to fulfill it. It can also be sent when a relay decides to kill a subscription on its side before a client has disconnected or sent a `CLOSE`. This message uses the same pattern of `OK` messages with the machine-readable prefix and human-readable message. Some examples:
   * `["CLOSED", "sub1", "duplicate: sub1 already opened"]`
   * `["CLOSED", "sub1", "unsupported: filter contains unknown elements"]`
   * `["CLOSED", "sub1", "error: could not connect to the database"]`
   * `["CLOSED", "sub1", "error: shutting down idle subscription"]`
+- The standardized machine-readable prefixes for `OK` and `CLOSED` are: `duplicate`, `pow`, `blocked`, `rate-limited`, `invalid`, and `error` for when none of that fits.

--- a/01.md
+++ b/01.md
@@ -162,7 +162,7 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
   * `["OK", "b1a649ebe8...", false, "invalid: event creation date is too far off from the current time. Is your system clock in sync?"]`
   * `["OK", "b1a649ebe8...", false, "pow: difficulty 26 is less than 30"]`
   * `["OK", "b1a649ebe8...", false, "error: could not connect to the database"]`
-- `CLOSED` messages MUST be sent when the relay in response to a `REQ` when the relay refuses to fulfill it. It can also be sent when a relay decides to kill a subscription on its side before a client has disconnected or sent a `CLOSE`. This message uses the same pattern of `OK` messages with the machine-readable prefix and human-readable message. The standardized machine-readable prefixes are: `duplicate`, `unsupported` and `error` for when none of that fits. Some examples:
+- `CLOSED` messages MUST be sent in response to a `REQ` when the relay refuses to fulfill it. It can also be sent when a relay decides to kill a subscription on its side before a client has disconnected or sent a `CLOSE`. This message uses the same pattern of `OK` messages with the machine-readable prefix and human-readable message. The standardized machine-readable prefixes are: `duplicate`, `unsupported` and `error` for when none of that fits. Some examples:
 
   * `["CLOSED", "sub1", "duplicate: sub1 already opened"]`
   * `["CLOSED", "sub1", "unsupported: filter contains unknown elements"]`

--- a/42.md
+++ b/42.md
@@ -66,16 +66,15 @@ subscriptions by clients):
 
 ## Protocol flow
 
-At any moment the relay may send an `AUTH` message to the client containing a challenge. The challenge is to be valid for the duration of
-the connection or until a next challenge is sent by the relay. The client MAY decide to send its `AUTH` event at any point and the
-authenticated session is valid afterwards for the duration of the connection.
+At any moment the relay may send an `AUTH` message to the client containing a challenge. The challenge is valid for the duration of
+the connection or until another challenge is sent by the relay. The client MAY decide to send its `AUTH` event at any point and the
 
 ### `auth-required` in response to a `REQ` message
 
 Given that a relay is likely to require clients to perform authentication only for certain jobs, like answering a `REQ` or accepting an
 `EVENT` write, these are some expected common flows:
 
-```json
+```
 relay: ["AUTH", "<challenge>"]
 client: ["REQ", "sub_1", {"kinds": [4]}]
 relay: ["CLOSED", "sub_1", "auth-required: we can't serve DMs to unauthenticated users"]
@@ -98,7 +97,7 @@ response to the `auth-required` `CLOSED` message.
 The same flow is valid for when a client wants to write an `EVENT` to the relay, except now the relay sends back an `OK` message instead of
 a `CLOSED` message:
 
-```json
+```
 relay: ["AUTH", "<challenge>"]
 client: ["EVENT", {"id": "012345...", ...}]
 relay: ["OK", "012345...", false, "auth-required: we only accept events from registered users"]

--- a/42.md
+++ b/42.md
@@ -68,6 +68,7 @@ subscriptions by clients):
 
 At any moment the relay may send an `AUTH` message to the client containing a challenge. The challenge is valid for the duration of
 the connection or until another challenge is sent by the relay. The client MAY decide to send its `AUTH` event at any point and the
+authenticated session is valid afterwards for the duration of the connection.
 
 ### `auth-required` in response to a `REQ` message
 

--- a/42.md
+++ b/42.md
@@ -66,7 +66,7 @@ subscriptions by clients):
 
 ## Protocol flow
 
-At any moment the relay may send an `AUTH` message to the client containing a challenge. The challenge is be valid for the duration of
+At any moment the relay may send an `AUTH` message to the client containing a challenge. The challenge is to be valid for the duration of
 the connection or until a next challenge is sent by the relay. The client MAY decide to send its `AUTH` event at any point and the
 authenticated session is valid afterwards for the duration of the connection.
 

--- a/42.md
+++ b/42.md
@@ -62,7 +62,7 @@ This NIP defines two new prefixes that can be used in `OK` (in response to event
 subscriptions by clients):
 
 - `"auth-required: "` - for when a client has not performed `AUTH` and the relay requires that to fulfill the query or write the event.
-- `"restricted: "` - for when a client has already performed `AUTH` but the key used to perform it is still not allowed by the relay.
+- `"restricted: "` - for when a client has already performed `AUTH` but the key used to perform it is still not allowed by the relay or is exceeding its authorization.
 
 ## Protocol flow
 

--- a/42.md
+++ b/42.md
@@ -21,6 +21,8 @@ A relay may want to require clients to authenticate to access restricted resourc
 
 ## Definitions
 
+### New client-relay protocol messages
+
 This NIP defines a new message, `AUTH`, which relays can send when they support authentication and clients can send to relays when they want
 to authenticate. When sent by relays, the message is of the following form:
 
@@ -33,6 +35,10 @@ And, when sent by clients, of the following form:
 ```json
 ["AUTH", <signed-event-json>]
 ```
+
+`AUTH` messages sent by clients should be answered with an `OK` message, like any `EVENT` message.
+
+### Canonical authentication event
 
 The signed event is an ephemeral event not meant to be published or queried, it must be of `kind: 22242` and it should have at least two tags,
 one for the relay URL and one for the challenge string as received from the relay.
@@ -50,27 +56,56 @@ Relays MUST exclude `kind: 22242` events from being broadcasted to any client.
 }
 ```
 
+### `OK` and `CLOSED` machine-readable prefixes
+
+This NIP defines two new prefixes that can be used in `OK` (in response to event writes by clients) and `CLOSED` (in response to rejected
+subscriptions by clients):
+
+- `"auth-required: "` - for when a client has not performed `AUTH` and the relay requires that to fulfill the query or write the event.
+- `"restricted: "` - for when a client has already performed `AUTH` but the key used to perform it is still not allowed by the relay.
+
 ## Protocol flow
 
-At any moment the relay may send an `AUTH` message to the client containing a challenge. After receiving that the client may decide to
-authenticate itself or not. The challenge is expected to be valid for the duration of the connection or until a next challenge is sent by
-the relay.
+At any moment the relay may send an `AUTH` message to the client containing a challenge. The challenge is be valid for the duration of
+the connection or until a next challenge is sent by the relay. The client MAY decide to send its `AUTH` event at any point and the
+authenticated session is valid afterwards for the duration of the connection.
 
-The client may send an auth message right before performing an action for which it knows authentication will be required -- for example, right
-before requesting `kind: 4` chat messages --, or it may do right on connection start or at some other moment it deems best. The authentication
-is expected to last for the duration of the WebSocket connection.
+### `auth-required` in response to a `REQ` message
 
-Upon receiving a message from an unauthenticated user it can't fulfill without authentication, a relay may choose to notify the client. For
-that it can use a `NOTICE` or `OK` message with a standard prefix `"restricted: "` that is readable both by humans and machines, for example:
+Given that a relay is likely to require clients to perform authentication only for certain jobs, like answering a `REQ` or accepting an
+`EVENT` write, these are some expected common flows:
 
 ```json
-["NOTICE", "restricted: we can't serve DMs to unauthenticated users, does your client implement NIP-42?"]
+relay: ["AUTH", "<challenge>"]
+client: ["REQ", "sub_1", {"kinds": [4]}]
+relay: ["CLOSED", "sub_1", "auth-required: we can't serve DMs to unauthenticated users"]
+client: ["AUTH", {"id": "abcdef...", ...}]
+relay: ["OK", "abcdef...", true, ""]
+client: ["REQ", "sub_1", {"kinds": [4]}]
+relay: ["EVENT", "sub_1", {...}]
+relay: ["EVENT", "sub_1", {...}]
+relay: ["EVENT", "sub_1", {...}]
+relay: ["EVENT", "sub_1", {...}]
+...
 ```
 
-or it can return an `OK` message noting the reason an event was not written using the same prefix:
+In this case, the `AUTH` message from the relay could be sent right as the client connects or it can be sent immediately before the `CLOSED`
+is sent. The only requirement is that _the client must have a stored challenge associated with that relay_ so it can act upon that in
+response to the `auth-required` `CLOSED` message.
+
+### `auth-required` in response to an `EVENT` message
+
+The same flow is valid for when a client wants to write an `EVENT` to the relay, except now the relay sends back an `OK` message instead of
+a `CLOSED` message:
 
 ```json
-["OK", <event-id>, false, "restricted: we do not accept events from unauthenticated users, please sign up at https://example.com/"]
+relay: ["AUTH", "<challenge>"]
+client: ["EVENT", {"id": "012345...", ...}]
+relay: ["OK", "012345...", false, "auth-required: we only accept events from registered users"]
+client: ["AUTH", {"id": "abcdef...", ...}]
+relay: ["OK", "abcdef...", true, ""]
+client: ["EVENT", {"id": "012345...", ...}]
+relay: ["OK", "012345...", true, ""]
 ```
 
 ## Signed Event Verification

--- a/42.md
+++ b/42.md
@@ -12,19 +12,15 @@ This NIP defines a way for clients to authenticate to relays by signing an ephem
 
 A relay may want to require clients to authenticate to access restricted resources. For example,
 
-  - A relay may request payment or other forms of whitelisting to publish events -- this can naïvely be achieved by limiting publication
-    to events signed by the whitelisted key, but with this NIP they may choose to accept any events as long as they are published from an
-    authenticated user;
-  - A relay may limit access to `kind: 4` DMs to only the parties involved in the chat exchange, and for that it may require authentication
-    before clients can query for that kind.
+  - A relay may request payment or other forms of whitelisting to publish events -- this can naïvely be achieved by limiting publication to events signed by the whitelisted key, but with this NIP they may choose to accept any events as long as they are published from an authenticated user;
+  - A relay may limit access to `kind: 4` DMs to only the parties involved in the chat exchange, and for that it may require authentication before clients can query for that kind.
   - A relay may limit subscriptions of any kind to paying users or users whitelisted through any other means, and require authentication.
 
 ## Definitions
 
 ### New client-relay protocol messages
 
-This NIP defines a new message, `AUTH`, which relays can send when they support authentication and clients can send to relays when they want
-to authenticate. When sent by relays, the message is of the following form:
+This NIP defines a new message, `AUTH`, which relays can send when they support authentication and clients can send to relays when they want to authenticate. When sent by relays, the message is of the following form:
 
 ```json
 ["AUTH", <challenge-string>]
@@ -40,10 +36,7 @@ And, when sent by clients, of the following form:
 
 ### Canonical authentication event
 
-The signed event is an ephemeral event not meant to be published or queried, it must be of `kind: 22242` and it should have at least two tags,
-one for the relay URL and one for the challenge string as received from the relay.
-Relays MUST exclude `kind: 22242` events from being broadcasted to any client.
-`created_at` should be the current time. Example:
+The signed event is an ephemeral event not meant to be published or queried, it must be of `kind: 22242` and it should have at least two tags, one for the relay URL and one for the challenge string as received from the relay. Relays MUST exclude `kind: 22242` events from being broadcasted to any client. `created_at` should be the current time. Example:
 
 ```json
 {
@@ -58,22 +51,18 @@ Relays MUST exclude `kind: 22242` events from being broadcasted to any client.
 
 ### `OK` and `CLOSED` machine-readable prefixes
 
-This NIP defines two new prefixes that can be used in `OK` (in response to event writes by clients) and `CLOSED` (in response to rejected
-subscriptions by clients):
+This NIP defines two new prefixes that can be used in `OK` (in response to event writes by clients) and `CLOSED` (in response to rejected subscriptions by clients):
 
 - `"auth-required: "` - for when a client has not performed `AUTH` and the relay requires that to fulfill the query or write the event.
 - `"restricted: "` - for when a client has already performed `AUTH` but the key used to perform it is still not allowed by the relay or is exceeding its authorization.
 
 ## Protocol flow
 
-At any moment the relay may send an `AUTH` message to the client containing a challenge. The challenge is valid for the duration of
-the connection or until another challenge is sent by the relay. The client MAY decide to send its `AUTH` event at any point and the
-authenticated session is valid afterwards for the duration of the connection.
+At any moment the relay may send an `AUTH` message to the client containing a challenge. The challenge is valid for the duration of the connection or until another challenge is sent by the relay. The client MAY decide to send its `AUTH` event at any point and the authenticated session is valid afterwards for the duration of the connection.
 
 ### `auth-required` in response to a `REQ` message
 
-Given that a relay is likely to require clients to perform authentication only for certain jobs, like answering a `REQ` or accepting an
-`EVENT` write, these are some expected common flows:
+Given that a relay is likely to require clients to perform authentication only for certain jobs, like answering a `REQ` or accepting an `EVENT` write, these are some expected common flows:
 
 ```
 relay: ["AUTH", "<challenge>"]
@@ -89,14 +78,11 @@ relay: ["EVENT", "sub_1", {...}]
 ...
 ```
 
-In this case, the `AUTH` message from the relay could be sent right as the client connects or it can be sent immediately before the `CLOSED`
-is sent. The only requirement is that _the client must have a stored challenge associated with that relay_ so it can act upon that in
-response to the `auth-required` `CLOSED` message.
+In this case, the `AUTH` message from the relay could be sent right as the client connects or it can be sent immediately before the `CLOSED` is sent. The only requirement is that _the client must have a stored challenge associated with that relay_ so it can act upon that in response to the `auth-required` `CLOSED` message.
 
 ### `auth-required` in response to an `EVENT` message
 
-The same flow is valid for when a client wants to write an `EVENT` to the relay, except now the relay sends back an `OK` message instead of
-a `CLOSED` message:
+The same flow is valid for when a client wants to write an `EVENT` to the relay, except now the relay sends back an `OK` message instead of a `CLOSED` message:
 
 ```
 relay: ["AUTH", "<challenge>"]

--- a/45.md
+++ b/45.md
@@ -27,7 +27,9 @@ In case a relay uses probabilistic counts, it MAY indicate it in the response wi
 ["COUNT", <subscription_id>, {"count": <integer>}]
 ```
 
-## Examples:
+Whenever the relay decides to refuse to fulfill the `COUNT` request, it MUST return a `CLOSED` message.
+
+## Examples
 
 ### Followers count
 
@@ -48,4 +50,11 @@ In case a relay uses probabilistic counts, it MAY indicate it in the response wi
 ```
 ["COUNT", <subscription_id>, {"kinds": [1]}]
 ["COUNT", <subscription_id>, {"count": 93412452, "approximate": true}]
+```
+
+### Relay refuses to count
+
+```
+["COUNT", <subscription_id>, {"kinds": [4], "authors": [<pubkey>], "#p": [<pubkey>]}]
+["CLOSED", <subscription_id>, "auth-required: cannot count other people's DMs"]
 ```

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `EVENT`  | used to send events requested to clients                | [01](01.md) |
 | `NOTICE` | used to send human-readable messages to clients         | [01](01.md) |
 | `OK`     | used to notify clients if an EVENT was successful       | [01](01.md) |
+| `CLOSED` | used to notify clients that a REQ was ended and why     | [01](01.md) |
 | `AUTH`   | used to send authentication challenges                  | [42](42.md) |
 | `COUNT`  | used to send requested event counts to clients          | [45](45.md) |
 


### PR DESCRIPTION
I will quote my own message from https://github.com/nostr-protocol/nips/pull/841#issuecomment-1828345933 to explain this:

> Basically we have two distinct problems:
> 
> 1. knowing why a relay is asking for `AUTH`
> 2. knowing why a subscription has failed
> 
> adding a third element to `AUTH` only solves them in the occasion that the two happen together.
> 
> creating a new message solves 2 and making `AUTH` be subservient to that (and also to `OK`) solves 1.

More relevant messages were posted to that other thread but should probably have been posted to this.