### PR TITLE
Add imeta tag

### DIFF
--- a/29.md
+++ b/29.md
@@ -1,0 +1,43 @@
+NIP029
+======
+
+imeta
+--------------
+
+`imeta` is a tag for adding media attachments to events. `imeta` tags MUST match URLs
+in the event content. Clients may replace imeta URLs with rich previews. `imeta` tags
+contain extra information about the media attachment, which clients can use to provide
+a better experience when loading images.
+
+The `imeta` tag is variadic, and each entry is a space-delimited key/value pair.
+Each `imeta` tag MUST have a `url`, and at least one other field. `imeta` may include
+any field specified by [NIP 94](./94.md). There SHOULD be only one `imeta` tag per url.
+
+## Example
+
+```json
+{
+  "content": "More image metadata tests don’t mind me https://nostr.build/i/my-image.jpg",
+  "kind": 1,
+  "tags": [
+    [
+      "imeta",
+      "url https://nostr.build/i/my-image.jpg",
+      "blurhash eVF$^OI:${M{o#*0-nNFxakD-?xVM}WEWB%iNKxvR-oetmo#R-aen$",
+      "dim 3024x4032",
+      "alt A scenic photo overlooking the coast of Costa Rica",
+      "x <sha256 hash as specified in NIP 94>",
+      "fallback https://nostrcheck.me/alt1.jpg"
+      "fallback https://void.cat/alt1.jpg"
+    ]
+  ]
+}
+```
+
+## Recommended client behavior
+
+When uploading images during a new post, clients MAY include this metadata
+after the image is uploaded and included in the post.
+
+When pasting urls during post composition, the client MAY download the image
+and add this metadata before the post is sent.

--- a/94.md
+++ b/94.md
@@ -25,6 +25,7 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
 * `image` (optional) url of preview image with same dimensions
 * `summary` (optional) text excerpt
 * `alt` (optional) description for accessibility
+* `fallback` (optional) zero or more fallback file sources in case `url` fails
 
 ```json
 {


### PR DESCRIPTION
This is adapted from Damus' DIPS repo: https://github.com/damus-io/dips/blob/master/01.md. I don't love the format, but I think there are probably a good number of events in the wild already using it. This PR is backwards-compatible except for renaming sha256 to x following NIP 94.

@jb55 correct me if I'm wrong and there is an opportunity to revisit the format. My preference would be to make the `url` the first argument of the tag rather than the value of the `url` key to make it more conventional. It would also be nice to use a query string or json or something instead of space delimited data.