### PR TITLE
NIP-64: Chess (Portable Game Notation)

### DIFF
--- a/64.md
+++ b/64.md
@@ -1,0 +1,125 @@
+NIP-64
+======
+
+Portable Game Notation
+-----
+
+`draft` `optional`
+
+This NIP defines `kind:30` notes representing Chess games in [PGN][pgn_specification] format, which can be read by humans and is also supported by most chess software.
+
+## Note
+
+### Content
+
+The `.content` of these notes is a string representing a [PGN-database][pgn_formal_syntax].
+
+### Tags
+
+A note can contain `e` tags of each move or a subset of moves with the hashed piece placement data of a [FEN][fen_wikipedia] string, e.g.
+```shell
+sha256('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR') := '63e2bcdcf5b275cd48b535ed210fb321197c4296b08d04329ca2d8f4391342a4'
+sha256('8/8/4R1p1/2k3p1/1p4P1/1P1b1P2/3K1n2/8') := 'e8f876dfe8adac7ee02413f2160bae5808b7ea27a190cc7d4896d5e64f600c3d'
+```
+
+```json
+[ "e", "63e2bcdcf5b275cd48b535ed210fb321197c4296b08d04329ca2d8f4391342a4"]
+[ "e", "e8f876dfe8adac7ee02413f2160bae5808b7ea27a190cc7d4896d5e64f600c3d"]
+```
+
+## Example
+
+### Content
+
+```pgn
+// A game where nothing is known. Game still in progress, game abandoned, or result otherwise unknown. 
+// Maybe players died before a move has been made.
+*
+```
+
+```pgn
+1. e4 *
+```
+
+```pgn
+[White "Fischer, Robert J."]
+[Black "Spassky, Boris V."]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 {This opening is called the Ruy Lopez.} *
+```
+
+```pgn
+[Event "F/S Return Match"]
+[Site "Belgrade, Serbia JUG"]
+[Date "1992.11.04"]
+[Round "29"]
+[White "Fischer, Robert J."]
+[Black "Spassky, Boris V."]
+[Result "1/2-1/2"]
+
+1. e4 e5 2. Nf3 Nc6 3. Bb5 {This opening is called the Ruy Lopez.} 3... a6
+4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8 10. d4 Nbd7
+11. c4 c6 12. cxb5 axb5 13. Nc3 Bb7 14. Bg5 b4 15. Nb1 h6 16. Bh4 c5 17. dxe5
+Nxe4 18. Bxe7 Qxe7 19. exd6 Qf6 20. Nbd2 Nxd6 21. Nc4 Nxc4 22. Bxc4 Nb6
+23. Ne5 Rae8 24. Bxf7+ Rxf7 25. Nxf7 Rxe1+ 26. Qxe1 Kxf7 27. Qe3 Qg5 28. Qxg5
+hxg5 29. b3 Ke6 30. a3 Kd6 31. axb4 cxb4 32. Ra5 Nd5 33. f3 Bc8 34. Kf2 Bf5
+35. Ra7 g6 36. Ra6+ Kc5 37. Ke1 Nf4 38. g3 Nxh3 39. Kd2 Kb5 40. Rd6 Kc5 41. Ra6
+Nf2 42. g4 Bd3 43. Re6 1/2-1/2
+```
+
+### Notes
+
+```json
+{
+  "kind": 30,
+  "content": "1. e4 *",
+  ...
+}
+```
+
+```json
+{
+  "kind": 30,
+  "tags": [
+    ["alt", "Fischer vs. Spassky in Belgrade on 1992-11-04 (F/S Return Match, Round 29)"],
+    [ "e", "63e2bcdcf5b275cd48b535ed210fb321197c4296b08d04329ca2d8f4391342a4"],
+    ...
+    [ "e", "e8f876dfe8adac7ee02413f2160bae5808b7ea27a190cc7d4896d5e64f600c3d"]
+  ],
+  "content": "[Event \"F/S Return Match\"]\n[Site \"Belgrade, Serbia JUG\"]\n[Date \"1992.11.04\"]\n[Round \"29\"]\n[White \"Fischer, Robert J.\"]\n[Black \"Spassky, Boris V.\"]\n[Result \"1/2-1/2\"]\n\n1. e4 e5 2. Nf3 Nc6 3. Bb5 {This opening is called the Ruy Lopez.} 3... a6\n4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8 10. d4 Nbd7\n11. c4 c6 12. cxb5 axb5 13. Nc3 Bb7 14. Bg5 b4 15. Nb1 h6 16. Bh4 c5 17. dxe5\nNxe4 18. Bxe7 Qxe7 19. exd6 Qf6 20. Nbd2 Nxd6 21. Nc4 Nxc4 22. Bxc4 Nb6\n23. Ne5 Rae8 24. Bxf7+ Rxf7 25. Nxf7 Rxe1+ 26. Qxe1 Kxf7 27. Qe3 Qg5 28. Qxg5\nhxg5 29. b3 Ke6 30. a3 Kd6 31. axb4 cxb4 32. Ra5 Nd5 33. f3 Bc8 34. Kf2 Bf5\n35. Ra7 g6 36. Ra6+ Kc5 37. Ke1 Nf4 38. g3 Nxh3 39. Kd2 Kb5 40. Rd6 Kc5 41. Ra6\nNf2 42. g4 Bd3 43. Re6 1/2-1/2"
+  ...
+}
+```
+
+## Client Behavior
+
+Clients SHOULD check whether the formatting is valid and all moves comply with chess rules.
+
+Clients SHOULD display the content represented as chessboard.
+
+Clients SHOULD publish PGN notes in ["export format"][pgn_export_format] ("strict mode", i.e. created by machines) but expect incoming notes to be in ["import format"][pgn_import_format] ("lax mode", i.e. created by humans).
+
+Clients SHOULD add `e` tags of each move or a subset of moves (hashed piece placement data of a [FEN][fen_wikipedia] string) in order to improve discoverability of certain board positions.
+
+Clients MAY include additional tags (e.g. like [`"alt"`](https://github.com/nostr-protocol/nips/blob/master/31.md)) in order to represent the note to users of non-supporting clients.
+
+## Relay Behavior
+
+Relays MAY validate PGN contents and reject invalid notes.
+
+## Resources
+- [PGN Specification][pgn_specification]: PGN (Portable Game Notation) specification
+- [PGN Specification Supplement](https://github.com/mliebelt/pgn-spec-commented/blob/main/pgn-spec-supplement.md): Addition for adding graphical elements, clock values, eval, ...
+- [PGN Formal Syntax][pgn_formal_syntax]
+- [PGN Seven Tag Roster][pgn_seven_tag_roster]
+- [PGN Import Format][pgn_import_format]
+- [PGN Export Format][pgn_export_format]
+- [Forsyth–Edwards Notation (FEN)][fen_wikipedia]
+- [lichess / pgn-viewer (GitHub)](https://github.com/lichess-org/pgn-viewer): PGN viewer widget, designed to be embedded in content pages
+
+[pgn_specification]: https://github.com/mliebelt/pgn-spec-commented/blob/main/pgn-specification.md
+[pgn_formal_syntax]: https://github.com/mliebelt/pgn-spec-commented/blob/main/pgn-specification.md#18-formal-syntax
+[pgn_seven_tag_roster]: https://github.com/mliebelt/pgn-spec-commented/blob/main/pgn-specification.md#811-seven-tag-roster
+[pgn_import_format]: https://github.com/mliebelt/pgn-spec-commented/blob/main/pgn-specification.md#31-import-format-allows-for-manually-prepared-data
+[pgn_export_format]: https://github.com/mliebelt/pgn-spec-commented/blob/main/pgn-specification.md#32-export-format-used-for-program-generated-output
+[fen_wikipedia]: https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation

--- a/64.md
+++ b/64.md
@@ -14,19 +14,6 @@ This NIP defines `kind:30` notes representing Chess games in [PGN][pgn_specifica
 
 The `.content` of these notes is a string representing a [PGN-database][pgn_formal_syntax].
 
-### Tags
-
-A note can contain `e` tags of each move or a subset of moves with the hashed piece placement data of a [FEN][fen_wikipedia] string, e.g.
-```shell
-sha256('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR') := '63e2bcdcf5b275cd48b535ed210fb321197c4296b08d04329ca2d8f4391342a4'
-sha256('8/8/4R1p1/2k3p1/1p4P1/1P1b1P2/3K1n2/8') := 'e8f876dfe8adac7ee02413f2160bae5808b7ea27a190cc7d4896d5e64f600c3d'
-```
-
-```json
-[ "e", "63e2bcdcf5b275cd48b535ed210fb321197c4296b08d04329ca2d8f4391342a4"]
-[ "e", "e8f876dfe8adac7ee02413f2160bae5808b7ea27a190cc7d4896d5e64f600c3d"]
-```
-
 ## Example
 
 ### Content
@@ -82,9 +69,7 @@ Nf2 42. g4 Bd3 43. Re6 1/2-1/2
   "kind": 30,
   "tags": [
     ["alt", "Fischer vs. Spassky in Belgrade on 1992-11-04 (F/S Return Match, Round 29)"],
-    [ "e", "63e2bcdcf5b275cd48b535ed210fb321197c4296b08d04329ca2d8f4391342a4"],
     ...
-    [ "e", "e8f876dfe8adac7ee02413f2160bae5808b7ea27a190cc7d4896d5e64f600c3d"]
   ],
   "content": "[Event \"F/S Return Match\"]\n[Site \"Belgrade, Serbia JUG\"]\n[Date \"1992.11.04\"]\n[Round \"29\"]\n[White \"Fischer, Robert J.\"]\n[Black \"Spassky, Boris V.\"]\n[Result \"1/2-1/2\"]\n\n1. e4 e5 2. Nf3 Nc6 3. Bb5 {This opening is called the Ruy Lopez.} 3... a6\n4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8 10. d4 Nbd7\n11. c4 c6 12. cxb5 axb5 13. Nc3 Bb7 14. Bg5 b4 15. Nb1 h6 16. Bh4 c5 17. dxe5\nNxe4 18. Bxe7 Qxe7 19. exd6 Qf6 20. Nbd2 Nxd6 21. Nc4 Nxc4 22. Bxc4 Nb6\n23. Ne5 Rae8 24. Bxf7+ Rxf7 25. Nxf7 Rxe1+ 26. Qxe1 Kxf7 27. Qe3 Qg5 28. Qxg5\nhxg5 29. b3 Ke6 30. a3 Kd6 31. axb4 cxb4 32. Ra5 Nd5 33. f3 Bc8 34. Kf2 Bf5\n35. Ra7 g6 36. Ra6+ Kc5 37. Ke1 Nf4 38. g3 Nxh3 39. Kd2 Kb5 40. Rd6 Kc5 41. Ra6\nNf2 42. g4 Bd3 43. Re6 1/2-1/2"
   ...
@@ -99,8 +84,6 @@ Clients SHOULD display the content represented as chessboard.
 
 Clients SHOULD publish PGN notes in ["export format"][pgn_export_format] ("strict mode", i.e. created by machines) but expect incoming notes to be in ["import format"][pgn_import_format] ("lax mode", i.e. created by humans).
 
-Clients SHOULD add `e` tags of each move or a subset of moves (hashed piece placement data of a [FEN][fen_wikipedia] string) in order to improve discoverability of certain board positions.
-
 Clients MAY include additional tags (e.g. like [`"alt"`](https://github.com/nostr-protocol/nips/blob/master/31.md)) in order to represent the note to users of non-supporting clients.
 
 ## Relay Behavior
@@ -114,7 +97,6 @@ Relays MAY validate PGN contents and reject invalid notes.
 - [PGN Seven Tag Roster][pgn_seven_tag_roster]
 - [PGN Import Format][pgn_import_format]
 - [PGN Export Format][pgn_export_format]
-- [Forsyth–Edwards Notation (FEN)][fen_wikipedia]
 - [lichess / pgn-viewer (GitHub)](https://github.com/lichess-org/pgn-viewer): PGN viewer widget, designed to be embedded in content pages
 
 [pgn_specification]: https://github.com/mliebelt/pgn-spec-commented/blob/main/pgn-specification.md
@@ -122,4 +104,3 @@ Relays MAY validate PGN contents and reject invalid notes.
 [pgn_seven_tag_roster]: https://github.com/mliebelt/pgn-spec-commented/blob/main/pgn-specification.md#811-seven-tag-roster
 [pgn_import_format]: https://github.com/mliebelt/pgn-spec-commented/blob/main/pgn-specification.md#31-import-format-allows-for-manually-prepared-data
 [pgn_export_format]: https://github.com/mliebelt/pgn-spec-commented/blob/main/pgn-specification.md#32-export-format-used-for-program-generated-output
-[fen_wikipedia]: https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation

--- a/64.md
+++ b/64.md
@@ -1,12 +1,12 @@
 NIP-64
 ======
 
-Portable Game Notation
+Chess (Portable Game Notation)
 -----
 
 `draft` `optional`
 
-This NIP defines `kind:64` notes representing games in [PGN][pgn_specification] format, which can be read by humans and is also supported by most chess software.
+This NIP defines `kind:64` notes representing chess games in [PGN][pgn_specification] format, which can be read by humans and is also supported by most chess software.
 
 ## Note
 

--- a/64.md
+++ b/64.md
@@ -6,7 +6,7 @@ Portable Game Notation
 
 `draft` `optional`
 
-This NIP defines `kind:30` notes representing Chess games in [PGN][pgn_specification] format, which can be read by humans and is also supported by most chess software.
+This NIP defines `kind:64` notes representing games in [PGN][pgn_specification] format, which can be read by humans and is also supported by most chess software.
 
 ## Note
 
@@ -18,7 +18,7 @@ The `.content` of these notes is a string representing a [PGN-database][pgn_form
 
 ```json
 {
-  "kind": 30,
+  "kind": 64,
   "content": "1. e4 *",
   ...
 }
@@ -26,7 +26,7 @@ The `.content` of these notes is a string representing a [PGN-database][pgn_form
 
 ```json
 {
-  "kind": 30,
+  "kind": 64,
   "tags": [
     ["alt", "Fischer vs. Spassky in Belgrade on 1992-11-04 (F/S Return Match, Round 29)"],
     ...
@@ -38,11 +38,11 @@ The `.content` of these notes is a string representing a [PGN-database][pgn_form
 
 ## Client Behavior
 
-Clients SHOULD check whether the formatting is valid and all moves comply with chess rules.
-
 Clients SHOULD display the content represented as chessboard.
 
 Clients SHOULD publish PGN notes in ["export format"][pgn_export_format] ("strict mode", i.e. created by machines) but expect incoming notes to be in ["import format"][pgn_import_format] ("lax mode", i.e. created by humans).
+
+Clients SHOULD check whether the formatting is valid and all moves comply with chess rules.
 
 Clients MAY include additional tags (e.g. like [`"alt"`](https://github.com/nostr-protocol/nips/blob/master/31.md)) in order to represent the note to users of non-supporting clients.
 

--- a/64.md
+++ b/64.md
@@ -14,9 +14,44 @@ This NIP defines `kind:30` notes representing Chess games in [PGN][pgn_specifica
 
 The `.content` of these notes is a string representing a [PGN-database][pgn_formal_syntax].
 
-## Example
+### Notes
 
-### Content
+```json
+{
+  "kind": 30,
+  "content": "1. e4 *",
+  ...
+}
+```
+
+```json
+{
+  "kind": 30,
+  "tags": [
+    ["alt", "Fischer vs. Spassky in Belgrade on 1992-11-04 (F/S Return Match, Round 29)"],
+    ...
+  ],
+  "content": "[Event \"F/S Return Match\"]\n[Site \"Belgrade, Serbia JUG\"]\n[Date \"1992.11.04\"]\n[Round \"29\"]\n[White \"Fischer, Robert J.\"]\n[Black \"Spassky, Boris V.\"]\n[Result \"1/2-1/2\"]\n\n1. e4 e5 2. Nf3 Nc6 3. Bb5 {This opening is called the Ruy Lopez.} 3... a6\n4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8 10. d4 Nbd7\n11. c4 c6 12. cxb5 axb5 13. Nc3 Bb7 14. Bg5 b4 15. Nb1 h6 16. Bh4 c5 17. dxe5\nNxe4 18. Bxe7 Qxe7 19. exd6 Qf6 20. Nbd2 Nxd6 21. Nc4 Nxc4 22. Bxc4 Nb6\n23. Ne5 Rae8 24. Bxf7+ Rxf7 25. Nxf7 Rxe1+ 26. Qxe1 Kxf7 27. Qe3 Qg5 28. Qxg5\nhxg5 29. b3 Ke6 30. a3 Kd6 31. axb4 cxb4 32. Ra5 Nd5 33. f3 Bc8 34. Kf2 Bf5\n35. Ra7 g6 36. Ra6+ Kc5 37. Ke1 Nf4 38. g3 Nxh3 39. Kd2 Kb5 40. Rd6 Kc5 41. Ra6\nNf2 42. g4 Bd3 43. Re6 1/2-1/2"
+  ...
+}
+```
+
+## Client Behavior
+
+Clients SHOULD check whether the formatting is valid and all moves comply with chess rules.
+
+Clients SHOULD display the content represented as chessboard.
+
+Clients SHOULD publish PGN notes in ["export format"][pgn_export_format] ("strict mode", i.e. created by machines) but expect incoming notes to be in ["import format"][pgn_import_format] ("lax mode", i.e. created by humans).
+
+Clients MAY include additional tags (e.g. like [`"alt"`](https://github.com/nostr-protocol/nips/blob/master/31.md)) in order to represent the note to users of non-supporting clients.
+
+## Relay Behavior
+
+Relays MAY validate PGN contents and reject invalid notes.
+
+
+## Examples
 
 ```pgn
 // A game where nothing is known. Game still in progress, game abandoned, or result otherwise unknown. 
@@ -54,41 +89,46 @@ hxg5 29. b3 Ke6 30. a3 Kd6 31. axb4 cxb4 32. Ra5 Nd5 33. f3 Bc8 34. Kf2 Bf5
 Nf2 42. g4 Bd3 43. Re6 1/2-1/2
 ```
 
-### Notes
+```pgn
+[Event "Hourly HyperBullet Arena"]
+[Site "https://lichess.org/wxx4GldJ"]
+[Date "2017.04.01"]
+[White "T_LUKE"]
+[Black "decidement"]
+[Result "1-0"]
+[UTCDate "2017.04.01"]
+[UTCTime "11:56:14"]
+[WhiteElo "2047"]
+[BlackElo "1984"]
+[WhiteRatingDiff "+10"]
+[BlackRatingDiff "-7"]
+[Variant "Standard"]
+[TimeControl "30+0"]
+[ECO "B00"]
+[Termination "Abandoned"]
 
-```json
-{
-  "kind": 30,
-  "content": "1. e4 *",
-  ...
-}
+1. e4 1-0
+
+
+[Event "Hourly HyperBullet Arena"]
+[Site "https://lichess.org/rospUdSk"]
+[Date "2017.04.01"]
+[White "Bastel"]
+[Black "oslochess"]
+[Result "1-0"]
+[UTCDate "2017.04.01"]
+[UTCTime "11:55:56"]
+[WhiteElo "2212"]
+[BlackElo "2000"]
+[WhiteRatingDiff "+6"]
+[BlackRatingDiff "-4"]
+[Variant "Standard"]
+[TimeControl "30+0"]
+[ECO "A01"]
+[Termination "Normal"]
+
+1. b3 d5 2. Bb2 c6 3. Nc3 Bf5 4. d4 Nf6 5. e3 Nbd7 6. f4 Bg6 7. Nf3 Bh5 8. Bd3 e6 9. O-O Be7 10. Qe1 O-O 11. Ne5 Bg6 12. Nxg6 hxg6 13. e4 dxe4 14. Nxe4 Nxe4 15. Bxe4 Nf6 16. c4 Bd6 17. Bc2 Qc7 18. f5 Be7 19. fxe6 fxe6 20. Qxe6+ Kh8 21. Qh3+ Kg8 22. Bxg6 Qd7 23. Qe3 Bd6 24. Bf5 Qe7 25. Be6+ Kh8 26. Qh3+ Nh7 27. Bf5 Rf6 28. Qxh7# 1-0
 ```
-
-```json
-{
-  "kind": 30,
-  "tags": [
-    ["alt", "Fischer vs. Spassky in Belgrade on 1992-11-04 (F/S Return Match, Round 29)"],
-    ...
-  ],
-  "content": "[Event \"F/S Return Match\"]\n[Site \"Belgrade, Serbia JUG\"]\n[Date \"1992.11.04\"]\n[Round \"29\"]\n[White \"Fischer, Robert J.\"]\n[Black \"Spassky, Boris V.\"]\n[Result \"1/2-1/2\"]\n\n1. e4 e5 2. Nf3 Nc6 3. Bb5 {This opening is called the Ruy Lopez.} 3... a6\n4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8 10. d4 Nbd7\n11. c4 c6 12. cxb5 axb5 13. Nc3 Bb7 14. Bg5 b4 15. Nb1 h6 16. Bh4 c5 17. dxe5\nNxe4 18. Bxe7 Qxe7 19. exd6 Qf6 20. Nbd2 Nxd6 21. Nc4 Nxc4 22. Bxc4 Nb6\n23. Ne5 Rae8 24. Bxf7+ Rxf7 25. Nxf7 Rxe1+ 26. Qxe1 Kxf7 27. Qe3 Qg5 28. Qxg5\nhxg5 29. b3 Ke6 30. a3 Kd6 31. axb4 cxb4 32. Ra5 Nd5 33. f3 Bc8 34. Kf2 Bf5\n35. Ra7 g6 36. Ra6+ Kc5 37. Ke1 Nf4 38. g3 Nxh3 39. Kd2 Kb5 40. Rd6 Kc5 41. Ra6\nNf2 42. g4 Bd3 43. Re6 1/2-1/2"
-  ...
-}
-```
-
-## Client Behavior
-
-Clients SHOULD check whether the formatting is valid and all moves comply with chess rules.
-
-Clients SHOULD display the content represented as chessboard.
-
-Clients SHOULD publish PGN notes in ["export format"][pgn_export_format] ("strict mode", i.e. created by machines) but expect incoming notes to be in ["import format"][pgn_import_format] ("lax mode", i.e. created by humans).
-
-Clients MAY include additional tags (e.g. like [`"alt"`](https://github.com/nostr-protocol/nips/blob/master/31.md)) in order to represent the note to users of non-supporting clients.
-
-## Relay Behavior
-
-Relays MAY validate PGN contents and reject invalid notes.
 
 ## Resources
 - [PGN Specification][pgn_specification]: PGN (Portable Game Notation) specification

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-57: Lightning Zaps](57.md)
 - [NIP-58: Badges](58.md)
 - [NIP-59: Gift Wrap](59.md)
+- [NIP-64: Chess (PGN)](64.md)
 - [NIP-65: Relay List Metadata](65.md)
 - [NIP-70: Protected Events](70.md)
 - [NIP-71: Video Events](71.md)
@@ -115,6 +116,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `42`          | Channel Message                 | [28](28.md)                            |
 | `43`          | Channel Hide Message            | [28](28.md)                            |
 | `44`          | Channel Mute User               | [28](28.md)                            |
+| `64`          | Chess (PGN)                     | [64](64.md)                            |
 | `818`         | Merge Requests                  | [54](54.md)                            |
 | `1021`        | Bid                             | [15](15.md)                            |
 | `1022`        | Bid confirmation                | [15](15.md)                            |


### PR DESCRIPTION
NIP-64
======


Reserving `kind := 64` for notes representing chess games in[ PGN format](https://en.wikipedia.org/wiki/Portable_Game_Notation).

NIP-64: https://github.com/theborakompanioni/nips/blob/nip-64/64.md
Website: https://jesterui.github.io/nip64/

(Former discussion: https://github.com/nostr-protocol/nips/pull/212)