### PR TITLE
NIP01 Clarify missing 'd' tag in Param Repl Event is interpreted as empty string

### DIFF
--- a/01.md
+++ b/01.md
@@ -96,7 +96,7 @@ And also a convention for kind ranges that allow for easier experimentation and 
 - for kind `n` such that `1000 <= n < 10000`, events are **regular**, which means they're all expected to be stored by relays.
 - for kind `n` such that `10000 <= n < 20000 || n == 0 || n == 3`, events are **replaceable**, which means that, for each combination of `pubkey` and `kind`, only the latest event MUST be stored by relays, older versions MAY be discarded.
 - for kind `n` such that `20000 <= n < 30000`, events are **ephemeral**, which means they are not expected to be stored by relays.
-- for kind `n` such that `30000 <= n < 40000`, events are **parameterized replaceable**, which means that, for each combination of `pubkey`, `kind` and the `d` tag's first value, only the latest event MUST be stored by relays, older versions MAY be discarded.
+- for kind `n` such that `30000 <= n < 40000`, events are **parameterized replaceable**, which means that, for each combination of `pubkey`, `kind` and the `d` tag's first value, only the latest event MUST be stored by relays, older versions MAY be discarded. A missing or a `d` tag with no value should be interpreted equivalent to a `d` tag with the value as an empty string.
 
 In case of replaceable events with the same timestamp, the event with the lowest id (first in lexical order) should be retained, and the other discarded.
 


### PR DESCRIPTION
clarify that when `d` tag is missing in parameterized replaceable events it will be interpreted as `d` tag with empty string

https://github.com/monlovesmango/nips/blob/NIP01-clarify-missing-d-tag/01.md