### PR TITLE
NIP-29: add to NIPs list, improve preamble phrasing

### DIFF
--- a/29.md
+++ b/29.md
@@ -6,7 +6,7 @@ Media Attachments
 
 Media attachments (images, videos, and other files) may be added to events by including a URL in the event content, along with a matching `imeta` tag.
 
-`imeta` ("inline metadata") tags add information about media URLs in the event's content. Each `imeta` tag SHOULD match a URL in the event content. Clients may replace imeta URLs with rich previews. `imeta` tags contain extra information about the media attachment, which clients can use to provide a better experience when loading previews.
+`imeta` ("inline metadata") tags add information about media URLs in the event's content. Each `imeta` tag SHOULD match a URL in the event content. Clients may replace imeta URLs with rich previews.
 
 The `imeta` tag is variadic, and each entry is a space-delimited key/value pair.
 Each `imeta` tag MUST have a `url`, and at least one other field. `imeta` may include

--- a/29.md
+++ b/29.md
@@ -36,8 +36,8 @@ any field specified by [NIP 94](./94.md). There SHOULD be only one `imeta` tag p
 
 ## Recommended client behavior
 
-When uploading images during a new post, clients MAY include this metadata
-after the image is uploaded and included in the post.
+When uploading files during a new post, clients MAY include this metadata
+after the file is uploaded and included in the post.
 
-When pasting urls during post composition, the client MAY download the image
+When pasting urls during post composition, the client MAY download the file
 and add this metadata before the post is sent.

--- a/29.md
+++ b/29.md
@@ -1,13 +1,12 @@
-NIP029
+NIP-29
 ======
 
-imeta
---------------
+Media Attachments
+-----------------
 
-`imeta` is a tag for adding media attachments to events. `imeta` tags MUST match URLs
-in the event content. Clients may replace imeta URLs with rich previews. `imeta` tags
-contain extra information about the media attachment, which clients can use to provide
-a better experience when loading images.
+Media attachments (images, videos, and other files) may be added to events by including a URL in the event content, along with a matching `imeta` tag.
+
+`imeta` ("inline metadata") tags add information about media URLs in the event's content. Each `imeta` tag SHOULD match a URL in the event content. Clients may replace imeta URLs with rich previews. `imeta` tags contain extra information about the media attachment, which clients can use to provide a better experience when loading previews.
 
 The `imeta` tag is variadic, and each entry is a space-delimited key/value pair.
 Each `imeta` tag MUST have a `url`, and at least one other field. `imeta` may include
@@ -23,6 +22,7 @@ any field specified by [NIP 94](./94.md). There SHOULD be only one `imeta` tag p
     [
       "imeta",
       "url https://nostr.build/i/my-image.jpg",
+      "m image/jpeg",
       "blurhash eVF$^OI:${M{o#*0-nNFxakD-?xVM}WEWB%iNKxvR-oetmo#R-aen$",
       "dim 3024x4032",
       "alt A scenic photo overlooking the coast of Costa Rica",

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-26: Delegated Event Signing](26.md)
 - [NIP-27: Text Note References](27.md)
 - [NIP-28: Public Chat](28.md)
+- [NIP-29: Media Attachments](29.md)
 - [NIP-30: Custom Emoji](30.md)
 - [NIP-31: Dealing with Unknown Events](31.md)
 - [NIP-32: Labeling](32.md)


### PR DESCRIPTION
This improves the intro of NIP-29 a little more, and adds a missing `m` (mime) value to the example event.