### PR TITLE
NIP-34: git stuff

### DIFF
--- a/34.md
+++ b/34.md
@@ -1,0 +1,45 @@
+NIP-34
+======
+
+`git` stuff
+-----------
+
+`draft` `optional`
+
+This NIP defines all the ways code collaboration using and adjacent to [`git`](https://git-scm.com/) can be done using Nostr.
+
+## Repository announcements
+
+Git repositories are hosted in Git-enabled servers, but their existence can be announced using Nostr events, as well as their willingness to receive patches, bug reports and comments in general.
+
+```jsonc
+{
+  "kind": 30617,
+  "content": "",
+  "tags": [
+    ["d", "<repo-id>"],
+    ["name", "<human-readable project name>"],
+    ["description", "brief human-readable project description>"],
+    ["web", "<url for browsing>"], // a webpage url, if the git server being used provides such a thing
+    ["clone", "<url for git-cloning>"], // a url to be given to `git clone` so anyone can clone it
+    ["patches", "<relay-url>"], // this signals that patches are welcome and will be searched for in this relay
+    ["issues", "<relay-url>"] // this signals that bug reports, questions, comments and so on are welcome
+  ]
+}
+```
+
+The tags `web`, `clone`, `patches` and `issues` can be specified multiple times.
+
+## Patches
+
+Patches can be sent by anyone to any repository. Patches to a specific repository SHOULD be sent to the relays specified in that repository's announcement event's `"patches"` tag. Patch events SHOULD include an `a` tag pointing to that repository's announcement address.
+
+```jsonc
+{
+  "kind": 1617,
+  "content": "<patch>", // contents of <git format-patch>
+  "tags": [
+    ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"]
+  ]
+}
+```

--- a/34.md
+++ b/34.md
@@ -20,7 +20,6 @@ Git repositories are hosted in Git-enabled servers, but their existence can be a
     ["d", "<repo-id>"],
     ["name", "<human-readable project name>"],
     ["description", "brief human-readable project description>"],
-    ["tag", "head", "<sha1-hex>"], // the current repository commit head, as hex
     ["web", "<url for browsing>", ...], // a webpage url, if the git server being used provides such a thing
     ["clone", "<url for git-cloning>", ...], // a url to be given to `git clone` so anyone can clone it
     ["relays", "<relay-url>", ...] // relays that this repository will monitor for patches and issues

--- a/34.md
+++ b/34.md
@@ -46,10 +46,6 @@ Patches can be sent by anyone to any repository. Patches to a specific repositor
 }
 ```
 
-## Branch merge
-
-To be defined.
-
 ## Issues
 
 Issues are Markdown text that is just human-readable conversational threads related to the repository: bug reports, feature requests, questions or comments of any kind.
@@ -80,3 +76,9 @@ Replies are also Markdown text. The difference is that they MUST refer to one ro
   ]
 }
 ```
+
+## Things to be added later
+
+- branch merge kind (specifying a URL from where to fetch the branch to be merged)
+- inline file comments kind
+- review type with multiple inline comments? -- or maybe this could just be an extension of the "reply" kind above

--- a/34.md
+++ b/34.md
@@ -77,9 +77,12 @@ Replies are also Markdown text. The difference is that they MUST refer to one ro
   "kind": 1622,
   "content": "<markdown text>",
   "tags": [
-    ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"],
-    ["e", "<root-event-id>"],
-    ["p", "<mentioned-pubkey>"]
+    ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>", "<relay-url>"],
+    ["e", "<issue-or-patch-id-hex>", "", "root"],
+
+    // other "e" and "p" tags should be applied here when necessary, following the threading rules of NIP-10
+    ["p", "<patch-author-pubkey-hex>", "", "mention"],
+    // ...
   ]
 }
 ```

--- a/34.md
+++ b/34.md
@@ -87,8 +87,9 @@ Replies are also Markdown text. The difference is that they MUST refer to one ro
 }
 ```
 
-## Things to be added later
+## Possible things to be added later
 
-- branch merge kind (specifying a URL from where to fetch the branch to be merged)
-- inline file comments kind
-- review type with multiple inline comments? -- or maybe this could just be an extension of the "reply" kind above
+- "status" kind (for letting people know a patch was merged or an issue was fixed or won't be fixed)
+- "branch merge" kind (specifying a URL from where to fetch the branch to be merged)
+- "cover letter" kind (to which multiple patches can refer and serve as a unifying layer to them)
+- inline file comments kind (we probably need one for patches and a different one for merged files)

--- a/34.md
+++ b/34.md
@@ -48,7 +48,7 @@ Patches can be sent by anyone to any repository. Patches to a specific repositor
     ["commit", "<current-commit-id>"],
     ["parent-commit", "<parent-commit-id>"],
     ["commit-pgp-sig", "-----BEGIN PGP SIGNATURE-----..."],
-    ["committer", "<name>", "<email>", "<timezone offset in minutes>"],
+    ["committer", "<name>", "<email>", "<timestamp>", "<timezone offset in minutes>"],
   ]
 }
 ```

--- a/34.md
+++ b/34.md
@@ -73,7 +73,7 @@ Issues are Markdown text that is just human-readable conversational threads rela
 
 ## Replies
 
-Replies are also Markdown text. The difference is that they MUST refer to one root thread event. Their root doesn't have to be a `kind:1621` _issue_, but also a `kind:1617` patch event.
+Replies are also Markdown text. The difference is that they MUST be issued as replies to either a `kind:1621` _issue_ or a `kind:1617` _patch_ event. The threading of replies and patches should follow NIP-10 rules.
 
 ```jsonc
 {
@@ -85,6 +85,7 @@ Replies are also Markdown text. The difference is that they MUST refer to one ro
 
     // other "e" and "p" tags should be applied here when necessary, following the threading rules of NIP-10
     ["p", "<patch-author-pubkey-hex>", "", "mention"],
+    ["e", "<previous-reply-id-hex>", "", "reply"],
     // ...
   ]
 }

