### PR TITLE
Adds Native Private Events

### DIFF
--- a/42.md
+++ b/42.md
@@ -6,7 +6,7 @@ Authentication of clients to relays
 
 `draft` `optional`
 
-This NIP defines a way for clients to authenticate to relays by signing an ephemeral event.
+This NIP defines a way for clients to authenticate to relays by signing an ephemeral event and a way to specify which events and private and MUST require authentication to be served.
 
 ## Motivation
 
@@ -17,6 +17,40 @@ A relay may want to require clients to authenticate to access restricted resourc
   - A relay may limit subscriptions of any kind to paying users or users whitelisted through any other means, and require authentication.
 
 ## Definitions
+
+### New field to identify private events
+
+Clients that want to force an authentication in any event can add a `requires_auth_by` with array of authorized pubkeys to the base event object. 
+
+```jsonc
+{
+  "id": <32-bytes lowercase hex-encoded sha256 of the serialized event data>,
+  "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>,
+  "requires_auth_by" [<32-bytes lowercase hex-encoded public key>, ... ]
+  "created_at": <unix timestamp in seconds>,
+  "kind": <integer between 0 and 65535>,
+  "tags": [
+    [<arbitrary string>...],
+    // ...
+  ],
+  "content": <arbitrary string>,
+  "sig": <64-bytes lowercase hex of the signature of the sha256 hash of the serialized event data, which is the same as the "id" field>
+}
+```
+
+NIP-42 supporting relays must then include the `requires_auth_by` field as the 7th position in the serialization of the event. This guarantees that relays and clients that do not support this NIP cannot validate private events and will never be able to receive them, avoiding leaking the event structure to a public relay. 
+
+```js
+[
+  0,
+  <pubkey, as a lowercase hex string>,
+  <created_at, as a number>,
+  <kind, as a number>,
+  <tags, as an array of arrays of non-null strings>,
+  <content, as a string>,
+  <requires_auth_by, as an array of non-null strings> 
+]
+```
 
 ### New client-relay protocol messages
 

--- a/42.md
+++ b/42.md
@@ -22,6 +22,8 @@ A relay may want to require clients to authenticate to access restricted resourc
 
 Clients that want to force an authentication in any event can add a `requires_auth_by` with array of authorized pubkeys to the base event object. 
 
+Relays MUST authenticate connections with at least one of the pubkeys listed in `requires_auth_by` to return events.
+
 ```jsonc
 {
   "id": <32-bytes lowercase hex-encoded sha256 of the serialized event data>,


### PR DESCRIPTION
This is a crazy new idea to add fully private events to Nostr in a backwards-compatible way where current relays won't even be able to verify private events. 

I did this first version as a change to NIP-42, but I am happy to create a new NIP if it makes more sense. 