### PR TITLE
Add annotations

### DIFF
--- a/37.md
+++ b/37.md
@@ -1,0 +1,25 @@
+NIP-37
+======
+
+Annotations
+-----------
+
+`draft` `optional`
+
+This NIP adds a new concept called "annotations" which allow authors to create privileged comments on their own notes.
+These can be used to indicate updates, edits, corrections, or retractions, without obscuring the content of the original
+note or forcing clients to handle multiple versions of the note. These MAY be applied to events of any kind.
+
+```js
+{
+  "kind": 1011,
+  "pubkey": "<pubkey>",
+  "tags": [
+    ["e", "<event_id>", "<relay_hint>"]
+  ],
+  "content": "EDIT: I forgot to say...",
+  // ...other fields
+}
+```
+
+Clients MUST check if the pubkey of the `kind:1011` is the same as the referenced `kind:1`.


### PR DESCRIPTION
Annotations are preferable to edits, because they leave the original content of a note unchanged. This reduces the amount of possible confusion when comments don't match the version of the note that is fetched. You can see a revealed preference for this behavior on github issues and stack overflow posts; it is far preferable when editing comments to add a new line beginning with EDIT or UPDATE than to transparently update the main body of content.