### PR TITLE
New version of NIP-46

### DIFF
--- a/46.md
+++ b/46.md
@@ -8,8 +8,9 @@ This NIP describes a method for 2-way communication between a remote signer and 
 
 ## Terminology
 
-- **Local keypair**: A local public and private key-pair used to encrypt content and communicate with the remote signer.
-- **Remote pubkey**: The public key that the user wants to sign as. The remote signer has control of the private key that matches this public key.
+- **Local keypair**: A local public and private key-pair used to encrypt content and communicate with the remote signer. Usually created by the client application.
+- **Remote user pubkey**: The public key that the user wants to sign as. The remote signer has control of the private key that matches this public key.
+- **Remote signer pubkey**: This is the public key of the remote signer itself. This is needed in both `create_account` command because you don't yet have a remote user pubkey.
 
 All pubkeys specified in this NIP are in hex format.
 
@@ -41,9 +42,9 @@ nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata
 
 In this last case, most often used to fascilitate an OAuth-like signin flow, the client first looks for remote signers that have announced themselves via NIP-89 application handler events.
 
-First the client will query for `kind: 31989` events that have a `k` tag of `24133`.
+First the client will query for `kind: 31990` events that have a `k` tag of `24133`.
 
-These are generally shown to a user, and once the user selects which remote signer to use and provides the remote pubkey they want to use (via npub, pubkey, or nip-05 value), the client can initiate a connection. Note that it's on the user to select the remote signer that is actually managing the remote key that they would like to use in this case. If the remote pubkey is managed on another remote signer, the connection will fail.
+These are generally shown to a user, and once the user selects which remote signer to use and provides the remote user pubkey they want to use (via npub, pubkey, or nip-05 value), the client can initiate a connection. Note that it's on the user to select the remote signer that is actually managing the remote key that they would like to use in this case. If the remote user pubkey is managed on another remote signer, the connection will fail.
 
 In addition, it's important that clients validate that the pubkey of the announced remote signer matches the pubkey of the `_` entry in the `/.well-known/nostr.json` file of the remote signer's announced domain.
 
@@ -55,7 +56,7 @@ Clients that allow users to create new accounts should also consider validating 
 
 1. Clients need several things to start: a local keypair and the details of the pubkey and remote signer the user would like to use.
    - The local keypair is roughly disposable. E.g. - it's ok to store it locally (ideally encrypted) for some period of time. Once authenticated, remote signers can choose to trust this local keypair for a period of time. This local keypair can be deleted/rotated at will by the client and will only trigger a new auth challenge or permissions on the remote signer.
-   - The remote pubkey is the pubkey that the user is trying to sign in / sign as. This can be fetched with an NIP-05 or entered directly by the user (e.g. by passing a `bunker://` token).
+   - The remote user pubkey is the pubkey that the user is trying to sign in / sign as. This can be fetched with an NIP-05 or entered directly by the user (e.g. by passing a `bunker://` token).
 2. Clients use the local keypair for encrypting request events that they send to remote signers.
 
 ### Remote signer-side
@@ -79,7 +80,7 @@ Coming soon...
     "kind": 24133,
     "pubkey": <local_keypair_pubkey>,
     "content": <nip04(<request>)>,
-    "tags": [["p", <remote pubkey>]],
+    "tags": [["p", <remote_user_pubkey>]], // NB: in the `create_account` event, the remote signer pubkey should be `p` tagged.
     "created_at": <unix timestamp in seconds>,
 }
 ```
@@ -104,8 +105,8 @@ Each of the following are methods that the client sends to the remote signer.
 
 | Command                  | Params                                            | Result                                                                 |
 | ------------------------ | ------------------------------------------------- | ---------------------------------------------------------------------- |
-| `create_account`         | `[<username>, <domain>, <optional_email>]`        | `<newly_created_remote_pubkey>`                                        |
-| `connect`                | `[<remote_pubkey>, <optional_secret>]`            | "ack"                                                                  |
+| `create_account`         | `[<username>, <domain>, <optional_email>]`        | `<newly_created_remote_user_pubkey>`                                   |
+| `connect`                | `[<remote_user_pubkey>, <optional_secret>]`       | "ack"                                                                  |
 | `sign_event`             | `[<json_stringified_event_to_sign>]`              | `json_stringified(<signed_event>)`                                     |
 | `ping`                   | `[]`                                              | "pong"                                                                 |
 | `get_relays`             | `[]`                                              | `json_stringified({<relay_url>: {read: <boolean>, write: <boolean>}})` |
@@ -124,7 +125,7 @@ Each of the following are methods that the client sends to the remote signer.
     "kind": 24133,
     "pubkey": <remote_signer_pubkey>,
     "content": <nip04(<response>)>,
-    "tags": [["p", <local keypair pubkey>]],
+    "tags": [["p", <local_keypair_pubkey>]],
     "created_at": <unix timestamp in seconds>,
 }
 ```

