### PR TITLE
Remove "d" tag reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Please update these lists when proposing NIPs introducing new event kinds.
 | `e`               | event id (hex)                       | relay URL, marker    | [01](01.md), [10](10.md)              |
 | `p`               | pubkey (hex)                         | relay URL, petname   | [01](01.md), [02](02.md)              |
 | `a`               | coordinates to an event              | relay URL            | [01](01.md)                           |
-| `d`               | identifier                           | --                   | [01](01.md)                           |
+| `d`               | identifier                           | --                   |                                       |
 | `g`               | geohash                              | --                   | [52](52.md)                           |
 | `i`               | identity                             | proof                | [39](39.md)                           |
 | `k`               | kind number (string)                 | --                   | [18](18.md), [25](25.md), [72](72.md) |


### PR DESCRIPTION
This is about the matter of replaceable events.

Even though a lot of NIPs still reference the "d" tag, I was confused by the explicit reference to NIP-01. The "d" tag lost its specific definition in https://github.com/nostr-protocol/nips/pull/703 where NIP-33 was merged into NIP-01.