### PR TITLE
Update 98.md

### DIFF
--- a/98.md
+++ b/98.md
@@ -18,7 +18,7 @@ The `content` SHOULD be empty.
 
 The following tags MUST be included.
 
-* `u` - absolute URL
+* `url` - absolute URL
 * `method` - HTTP Request Method
 
 Example event:
@@ -30,7 +30,7 @@ Example event:
   "kind": 27235,
   "created_at": 1682327852,
   "tags": [
-    ["u", "https://api.snort.social/api/v1/n5sp/list"],
+    ["url", "https://api.snort.social/api/v1/n5sp/list"],
     ["method", "GET"]
   ],
   "sig": "5ed9d8ec958bc854f997bdc24ac337d005af372324747efe4a00e24f4c30437ff4dd8308684bed467d9d6be3e5a517bb43b1732cc7d33949a3aaf86705c22184"


### PR DESCRIPTION
Amended required tag 'u' and example event 'u' to 'url' to match linked implementation example.