### PR TITLE
Add Private Event Kind Range to NIP-42

### DIFF
--- a/42.md
+++ b/42.md
@@ -6,7 +6,8 @@ Authentication of clients to relays
 
 `draft` `optional`
 
-This NIP defines a way for clients to authenticate to relays by signing an ephemeral event.
+This NIP defines a way for clients to authenticate to relays by signing an ephemeral event
+and determines a kind range for events that require client authentication to access them.
 
 ## Motivation
 
@@ -17,6 +18,26 @@ A relay may want to require clients to authenticate to access restricted resourc
   - A relay may limit subscriptions of any kind to paying users or users whitelisted through any other means, and require authentication.
 
 ## Definitions
+
+### Private Event Kind Range
+
+Events in the `40000-49999` kind range are considered always private.
+They MUST have atleast one `A` tag.
+Each of these tags is set to a `pubkey` allowed to request the event after authenticating using the `AUTH` flow defined on the section below.
+
+These events should always be treated by `relays` as parameterized replaceable events. However, when a new NIP chooses a kind number in this range for a newly defined event, it should inform if `clients` will consider that the event will:
+
+1) Act as a regular (not replaceable) event, by being referenced by its `id` and by using a random `d` tag value OR;
+2) Act as a replaceable event, by using a `d` tag set to an empty string OR;
+3) Act as a parameterized replaceable event, by using a `d` tag set to a non-empty string OR;
+4) Act as an ephemeral event, by using an `expiration` tag set to a value soon to expire, by being referenced by its `id` and by using a random `d` tag value.
+
+When requesting such events from relays, it is recommended to explicitly state which event kinds and which pubkey are involved. This way relays can know, just by looking at the `REQ` filter, that an authentication is required and who should do it.
+In other words, relays won't need to query and inspect events from their DB to be able to know an authentication is required, thus saving resources.
+
+Example `REQ` message:
+
+`["REQ", "sub_1", { "kinds": [40042, 42343], #A: ["<client's-user-pubkey>"], ... }]`
 
 ### New client-relay protocol messages
 


### PR DESCRIPTION
This is an alternative to #1029. It simply uses `A` tags that are set to `pubkeys` that are allowed to download the event after authenticating with NIP-42. Private events also must be in a specific kind range and I explain why below.

– Why define a kind range when the `A` tag alone would be enough to know an event requires authentication?
Because a filter like `{ kinds: [1] }` may or may not require authentication, which would need relay to get events from DB to figure out by checking if some of these events include `A` tags. While `{ kinds: ["<a-number-in-the-new-range>"] }` clearly requires authentication.

– What if I want to add access control to a public event such as a `kind:1` one?
Imo best way would be using #1033 to point clients to an auxiliary event in the new kind range. Or you could define a new event in the new range such as `40001` that is exactly like a `kind:1` and that also must have `A` tag(s).

– Why use an indexable tag?
For a relay to be able to know if a currently authenticated user is authorized to download the requested events while simultaneously filtering them just by looking at a filter like `{ #A: ["<someone>"], ... }`

In a nutshell, this approach should make relay life easy.

@monlovesmango @fiatjaf @staab @vitorpamplona 