### PR TITLE
NIP-46, NIP-49, NIP-65: fix typos

### DIFF
--- a/46.md
+++ b/46.md
@@ -96,7 +96,7 @@ nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata
     "pubkey": <local_keypair_pubkey>,
     "content": <nip04(<request>)>,
     "tags": [["p", <remote_user_pubkey>]], // NB: in the `create_account` event, the remote signer pubkey should be `p` tagged.
-    "created_at": <unix timestamp in seconds>,
+    "created_at": <unix timestamp in seconds>
 }
 ```
 
@@ -139,7 +139,7 @@ Each of the following are methods that the client sends to the remote signer.
     "pubkey": <remote_signer_pubkey>,
     "content": <nip04(<response>)>,
     "tags": [["p", <local_keypair_pubkey>]],
-    "created_at": <unix timestamp in seconds>,
+    "created_at": <unix timestamp in seconds>
 }
 ```
 

--- a/49.md
+++ b/49.md
@@ -16,13 +16,13 @@ PASSWORD = Read from the user. The password should be unicode normalized to NFKC
 
 LOG\_N = Let the user or implementer choose one byte representing a power of 2 (e.g. 18 represents 262,144) which is used as the number of rounds for scrypt. Larger numbers take more time and more memory, and offer better protection:
 
-    | LOG\_N | MEMORY REQUIRED | APPROX TIME ON FAST COMPUTER |
-    |--------|-----------------|----------------------------- |
-    | 16     | 64 MiB          | 100 ms                       |
-    | 18     | 256 MiB         |                              |
-    | 20     | 1 GiB           | 2 seconds                    |
-    | 21     | 2 GiB           |                              |
-    | 22     | 4 GiB           |                              |
+    | LOG_N | MEMORY REQUIRED | APPROX TIME ON FAST COMPUTER |
+    |-------|-----------------|----------------------------- |
+    | 16    | 64 MiB          | 100 ms                       |
+    | 18    | 256 MiB         |                              |
+    | 20    | 1 GiB           | 2 seconds                    |
+    | 21    | 2 GiB           |                              |
+    | 22    | 4 GiB           |                              |
 
 SALT = 16 random bytes
 

--- a/65.md
+++ b/65.md
@@ -19,7 +19,7 @@ The `.content` is not used.
     ["r", "wss://alicerelay.example.com"],
     ["r", "wss://brando-relay.com"],
     ["r", "wss://expensive-relay.example2.com", "write"],
-    ["r", "wss://nostr-relay.example.com", "read"],
+    ["r", "wss://nostr-relay.example.com", "read"]
   ],
   "content": "",
   ...other fields


### PR DESCRIPTION
NIP-49: `LOG\_N` -> `LOG_N`