### PR TITLE
Remove NIP-54 mention temporarily

### DIFF
--- a/96.md
+++ b/96.md
@@ -189,7 +189,7 @@ Note that if the server didn't apply any transformation to the received file, bo
 `Clients` may upload the same file to one or many `servers`.
 After successful upload, the `client` may optionally generate and send to any set of nostr `relays` a [NIP-94](94.md) event by including the missing fields.
 
-Alternatively, instead of using NIP-94, the `client` can share or embed on a nostr note just the above url with added "ox" field and optionally other ones.
+Alternatively, instead of using NIP-94, the `client` can share or embed on a nostr note just the above url.
 
 ### Delayed Processing
 

--- a/96.md
+++ b/96.md
@@ -189,7 +189,7 @@ Note that if the server didn't apply any transformation to the received file, bo
 `Clients` may upload the same file to one or many `servers`.
 After successful upload, the `client` may optionally generate and send to any set of nostr `relays` a [NIP-94](94.md) event by including the missing fields.
 
-Alternatively, instead of using NIP-94, the `client` can share or embed on a nostr note just the above url with added "ox" [NIP-54](54.md) inline metadata field and optionally other ones.
+Alternatively, instead of using NIP-94, the `client` can share or embed on a nostr note just the above url with added "ox" field and optionally other ones.
 
 ### Delayed Processing
 


### PR DESCRIPTION
[NIP-54: Inline Resource Metadata](https://github.com/nostr-protocol/nips/pull/521) is not merged yet.