--- a/34.md
+++ b/34.md
@@ -20,6 +20,7 @@ Git repositories are hosted in Git-enabled servers, but their existence can be a
     ["d", "<repo-id>"],
     ["name", "<human-readable project name>"],
     ["description", "brief human-readable project description>"],
+    ["head", "<sha1-hex>"], // the current repository commit head, as hex
     ["web", "<url for browsing>"], // a webpage url, if the git server being used provides such a thing
     ["clone", "<url for git-cloning>"], // a url to be given to `git clone` so anyone can clone it
     ["patches", "<relay-url>"], // this signals that patches are welcome and will be searched for in this relay
@@ -28,7 +29,7 @@ Git repositories are hosted in Git-enabled servers, but their existence can be a
 }
 ```
 
-The tags `web`, `clone`, `patches` and `issues` can be specified multiple times.
+The tags `web`, `clone`, `patches` and `issues` can be specified multiple times. Except `d`, all tags are optional.
 
 ## Patches
 

--- a/34.md
+++ b/34.md
@@ -44,6 +44,9 @@ Patches can be sent by anyone to any repository. Patches to a specific repositor
     ["p", "<repository-owner>"],
     ["p", "<other-user>"], // optionally send the patch to another user to bring it to their attention
 
+    // for the first patch in a thread or series
+    ["t", "root"],
+
     // optional tags for when it is desirable that the merged patch has a stable commit id
     // these fields are necessary for ensuring that the commit resulting from applying a patch
     // has the same id as it had in the proposer's machine -- all these tags can be omitted

--- a/34.md
+++ b/34.md
@@ -44,3 +44,36 @@ Patches can be sent by anyone to any repository. Patches to a specific repositor
   ]
 }
 ```
+
+## Branch merge
+
+To be defined.
+
+## Issues
+
+Issues are Markdown text that is just human-readable conversational threads related to the repository: bug reports, feature requests, questions or comments of any kind.
+
+```jsonc
+{
+  "kind": 1621,
+  "content": "<markdown text>",
+  "tags": [
+    ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"]
+  ]
+}
+```
+
+## Replies
+
+Replies are also Markdown text. The difference is that they MUST refer to one root thread event. Their root doesn't have to be a `kind:1621` _issue_, but also a `kind:1617` patch event.
+
+```jsonc
+{
+  "kind": 1622,
+  "content": "<markdown text>",
+  "tags": [
+    ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"],
+    ["e", "<root-event-id>"],
+  ]
+}
+```

--- a/34.md
+++ b/34.md
@@ -40,7 +40,8 @@ Patches can be sent by anyone to any repository. Patches to a specific repositor
   "kind": 1617,
   "content": "<patch>", // contents of <git format-patch>
   "tags": [
-    ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"]
+    ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"],
+    ["p", "<repository-owner>"]
   ]
 }
 ```
@@ -58,7 +59,8 @@ Issues are Markdown text that is just human-readable conversational threads rela
   "kind": 1621,
   "content": "<markdown text>",
   "tags": [
-    ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"]
+    ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"],
+    ["p", "<repository-owner>"]
   ]
 }
 ```
@@ -74,6 +76,7 @@ Replies are also Markdown text. The difference is that they MUST refer to one ro
   "tags": [
     ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"],
     ["e", "<root-event-id>"],
+    ["p", "<mentioned-pubkey>"]
   ]
 }
 ```

--- a/34.md
+++ b/34.md
@@ -45,9 +45,12 @@ Patches can be sent by anyone to any repository. Patches to a specific repositor
     ["p", "<other-user>"], // optionally send the patch to another user to bring it to their attention
 
     // optional tags for when it is desirable that the merged patch has a stable commit id
+    // these fields are necessary for ensuring that the commit resulting from applying a patch
+    // has the same id as it had in the proposer's machine -- all these tags can be omitted
+    // if the maintainer doesn't care about these things
     ["commit", "<current-commit-id>"],
     ["parent-commit", "<parent-commit-id>"],
-    ["commit-pgp-sig", "-----BEGIN PGP SIGNATURE-----..."],
+    ["commit-pgp-sig", "-----BEGIN PGP SIGNATURE-----..."], // empty string for unsigned commit
     ["committer", "<name>", "<email>", "<timestamp>", "<timezone offset in minutes>"],
   ]
 }

--- a/34.md
+++ b/34.md
@@ -23,19 +23,18 @@ Git repositories are hosted in Git-enabled servers, but their existence can be a
     ["tag", "head", "<sha1-hex>"], // the current repository commit head, as hex
     ["web", "<url for browsing>", ...], // a webpage url, if the git server being used provides such a thing
     ["clone", "<url for git-cloning>", ...], // a url to be given to `git clone` so anyone can clone it
-    ["patches", "<relay-url>", ...], // this signals that patches are welcome and will be searched for in this relay
-    ["issues", "<relay-url>", ...] // this signals that bug reports, questions, comments and so on are welcome
+    ["relays", "<relay-url>", ...] // relays that this repository will monitor for patches and issues
   ]
 }
 ```
 
