### PR TITLE
Add OneKey to NIP-07 Supported Apps List

### DIFF
--- a/07.md
+++ b/07.md
@@ -36,3 +36,4 @@ async window.nostr.nip04.decrypt(pubkey, ciphertext): string // takes ciphertext
 - [Spring Browser](https://spring.site) (Android)
 - [nodestr](https://github.com/lightning-digital-entertainment/nodestr) (NodeJS polyfill)
 - [Nostore](https://apps.apple.com/us/app/nostore/id1666553677) (Safari on iOS/MacOS)
+- [OneKey](https://onekey.so/) (Android, IOS, Chrome and derivatives)


### PR DESCRIPTION
Adding OneKey to the NIP-07 App List.

I'm excited to share with everyone that OneKey now fully supports NIP07. 

[OneKey](https://onekey.so) is a completely open-source wallet. Here is our PR and documentation for the work we've done for Nostr.

PR: https://github.com/OneKeyHQ/app-monorepo/pull/3864
Document: https://developer.onekey.so/connect-to-software/webapp-connect-onekey/nostr/guide