### PR TITLE
Mention deprecation of kind 2 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | ------------- | -------------------------- | -----------              |
 | `0`           | Metadata                   | [1](01.md)               |
 | `1`           | Short Text Note            | [1](01.md)               |
-| `2`           | Recommend Relay            |                          |
+| `2`           | Recommend Relay            | 1 (before 2023-08-13)    |
 | `3`           | Follows                    | [2](02.md)               |
 | `4`           | Encrypted Direct Messages  | [4](04.md)               |
 | `5`           | Event Deletion             | [9](09.md)               |


### PR DESCRIPTION
It's now the second time that I searched for what's the matter with kind `2`.

Kind `2` was [consciously](https://github.com/nostr-protocol/nips/pull/703#issuecomment-1672098794) removed in https://github.com/nostr-protocol/nips/commit/72bb8a128b2d7d3c2c654644cd68d0d0fe58a3b1#diff-39307f1617417657ee9874be314f13aabdc74401b124d0afe8217f2919c9c7d8L105.
Mentioning the fact in the event kinds table should help prevent further confusion.