### PR TITLE
Community scoped events

### DIFF
--- a/72.md
+++ b/72.md
@@ -6,7 +6,7 @@ Moderated Communities (Reddit Style)
 
 `draft` `optional`
 
-The goal of this NIP is to create moderator-approved public communities around a topic. It defines the replaceable event `kind:34550` to define the community and the current list of moderators/administrators. Users that want to post into the community, simply tag any Nostr event with the community's `a` tag. Moderators issue an approval event `kind:4550` that links the community with the new post.
+The goal of this NIP is to create moderator-approved public communities around a topic. It defines the replaceable event `kind:34550` to define the community and the current list of moderators/administrators. Users that want to post into the community can issue an event `kind:11` tagged with the communitie's `a` tag and include the *stringified JSON* of the post to be submitted to the community in `.content`. Moderators issue an approval event `kind:4550` that links the community with the new post.
 
 # Community Definition
 
@@ -40,15 +40,15 @@ The goal of this NIP is to create moderator-approved public communities around a
 
 # New Post Request
 
-Any Nostr event can be submitted to a community by anyone for approval. Clients MUST add the community's `a` tag to the new post event in order to be presented for the moderator's approval.
+Any Nostr event can be submitted to a community by anyone for approval. Clients MUST add the community's `a` tag to the new post event in order to be presented for the moderator's approval. The `content` MUST contain the *stringified JSON* of the event to be sumbitted to the community.
 
 ```jsonc
 {
-  "kind": 1,
+  "kind": 11,
   "tags": [
     ["a", "34550:<community event author pubkey>:<community-d-identifier>", "<optional-relay-url>"],
   ],
-  "content": "hello world",
+  "content": "<the full event to be submitted, JSON-encoded>",
   // ...
 }
 ```

--- a/72.md
+++ b/72.md
@@ -40,13 +40,14 @@ The goal of this NIP is to create moderator-approved public communities around a
 
 # New Post Request
 
-Any Nostr event can be submitted to a community by anyone for approval. Clients MUST add the community's `a` tag to the new post event in order to be presented for the moderator's approval. The `content` MUST contain the *stringified JSON* of the event to be sumbitted to the community.
+Any Nostr event can be submitted to a community by anyone for approval. Clients MUST add the community's `a` tag to the new post event in order to be presented for the moderator's approval. The `content` MUST contain the *stringified JSON* of the event to be sumbitted to the community and a `k` tag with the original post's event kind to allow filtering posts by kind.
 
 ```jsonc
 {
   "kind": 11,
   "tags": [
     ["a", "34550:<community event author pubkey>:<community-d-identifier>", "<optional-relay-url>"],
+    ["k", "<post-request-kind>"],
   ],
   "content": "<the full event to be submitted, JSON-encoded>",
   // ...


### PR DESCRIPTION
Alternative to #848, basically my interpretation of https://github.com/nostr-protocol/nips/pull/848#issuecomment-1817495570.

The basic idea is to wrap posts into post requests instead of defining a lot of new kinds. This way one could wrap any existing kind into the new community post request wrapper `kind:11`.

I'd also like to revisit something like `approvedUntilRevoked` from https://github.com/nostr-protocol/nips/pull/602#issuecomment-1642762330, since people expressed support in favor of having the option to approve posts by default. This would maybe require adding a new kind for moderators to remove the default approved posts (like `kind:4550` but in reverse). However, this might make more sense as a separate PR.