### PR TITLE
Change NIP-46 App to Client

### DIFF
--- a/46.md
+++ b/46.md
@@ -15,14 +15,14 @@ Entering private keys can also be annoying and requires exposing them to even mo
 
 ## Terms
 
-* **App**: Nostr app on any platform that *requires* to act on behalf of a nostr account.
-* **Signer**: Nostr app that holds the private key of a nostr account and *can sign* on its behalf.
+* **Client**: Nostr client on any platform that *requires* to act on behalf of a nostr account.
+* **Signer**: Nostr application that holds the private key of a nostr account and *can sign* on its behalf.
 
 
 ## `TL;DR`
 
 
-**App** and **Signer** sends ephemeral encrypted messages to each other using kind `24133`, using a relay of choice. 
+**Client** and **Signer** sends ephemeral encrypted messages to each other using kind `24133`, using a relay of choice. 
 
 App prompts the Signer to do things such as fetching the public key or signing events.
 
@@ -57,7 +57,7 @@ The `content` field must be an encrypted JSONRPC-ish **request** or **response**
 
 #### Mandatory 
 
-These are mandatory methods the remote signer app MUST implement:
+These are mandatory methods the remote signer application MUST implement:
 
 - **describe**
   - params []
@@ -95,16 +95,16 @@ NOTICE: `pubkey` and `signature` are hex-encoded strings.
 
 ### Nostr Connect URI
 
-**Signer** discovers **App** by scanning a QR code, clicking on a deep link or copy-pasting an URI.
+**Signer** discovers **Client** by scanning a QR code, clicking on a deep link or copy-pasting an URI.
 
-The **App** generates a special URI with prefix `nostrconnect://` and base path the hex-encoded `pubkey` with the following querystring parameters **URL encoded**
+The **Client** generates a special URI with prefix `nostrconnect://` and base path the hex-encoded `pubkey` with the following querystring parameters **URL encoded**
 
-- `relay` URL of the relay of choice where the **App** is connected and the **Signer** must send and listen for messages.
-- `metadata`  metadata JSON of the **App** 
-    - `name` human-readable name of the **App** 
+- `relay` URL of the relay of choice where the **Client** is connected and the **Signer** must send and listen for messages.
+- `metadata`  metadata JSON of the **Client** 
+    - `name` human-readable name of the **Client** 
     - `url` (optional) URL of the website requesting the connection
-    - `description` (optional) description of the **App**
-    - `icons` (optional) array of URLs for icons of the **App**.
+    - `description` (optional) description of the **Client**
+    - `icons` (optional) array of URLs for icons of the **Client**.
 
 #### JavaScript
 
@@ -127,36 +127,36 @@ The `content` field contains encrypted message as specified by [NIP04](https://g
 
 1. User clicks on **"Connect"** button on a website or scan it with a QR code
 2. It will show an URI to open a "nostr connect" enabled **Signer** 
-3. In the URI there is a pubkey of the **App** ie. `nostrconnect://<pubkey>&relay=<relay>&metadata=<metadata>`
+3. In the URI there is a pubkey of the **Client** ie. `nostrconnect://<pubkey>&relay=<relay>&metadata=<metadata>`
 4. The **Signer** will send a message to ACK the `connect` request, along with his public key
 
 ### Disconnect (from App)
 
-1. User clicks on **"Disconnect"** button on the **App**
+1. User clicks on **"Disconnect"** button on the **Client**
 2. The **App** will send a message to the **Signer** with a `disconnect` request
 3. The **Signer** will send a message to ACK the `disconnect` request
 
 ### Disconnect (from Signer)
 
 1. User clicks on **"Disconnect"** button on the **Signer**
-2. The **Signer** will send a message to the **App** with a `disconnect` request
+2. The **Signer** will send a message to the **Client** with a `disconnect` request
 
 
 ### Get Public Key
 
-1. The **App** will send a message to the **Signer** with a `get_public_key` request
+1. The **Client** will send a message to the **Signer** with a `get_public_key` request
 3. The **Signer** will send back a message with the public key as a response to the `get_public_key` request
 
 ### Sign Event
 
-1. The **App** will send a message to the **Signer** with a `sign_event` request along with the **event** to be signed
+1. The **Client** will send a message to the **Signer** with a `sign_event` request along with the **event** to be signed
 2. The **Signer** will show a popup to the user to inspect the event and sign it
 3. The **Signer** will send back a message with the event including the `id` and the schnorr `signature` as a response to the `sign_event` request
 
 ### Delegate
 
-1. The **App** will send a message with metadata to the **Signer** with a `delegate` request along with the **conditions** query string and the **pubkey** of the **App** to be delegated.
-2. The **Signer** will show a popup to the user to delegate the **App** to sign on his behalf
+1. The **Client** will send a message with metadata to the **Signer** with a `delegate` request along with the **conditions** query string and the **pubkey** of the **Client** to be delegated.
+2. The **Signer** will show a popup to the user to delegate the **Client** to sign on his behalf
 3. The **Signer** will send back a message with the signed [NIP-26 delegation token](https://github.com/nostr-protocol/nips/blob/master/26.md) or reject it
 
 


### PR DESCRIPTION
The word "App" reminds us of a smartphone application, and **Signer** is also an application, making it difficult to understand the difference between the two.
I suggest that **App** be changed to **Client**, as a similar position is considered a client in NIP-47.

Furthermore, change the word app to application to avoid the word app being associated with a smartphone application.