### PR TITLE
relay-based event access-control with the `["-"]` tag

### DIFF
--- a/70.md
+++ b/70.md
@@ -50,7 +50,7 @@ This NIP gives these authors and relays the means to know when a given event is 
 
 ## How
 
-The default behavior for most relays will be to reject all events with the `"-"` tag. Only relays previously programmed to enforce access-control on these events would have to write special code for handling them.
+The default behavior for relays will be to reject all events with the `"-"` tag. The only relays that should accept these events are those that have been explicitly programmed to enforce write access control for all events with the `"-"` tag.
 
 Authors of protected events would have to have some kind of relationship with some specific relays -- for example, using [NIP-29](29.md) -- that would enable relays to know to whom these events can be served once they're published by the author.
 

--- a/70.md
+++ b/70.md
@@ -1,0 +1,51 @@
+NIP-70
+======
+
+Protected Events
+----------------
+
+`draft` `optional`
+
+When the `protected` tag is present, relays must enforce that the event is being published willingly by its author. In order to do that relays must require authentication before accepting the event and verify that the authenticated public key matches the event author public key.
+
+## The tag
+
+The tag is a simple tag with a single item: `["protected"]`. It may be added to any event.
+
+## Example flow
+
+- User `79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798` connects to relay `wss://example.com`:
+
+```jsonc
+/* user: */
+["EVENT",{"id":"cb8feca582979d91fe90455867b34dbf4d65e4b86e86b3c68c368ca9f9eef6f2","pubkey":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","created_at":1707409439,"kind":1,"tags":[["protected"]],"content":"hello members of the secret group","sig":"fa163f5cfb75d77d9b6269011872ee22b34fb48d23251e9879bb1e4ccbdd8aaaf4b6dc5f5084a65ef42c52fbcde8f3178bac3ba207de827ec513a6aa39fa684c"}]
+/* relay: */
+["AUTH", "<challenge>"]
+["OK", "cb8feca582979d91fe90455867b34dbf4d65e4b86e86b3c68c368ca9f9eef6f2", false, "auth-required: this event may only be published by its author"]
+/* client: */
+["AUTH", {}]
+["EVENT",{"id":"cb8feca582979d91fe90455867b34dbf4d65e4b86e86b3c68c368ca9f9eef6f2","pubkey":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","created_at":1707409439,"kind":1,"tags":[["protected"]],"content":"hello members of the secret group","sig":"fa163f5cfb75d77d9b6269011872ee22b34fb48d23251e9879bb1e4ccbdd8aaaf4b6dc5f5084a65ef42c52fbcde8f3178bac3ba207de827ec513a6aa39fa684c"}]
+["OK", "cb8feca582979d91fe90455867b34dbf4d65e4b86e86b3c68c368ca9f9eef6f2", true, ""]
+```
+
+## Use cases
+
+- private groups
+- private feeds
+- optimistic hiding of DMs or other encrypted material metadata
+
+## Why
+
+Many people want to restrict access to some of their data to a closed group: by having, for example, a private feed for paying subscribers.
+
+Even though it's ultimately impossible to restrict the spread of information on the internet (for example, one of the members of the closed group may want to take an event intended to be restricted and republish it to other relays), most relays would be happy to not facilitate the acts of these so-called "pirates", in respect to the original decision of the author.
+
+This NIP gives these authors and relays the means to know when a given event is not intended to be broadcasted to all and everywhere.
+
+## How
+
+In practice, authors of protected events would have to have some kind of relationship with some specific relays -- for example, using [NIP-29](29.md) -- that would enable relays to know to whom these events can be served once they're published by the author.
+
+If someone tries to copy the event and publish it to other relays that wouldn't enforce the rules intended by the author that won't work as these relays will reject the event.
+
+In practice there may be relays that accept these "pirated" events, but that isn't different from what happens in the current internet.

--- a/70.md
+++ b/70.md
@@ -12,7 +12,7 @@ A protected event is an event that can only be published to relays by its author
 
 The default behavior of a relay MUST be to reject any event that contains `["-"]`.
 
