### PR TITLE
Content-editable kind1s without creating a new kind1. 

### DIFF
--- a/37.md
+++ b/37.md
@@ -16,7 +16,7 @@ This NIP adds content modification directly to `kind:1` short notes.
   "kind": 31010,
   "pubkey": "<32-bytes hex-encoded public key of the event creator>",
   "tags": [
-    ["d", "<kind_10_event_id>"]
+    ["d", "<kind_1_event_id>"]
   ],
   "content": "this is a modified note",
   // ...other fields

--- a/37.md
+++ b/37.md
@@ -1,0 +1,26 @@
+
+NIP-37
+======
+
+Editable Short Notes
+--------------------
+
+`draft` `optional`
+
+This NIP adds content modification directly to `kind:1` short notes. 
+
+`kind:31010` stores the updated content with a `d` tag pointing back to the `kind:1` id. 
+
+```js
+{
+  "kind": 31010,
+  "pubkey": "<32-bytes hex-encoded public key of the event creator>",
+  "tags": [
+    ["d", "<kind_10_event_id>"]
+  ],
+  "content": "this is a modified note",
+  // ...other fields
+}
+```
+
+Clients MUST check if the pubkey of the `kind:31010` is the same as the referenced `kind:1`


### PR DESCRIPTION
This option applies content updates directly into kind1. 

Instead of creating separate short post clients with a different kind, this one modifies the behavior of the current kind1. 

Read [here](https://github.com/vitorpamplona/nips/blob/content-editable-kind1-2/37.md)

Recap of the 3 options: 
- Updates kind1 to accept edits with full history #1090
- Updates kind1 to accept edits #1089 
- Creates a new content-modifiable short note kind #1088 
- Creates a new fully modifiable short note kind #1087 