### PR TITLE
NIP-114: ids_only filter

### DIFF
--- a/114.md
+++ b/114.md
@@ -1,0 +1,27 @@
+NIP-114
+=======
+
+ids_only filter
+---------------
+
+### Description
+
+When a filter has `ids_only: true`, the relay must return only the ids of the events that match the filter.
+
+The ids are returned as `["HAVE", subscriptionID, eventID]` messages.
+
+Clients may request the full events by id with a `["GET", eventId]` message. Relays reply to `GET` requests with `["EVENT", "*", eventJson]` messages, where `*` is a placeholder subscription id.
+
+Clients may also request the full events by id with a normal `["REQ", subscriptionId, {ids}]` message.
+
+### Motivation
+
+`ids_only` filter allows a client to request the full event only when it is not already stored locally or received from another relay. This can save a lot of bandwidth, especially when connecting to multiple relays or subscribing to a lot of data.
+
+### Implementations
+
+- [@mmalmi/strfry](https://github.com/mmalmi/strfry) ([Pull request](https://github.com/hoytech/strfry/pull/99))
+- [@mmalmi/nostr-rs-relay](https://github.com/mmalmi/nostr-rs-relay) ([Pull request](https://github.com/scsibug/nostr-rs-relay/pull/186))
+- [Snort & Iris](https://git.v0l.io/Kieran/snort).
+  - [HAVE message handling](https://git.v0l.io/Kieran/snort/src/commit/edbfa02c5202c5a7035e146d446e7bf4bb3feb84/packages/system/src/connection-pool.ts#L74)
+  - [Adding ids_only filter](https://git.v0l.io/Kieran/snort/src/commit/edbfa02c5202c5a7035e146d446e7bf4bb3feb84/packages/system/src/query.ts#L397) for relays that support nip 114 


### PR DESCRIPTION
When a filter has `ids_only: true`, the relay must return only the ids of the events that match the filter.

This allows a client to request the full event only when it is not already stored locally or received from another relay. It can save a lot of bandwidth, especially when connecting to multiple relays or subscribing to a lot of data.