### PR TITLE
Pseudonym DM

### DIFF
--- a/43.md
+++ b/43.md
@@ -1,0 +1,108 @@
+NIP-43
+======
+
+Nym DM
+------
+
+`draft` `optional`
+
+This direct message (DM) scheme between two participants aims to hide metadata while keeping the regular client-relay filtering experience.
+
+## Sending a Message
+
+To send a message, first the sender known as `<pubkey-Alice>` picks a random pseudonym (nym) keypair to use just to talk to the receiver known as `<pubkey-Bob>`.
+She updates its own [NIP-51](#51.md) `kind:10043` "Nym List" event:
+
+```js
+{
+  "kind": 10043,
+  "pubkey": "<pubkey-Alice>"
+  "content": "<nip44EncryptToMyself(JSON.stringify([
+    [
+      "<pubkey-Bob>", // acts like a chat "id"
+      "<privkey-Alice-Nym>", // the chosen private key pseudonym
+      "", // the third array item will later be filled with <pubkey-Bob-Nym>
+      "" // the fourth array item will later be filled with <signed-pubkey-Bob-Nym> as a proof it is really Bob's nym
+    ],
+    // others nym arrays related to other chats
+  ]))>",
+  // ...other fields
+}
+```
+
+The second step is to send a `kind:1043` "Request Nym List Update" event by a random pubkey with the current timestamp,
+wrapping a disposable [NIP-78](#78.md) `kind:30078` event by `<pubkey-Alice>` with a random timestamp.
+
+The inner event `.content` is a set of stringified tags encrypted to Bob:
+- "my_nym": Alice's pubkey-nym followed by a [NIP-01](#01.md) signed proof;
+- "your_nym": Empty string, indicating Alice wants to know Bob's pubkey-nym, meaning Bob should also send a similar event to her if he wants to talk to her
+
+```js
+{
+  "kind": 1043,
+  "pubkey": "<random>",
+  "tags": [
+    ["p", "<pubkey-Bob>"]
+  ]
+  "content": "<nip44EncryptToBob(JSON.stringify({
+    "kind": 30078,
+    "pubkey": "<pubkey-Alice>",
+    "tags": [], // empty, not even a "d" tag
+    "content": "<nip44EncryptToBob(JSON.stringify([
+      ["my_nym", "<pubkey-Alice-Nym>", signWithAlicePrivkey("<pubkey-Alice-Nym>")],
+      ["your_nym", ""]
+    ]))>",
+    "created_at": 1702711587 // random
+    // ...other fields
+  }))>",
+  "created_at": 1702711000 // now
+  // ...other fields
+}
+```
+
+The last step is to start sending the `kind:1004` (Nym) DMs, with the current timestamp, encrypted to Bob but **without** a `p` tag set to `<pubkey-Bob>`. Notice that she doesn't need to know Bob's nym to
+be able to send him DMs.
+
+If Bob wants to read messages from Alice, he will request at his [NIP-65](#65.md) read relays with a `{ authors: ["<pubkey-Alice-Nym>"], kinds: [14] }` filter because this pubkey is just used to talk to him.
+
+```js
+{
+  "kind": 1004,
+  "pubkey" "<pubkey-Alice-Nym>",
+  "tags": [],
+  "content": "<nip44EncryptToBob('Hello, Bob.')>",
+  "created_at": 1702812000 // now
+  // ....other fields
+}
+```
+
+## Replying
+
+To reply, Bob will do the same above steps so that Alice knows what nym Bob will use to talk to her.
+Inside his `kind:1043` event, the inner `kind:30078` event `.content` will have the following encrypted tags:
+```js
+[
+  ["my_nym", "<pubkey-Bob-Nym>", signWithBobPrivkey("<pubkey-Bob-Nym>")],
+  ["your_nym", "<pubkey-Alice-Nym>"] // meaning Bob already knows Alice's nym so she won't need to reply with a `kind:1043` event
+]
+```
+
+Now Bob will have a `kind:10043` Nym List event with a complete tag (4 array items) corresponding to Bob-Alice chat:
+
+```js
+{
+  "kind": 10043,
+  "pubkey": "<pubkey-Bob>"
+  "content": "<nip44EncryptToMyself(JSON.stringify([
+    [
+      "<pubkey-Alice>",
+      "<privkey-Bob-Nym>",
+      "<pubkey-Alice-Nym>",
+      "<signed-pubkey-Alice-Nym>"
+    ]
+  ]))>",
+  // ...other fields
+}
+```
+
+If Bob has never responded with a `kind:1043` "Request Nym List Update" event, Alice can send again a `kind:1043` event with the same `<pubkey-Alice-Nym>` as `my_nym` (along with the signature) and an empty string as `your_nym`.


### PR DESCRIPTION
This is an alternative to #686 Sealed Gift-wrapped DMs (SGWDMs).

The SGWDMs hides metadata but:
1) The receiver has no way to fetch just DMs (Gift-wrap is a generic `kind:1059` event)
2) The receiver has no way to fetch just Gift-wraps/DMs from a specific person
3) The receiver needs to fetch messages from the "last read at" moment minus one week onwards

This all translates into the receiver fetching too much events it doesn't want;

Read [here](https://github.com/arthurfranca/nips/blob/dm/43.md)