### PR TITLE
Access Control Upgrade

### DIFF
--- a/00.md
+++ b/00.md
@@ -1,0 +1,63 @@
+NIP-XX
+======
+
+Access Control Upgrade
+----------------------
+
+`draft` `optional`
+
+This NIP defines how to upgrade a public event with the property of limiting access to itself.
+
+## Upgrading a Public Event
+
+A public event (with no access control), such as of `kind:1`,
+must be published or updated with a `full_event` tag pointing to a
+`kind:30042` event address.
+
+It may include one of the following tags holding a preview of the full event content:
+`summary`, `image`, `audio`, `video`. The first holds a text excerpt while the others an URL.
+
+Example:
+
+```json
+{
+  "kind": 1063,
+  "tags": [
+    ["full_event", "30042:<32-bytes lowercase hex of a pubkey>:abc", "<recommended relay URL, optional>"],
+    ["image", "<string with preview URI>"],
+    ["dim", "800x600"]
+  ],
+  "content": "",
+  ...
+}
+```
+
+## Full Event
+
+A "Full Event" is of `kind:30042`. It has [NIP-42](42.md) `A` tags the author
+can update at will with the pubkeys allowed to access it.
+
+It uses the custom NIP-42 event serialization for events that require `AUTH`.
+
+The `.content` and other tags aren't fixed. The structure depends on the
+kind of the public event it is protecting. For example, if it is
+protecting a `kind:30023`, it should have the structure defined on [NIP-23](23.md).
+
+Example:
+
+```json
+{
+  "kind": 30042,
+  "pubkey": "<author_pubkey>",
+  "tags": [
+    ["d", "<random>"],
+    ["A", "<author_pubkey>"], // important to keep author access right
+    ["A", "<buyer_1_pubkey>"],
+    ["A", "<buyer_2_pubkey>"],
+    ["url", "https://some.place/file.webp"],
+    ["dim", "800x600"]
+  ],
+  "content": "Happy New Year, my dear supporters!!",
+  ...
+}
+```


### PR DESCRIPTION
This uses https://github.com/nostr-protocol/nips/pull/1029#issuecomment-1936120725 enhancement idea from #1029 to easily turn a public event such as a `kind:1` or `kind:30023` one into an event that can only be fetched by some pubkeys.

Read [here](https://github.com/arthurfranca/nips/blob/acu/00.md)