### PR TITLE
Add feature support signaling

### DIFF
--- a/89.md
+++ b/89.md
@@ -129,3 +129,33 @@ Alternatively, users might choose to query directly for `kind:31990` for an even
 ```json
 ["REQ", <id>, '[{ "kinds": [31990], "#k": [<desired-event-kind>], 'authors': [...] }]']
 ```
+
+## Feature Support Signaling
+
+In order to facilitate deprecations of protocol features on nostr, a consensus must be reached _before_ support
+for old features is removed. New features might also benefit from a voting mechanism.
+
+Applications may signal their support of a protocol update using a `kind 36341` event with a `d` tag pointing
+to a url detailing the change, an `a` tag pointing to a `kind 31990` handler, and a `fork` tag. `content` MAY
+be an explanation of the deprecation support.
+
+Valid `fork` values are:
+
+- `hard` - the application fully supports all relevant new features, and has dropped support for deprecated features.
+- `soft` - the application fully supports all relevant new features, but has not dropped support for deprecations.
+- `none` - the application does not support new features, or relies on deprecated features.
+- `never` - the application does not intend to adopt the new standard.
+
+In order to be valid, this event MUST be published by the same key that published the referenced handler.
+
+```json
+{
+  "kind": 36341,
+  "content": "I read and write relays to both kind 3 and kind 10002.",
+  "tags": [
+    ["d", "https://github.com/nostrability/nostrability/issues/10"],
+    ["a", "31990:1743058db7078661b94aaf4286429d97ee5257d14a86d6bfa54cb0482b876fb0:abcd", "<relay-url>"],
+    ["fork", "soft"]
+  ],
+}
+```


### PR DESCRIPTION
A few different conversations in the last few weeks have made me re-think my position on deprecations. I naively thought that:

- People developing applications would want to keep them up to date
- If they opposed a change, they would participate on discussions on github
- It is acceptable for clients to encourage others to upgrade by dropping support

This turns out not to be true, and that nostr currently has two ways to support protocol feature deprecations:

- Merge a PR, update some clients, and break everything without getting developer input
- Never deprecate old features

Our most successful deprecation to date that I'm aware of is the old #[0] notation for mentions. However, more-speech still publishes notes with this notation. It seems to me that "never deprecate" is the only option that will ever _really_ work. But I'm not ready to give up on deprecations yet.

This PR adds a signaling mechanism to allow application developers to advertise feature support in general, but in particular backwards-incompatible protocol changes.

These events could then be pulled into an interface to give a quick overview of developer buy-in for a particular feature. Developers could also automatically be notified of new updates so that they have an opportunity to advertise their support. Sybil attacks can be mitigated through WoT. Relay developers can participate in this as well by creating application listings with no kind handlers.

@fiatjaf @pablof7z @jb55 @vitorpamplona @v0l