### PR TITLE
Don't let NIP-26 delegatee publish old events

### DIFF
--- a/26.md
+++ b/26.md
@@ -8,7 +8,7 @@ Delegated Event Signing
 
 This NIP defines how events can be delegated so that they can be signed by other keypairs.
 
-Another application of this proposal is to abstract away the use of the 'root' keypairs when interacting with clients. For example, a user could generate new keypairs for each client they wish to use and authorize those keypairs to generate events on behalf of their root pubkey, where the root keypair is stored in cold storage. 
+Another application of this proposal is to abstract away the use of the 'root' keypairs when interacting with clients. For example, a user could generate new keypairs for each client they wish to use and authorize those keypairs to generate events on behalf of their root pubkey, where the root keypair is stored in cold storage.
 
 #### Introducing the 'delegation' tag
 
@@ -108,3 +108,5 @@ Clients should display the delegated note as if it was published directly by the
 Relays should answer requests such as `["REQ", "", {"authors": ["A"]}]` by querying both the `pubkey` and delegation tags `[1]` value.
 
 Relays SHOULD allow the delegator (8e0d3d3e) to delete the events published by the delegatee (477318cf).
+
+Relays SHOULD NOT store a delegatee's event if the timestamp of the moment they receive the publishing request isn't in the "created_at" condition range (if present), even if the event's `.created_at` satisfies the condition. Only authenticated delegators SHOULD be allowed to publish it in this case.


### PR DESCRIPTION
I imagine that delegator doesn't want delegatee to publish old events (long after the created_at condition is over).