### PR TITLE
cleanup NIP-52: remove confusing parts

### DIFF
--- a/52.md
+++ b/52.md
@@ -35,9 +35,6 @@ The list of tags are as follows:
 * `t` (optional, repeated) hashtag to categorize calendar event
 * `r` (optional, repeated) references / links to web pages, documents, video calls, recorded videos, etc.
 
-The following tags are deprecated:
-* `name` name of the calendar event. Use only if `title` is not available.
-
 ```json
 {
   "id": <32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>,
@@ -95,9 +92,6 @@ The list of tags are as follows:
 * `p` (optional, repeated) 32-bytes hex pubkey of a participant, optional recommended relay URL, and participant's role in the meeting
 * `t` (optional, repeated) hashtag to categorize calendar event
 * `r` (optional, repeated) references / links to web pages, documents, video calls, recorded videos, etc.
-
-The following tags are deprecated:
-* `name` name of the calendar event. Use only if `title` is not available.
 
 ```json
 {
@@ -210,13 +204,7 @@ The list of tags are as follows:
 }
 ```
 
-## Unsolved Limitations
-
-* No private events
-
-## Intentionally Unsupported Scenarios
-
-### Recurring Calendar Events
+## Recurring Calendar Events
 
 Recurring calendar events come with a lot of complexity, making it difficult for software and humans to deal with. This complexity includes time zone differences between invitees, daylight savings, leap years, multiple calendar systems, one-off changes in schedule or other metadata, etc.
 


### PR DESCRIPTION
I don't think anyone has implemented anything with the `name` tag so it's better to not even mention it. People who know about it already know that it should be removed.

Removing the mention to the private events limitation since it isn't relevant. There are infinite things each NIP _doesn't_ do and there is no need to mention all of them, so we should stick to what it does.