### PR TITLE
Content-editable Kind1

### DIFF
--- a/37.md
+++ b/37.md
@@ -46,30 +46,3 @@ For example:
   // ...other fields
 }
 ```
-
-
-
-
-
-
-`kind:31001` operates in the same way `kind:1` does, with the same tagging options, including threading and markers, and content structure. The only difference is that for each `e` tag tagging another `kind:31001`, the equivalent `a` tag is also produced. 
-
-A `d`-tag holds the identifier for further edits. The optional `published_at` keeps the original publication date. 
-
-For example:
-
-```js
-{
-  "kind": 31001,
-  "pubkey": "<32-bytes hex-encoded public key of the event creator>",
-  "tags": [
-    ["d", "<Random UUID>"]
-    ["e", "<event_id>", "<relay>", "root"],
-    ["e", "<event_id>", "<relay>", "reply"],
-    ["a", "<kind>:<pubkey>:<d-identifier>", "<relay>", "root"]
-    ["a", "<kind>:<pubkey>:<d-identifier>", "<relay>", "reply"]
-  ],
-  "content": "this is an editable short note",
-  // ...other fields
-}
-```

--- a/37.md
+++ b/37.md
@@ -40,7 +40,7 @@ For example:
   "kind": 31010,
   "pubkey": "<32-bytes hex-encoded public key of the event creator>",
   "tags": [
-    ["d", "<Kind10-EventId>"]
+    ["d", "<kind_10_event_id>"]
   ],
   "content": "this is an editable short note",
   // ...other fields

--- a/37.md
+++ b/37.md
@@ -1,0 +1,75 @@
+
+NIP-37
+======
+
+Editable Short Notes
+--------------------
+
+`draft` `optional`
+
+This NIP creates a content-editable version of `kind:1`'s short notes using `kind:10` for tags and `kind:31010` for content. 
+
+The usual `kind:1` note is separated into 2 kinds: 
+- `kind:10` receives the tags related to the note. 
+- `kind:31010` receives the content.
+
+To improve loading time, `kind:10`'s `.content` contains the stringified version of the first `kind:31010` created for this post. 
+
+Clients SHOULD seek updated versions as the user navigates the feed.
+
+For example:
+
+```js
+{
+  "kind": 10,
+  "pubkey": "<32-bytes hex-encoded public key of the event creator>",
+  "tags": [
+    ["e", "<event_id>", "<relay>", "root"],
+    ["e", "<event_id>", "<relay>", "reply"],
+    ["content", "<kind>:<pubkey>:<d-identifier>", "<relay>"]
+  ],
+  "content": "<JSON.stringify(first kind:31010)>",
+  // ...other fields
+}
+```
+
+`kind:31010` then stores the content with a `d` tag with the `kind:10` id. 
+
+```js
+{
+  "kind": 31010,
+  "pubkey": "<32-bytes hex-encoded public key of the event creator>",
+  "tags": [
+    ["d", "<Kind10-EventId>"]
+  ],
+  "content": "this is an editable short note",
+  // ...other fields
+}
+```
+
+
+
+
+
+
+`kind:31001` operates in the same way `kind:1` does, with the same tagging options, including threading and markers, and content structure. The only difference is that for each `e` tag tagging another `kind:31001`, the equivalent `a` tag is also produced. 
+
+A `d`-tag holds the identifier for further edits. The optional `published_at` keeps the original publication date. 
+
+For example:
+
+```js
+{
+  "kind": 31001,
+  "pubkey": "<32-bytes hex-encoded public key of the event creator>",
+  "tags": [
+    ["d", "<Random UUID>"]
+    ["e", "<event_id>", "<relay>", "root"],
+    ["e", "<event_id>", "<relay>", "reply"],
+    ["a", "<kind>:<pubkey>:<d-identifier>", "<relay>", "root"]
+    ["a", "<kind>:<pubkey>:<d-identifier>", "<relay>", "reply"]
+  ],
+  "content": "this is an editable short note",
+  // ...other fields
+}
+```


### PR DESCRIPTION
Creates a kind1-equivalent that only the content can be edited. 

Read [here](https://github.com/vitorpamplona/nips/blob/content-editable-kind1/37.md)

Recap of the 3 options: 
- Updates kind1 to accept edits with full history #1090
- Updates kind1 to accept edits #1089 
- Creates a new content-modifiable short note kind #1088 
- Creates a new fully modifiable short note kind #1087 