### PR TITLE
NIP96 - Adding pubkeys to file urls to allow data migration between media servers.

### DIFF
--- a/96.md
+++ b/96.md
@@ -164,7 +164,7 @@ The upload response is a json object as follows:
       // Could also be any url to download the file
       // (using or not using the /.well-known/nostr/nip96.json's "download_url" prefix),
       // for load balancing purposes for example.
-      ["url", "https://your-file-server.example/custom-api-path/719171db19525d9d08dd69cb716a18158a249b7b3b3ec4bbdec5698dca104b7b.png"],
+      ["url", "https://your-file-server.example/custom-api-path/pubkey/719171db19525d9d08dd69cb716a18158a249b7b3b3ec4bbdec5698dca104b7b.png"],
       // SHA-256 hash of the ORIGINAL file, before transformations.
       // The server MUST store it even though it represents the ORIGINAL file because
       // users may try to download/delete the transformed file using this value
@@ -226,7 +226,7 @@ However, for all file actions, such as download and deletion, the **original** f
 
 ## Download
 
-`Servers` must make available the route `https://your-file-server.example/custom-api-path/<sha256-file-hash>(.ext)` (route taken from `https://your-file-server.example/.well-known/nostr/nip96.json` "api_url" or "download_url" field) with `GET` method for file download.
+`Servers` must make available the route `https://your-file-server.example/custom-api-path/<pubkey>/<sha256-file-hash>(.ext)` (route taken from `https://your-file-server.example/.well-known/nostr/nip96.json` "api_url" or "download_url" field) with `GET` method for file download.
 
 The primary file download url informed at the upload's response field `nip94_event.tags.*.url`
 can be that or not (it can be any non-standard url the server wants).
@@ -234,13 +234,19 @@ If not, the server still MUST also respond to downloads at the standard url
 mentioned on the previous paragraph, to make it possible for a client
 to try downloading a file on any NIP-96 compatible server by knowing just the SHA-256 file hash.
 
+The server **must** report the pubkey that uploaded the file in the url, thus enabling interoperability between servers, allowing uploaded data to be migrated from one server to another while respecting the structure of the url.
+
+Clients should scan the user's configured NIP96 server list when a file is not available at the original url using the 
+
+Example: `<download_url>/375fdc8cb766664da915d638f46ca0399cd13cbd81a3f25eb37371d9dbe1bc81/719171db19525d9d08dd69cb716a18158a249b7b3b3ec4bbdec5698dca104b7b.png`
+
 Note that the "\<sha256-file-hash\>" part is from the **original** file, **not** from the **transformed** file if the uploaded file went through any server transformation.
 
 Supporting ".ext", meaning "file extension", is required for `servers`. It is optional, although recommended, for `clients` to append it to the path.
 When present it may be used by `servers` to know which `Content-Type` header to send (e.g.: "Content-Type": "image/png" for ".png" extension).
 The file extension may be absent because the hash is the only needed string to uniquely identify a file.
 
-Example: `https://your-file-server.example/custom-api-path/719171db19525d9d08dd69cb716a18158a249b7b3b3ec4bbdec5698dca104b7b.png`
+Example: `https://your-file-server.example/custom-api-path/375fdc8cb766664da915d638f46ca0399cd13cbd81a3f25eb37371d9dbe1bc81/719171db19525d9d08dd69cb716a18158a249b7b3b3ec4bbdec5698dca104b7b.png`
 
 ### Media Transformations
 


### PR DESCRIPTION
**Background:**

Thanks to [NIP96](https://github.com/nostr-protocol/nips/blob/master/96.md) we have standardised the way most (some 😅) of nostr clients upload files to media servers. Allowing the user to decide where to upload their files freely. 

**Problem:**

Once the user has started using a server, if they decide to change, their data is scattered across multiple servers at once. Making administration (deletion, etc.) difficult.

**Solution:**

Report the pubkey that uploaded the file in the url's published by the servers, allowing to standardize the paths, not only of the files but also of the pubkey that uploaded it.

**Example:**

https://nostrcheck.me/media/89e14be49ed0073da83b678279cd29ba5ad86cf000b6a3d1a4c3dc4aa4fdd02c/1d7e174198e61331bee68c07c9df6d66ab3a904dc47704803abad9deebd635f0.webp

As you can see, the path contains the **pubkey** and the **original_hash** of the file, apart from its extension.

/89e14be49ed0073da83b678279cd29ba5ad86cf000b6a3d1a4c3dc4aa4fdd02c/1d7e174198e61331bee68c07c9df6d66ab3a904dc47704803abad9deebd635f0.webp

If nostr clients remove the server and use the list of NIP96 servers that has configured (example bellow of how I implemented it in Coracle), we will add resilience to the availability of the files over time, and we will also allow the user to decide where to have these files. 

![image](https://github.com/nostr-protocol/nips/assets/125748180/73c14887-2ba8-4a40-a38c-8233ebd61e7a)


Having (or not) the feature of data migration by the servers would not be necessary, since the path of the files uploaded by the user to a new server should be the same (same pubkey + same original hash).

Finally, my server ([nostrcheck-server](https://github.com/quentintaranpino/nostrcheck-api-ts)) and all implementations using it, will have the option to download all user data in a compressed file to be **imported / exported on demand** wherever you want.