--- a/46.md
+++ b/46.md
@@ -69,7 +69,7 @@ nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata
 }
 ```
 
-#### Response
+#### Response event
 
 ```json
 {
@@ -82,6 +82,10 @@ nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata
     "tags": [["p", "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86"]], // p-tags the local keypair pubkey
 }
 ```
+
+#### Diagram
+
+![signing-example](https://i.nostr.build/P3gW.png)
 
 ## Request Events `kind: 24133`
 
@@ -167,6 +171,10 @@ An Auth Challenge is a response that a remote signer can send back when it needs
 ```
 
 Clients should display (in a popup or new tab) the URL from the `error` field and then subscribe/listen for another response from the remote signer (reusing the same request ID). This event will be sent once the user authenticates in the other window (or will never arrive if the user doesn't authenticate). It's also possible to add a `redirect_uri` url parameter to the auth_url, which is helpful in situations when a client cannot open a new window or tab to display the auth challenge.
+
+#### Example event signing request with auth challenge
+
+![signing-example-with-auth-challenge](https://i.nostr.build/W3aj.png)
 
 ## Remote Signer Commands
 

--- a/46.md
+++ b/46.md
@@ -15,6 +15,8 @@ This also allows us to incorporate [NIP-44](https://github.com/nostr-protocol/ni
 - **Local keypair**: A local public and private key-pair used to encrypt content and communicate with the remote signer.
 - **Remote pubkey**: The public key that the user wants to sign as. The remote signer has control of the private key that matches this public key.
 
+All pubkeys specified in this NIP are in hex format.
+
 ## Signer Discovery
 
 To initiate a connection between a client and a remote signer there are a few different options.
@@ -26,7 +28,7 @@ This is most common in a situation where you have your own nsecbunker or other t
 The remote signer would provide a connection token in the form:
 
 ```
-bunker://<hex-pubkey-you-want-to-sign-as>?relay=<wss://relay-to-connect-on>&relay=<wss://another-relay-to-connect-on>&secret=<optional-secret-value>
+bunker://<remote-pubkey>?relay=<wss://relay-to-connect-on>&relay=<wss://another-relay-to-connect-on>&secret=<optional-secret-value>
 ```
 
 This token is pasted into the client by the user and the client then uses the details to connect to the remote signer via the specified relay(s).
@@ -36,7 +38,7 @@ This token is pasted into the client by the user and the client then uses the de
 In this case, basically the opposite direction of the first case, the client provides a connection token (or encodes the token in a QR code) and the signer initiates a connection to the client via the specified relay(s).
 
 ```
-nostrconnect://<client-key-hex>?relay=<wss://relay-to-connect-on>&metadata=<json metadata in the form: {"name":"...", "url": "...", "description": "..."}>
+nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata=<json metadata in the form: {"name":"...", "url": "...", "description": "..."}>
 ```
 
 ### Remote signer discovery via NIP-89
@@ -83,7 +85,7 @@ Clients can subscribe to events of `kind: 24136`, `kind: 24137`, and `kind: 2413
 {
     "id": <id>,
     "kind": <kind for command>, // Each command has it's own kind
-    "pubkey": <local pubkey of the user>,
+    "pubkey": <local keypair pubkey>,
     "content": <nip44(<request>)>,
     "tags": [["p", <remote pubkey>]],
     "created_at": <unix timestamp in seconds>,
@@ -97,11 +99,11 @@ Clients can subscribe to events of `kind: 24136`, `kind: 24137`, and `kind: 2413
 | `24142` | `sign_event`             | nostr event to sign                                                             | JSON stringified object |
 | `24143` | `ping`                   | -                                                                               | null                    |
 | `24144` | `get_relays`             | -                                                                               | null                    |
-| `24145` | `nip04_encrypt`          | {third_party_pubkey: <third_party_pubkey>, content: <plaintext to encrypt>}     | JSON stringified object |
-| `24146` | `nip04_decrypt`          | {third_party_pubkey: <third_party_pubkey>, content: <ciphertext to decrypt>}    | JSON stringified object |
-| `24147` | `nip44_conversation_key` | third_party_pubkey                                                              | string                  |
-| `24148` | `nip44_encrypt`          | {third_party_pubkey: <third_party_pubkey>, content: <plaintext to encrypt>}     | JSON stringified object |
-| `24149` | `nip44_decrypt`          | {third_party_pubkey: <third_party_pubkey>, content: <ciphertext to decrypt>}    | JSON stringified object |
+| `24145` | `nip04_encrypt`          | {pubkey: <third_party_pubkey>, content: <plaintext to encrypt>}                 | JSON stringified object |
+| `24146` | `nip04_decrypt`          | {pubkey: <third_party_pubkey>, content: <ciphertext to decrypt>}                | JSON stringified object |
+| `24147` | `nip44_conversation_key` | <third_party_pubkey>                                                            | string                  |
+| `24148` | `nip44_encrypt`          | {pubkey: <third_party_pubkey>, content: <plaintext to encrypt>}                 | JSON stringified object |
+| `24149` | `nip44_decrypt`          | {pubkey: <third_party_pubkey>, content: <ciphertext to decrypt>}                | JSON stringified object |
 
 ## Response Event `kind: 24136`
 

--- a/46.md
+++ b/46.md
@@ -54,14 +54,14 @@ Clients that allow users to create new accounts should also consider validating 
 
 ### Client-side
 
-1. Clients need several things to start: a local keypair and the details of the pubkey and remote signer the user would like to use.
+1. Clients need several things to start: a local keypair and the details of the pubkey and relays used by the remote signer the user would like to use.
    - The local keypair is roughly disposable. E.g. - it's ok to store it locally (ideally encrypted) for some period of time. Once authenticated, remote signers can choose to trust this local keypair for a period of time. This local keypair can be deleted/rotated at will by the client and will only trigger a new auth challenge or permissions on the remote signer.
    - The remote user pubkey is the pubkey that the user is trying to sign in / sign as. This can be fetched with an NIP-05 or entered directly by the user (e.g. by passing a `bunker://` token).
 2. Clients use the local keypair for encrypting request events that they send to remote signers.
 
 ### Remote signer-side
 
-1. Remote signers manage the private key of the user that will be used for signing. There are many different remote signers out there (e.g. Nsecbunker, Amber, etc.) that operate in different ways and have different features.
+1. Remote signers manage the private key of the user that will be used for signing. There are many different remote signers out there (e.g. Nsecbunker, nsec.app, etc.) that operate in different ways and have different features.
 2. Remote signers wait for request events and then act.
 
 ### Example flow for signing an event
@@ -103,19 +103,19 @@ The `content` field is a JSON-RPC-like message that is [NIP-04](https://github.c
 
 Each of the following are methods that the client sends to the remote signer.
 
-| Command                  | Params                                            | Result                                                                 |
-| ------------------------ | ------------------------------------------------- | ---------------------------------------------------------------------- |
-| `create_account`         | `[<username>, <domain>, <optional_email>]`        | `<newly_created_remote_user_pubkey>`                                   |
-| `connect`                | `[<remote_user_pubkey>, <optional_secret>]`       | "ack"                                                                  |
-| `sign_event`             | `[<json_stringified_event_to_sign>]`              | `json_stringified(<signed_event>)`                                     |
-| `ping`                   | `[]`                                              | "pong"                                                                 |
-| `get_relays`             | `[]`                                              | `json_stringified({<relay_url>: {read: <boolean>, write: <boolean>}})` |
-| `get_public_key`         | `[]`                                              | `<hex-pubkey>`                                                         |
-| `nip04_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`  | `<nip04_ciphertext>`                                                   |
-| `nip04_decrypt`          | `[<third_party_pubkey>, <ciphertext_to_decrypt>]` | `<plaintext>`                                                          |
-| `nip44_conversation_key` | `[<third_party_pubkey>]`                          | `<nip44_conversation_key>`                                             |
-| `nip44_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`  | `<nip44_ciphertext>`                                                   |
-| `nip44_decrypt`          | `[<third_party_pubkey>, <ciphertext_to_decrypt>]` | `<plaintext>`                                                          |
+| Command                  | Params                                              | Result                                                                 |
+| ------------------------ | --------------------------------------------------- | ---------------------------------------------------------------------- |
+| `create_account`         | `[<username>, <domain>, <optional_email>]`          | `<newly_created_remote_user_pubkey>`                                   |
+| `connect`                | `[<remote_user_pubkey>, <optional_secret>]`         | "ack"                                                                  |
+| `sign_event`             | `[<json_stringified_event_to_sign>]`                | `json_stringified(<signed_event>)`                                     |
+| `ping`                   | `[]`                                                | "pong"                                                                 |
+| `get_relays`             | `[]`                                                | `json_stringified({<relay_url>: {read: <boolean>, write: <boolean>}})` |
+| `get_public_key`         | `[]`                                                | `<hex-pubkey>`                                                         |
+| `nip04_encrypt`          | `[<third_party_pubkey>, [<plaintext_to_encrypt>]]`  | `array of <nip04_ciphertext> results of encryption`                    |
+| `nip04_decrypt`          | `[<third_party_pubkey>, [<ciphertext_to_decrypt>]]` | `array of <plaintext> results of decryption`                           |
+| `nip44_conversation_key` | `[<third_party_pubkey>]`                            | `<nip44_conversation_key>`                                             |
+| `nip44_encrypt`          | `[<third_party_pubkey>, [<plaintext_to_encrypt>]]`  | `array of <nip44_ciphertext> results of encryption`                    |
+| `nip44_decrypt`          | `[<third_party_pubkey>, [<ciphertext_to_decrypt>]]` | `array of <plaintext> results of decryption`                           |
 
 ## Response Events `kind:24133`
 
@@ -156,7 +156,7 @@ An Auth Challenge is a response that a remote signer can send back when it needs
 }
 ```
 
-Clients should display (in a popup or new tab) the URL from the `error` field and then subscribe/listen for another response from the remote signer (reusing the same request ID). This event will be sent once the user authenticates in the other window (or will never arrive if the user doesn't authenticate).
+Clients should display (in a popup or new tab) the URL from the `error` field and then subscribe/listen for another response from the remote signer (reusing the same request ID). This event will be sent once the user authenticates in the other window (or will never arrive if the user doesn't authenticate). It's also possible to add a `redirect_uri` url parameter to the auth_url, which is helpful in situations when a client cannot open a new window or tab to display the auth challenge.
 
 ## References
 

--- a/46.md
+++ b/46.md
@@ -6,10 +6,6 @@ Private keys should be exposed to as few systems - apps, operating systems, devi
 
 This NIP describes a method for 2-way communication between a remote signer and a Nostr client. The remote signer could be, for example, a hardware device dedicated to signing Nostr events, while the client is a normal Nostr client.
 
-Currently, NIP-46 uses a JSON-RPC style flow where you pass encrypted commands in `kind:24133` events. This rewrite strives to remove as much of the JSON-RPC as possible and uses new event kinds that correspond to each command a client might send and the three types of responses that remote signers can send back.
-
-This also allows us to incorporate [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) encryption in a way that doesn't break current NIP-46 implementations.
-
 ## Terminology
 
 - **Local keypair**: A local public and private key-pair used to encrypt content and communicate with the remote signer.
@@ -45,21 +41,21 @@ nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata
 
 In this last case, most often used to fascilitate an OAuth-like signin flow, the client first looks for remote signers that have announced themselves via NIP-89 application handler events.
 
-First the client will query for `kind: 31989` events that have a `k` tag of `24133` and/or any of the new request kinds detailed below.
+First the client will query for `kind: 31989` events that have a `k` tag of `24133`.
 
 These are generally shown to a user, and once the user selects which remote signer to use and provides the remote pubkey they want to use (via npub, pubkey, or nip-05 value), the client can initiate a connection. Note that it's on the user to select the remote signer that is actually managing the remote key that they would like to use in this case. If the remote pubkey is managed on another remote signer, the connection will fail.
 
 In addition, it's important that clients validate that the pubkey of the announced remote signer matches the pubkey of the `_` entry in the `/.well-known/nostr.json` file of the remote signer's announced domain.
 
-Clients that allow users to create new accounts should also consider validating the availability of a given username in the namespace of remote signer's domain by checking the `/.well-known/nostr.json` file for existing usernames. Clients can then show users feedback in the UI before sending a `create_account` event to the remote signer and receiving an error in return.
+Clients that allow users to create new accounts should also consider validating the availability of a given username in the namespace of remote signer's domain by checking the `/.well-known/nostr.json` file for existing usernames. Clients can then show users feedback in the UI before sending a `create_account` event to the remote signer and receiving an error in return. Ideally, remote signers would also respond with understandable error messages if a client tries to create an account with an existing username.
 
 ## The flow
 
 ### Client-side
 
-1. Clients need two things to start: a local keypair and the pubkey that the user wants to use for signing events.
-   - The local keypair is roughly disposable. E.g. - it's ok to store it locally (ideally encrypted) for some period of time. Once authenticated, remote signers can choose to trust this local keypair for a period of time. This local keypair can be deleted/rotated at will by the client and will only trigger a new auth challenge for the user.
-   - The remote pubkey is the pubkey that the user is trying to sign in / sign as. This can be fetched with an NIP-05 or entered directly by the user.
+1. Clients need several things to start: a local keypair and the details of the pubkey and remote signer the user would like to use.
+   - The local keypair is roughly disposable. E.g. - it's ok to store it locally (ideally encrypted) for some period of time. Once authenticated, remote signers can choose to trust this local keypair for a period of time. This local keypair can be deleted/rotated at will by the client and will only trigger a new auth challenge or permissions on the remote signer.
+   - The remote pubkey is the pubkey that the user is trying to sign in / sign as. This can be fetched with an NIP-05 or entered directly by the user (e.g. by passing a `bunker://` token).
 2. Clients use the local keypair for encrypting request events that they send to remote signers.
 
 ### Remote signer-side
@@ -75,102 +71,92 @@ Coming soon...
 
 Coming soon...
 
-## Request Events `Multiple kinds`
-
-Request events take the following form. In order simplify requests and payloads as much as possible, there are different event kinds for each command which help remote signers to understand the request and process the content properly.
-
-Clients can subscribe to events of `kind: 24136`, `kind: 24137`, and `kind: 24138` that have an "e" tag containing the ID of their request event to listen for the response, auth_challenge, or error to their command.
+## Request Events `kind: 24133`
 
 ```json
 {
     "id": <id>,
-    "kind": <kind for command>, // Each command has it's own kind
-    "pubkey": <local keypair pubkey>,
-    "content": <nip44(<request>)>,
+    "kind": 24133,
+    "pubkey": <local_keypair_pubkey>,
+    "content": <nip04(<request>)>,
     "tags": [["p", <remote pubkey>]],
     "created_at": <unix timestamp in seconds>,
 }
 ```
 
-| Kind    | Command                  | Content field (always NIP-44 encrypted)                                         | Data Type               |
-| ------- | ------------------------ | ------------------------------------------------------------------------------- | ----------------------- |
-| `24140` | `create_account`         | {username: <username>, domain: <domain>, <any other arbitrary key/value pairs>} | JSON stringified object |
-| `24141` | `connect`                | -                                                                               | null                    |
-| `24142` | `sign_event`             | nostr event to sign                                                             | JSON stringified object |
-| `24143` | `ping`                   | -                                                                               | null                    |
-| `24144` | `get_relays`             | -                                                                               | null                    |
-| `24145` | `nip04_encrypt`          | {pubkey: <third_party_pubkey>, content: <plaintext to encrypt>}                 | JSON stringified object |
-| `24146` | `nip04_decrypt`          | {pubkey: <third_party_pubkey>, content: <ciphertext to decrypt>}                | JSON stringified object |
-| `24147` | `nip44_conversation_key` | <third_party_pubkey>                                                            | string                  |
-| `24148` | `nip44_encrypt`          | {pubkey: <third_party_pubkey>, content: <plaintext to encrypt>}                 | JSON stringified object |
-| `24149` | `nip44_decrypt`          | {pubkey: <third_party_pubkey>, content: <ciphertext to decrypt>}                | JSON stringified object |
+The `content` field is a JSON-RPC-like message that is [NIP-04](https://github.com/nostr-protocol/nips/blob/master/04.md) encrypted and has the following structure:
 
-## Response Event `kind: 24136`
+```json
+{
+    "id": <random_string>,
+    "method": <method_name>,
+    "params": [array_of_strings]
+}
+```
+
+- `id` is a random string that is a request ID. This same ID will be sent back in the response payload.
+- `method` is the name of the method/command (detailed below).
+- `params` is a positional array of string parameters.
+
+### Methods/Commands
+
+Each of the following are methods that the client sends to the remote signer.
+
+| Command                  | Params                                            | Result                                                                 |
+| ------------------------ | ------------------------------------------------- | ---------------------------------------------------------------------- |
+| `create_account`         | `[<username>, <domain>, <optional_email>]`        | `<newly_created_remote_pubkey>`                                        |
+| `connect`                | `[<remote_pubkey>, <optional_secret>]`            | "ack"                                                                  |
+| `sign_event`             | `[<json_stringified_event_to_sign>]`              | `json_stringified(<signed_event>)`                                     |
+| `ping`                   | `[]`                                              | "pong"                                                                 |
+| `get_relays`             | `[]`                                              | `json_stringified({<relay_url>: {read: <boolean>, write: <boolean>}})` |
+| `get_public_key`         | `[]`                                              | `<hex-pubkey>`                                                         |
+| `nip04_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`  | `<nip04_ciphertext>`                                                   |
+| `nip04_decrypt`          | `[<third_party_pubkey>, <ciphertext_to_decrypt>]` | `<plaintext>`                                                          |
+| `nip44_conversation_key` | `[<third_party_pubkey>]`                          | `<nip44_conversation_key>`                                             |
+| `nip44_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`  | `<nip44_ciphertext>`                                                   |
+| `nip44_decrypt`          | `[<third_party_pubkey>, <ciphertext_to_decrypt>]` | `<plaintext>`                                                          |
+
+## Response Events `kind:24133`
 
 ```json
 {
     "id": <id>,
-    "kind": 24136,
-    "pubkey": <pubkey of the remote signer>,
-    "content": <nip44(<response>)>,
-    "tags": [["p", <local keypair pubkey>], ["e", <id of the request event>]],
+    "kind": 24133,
+    "pubkey": <remote_signer_pubkey>,
+    "content": <nip04(<response>)>,
+    "tags": [["p", <local keypair pubkey>]],
     "created_at": <unix timestamp in seconds>,
 }
 ```
 
-#### Response content to various kinds of requests. Response kind is always `24136`
-
-| Request kind | Command                  | Response Content field (always NIP-44 encrypted) | Response Data Type      |
-| ------------ | ------------------------ | ------------------------------------------------ | ----------------------- |
-| `24140`      | `create_account`         | newly created pubkey                             | string                  |
-| `24141`      | `connect`                | "ack"                                            | string                  |
-| `24142`      | `sign_event`             | nostr event with signature                       | JSON stringified object |
-| `24143`      | `ping`                   | "pong"                                           | string                  |
-| `24144`      | `get_relays`             | array of relay objects                           | JSON stringified object |
-| `24145`      | `nip04_encrypt`          | ciphertext                                       | string                  |
-| `24146`      | `nip04_decrypt`          | plaintext                                        | string                  |
-| `24147`      | `nip44_conversation_key` | conversation key                                 | string                  |
-| `24148`      | `nip44_encrypt`          | ciphertext                                       | string                  |
-| `24149`      | `nip44_decrypt`          | plaintext                                        | string                  |
-
-## Auth Challenge Event `kind: 24137`
-
-All requests / commands can potentially trigger an auth challenge, which is a special kind of repsonse event that tells the client that the user needs to provide a password or another form of authentication before the remote signer will process their request. The response content is always a URL that the client should display to the user. This URL is a page that is created/controlled by the remote signer in a way that allows the signer to collect the needed data before proceeding.
+The `content` field is a JSON-RPC-like message that is [NIP-04](https://github.com/nostr-protocol/nips/blob/master/04.md) encrypted and has the following structure:
 
 ```json
 {
-    "id": <id>,
-    "kind": 24137,
-    "pubkey": <pubkey of the remote signer>,
-    "content": <nip44(<auth_url>)>,
-    "tags": [["p", <local keypair pubkey>], ["e", <id of the request event>]],
-    "created_at": <unix timestamp in seconds>,
+    "id": <request_id>,
+    "result": <results_string>,
+    "error": <error_string>
 }
 ```
 
-## Error Event `kind: 24138`
+- `id` is the request ID that this response is for.
+- `results` is a string of the result of the call (this can be either a string or a JSON stringified object)
+- `error` is an error in string form.
 
-Error response (a separate kind in order to make errors easier to handle on the client side).
-Content is NIP-44 encrypted string in the following format: `CODE: Error message text`. [Error codes](#error-codes) are detailed below.
+### Auth Challenges
+
+An Auth Challenge is a response that a remote signer can send back when it needs the user to authenticate via other means. This is currently used in the OAuth-like flow enabled by signers like [Nsecbunker](https://github.com/kind-0/nsecbunkerd/). The response `content` object will take the following form:
 
 ```json
 {
-    "id": <id>,
-    "kind": 24138,
-    "pubkey": <pubkey of the remote signer>,
-    "content": <nip44(<error>)>,
-    "tags": [["p", <local keypair pubkey>], ["e", <id of the request event>]],
-    "created_at": <unix timestamp in seconds>,
+    "id": <request_id>,
+    "result": "auth_url",
+    "error": <URL_to_display_to_end_user>
 }
 ```
 
-### Error Codes
-
-- `UNAUTHORIZED`: Returned if the user fails the auth challenge.
-- `NOT FOUND`: Returned if the remote signer doesn't have access to the remote pubkeys corresponding private key.
-- `UNPROCESSABLE`: Returned if a request is malformed (e.g. incorrect request content).
-- `OTHER`: Other error.
+Clients should display (in a popup or new tab) the URL from the `error` field and then subscribe/listen for another response from the remote signer (reusing the same request ID). This event will be sent once the user authenticates in the other window (or will never arrive if the user doesn't authenticate).
 
 ## References
 
-- [NIP-44 - Encryption](https://github.com/nostr-protocol/nips/blob/master/44.md)
+- [NIP-04 - Encryption](https://github.com/nostr-protocol/nips/blob/master/04.md)

--- a/46.md
+++ b/46.md
@@ -14,7 +14,7 @@ This NIP describes a method for 2-way communication between a remote signer and 
 
 All pubkeys specified in this NIP are in hex format.
 
-## Signer Discovery
+## Initiating a connection
 
 To initiate a connection between a client and a remote signer there are a few different options.
 
@@ -38,39 +38,50 @@ In this case, basically the opposite direction of the first case, the client pro
 nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata=<json metadata in the form: {"name":"...", "url": "...", "description": "..."}>
 ```
 
-### Remote signer discovery via NIP-89
-
-In this last case, most often used to fascilitate an OAuth-like signin flow, the client first looks for remote signers that have announced themselves via NIP-89 application handler events.
-
-First the client will query for `kind: 31990` events that have a `k` tag of `24133`.
-
-These are generally shown to a user, and once the user selects which remote signer to use and provides the remote user pubkey they want to use (via npub, pubkey, or nip-05 value), the client can initiate a connection. Note that it's on the user to select the remote signer that is actually managing the remote key that they would like to use in this case. If the remote user pubkey is managed on another remote signer, the connection will fail.
-
-In addition, it's important that clients validate that the pubkey of the announced remote signer matches the pubkey of the `_` entry in the `/.well-known/nostr.json` file of the remote signer's announced domain.
-
-Clients that allow users to create new accounts should also consider validating the availability of a given username in the namespace of remote signer's domain by checking the `/.well-known/nostr.json` file for existing usernames. Clients can then show users feedback in the UI before sending a `create_account` event to the remote signer and receiving an error in return. Ideally, remote signers would also respond with understandable error messages if a client tries to create an account with an existing username.
-
 ## The flow
 
-### Client-side
-
-1. Clients need several things to start: a local keypair and the details of the pubkey and relays used by the remote signer the user would like to use.
-   - The local keypair is roughly disposable. E.g. - it's ok to store it locally (ideally encrypted) for some period of time. Once authenticated, remote signers can choose to trust this local keypair for a period of time. This local keypair can be deleted/rotated at will by the client and will only trigger a new auth challenge or permissions on the remote signer.
-   - The remote user pubkey is the pubkey that the user is trying to sign in / sign as. This can be fetched with an NIP-05 or entered directly by the user (e.g. by passing a `bunker://` token).
-2. Clients use the local keypair for encrypting request events that they send to remote signers.
-
-### Remote signer-side
-
-1. Remote signers manage the private key of the user that will be used for signing. There are many different remote signers out there (e.g. Nsecbunker, nsec.app, etc.) that operate in different ways and have different features.
-2. Remote signers wait for request events and then act.
+1. Client creates a local keypair. This keypair doesn't need to be communicated to the user since it's largely disposable (i.e. the user doesn't need to see this pubkey). Clients might choose to store it locally and they should delete it when the user logs out.
+2. Client gets the remote user pubkey (either via a `bunker://` connection string or a NIP-05 login-flow; shown below)
+3. Clients use the local keypair to send requests to the remote signer by `p`-tagging and encrypting to the remote user pubkey.
+4. The remote signer responds to the client by `p`-tagging and encrypting to the local keypair pubkey.
 
 ### Example flow for signing an event
 
-Coming soon...
+- Remote user pubkey (e.g. signing as) `fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52`
+- Local pubkey is `eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86`
 
-### Example Oauth-like flow to create a new user account with Nsecbunker
+#### Signature request
 
-Coming soon...
+```json
+{
+    "kind": 24133,
+    "pubkey": "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86",
+    "content": nip04({
+        "id": <random_string>,
+        "method": "sign_event",
+        "params": [json_stringified(<{
+            content: "Hello, I'm signing remotely",
+            pubkey: "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
+            // ...the rest of the event data
+        }>)]
+    }),
+    "tags": [["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"]], // p-tags the remote user pubkey
+}
+```
+
+#### Response
+
+```json
+{
+    "kind": 24133,
+    "pubkey": "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
+    "content": nip04({
+        "id": <random_string>,
+        "result": json_stringified(<signed-event>)
+    }),
+    "tags": [["p", "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86"]], // p-tags the local keypair pubkey
+}
+```
 
 ## Request Events `kind: 24133`
 
@@ -103,19 +114,18 @@ The `content` field is a JSON-RPC-like message that is [NIP-04](https://github.c
 
 Each of the following are methods that the client sends to the remote signer.
 
-| Command                  | Params                                              | Result                                                                 |
-| ------------------------ | --------------------------------------------------- | ---------------------------------------------------------------------- |
-| `create_account`         | `[<username>, <domain>, <optional_email>]`          | `<newly_created_remote_user_pubkey>`                                   |
-| `connect`                | `[<remote_user_pubkey>, <optional_secret>]`         | "ack"                                                                  |
-| `sign_event`             | `[<json_stringified_event_to_sign>]`                | `json_stringified(<signed_event>)`                                     |
-| `ping`                   | `[]`                                                | "pong"                                                                 |
-| `get_relays`             | `[]`                                                | `json_stringified({<relay_url>: {read: <boolean>, write: <boolean>}})` |
-| `get_public_key`         | `[]`                                                | `<hex-pubkey>`                                                         |
-| `nip04_encrypt`          | `[<third_party_pubkey>, [<plaintext_to_encrypt>]]`  | `array of <nip04_ciphertext> results of encryption`                    |
-| `nip04_decrypt`          | `[<third_party_pubkey>, [<ciphertext_to_decrypt>]]` | `array of <plaintext> results of decryption`                           |
-| `nip44_conversation_key` | `[<third_party_pubkey>]`                            | `<nip44_conversation_key>`                                             |
-| `nip44_encrypt`          | `[<third_party_pubkey>, [<plaintext_to_encrypt>]]`  | `array of <nip44_ciphertext> results of encryption`                    |
-| `nip44_decrypt`          | `[<third_party_pubkey>, [<ciphertext_to_decrypt>]]` | `array of <plaintext> results of decryption`                           |
+| Command                  | Params                                            | Result                                                                 |
+| ------------------------ | ------------------------------------------------- | ---------------------------------------------------------------------- |
+| `connect`                | `[<remote_user_pubkey>, <optional_secret>]`       | "ack"                                                                  |
+| `sign_event`             | `[<json_stringified_event_to_sign>]`              | `json_stringified(<signed_event>)`                                     |
+| `ping`                   | `[]`                                              | "pong"                                                                 |
+| `get_relays`             | `[]`                                              | `json_stringified({<relay_url>: {read: <boolean>, write: <boolean>}})` |
+| `get_public_key`         | `[]`                                              | `<hex-pubkey>`                                                         |
+| `nip04_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`  | `<nip04_ciphertext>`                                                   |
+| `nip04_decrypt`          | `[<third_party_pubkey>, <ciphertext_to_decrypt>]` | `<plaintext>`                                                          |
+| `nip44_conversation_key` | Potential future addition                         |                                                                        |
+| `nip44_encrypt`          | Potential future addition                         |                                                                        |
+| `nip44_decrypt`          | Potential future addition                         |                                                                        |
 
 ## Response Events `kind:24133`
 
@@ -157,6 +167,48 @@ An Auth Challenge is a response that a remote signer can send back when it needs
 ```
 
 Clients should display (in a popup or new tab) the URL from the `error` field and then subscribe/listen for another response from the remote signer (reusing the same request ID). This event will be sent once the user authenticates in the other window (or will never arrive if the user doesn't authenticate). It's also possible to add a `redirect_uri` url parameter to the auth_url, which is helpful in situations when a client cannot open a new window or tab to display the auth challenge.
+
+## Remote Signer Commands
+
+Remote signers might support additional commands when communicating directly with it. These commands follow the same flow as noted above, the only difference is that when the client sends a request event, the `p`-tag is the pubkey of the remote signer itself and the `content` payload is encrypted to the same remote signer pubkey.
+
+### Methods/Commands
+
+Each of the following are methods that the client sends to the remote signer.
+
+| Command          | Params                                     | Result                               |
+| ---------------- | ------------------------------------------ | ------------------------------------ |
+| `create_account` | `[<username>, <domain>, <optional_email>]` | `<newly_created_remote_user_pubkey>` |
+
+## Appendix
+
+### NIP-05 Login Flow
+
+Clients might choose to present a more familiar login flow, so users can type a NIP-05 address instead of a `bunker://` string.
+
+When the user types a NIP-05 the client:
+
+- Queries the `/.well-known/nostr.json` file from the domain for the NIP-05 address provided to get the user's pubkey (this is the **remote user pubkey**)
+- In the same `/.well-known/nostr.json` file, queries for the `nip46` key to get the relays that the remote signer will be listening on.
+- Now the client has enough information to send commands to the remote signer on behalf of the user.
+
+### OAuth-like Flow
+
+#### Remote signer discovery via NIP-89
+
+In this last case, most often used to fascilitate an OAuth-like signin flow, the client first looks for remote signers that have announced themselves via NIP-89 application handler events.
+
+First the client will query for `kind: 31990` events that have a `k` tag of `24133`.
+
+These are generally shown to a user, and once the user selects which remote signer to use and provides the remote user pubkey they want to use (via npub, pubkey, or nip-05 value), the client can initiate a connection. Note that it's on the user to select the remote signer that is actually managing the remote key that they would like to use in this case. If the remote user pubkey is managed on another remote signer, the connection will fail.
+
+In addition, it's important that clients validate that the pubkey of the announced remote signer matches the pubkey of the `_` entry in the `/.well-known/nostr.json` file of the remote signer's announced domain.
+
+Clients that allow users to create new accounts should also consider validating the availability of a given username in the namespace of remote signer's domain by checking the `/.well-known/nostr.json` file for existing usernames. Clients can then show users feedback in the UI before sending a `create_account` event to the remote signer and receiving an error in return. Ideally, remote signers would also respond with understandable error messages if a client tries to create an account with an existing username.
+
+#### Example Oauth-like flow to create a new user account with Nsecbunker
+
+Coming soon...
 
 ## References
 

--- a/46.md
+++ b/46.md
@@ -1,98 +1,174 @@
-NIP-46
-======
+# NIP-46 - Nostr Remote Signing
 
-Nostr Connect
--------------
+## Rationale
 
-`draft` `optional`
+Private keys should be exposed to as few systems - apps, operating systems, devices - as possible as each system adds to the attack surface.
 
-This NIP describes a method for 2-way communication between a **remote signer** and a normal Nostr client. The remote signer could be, for example, a hardware device dedicated to signing Nostr events, while the client is a normal Nostr client.
+This NIP describes a method for 2-way communication between a remote signer and a Nostr client. The remote signer could be, for example, a hardware device dedicated to signing Nostr events, while the client is a normal Nostr client.
+
+Currently, NIP-46 uses a JSON-RPC style flow where you pass encrypted commands in `kind:24133` events. This rewrite strives to remove as much of the JSON-RPC as possible and uses new event kinds that correspond to each command a client might send and the three types of responses that remote signers can send back.
+
+This also allows us to incorporate [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) encryption in a way that doesn't break current NIP-46 implementations.
+
+## Terminology
+
+- **Local keypair**: A local public and private key-pair used to encrypt content and communicate with the remote signer.
+- **Remote pubkey**: The public key that the user wants to sign as. The remote signer has control of the private key that matches this public key.
 
 ## Signer Discovery
 
-The client always starts by generating a random key which is used to communicate with the signer, then it one of the methods below is used to allow the client to know what is the signer public key for the session and which relays to use.
+To initiate a connection between a client and a remote signer there are a few different options.
 
-### Started by the signer (nsecBunker)
+### Direct connection initiated by remote signer
 
-The remote signer generates a connection token in the form
+This is most common in a situation where you have your own nsecbunker or other type of remote signer and want to connect through a client that supports remote signing.
 
-```
-bunker://<hex-pubkey>?relay=wss://...&relay=wss://...&secret=<optional-secret>
-```
-
-The user copies that token and pastes it in the client UI somehow. Then the client can send events of kind `24133` to the specified relays and wait for responses from the remote signer.
-
-### Started by the client
-
-The client generates a QR code in the following form (URL-encoded):
+The remote signer would provide a connection token in the form:
 
 ```
-nostrconnect://<client-key-hex>?relay=wss://...&metadata={"name":"...", "url": "...", "description": "..."}
+bunker://<hex-pubkey-you-want-to-sign-as>?relay=<wss://relay-to-connect-on>&relay=<wss://another-relay-to-connect-on>&secret=<optional-secret-value>
 ```
 
-The signer scans the QR code and sends a `connect` message to the client in the specified relays.
+This token is pasted into the client by the user and the client then uses the details to connect to the remote signer via the specified relay(s).
 
-## Event payloads
+### Direct connection initiated by the client
 
-Event payloads are [NIP-04](04.md)-encrypted JSON blobs that look like JSONRPC messages (their format is specified inside the `.content` of the event formats below).
+In this case, basically the opposite direction of the first case, the client provides a connection token (or encodes the token in a QR code) and the signer initiates a connection to the client via the specified relay(s).
 
-Events sent by the client to the remote signer have the following format:
+```
+nostrconnect://<client-key-hex>?relay=<wss://relay-to-connect-on>&metadata=<json metadata in the form: {"name":"...", "url": "...", "description": "..."}>
+```
 
-```js
+### Remote signer discovery via NIP-89
+
+In this last case, most often used to fascilitate an OAuth-like signin flow, the client first looks for remote signers that have announced themselves via NIP-89 application handler events.
+
+First the client will query for `kind: 31989` events that have a `k` tag of `24133` and/or any of the new request kinds detailed below.
+
+These are generally shown to a user, and once the user selects which remote signer to use and provides the remote pubkey they want to use (via npub, pubkey, or nip-05 value), the client can initiate a connection. Note that it's on the user to select the remote signer that is actually managing the remote key that they would like to use in this case. If the remote pubkey is managed on another remote signer, the connection will fail.
+
+In addition, it's important that clients validate that the pubkey of the announced remote signer matches the pubkey of the `_` entry in the `/.well-known/nostr.json` file of the remote signer's announced domain.
+
+Clients that allow users to create new accounts should also consider validating the availability of a given username in the namespace of remote signer's domain by checking the `/.well-known/nostr.json` file for existing usernames. Clients can then show users feedback in the UI before sending a `create_account` event to the remote signer and receiving an error in return.
+
+## The flow
+
+### Client-side
+
+1. Clients need two things to start: a local keypair and the pubkey that the user wants to use for signing events.
+   - The local keypair is roughly disposable. E.g. - it's ok to store it locally (ideally encrypted) for some period of time. Once authenticated, remote signers can choose to trust this local keypair for a period of time. This local keypair can be deleted/rotated at will by the client and will only trigger a new auth challenge for the user.
+   - The remote pubkey is the pubkey that the user is trying to sign in / sign as. This can be fetched with an NIP-05 or entered directly by the user.
+2. Clients use the local keypair for encrypting request events that they send to remote signers.
+
+### Remote signer-side
+
+1. Remote signers manage the private key of the user that will be used for signing. There are many different remote signers out there (e.g. Nsecbunker, Amber, etc.) that operate in different ways and have different features.
+2. Remote signers wait for request events and then act.
+
+### Example flow for signing an event
+
+Coming soon...
+
+### Example Oauth-like flow to create a new user account with Nsecbunker
+
+Coming soon...
+
+## Request Events `Multiple kinds`
+
+Request events take the following form. In order simplify requests and payloads as much as possible, there are different event kinds for each command which help remote signers to understand the request and process the content properly.
+
+Clients can subscribe to events of `kind: 24136`, `kind: 24137`, and `kind: 24138` that have an "e" tag containing the ID of their request event to listen for the response, auth_challenge, or error to their command.
+
+```json
 {
-  "pubkey": "<client-key-hex>"
-  "kind": 24133,
-  "tags": [
-    ["p", "<signer-key-hex>"]
-  ],
-  "content": "nip04_encrypted_json({id: <random-string>, method: <see-below>, params: [array_of_strings]})",
-  ...
+    "id": <id>,
+    "kind": <kind for command>, // Each command has it's own kind
+    "pubkey": <local pubkey of the user>,
+    "content": <nip44(<request>)>,
+    "tags": [["p", <remote pubkey>]],
+    "created_at": <unix timestamp in seconds>,
 }
 ```
 
-And the events the remote signer sends to the client have the following format:
+| Kind    | Command                  | Content field (always NIP-44 encrypted)                                         | Data Type               |
+| ------- | ------------------------ | ------------------------------------------------------------------------------- | ----------------------- |
+| `24140` | `create_account`         | {username: <username>, domain: <domain>, <any other arbitrary key/value pairs>} | JSON stringified object |
+| `24141` | `connect`                | -                                                                               | null                    |
+| `24142` | `sign_event`             | nostr event to sign                                                             | JSON stringified object |
+| `24143` | `ping`                   | -                                                                               | null                    |
+| `24144` | `get_relays`             | -                                                                               | null                    |
+| `24145` | `nip04_encrypt`          | {third_party_pubkey: <third_party_pubkey>, content: <plaintext to encrypt>}     | JSON stringified object |
+| `24146` | `nip04_decrypt`          | {third_party_pubkey: <third_party_pubkey>, content: <ciphertext to decrypt>}    | JSON stringified object |
+| `24147` | `nip44_conversation_key` | third_party_pubkey                                                              | string                  |
+| `24148` | `nip44_encrypt`          | {third_party_pubkey: <third_party_pubkey>, content: <plaintext to encrypt>}     | JSON stringified object |
+| `24149` | `nip44_decrypt`          | {third_party_pubkey: <third_party_pubkey>, content: <ciphertext to decrypt>}    | JSON stringified object |
 
-```js
-  "pubkey": "<signer-key-hex>"
-  "kind": 24133,
-  "tags": [
-    ["p", "<client-key-hex>"]
-  ],
-  "content": "nip04_encrypted_json({id: <request-id>, result: <string>, error: <reason-string>})",
-  ...
+## Response Event `kind: 24136`
+
+```json
+{
+    "id": <id>,
+    "kind": 24136,
+    "pubkey": <pubkey of the remote signer>,
+    "content": <nip44(<response>)>,
+    "tags": [["p", <local keypair pubkey>], ["e", <id of the request event>]],
+    "created_at": <unix timestamp in seconds>,
+}
 ```
 
-The signer key will always be the key of the user who controls the signer device.
+#### Response content to various kinds of requests. Response kind is always `24136`
 
-### Methods
+| Request kind | Command                  | Response Content field (always NIP-44 encrypted) | Response Data Type      |
+| ------------ | ------------------------ | ------------------------------------------------ | ----------------------- |
+| `24140`      | `create_account`         | newly created pubkey                             | string                  |
+| `24141`      | `connect`                | "ack"                                            | string                  |
+| `24142`      | `sign_event`             | nostr event with signature                       | JSON stringified object |
+| `24143`      | `ping`                   | "pong"                                           | string                  |
+| `24144`      | `get_relays`             | array of relay objects                           | JSON stringified object |
+| `24145`      | `nip04_encrypt`          | ciphertext                                       | string                  |
+| `24146`      | `nip04_decrypt`          | plaintext                                        | string                  |
+| `24147`      | `nip44_conversation_key` | conversation key                                 | string                  |
+| `24148`      | `nip44_encrypt`          | ciphertext                                       | string                  |
+| `24149`      | `nip44_decrypt`          | plaintext                                        | string                  |
 
-- **connect**
-  - params: [`pubkey`, `secret`]
-  - result: `"ack"`
-- **get_public_key**
-  - params: []
-  - result: `pubkey-hex`
-- **sign_event**
-  - params: [`event`]
-  - result: `json_string(event_with_pubkey_id_and_signature)`
-- **get_relays**
-  - params: []
-  - result: `json_string({[url: string]: {read: boolean, write: boolean}})`
-- **nip04_encrypt**
-  - params: [`third-party-pubkey`, `plaintext`]
-  - result: `nip04-ciphertext`
-- **nip04_decrypt**
-  - params: [`third-party-pubkey`, `nip04-ciphertext`]
-  - result: `plaintext`
-- **nip44_get_key**
-  - params: [`third-party-pubkey`]
-  - result: `nip44-conversation-key`
-- **nip44_encrypt**
-  - params: [`third-party-pubkey`, `plaintext`]
-  - result: `nip44-ciphertext`
-- **nip44_decrypt**
-  - params: [`third-party-pubkey`, `nip44-ciphertext`]
-  - result: `plaintext`
-- **ping**
-  - params: []
-  - result: `"pong"`
+## Auth Challenge Event `kind: 24137`
+
+All requests / commands can potentially trigger an auth challenge, which is a special kind of repsonse event that tells the client that the user needs to provide a password or another form of authentication before the remote signer will process their request. The response content is always a URL that the client should display to the user. This URL is a page that is created/controlled by the remote signer in a way that allows the signer to collect the needed data before proceeding.
+
+```json
+{
+    "id": <id>,
+    "kind": 24137,
+    "pubkey": <pubkey of the remote signer>,
+    "content": <nip44(<auth_url>)>,
+    "tags": [["p", <local keypair pubkey>], ["e", <id of the request event>]],
+    "created_at": <unix timestamp in seconds>,
+}
+```
+
+## Error Event `kind: 24138`
+
+Error response (a separate kind in order to make errors easier to handle on the client side).
+Content is NIP-44 encrypted string in the following format: `CODE: Error message text`. [Error codes](#error-codes) are detailed below.
+
+```json
+{
+    "id": <id>,
+    "kind": 24138,
+    "pubkey": <pubkey of the remote signer>,
+    "content": <nip44(<error>)>,
+    "tags": [["p", <local keypair pubkey>], ["e", <id of the request event>]],
+    "created_at": <unix timestamp in seconds>,
+}
+```
+
+### Error Codes
+
+- `UNAUTHORIZED`: Returned if the user fails the auth challenge.
+- `NOT FOUND`: Returned if the remote signer doesn't have access to the remote pubkeys corresponding private key.
+- `UNPROCESSABLE`: Returned if a request is malformed (e.g. incorrect request content).
+- `OTHER`: Other error.
+
+## References
+
+- [NIP-44 - Encryption](https://github.com/nostr-protocol/nips/blob/master/44.md)


### PR DESCRIPTION
I recently implemented the current version of NIP-46 in [nostr-ignition](https://github.com/erskingardner/nostr-ignition) and found it very painful. After talking to several other folks that have also implemented this NIP and found it painful, I decided to try and improve the NIP to make it more likely that remote signing is adopted by more of Nostr.

My proposal changes NIP-46 significantly based on a few principles. 
* Use separate event kinds instead of JSON-RPC style payloads with methods.
* Simplify payloads as much as possible, only using objects or arrays where absolutely necessary.
* Use NIP-44 encryption for payloads instead of NIP-04

I've talked to quite a few folks over the last few weeks on this so thanks for all the input @fiatjaf, @pablof7z, @staab, @nostrband, and others. 

I have a shed, it is ready for your bikes. 🚴‍♂️