-The tags `web`, `clone`, `patches` and `issues` can have multiple values.
+The tags `web`, `clone`, `relays` can have multiple values.
 
 Except `d`, all tags are optional.
 
 ## Patches
 
-Patches can be sent by anyone to any repository. Patches to a specific repository SHOULD be sent to the relays specified in that repository's announcement event's `"patches"` tag. Patch events SHOULD include an `a` tag pointing to that repository's announcement address.
+Patches can be sent by anyone to any repository. Patches to a specific repository SHOULD be sent to the relays specified in that repository's announcement event's `"relays"` tag. Patch events SHOULD include an `a` tag pointing to that repository's announcement address.
 
 ```jsonc
 {
@@ -50,7 +49,7 @@ Patches can be sent by anyone to any repository. Patches to a specific repositor
 
 ## Issues
 
-Issues are Markdown text that is just human-readable conversational threads related to the repository: bug reports, feature requests, questions or comments of any kind.
+Issues are Markdown text that is just human-readable conversational threads related to the repository: bug reports, feature requests, questions or comments of any kind. Like patches, these SHOULD be sent to the relays specified in that repository's announcement event's `"relays"` tag.
 
 ```jsonc
 {

--- a/34.md
+++ b/34.md
@@ -42,6 +42,7 @@ Patches can be sent by anyone to any repository. Patches to a specific repositor
   "tags": [
     ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"],
     ["p", "<repository-owner>"],
+    ["p", "<other-user>"], // optionally send the patch to another user to bring it to their attention
 
     // optional tags for when it is desirable that the merged patch has a stable commit id
     ["commit", "<current-commit-id>"],

--- a/34.md
+++ b/34.md
@@ -20,16 +20,18 @@ Git repositories are hosted in Git-enabled servers, but their existence can be a
     ["d", "<repo-id>"],
     ["name", "<human-readable project name>"],
     ["description", "brief human-readable project description>"],
-    ["head", "<sha1-hex>"], // the current repository commit head, as hex
-    ["web", "<url for browsing>"], // a webpage url, if the git server being used provides such a thing
-    ["clone", "<url for git-cloning>"], // a url to be given to `git clone` so anyone can clone it
-    ["patches", "<relay-url>"], // this signals that patches are welcome and will be searched for in this relay
-    ["issues", "<relay-url>"] // this signals that bug reports, questions, comments and so on are welcome
+    ["tag", "head", "<sha1-hex>"], // the current repository commit head, as hex
+    ["web", "<url for browsing>", ...], // a webpage url, if the git server being used provides such a thing
+    ["clone", "<url for git-cloning>", ...], // a url to be given to `git clone` so anyone can clone it
+    ["patches", "<relay-url>", ...], // this signals that patches are welcome and will be searched for in this relay
+    ["issues", "<relay-url>", ...] // this signals that bug reports, questions, comments and so on are welcome
   ]
 }
 ```
 
-The tags `web`, `clone`, `patches` and `issues` can be specified multiple times. Except `d`, all tags are optional.
+The tags `web`, `clone`, `patches` and `issues` can have multiple values.
+
+Except `d`, all tags are optional.
 
 ## Patches
 

--- a/34.md
+++ b/34.md
@@ -42,7 +42,13 @@ Patches can be sent by anyone to any repository. Patches to a specific repositor
   "content": "<patch>", // contents of <git format-patch>
   "tags": [
     ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"],
-    ["p", "<repository-owner>"]
+    ["p", "<repository-owner>"],
+
+    // optional tags for when it is desirable that the merged patch has a stable commit id
+    ["commit", "<current-commit-id>"],
+    ["parent-commit", "<parent-commit-id>"],
+    ["commit-pgp-sig", "-----BEGIN PGP SIGNATURE-----..."],
+    ["committer", "<name>", "<email>", "<timezone offset in minutes>"],
   ]
 }
 ```


### PR DESCRIPTION
The simplest possible git collaboration flow that has a chance of working.

The patch stuff is based on http://git.jb55.com/git-nostr-tools, with some changes.

https://github.com/nostr-protocol/nips/blob/git/34.md

Here's a standalone CLI tool that allows for announcing a repository, sending and downloading patches: https://github.com/fiatjaf/gitstr -- probably very rough still, but I just merged a patch from myself using it so I am happy.