### PR TITLE
NIP-49 [breaking]: password normalized to unicode NFKC format

### DIFF
--- a/49.md
+++ b/49.md
@@ -12,7 +12,7 @@ This NIP defines a method by which clients can encrypt (and decrypt) a user's pr
 Symmetric Encryption Key derivation
 -----------------------------------
 
-PASSWORD = read from the user
+PASSWORD = Read from the user. The password should be unicode normalized to NFKC format to ensure that the password can be entered identically on other computers/clients.
 
 LOG\_N = Let the user or implementer choose one byte representing a power of 2 (e.g. 18 represents 262,144) which is used as the number of rounds for scrypt. Larger numbers take more time and more memory, and offer better protection:
 


### PR DESCRIPTION
This will aid compatibility.

Shocking for me to suggest a breaking change after my hissy fit last night. But I'm actually ok with important breaking changes as long as we document them (see my other PR here https://github.com/nostr-protocol/nips/pull/1052).