### PR TITLE
Fix NIP-46 wording error

### DIFF
--- a/46.md
+++ b/46.md
@@ -157,6 +157,6 @@ The `content` field contains encrypted message as specified by [NIP04](https://g
 
 1. The **App** will send a message with metadata to the **Signer** with a `delegate` request along with the **conditions** query string and the **pubkey** of the **App** to be delegated.
 2. The **Signer** will show a popup to the user to delegate the **App** to sign on his behalf
-3. The **Signer** will send back a message with the signed [NIP-26 delegation token](https://github.com/nostr-protocol/nips/blob/master/26.md) or reject it
+3. The **Signer** will send back a message with the [NIP-26 delegation token](https://github.com/nostr-protocol/nips/blob/master/26.md) or reject it
 
 


### PR DESCRIPTION
According to the [NIP-26](https://github.com/nostr-protocol/nips/blob/master/26.md) definition, delegation token is a signature of the SHA256 hash of the delegation string, so it is considered unnatural to say that "signed" delegation token.