### PR TITLE
Fully-editable Kind1

### DIFF
--- a/37.md
+++ b/37.md
@@ -9,7 +9,7 @@ Editable Short Notes
 
 This NIP creates an editable version of `kind:1`'s short notes using `kind:31001`. 
 
-`kind:31001` operates in the same way `kind:1` does, with the same tagging options, including threading and markers, and content structure. The only difference is that for each `e` tag tagging another `kind:31001`, the equivalent `a` tag is also produced. 
+`kind:31001` operates in the same way `kind:1` does, with the same content structure and tagging options, including threading and markers. The only difference is that for each `e` tag pointing to another `kind:31001`, the equivalent `a` tag MUST also be created. 
 
 A `d`-tag holds the identifier for further edits. The optional `published_at` keeps the original publication date. 
 

--- a/37.md
+++ b/37.md
@@ -1,0 +1,32 @@
+
+NIP-37
+======
+
+Editable Short Notes
+--------------------
+
+`draft` `optional`
+
+This NIP creates an editable version of `kind:1`'s short notes using `kind:31001`. 
+
+`kind:31001` operates in the same way `kind:1` does, with the same tagging options, including threading and markers, and content structure. The only difference is that for each `e` tag tagging another `kind:31001`, the equivalent `a` tag is also produced. 
+
+A `d`-tag holds the identifier for further edits. The optional `published_at` keeps the original publication date. 
+
+For example:
+
+```js
+{
+  "kind": 31001,
+  "pubkey": "<32-bytes hex-encoded public key of the event creator>",
+  "tags": [
+    ["d", "<Random UUID>"]
+    ["e", "<event_id>", "<relay>", "root"],
+    ["e", "<event_id>", "<relay>", "reply"],
+    ["a", "<kind>:<pubkey>:<d-identifier>", "<relay>", "root"]
+    ["a", "<kind>:<pubkey>:<d-identifier>", "<relay>", "reply"]
+  ],
+  "content": "this is an editable short note",
+  // ...other fields
+}
+```


### PR DESCRIPTION
This opens the gates of hell for editable kind1 clients. 

Read [here](https://github.com/vitorpamplona/nips/blob/editable-kind1/37.md)

Recap of the 3 options: 
- Updates kind1 to accept edits with full history #1090
- Updates kind1 to accept edits #1089 
- Creates a new content-modifiable short note kind #1088 
- Creates a new fully modifiable short note kind #1087 