### PR TITLE
Emphasis on multiple filters in NIP-01

### DIFF
--- a/01.md
+++ b/01.md
@@ -101,7 +101,7 @@ Relays expose a websocket endpoint to which clients can connect. Clients SHOULD 
 Clients can send 3 types of messages, which must be JSON arrays, according to the following patterns:
 
   * `["EVENT", <event JSON as defined above>]`, used to publish events.
-  * `["REQ", <subscription_id>, <filters JSON>...]`, used to request events and subscribe to new updates.
+  * `["REQ", <subscription_id>, <filters JSON>, ...]`, used to request events and subscribe to new updates.
   * `["CLOSE", <subscription_id>]`, used to stop previous subscriptions.
 
 `<subscription_id>` is an arbitrary, non-empty string of max length 64 chars, that should be used to represent a subscription. Relays should manage `<subscription_id>`s independently for each WebSocket connection; even if `<subscription_id>`s are the same string, they should be treated as different subscriptions for different connections.


### PR DESCRIPTION
As mentioned further down in NIP-01

> A REQ message may contain multiple filters.

The comma makes it more clear that the message array can container more than 3 items. So it is understood easily to match

```
// correct:
["REQ", <subscription_id>, filters1, filters2, …]
```

instead of 

```
// wrong:
["REQ", <subscription_id>, [filters1, filters2, …]]
```