-Relays that want to accept such events MUST first require that the client perform the `AUTH` flow and then check if the authenticated client has the same pubkey as the event being published and only accept the event in that case.
+Relays that want to accept such events MUST first require that the client perform the [NIP-42](https://github.com/nostr-protocol/nips/blob/master/42.md) `AUTH` flow and then check if the authenticated client has the same pubkey as the event being published and only accept the event in that case.
 
 ## The tag
 

--- a/70.md
+++ b/70.md
@@ -6,11 +6,17 @@ Protected Events
 
 `draft` `optional`
 
-When the `protected` tag is present, relays must enforce that the event is being published willingly by its author. In order to do that relays must require authentication before accepting the event and verify that the authenticated public key matches the event author public key.
+When the `"-"` tag is present, that means the event is "protected".
+
+A protected event is an event that can only be published to relays by its author. That allows the author to choose who can access their events (either by knowing in advance the relay policy with regards to reads or by means of an external relationship with the relay that is not specified here).
+
+The default behavior of a relay MUST be to reject any event that contains `["-"]`.
+
+Relays that want to accept such events MUST first require that the client perform the `AUTH` flow and then check if the authenticated client has the same pubkey as the event being published and only accept the event in that case.
 
 ## The tag
 
-The tag is a simple tag with a single item: `["protected"]`. It may be added to any event.
+The tag is a simple tag with a single item: `["-"]`. It may be added to any event.
 
 ## Example flow
 
@@ -18,13 +24,13 @@ The tag is a simple tag with a single item: `["protected"]`. It may be added to 
 
 ```jsonc
 /* user: */
-["EVENT",{"id":"cb8feca582979d91fe90455867b34dbf4d65e4b86e86b3c68c368ca9f9eef6f2","pubkey":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","created_at":1707409439,"kind":1,"tags":[["protected"]],"content":"hello members of the secret group","sig":"fa163f5cfb75d77d9b6269011872ee22b34fb48d23251e9879bb1e4ccbdd8aaaf4b6dc5f5084a65ef42c52fbcde8f3178bac3ba207de827ec513a6aa39fa684c"}]
+["EVENT",{"id":"cb8feca582979d91fe90455867b34dbf4d65e4b86e86b3c68c368ca9f9eef6f2","pubkey":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","created_at":1707409439,"kind":1,"tags":[["-"]],"content":"hello members of the secret group","sig":"fa163f5cfb75d77d9b6269011872ee22b34fb48d23251e9879bb1e4ccbdd8aaaf4b6dc5f5084a65ef42c52fbcde8f3178bac3ba207de827ec513a6aa39fa684c"}]
 /* relay: */
 ["AUTH", "<challenge>"]
 ["OK", "cb8feca582979d91fe90455867b34dbf4d65e4b86e86b3c68c368ca9f9eef6f2", false, "auth-required: this event may only be published by its author"]
 /* client: */
 ["AUTH", {}]
-["EVENT",{"id":"cb8feca582979d91fe90455867b34dbf4d65e4b86e86b3c68c368ca9f9eef6f2","pubkey":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","created_at":1707409439,"kind":1,"tags":[["protected"]],"content":"hello members of the secret group","sig":"fa163f5cfb75d77d9b6269011872ee22b34fb48d23251e9879bb1e4ccbdd8aaaf4b6dc5f5084a65ef42c52fbcde8f3178bac3ba207de827ec513a6aa39fa684c"}]
+["EVENT",{"id":"cb8feca582979d91fe90455867b34dbf4d65e4b86e86b3c68c368ca9f9eef6f2","pubkey":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","created_at":1707409439,"kind":1,"tags":[["-"]],"content":"hello members of the secret group","sig":"fa163f5cfb75d77d9b6269011872ee22b34fb48d23251e9879bb1e4ccbdd8aaaf4b6dc5f5084a65ef42c52fbcde8f3178bac3ba207de827ec513a6aa39fa684c"}]
 ["OK", "cb8feca582979d91fe90455867b34dbf4d65e4b86e86b3c68c368ca9f9eef6f2", true, ""]
 ```
 
@@ -44,7 +50,7 @@ This NIP gives these authors and relays the means to know when a given event is 
 
 ## How
 
-The default behavior for most relays will be to reject all events with the `protected` tag. Only relays previously programmed to enforce access-control on these events would have to write special code for handling them.
+The default behavior for most relays will be to reject all events with the `"-"` tag. Only relays previously programmed to enforce access-control on these events would have to write special code for handling them.
 
 Authors of protected events would have to have some kind of relationship with some specific relays -- for example, using [NIP-29](29.md) -- that would enable relays to know to whom these events can be served once they're published by the author.
 

--- a/70.md
+++ b/70.md
@@ -8,7 +8,7 @@ Protected Events
 
 When the `"-"` tag is present, that means the event is "protected".
 
-A protected event is an event that can only be published to relays by its author. That allows the author to choose who can access their events (either by knowing in advance the relay policy with regards to reads or by means of an external relationship with the relay that is not specified here).
+A protected event is an event that can only be published to relays by its author. This is achieved by relays ensuring that the author is [authenticated](42.md) before publishing their own events or by just rejecting events with `["-"]` outright.
 
 The default behavior of a relay MUST be to reject any event that contains `["-"]`.
 
@@ -34,26 +34,12 @@ The tag is a simple tag with a single item: `["-"]`. It may be added to any even
 ["OK", "cb8feca582979d91fe90455867b34dbf4d65e4b86e86b3c68c368ca9f9eef6f2", true, ""]
 ```
 
-## Use cases
-
-- private groups
-- private feeds
-- optimistic hiding of DMs or other encrypted material metadata
-
 ## Why
 
-Many people want to restrict access to some of their data to a closed group: by having, for example, a private feed for paying subscribers.
+There are multiple circumstances in which it would be beneficial to prevent the unlimited spreading of an event through all relays imaginable and restrict some to only a certain demographic or to a semi-closed community relay. Even when the information is public it may make sense to keep it compartimentalized across different relays.
 
-Even though it's ultimately impossible to restrict the spread of information on the internet (for example, one of the members of the closed group may want to take an event intended to be restricted and republish it to other relays), most relays would be happy to not facilitate the acts of these so-called "pirates", in respect to the original decision of the author.
+It's also possible to create closed access feeds with this when the publisher has some relationship with the relay and trusts the relay to not release their published events to anyone.
 
-This NIP gives these authors and relays the means to know when a given event is not intended to be broadcasted to all and everywhere.
+Even though it's ultimately impossible to restrict the spread of information on the internet (for example, one of the members of the closed group may want to take an event intended to be restricted and republish it to other relays), most relays would be happy to not facilitate the acts of these so-called "pirates", in respect to the original decision of the author and therefore gladly reject these republish acts if given the means to.
 
-## How
-
-The default behavior for relays will be to reject all events with the `"-"` tag. The only relays that should accept these events are those that have been explicitly programmed to enforce write access control for all events with the `"-"` tag.
-
-Authors of protected events would have to have some kind of relationship with some specific relays -- for example, using [NIP-29](29.md) -- that would enable relays to know to whom these events can be served once they're published by the author.
-
-If someone tries to copy the event and publish it to other relays that wouldn't enforce the rules intended by the author that won't work as these relays will reject the event.
-
-In practice there may be relays that accept these "pirated" events, but that isn't different from what happens in the current internet.
+This NIP gives these authors and relays the means to clearly signal when a given event is not intended to be republished by third parties.

--- a/70.md
+++ b/70.md
@@ -44,7 +44,9 @@ This NIP gives these authors and relays the means to know when a given event is 
 
 ## How
 
-In practice, authors of protected events would have to have some kind of relationship with some specific relays -- for example, using [NIP-29](29.md) -- that would enable relays to know to whom these events can be served once they're published by the author.
+The default behavior for most relays will be to reject all events with the `protected` tag. Only relays previously programmed to enforce access-control on these events would have to write special code for handling them.
+
+Authors of protected events would have to have some kind of relationship with some specific relays -- for example, using [NIP-29](29.md) -- that would enable relays to know to whom these events can be served once they're published by the author.
 
 If someone tries to copy the event and publish it to other relays that wouldn't enforce the rules intended by the author that won't work as these relays will reject the event.
 

--- a/70.md
+++ b/70.md
@@ -23,7 +23,7 @@ The tag is a simple tag with a single item: `["-"]`. It may be added to any even
 - User `79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798` connects to relay `wss://example.com`:
 
 ```jsonc
-/* user: */
+/* client: */
 ["EVENT",{"id":"cb8feca582979d91fe90455867b34dbf4d65e4b86e86b3c68c368ca9f9eef6f2","pubkey":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","created_at":1707409439,"kind":1,"tags":[["-"]],"content":"hello members of the secret group","sig":"fa163f5cfb75d77d9b6269011872ee22b34fb48d23251e9879bb1e4ccbdd8aaaf4b6dc5f5084a65ef42c52fbcde8f3178bac3ba207de827ec513a6aa39fa684c"}]
 /* relay: */
 ["AUTH", "<challenge>"]


### PR DESCRIPTION
Read about it in the NIP body: https://github.com/nostr-protocol/nips/blob/protected-events-tag/70.md

This is inspired by https://github.com/nostr-protocol/nips/pull/1029, there is more discussion there.