### PR TITLE
NIP-32: Clarify Language in summary

### DIFF
--- a/32.md
+++ b/32.md
@@ -6,8 +6,7 @@ Labeling
 
 `draft` `optional`
 
-A label is a `kind 1985` event that is used to label other entities. This supports a number of use cases,
-including distributed moderation, collection management, license assignment, and content classification.
+A label uses two new indexable tags to label events. Additionally, it adds a new event kind, `kind 1985`, that is used to label other entities. This supports a number of use cases, including distributed moderation, collection management, license assignment, and content classification.
 
 This NIP introduces two new tags:
 

--- a/32.md
+++ b/32.md
@@ -6,7 +6,7 @@ Labeling
 
 `draft` `optional`
 
-A label uses two new indexable tags to label events. Additionally, it adds a new event kind, `kind 1985`, that is used to label other entities. This supports a number of use cases, including distributed moderation, collection management, license assignment, and content classification.
+This NIP defines two new indexable tags to label events and a new event kind (kind:1985) to attach those labels to existing events. This supports several use cases, including distributed moderation, collection management, license assignment, and content classification.
 
 This NIP introduces two new tags:
 

--- a/32.md
+++ b/32.md
@@ -8,7 +8,7 @@ Labeling
 
 This NIP defines two new indexable tags to label events and a new event kind (kind:1985) to attach those labels to existing events. This supports several use cases, including distributed moderation, collection management, license assignment, and content classification.
 
-This NIP introduces two new tags:
+New Tags: 
 
 - `L` denotes a label namespace
 - `l` denotes a label

--- a/32.md
+++ b/32.md
@@ -6,7 +6,7 @@ Labeling
 
 `draft` `optional`
 
-This NIP defines two new indexable tags to label events and a new event kind (kind:1985) to attach those labels to existing events. This supports several use cases, including distributed moderation, collection management, license assignment, and content classification.
+This NIP defines two new indexable tags to label events and a new event kind (`kind:1985`) to attach those labels to existing events. This supports several use cases, including distributed moderation, collection management, license assignment, and content classification.
 
 New Tags: 
 


### PR DESCRIPTION
The language in the introductory paragraph is misleading. 

```
A label is a `kind 1985` event that is used to label other entities.
``` 

Is not an accurate statement, particularly as the opening sentence. The definition is out of order when it comes to communicating the purpose of the NIP. 

As written, it requires an implementer to read the entire NIP before it is communicated that `l` and `L` tags may be applied to any event. 

If summarizing NIP-32 in its entirety: 

```
A label is two new indexable tags used label events. It additionally adds an event kind used for labeling other events. 
```

See changes for actual language used.

