### PR TITLE
Add read status NIP

### DIFF
--- a/97.md
+++ b/97.md
@@ -1,0 +1,27 @@
+NIP-97
+======
+
+Read Status
+-----------
+
+`draft` `optional`
+
+Clients may wish to track whether certain events have been seen by a user, including mentions, replies, likes, messages, community posts, and more.
+
+A kind `15` event may be used to mark one or more `e` tags as read.
+
+```json
+{
+  "kind": "15",
+  "tags": [
+    ["expiration", "<one year in the future>"],
+    ["e", "<event1_id>"],
+    ["e", "<event1_id>"]
+  ]
+}
+```
+
+Events MAY be wrapped as described in [NIP 59](./59.md) in order to create private read status events. These can be useful for preserving user privacy, or to selectively reveal read status to other users, for example in a group chat or message thread.
+
+Read status events SHOULD expire after a sufficient amount of time to save storage space, since very old events can be assumed to have been seen. Wrapped events SHOULD put the `expiration` tag on the wrapper event. See [NIP 40](./40.md) for more information expiration.
+

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-92: Media Attachments](92.md)
 - [NIP-94: File Metadata](94.md)
 - [NIP-96: HTTP File Storage Integration](96.md)
+- [NIP-97: Read Status](97.md)
 - [NIP-98: HTTP Auth](98.md)
 - [NIP-99: Classified Listings](99.md)
 


### PR DESCRIPTION
This is simple, and granular. It uses `e` tags, not `a` tags to allow clients to differentiate versions of replaceable events. It allows for expiration and tagging multiple events at once to reduce storage requirements. It's not a replaceable list, so there won't be conflicts between writes. It allows for public and private read receipts, so it covers DM/group chat read receipts as well as user notification read status.