### PR TITLE
Minor NIP-42 Example Update

### DIFF
--- a/42.md
+++ b/42.md
@@ -66,11 +66,11 @@ Given that a relay is likely to require clients to perform authentication only f
 
 ```
 relay: ["AUTH", "<challenge>"]
-client: ["REQ", "sub_1", {"kinds": [4]}]
+client: ["REQ", "sub_1", {"kinds": [4, 1]}]
 relay: ["CLOSED", "sub_1", "auth-required: we can't serve DMs to unauthenticated users"]
 client: ["AUTH", {"id": "abcdef...", ...}]
 relay: ["OK", "abcdef...", true, ""]
-client: ["REQ", "sub_1", {"kinds": [4]}]
+client: ["REQ", "sub_1", {"kinds": [4, 1]}]
 relay: ["EVENT", "sub_1", {...}]
 relay: ["EVENT", "sub_1", {...}]
 relay: ["EVENT", "sub_1", {...}]


### PR DESCRIPTION
@fiatjaf I would like to make it clearer that the `CLOSED` message refers to a subscription as a whole.

So in the specifc AUTH flow case, client would retry the request with exactly the same filter after authenticating.