### PR TITLE
NIP-29 Shared Event Ownership through DVMs

### DIFF
--- a/29.md
+++ b/29.md
@@ -1,0 +1,64 @@
+NIP-29
+======
+
+Shared Event Ownership Through Trusted DVMs
+-------------------------------------------
+
+`draft` `optional`
+
+This NIP proposes a standardized way that 2+ pubkeys unilaterally control a single replaceable event. The managing keys choose a trustworthy [DVM](90.md) to own and update the event. Such actions are performed via the usual Job Request and Responses of [DVMs](90.md). 
+
+## Motivation
+
+Some applications require the ability for several pubkeys to be able to change a single replaceable event. Collaborative document writing tools, for instance, generally allow several users to change the same document. Group metadata events, for instance, must be updated by a set of admins to include and remove people from the group. The current Nostr proposals require sharing a private key between several individuals, which creates potential security issues. 
+
+This NIP creates a simple event changing protocol to be run by DVMs. The private key that controls the event is owned by the DVM. Authorized pubkeys request the DVM to make the changes for them. 
+
+## Access controls
+
+The DVM will add and update `admin` tags in the replaceable event. Any request coming from a signed admin will be executed. 
+
+```js
+{
+    ...
+    "tags": [
+        [ "admin", "<pubkey>" ]
+    ],
+    ...
+}
+```
+
+Admins can add and remove any other admin. By removing all admins, the sender renders the replaceable event immutable. 
+
+## DVM kinds
+
+This NIP defines `kind:5003` (Job Request) as a create or update event. The `p` tag points to the DVM that should run the update. The `content` contains a tag `i` with the modified event signed by an admin and `param` as `relays` to tell the DVM where to broadcast this change.  
+
+Before applying the modification, the DVM MUST verify the signature of the stringified event and MUST check if the pubkey is an admin. 
+
+```js
+{
+    "kind": 5003,
+    "tags": [
+        [ "p", "<dvm-pubkey>" ]
+    ],
+    "content": nip04_encrypt(JSON.stringify(
+        [ "i", "<stringified-signed-event>", "text" ]
+        [ "param", "relays", "wss://nos.lol", "wss://nostr.mom" ]
+    ))
+}
+```
+
+The DVM replies with a `kind:6900` event that MUST `p`-tag all admins and MAY include the modified event in its contents. 
+
+```js
+{
+    "content": "<stringified-updated-event>",
+    "kind": 6900,
+    "tags": [
+        [ "p", "<admin1-pubkey>" ],
+        [ "p", "<admin2-pubkey>" ],
+        [ "e", "<event-id-of-5003>" ]
+    ]
+}
+```


### PR DESCRIPTION
Creates a new flow to use Trusted DVMs to collaboratively control events without having to share the private key for that event between authorized individuals. 

Use cases: 
- Collaborative document writing tools generally allow several users to change the same document. 
- Group metadata events must be updated by a set of admins, including adding and removing people from the group. 

We might add another Job request with a DIFF-type of payload. 

Read: [here](https://github.com/vitorpamplona/nips/blob/dvm-replaceables/29.md)