### PR TITLE
Bring back non-pubkey zap tags

### DIFF
--- a/57.md
+++ b/57.md
@@ -169,14 +169,21 @@ A client can retrieve `zap receipt`s on events and pubkeys using a NIP-01 filter
 
 ### Appendix G: `zap` tag on other events
 
-When an event includes one or more `zap` tags, clients wishing to zap it SHOULD calculate the lnurl pay request based on the tags value instead of the event author's profile field. The tag's second argument is the `hex` string of the receiver's pub key and the third argument is the relay to download the receiver's metadata (Kind-0). An optional fourth parameter specifies the weight (a generalization of a percentage) assigned to the respective receiver. Clients should parse all weights, calculate a sum, and then a percentage to each receiver. If weights are not present, CLIENTS should equally divide the zap amount to all receivers. If weights are only partially present, receivers without a weight should not be zapped (`weight = 0`).
+When an event includes one or more `zap` tags, clients wishing to zap it SHOULD calculate the lnurl pay request
+based on the tags value instead of the event author's profile field.
+
+The tag's second argument is a `lud06` address, a `lud16` identifier or a `hex` string of the receiver's pub key, and
+and the third argument is a relay hint that can be used to download the receiver's `kind 0` profile metadata.
+Clients SHOULD validate the relay url, because a previous version of this spec used this argument differently.
+
+An optional fourth parameter specifies the weight (a generalization of a percentage) assigned to the respective receiver. Clients should parse all weights, calculate a sum, and then a percentage to each receiver. If weights are not present, CLIENTS should equally divide the zap amount to all receivers. If weights are only partially present, receivers without a weight should not be zapped (`weight = 0`).
 
 ```js
 {
     "tags": [
-        [ "zap", "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2", "wss://nostr.oxtr.dev", "1" ],  // 25%
-        [ "zap", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52", "wss://nostr.wine/",    "1" ],  // 25%
-        [ "zap", "460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c", "wss://nos.lol/",       "2" ]   // 50%
+        [ "zap", "LNURL..", "wss://nostr.oxtr.dev/", "1" ],  // 25%
+        [ "zap", "pablo@f7z.io", "wss://nostr.wine/", "1" ], // 25%
+        [ "zap", "460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c", "wss://nos.lol/", "2" ] // 50%
     ]
 }
 ```


### PR DESCRIPTION
[Last May](https://github.com/nostr-protocol/nips/pull/552#issuecomment-1561287442) we removed lightning address support from zap splits, which [broke Wavlake's implementation](https://github.com/nostr-protocol/nips/pull/1043#issuecomment-1940261772). Should we restore this behavior?

@jb55 @vitorpamplona @pablof7z 