### PR TITLE
NIP-01 Tighten-up subscription_id management rule

### DIFF
--- a/01.md
+++ b/01.md
@@ -104,7 +104,7 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
   * `["REQ", <subscription_id>, <filters1>, <filters2>, ...]`, used to request events and subscribe to new updates.
   * `["CLOSE", <subscription_id>]`, used to stop previous subscriptions.
 
-`<subscription_id>` is an arbitrary, non-empty string of max length 64 chars, that should be used to represent a subscription. Relays should manage `<subscription_id>`s independently for each WebSocket connection; even if `<subscription_id>`s are the same string, they should be treated as different subscriptions for different connections.
+`<subscription_id>` is an arbitrary, non-empty string of max length 64 chars. It represents a subscription per connection. Relays MUST manage `<subscription_id>`s independently for each WebSocket connection. `<subscription_id>`s are not guarantueed to be globally unique.
 
 `<filtersX>` is a JSON object that determines what events will be sent in that subscription, it can have the following attributes:
 


### PR DESCRIPTION
Rephrase to "MUST" so that one does not assume a connection could `CLOSE` any `subscription_id`, which it must not. Otherwise one could close other people's subscriptions.