### PR TITLE
NIP-49: Fix correct PASSPHRASE to PASSWORD

### DIFF
--- a/49.md
+++ b/49.md
@@ -7,12 +7,12 @@ Private Key Encryption
 
 `draft` `optional`
 
-This NIP defines a method by which clients can encrypt (and decrypt) a user's private key with a passphrase.
+This NIP defines a method by which clients can encrypt (and decrypt) a user's private key with a password.
 
 Symmetric Encryption Key derivation
 -----------------------------------
 
-PASSPHRASE = read from the user
+PASSWORD = read from the user
 
 LOG\_N = Let the user or implementer choose one byte representing a power of 2 (e.g. 18 represents 262,144) which is used as the number of rounds for scrypt. Larger numbers take more time and more memory, and offer better protection:
 
@@ -26,7 +26,7 @@ LOG\_N = Let the user or implementer choose one byte representing a power of 2 (
 
 SALT = 16 random bytes
 
-SYMMETRIC_KEY = scrypt(passphrase=PASSPHRASE, salt=SALT, log\_n=LOG\_N, r=8, p=1)
+SYMMETRIC_KEY = scrypt(password=PASSWORD, salt=SALT, log\_n=LOG\_N, r=8, p=1)
 
 The symmetric key should be 32 bytes long.
 


### PR DESCRIPTION
In NIP-49, the words PASSPHRASE and PASSWORD both existed to mean the same thing. 
After checking the scrypt documentation, password seemed to be correct.

FYI. https://nodejs.org/api/crypto.html#cryptoscryptpassword-salt-keylen-options-callback

So I unified the words into password.