### PR TITLE
Update NIP58 Badges: Remove section on PoW

### DIFF
--- a/58.md
+++ b/58.md
@@ -62,8 +62,6 @@ Users MAY choose to decorate their profiles with badges for fame, notoriety, rec
 
 ### Recommendations
 
-Badge issuers MAY include some Proof of Work as per [NIP-13](13.md) when minting Badge Definitions or Badge Awards to embed them with a combined energy cost, arguably making them more special and valuable for users that wish to collect them.
-
 Clients MAY whitelist badge issuers (pubkeys) for the purpose of ensuring they retain a valuable/special factor for their users.
 
 Badge image recommended aspect ratio is 1:1 with a high-res size of 1024x1024 pixels.


### PR DESCRIPTION
This paragraph may have been valid in an earlier iteration of the Badges NIP, but IMO it's not the case anymore, so this PR removes it.

My reasoning is as follows:

- PoW cannot be used for Badge Definitions to imbue value to the Badge, because the Badge Definition is a parametrized replaceable event. This means one version of it could have some PoW, but the event can be edited and replaced, thus losing the PoW. So any difficulty bits here are only temporary and cannot be used as an enduring property of the Badge. A collector would feel rugged if they got a high-PoW badge, then later it was edited and the badge lost the difficulty bits.

- Similarly, it makes little sense to rely on PoW in the Badge Awards to signify a higher value of the Badge. It's not the awarding that people value, but the badge that was awarded. If clients would show the awarding PoW as a separate indicator in addition to the badge, it would only lead to confusion: different people who received the same badge would see the badge displayed differently (ones with high PoW would show it as more valuable).

With this in mind, IMO its distracting and counter-productive to keep this paragraph in the NIP, as PoW cannot be used for the stated purpose.