### PR TITLE
Add PGP as NIP-39 external identity

### DIFF
--- a/39.md
+++ b/39.md
@@ -20,6 +20,7 @@ A new optional `i` tag is introduced for `kind 0` metadata event contents in add
     ["i", "twitter:semisol_public", "1619358434134196225"],
     ["i", "mastodon:bitcoinhackers.org/@semisol", "109775066355589974"]
     ["i", "telegram:1087295469", "nostrdirectory/770"]
+    ["i", "pgp:A999B7498D1A8DC473E53C92309F635DAD1B5517", "xsFNBF2V8eEBEADmjYzGOpxEI0J7jQ1qFzlsrjF6NaBSq+UqKw..."]
   ],
   ...
 }
@@ -62,3 +63,9 @@ Identity: A Telegram user ID.
 
 Proof: A string in the format `<ref>/<id>` which points to a message published in the public channel or group with name `<ref>` and message ID `<id>`. This message should be sent by user ID `<identity>` and have the text `Verifying that I control the following Nostr public key: "<npub encoded public key>"`.
 This can be located at `https://t.me/<proof>`.
+
+### `pgp`
+
+Identity: A PGP fingerprint.
+
+Proof: PGP signature of the fingerprint used in the identity field.


### PR DESCRIPTION
I thought it would make sense to add PGP here as it is an external identity, but open to move it somewhere else

Should the full PGP public key be included as well?