### PR TITLE
NIP-07 - Add signString

### DIFF
--- a/07.md
+++ b/07.md
@@ -20,6 +20,7 @@ Aside from these two basic above, the following functions can also be implemente
 async window.nostr.getRelays(): { [url: string]: {read: boolean, write: boolean} } // returns a basic map of relay urls to relay policies
 async window.nostr.nip04.encrypt(pubkey, plaintext): string // returns ciphertext and iv as specified in nip-04 (deprecated)
 async window.nostr.nip04.decrypt(pubkey, ciphertext): string // takes ciphertext and iv as specified in nip-04 (deprecated)
+async window.nostr.signString(string): string // returns a signature on an arbitrary string
 ```
 
 ### Implementation


### PR DESCRIPTION
In order to extend cross protocol interoperability, NIP-07 providers should be able to sign arbitrary strings and return the signature. This allows non-nostr-native apps to use nostr identities to do... things. For example Cashu web-wallets could use this to un-/lock eCash to nostr public keys. 

Alby has already implemented this as `signSchnorr', but it should be part of the specification.

There really isn't any overhead, as this is very similar to the signature part of signEvent, without the validation.