### PR TITLE
NIP-57: Define private zaps

### DIFF
--- a/57.md
+++ b/57.md
@@ -183,6 +183,82 @@ When an event includes one or more `zap` tags, clients wishing to zap it SHOULD 
 
 Clients MAY display the zap split configuration in the note.
 
-## Future Work
+### Appendix G: Anon Zap Request Event
 
-Zaps can be extended to be more private by encrypting `zap request` notes to the target user, but for simplicity it has been left out of this initial draft.
+The same as a zap request, with the `anon` tag added.
+
+Example:
+
+```json
+{
+  "kind": 9734,
+  "content": "Zap!",
+  "tags": [
+    ["relays", "wss://nostr-pub.wellorder.com", "wss://anotherrelay.example.com"],
+    ["amount", "21000"],
+    ["lnurl", "lnurl1dp68gurn8ghj7um5v93kketj9ehx2amn9uh8wetvdskkkmn0wahz7mrww4excup0dajx2mrv92x9xp"],
+    ["p", "04c915daefee38317fa734444acee390a8269fe5810b2241e5e6dd343dfbecc9"],
+    ["e", "9ae37aa68f48645127299e9453eb5d908a0cbb6058ff340d528ed4d37c8994fb"]
+    ["anon"]
+  ],
+  "pubkey": "97c70a44366a6535c145b333f973ea86dfdc2d7a99da618c40c64705ad98e322",
+  "created_at": 1679673265,
+  "id": "30efed56a035b2549fcaeec0bf2c1595f9a9b3bb4b1a38abaf8ee9041c4b7d93",
+  "sig": "f2cb581a84ed10e4dc84937bd98e27acac71ab057255f6aa8dfa561808c981fe8870f4a03c1e3666784d82a9c802d3704e174371aa13d63e2aeaf24ff5374d9d"
+}
+```
+
+### Appendix H: Private Zap Request Event
+
+A `private zap request` is used to send a zap to a user but only revealing the sender's identity to the receiver. 
+An `anon` tag is added to the `zap request` event with the encrypted `private zap request` event.
+
+The `private zap event` is encrypted using [NIP-04](04.md) between the `zap request` key and the recipient's pubkey. The `zap request` key is the ephemeral key used to sign the `zap request` event.
+The encrypted `private zap request` event is then added to the `zap request` event as the `anon` tag bech32 encoded with the `hrp` of `pzap1` and the `iv` values of the encryption are added with an underscore followed by the iv being bech32 encoded wit the `hrp` of `iv`.
+
+Example Private Zap Event:
+
+```json
+{
+  "id": "9bf0e1d812e10faa5fd3d2560637f8e99fcbfff478583d2c835754d791acfda5",
+  "pubkey": "385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd",
+  "created_at": 1708467377,
+  "kind": 9733,
+  "tags": [
+    [
+      "p",
+      "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4"
+    ]
+  ],
+  "content": "Private Zap message!",
+  "sig": "48cc725483f41207e83c48f3d01a4e5d341bedcf556e158c19b9faac42bca30e92113049268522cd5052ab3c69850c5df7e2b4fb40c72ce770996edee5a57c8d"
+}
+
+```
+
+Example Private Zap Request Event:
+
+```json
+{
+  "id": "4ef9df0a6c7dd8b761145acc7055ae077df716bd8c374496d1f598c5b63bcd7a",
+  "pubkey": "79d4773fded68a3ea9a30f13e651ff83e150957dacb0c2f6038883d837e1b17b",
+  "created_at": 1708466564,
+  "kind": 9734,
+  "tags": [
+    [
+      "p",
+      "aa4fc8665f5696e33db7e1a572e3b0f5b3d615837b0f362dcb1c8068b098c7b4"
+    ],
+    [
+      "relays",
+      "wss://relay.damus.io"
+    ],
+    [
+      "anon",
+      "pzap1n0pkup9fxc9w3yd2tvfr03shffrapfz8rtzu9kkq6v222jw5rgtp9myyh378gdtwptpnls8f0rv0v2dyapgt7sssu4263puepgshsj9g4u9y5lvfv9fsujlgvywsuejvftlfzcanu5fmnf2a3grlelwe8v0z4mdkyhr9mddxpswtvp7mtlc4acdys7740t0x5ej36qs5amfzwz5dpwlaf4gsl69lzhqdgc3hgt62xw4y8384a6zvsnf96l3ardkd2vkk6cm77p6v7ul3gwgjr7tra7uzpkvf4hncxp5qd75h6cdadf6n2d7edhc3dyyy7qpdka2mgqhvckhzhd2gcaux34jyw6qfk3nxhaaqs6pqkuy6z34wu2p2fvqqvg55eyqlrndjlgekm7xu08lqc3g0nje59uqu0adqerv2puypez3eck9xzupg4vxyfclk37qfqxra8nt4tk9ydc2tzhpnl4wpf7jf2nrkchknfnfgmezfyqe074dexe5mkxgw67j7zn8s24tae8tml747qnq0edw5jxsx6xfc4qhshf3man0s5duw6wm63ue8fese8c7hanqzphjna3g0ee4jgpwceqzk9jgrvf9rnkt89tkvh75qm65nvtqpud30vecwlqzdlu9fhcaj7jv89gpy32y2k828vsj7x8hmlq55rleeq23e062apenymv96tkvltv266ww6kly2q2t7k6z_iv189a0s9afn7ehz4gpeanueh56cv6t79qk"
+    ]
+  ],
+  "content": "",
+  "sig": "95984f4403a4f414436270584a2ea1e3b83c988a0794ed8438f7d214714de3d982edf5eaf494362333ee07b2ce49c64c1d1206ec3914e9c7d7d4bf958d8bbfad"
+}
+```

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `6000`-`6999` | Job Result                 | [90](90.md)              |
 | `7000`        | Job Feedback               | [90](90.md)              |
 | `9041`        | Zap Goal                   | [75](75.md)              |
+| `9733`        | Private Zap Request        | [57](57.md)              |
 | `9734`        | Zap Request                | [57](57.md)              |
 | `9735`        | Zap                        | [57](57.md)              |
 | `9802`        | Highlights                 | [84](84.md)              |


### PR DESCRIPTION
Been working on zap stuff and noticed these weren't defined in the NIP. One thing I left out was how to derive the encryption key for private zaps. The [current standard](https://github.com/rust-nostr/nostr/blob/5bc7193d9ab5dafdc8df7a276d3f2f79c5512120/crates/nostr/src/nips/nip57.rs#L302) for this is really ugly and does not work for things like NIP-07 extensions or nsecbunker use cases. Been trying to come up with a better way to do it but don't think there is a way to do it deterministically without direct access to the private key