### PR TITLE
Removes the `aes-256-gcm` tag from NIP-94

### DIFF
--- a/94.md
+++ b/94.md
@@ -6,7 +6,7 @@ File Metadata
 
 `draft` `optional`
 
-The purpose of this NIP is to allow an organization and classification of shared files. So that relays can filter and organize in any way that is of interest. With that, multiple types of filesharing clients can be created. NIP-94 support is not expected to be implemented by "social" clients that deal with kind:1 notes or by longform clients that deal with kind:30023 articles.
+The purpose of this NIP is to allow an organization and classification of shared files. So that relays can filter and organize in any way that is of interest. With that, multiple types of filesharing clients can be created. NIP-94 support is not expected to be implemented by "social" clients that deal with `kind:1` notes or by longform clients that deal with `kind:30023` articles.
 
 ## Event format
 
@@ -14,7 +14,6 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
 
 * `url` the url to download the file
 * `m` a string indicating the data type of the file. The [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) format must be used, and they should be lowercase.
-* `"aes-256-gcm"` (optional)  key and nonce for AES-GCM encryption with tagSize always 128bits
 * `x` containing the SHA-256 hexencoded string of the file.
 * `size` (optional) size of file in bytes
 * `dim` (optional) size of file in pixels in the form `<width>x<height>`
@@ -31,7 +30,6 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
   "kind": 1063,
   "tags": [
     ["url",<string with URI of file>],
-    ["aes-256-gcm",<key>, <iv>],
     ["m", <MIME type>],
     ["x",<Hash SHA-256>],
     ["size", <size of file in bytes>],


### PR DESCRIPTION
1. No one seems to be using it. 
2. People who wish to use encryption can now use the new NIP-44 scheme.
3. The existence of the tag as is creates more questions than solutions. 