### PR TITLE
NIP-50: search by nip05 domain

### DIFF
--- a/50.md
+++ b/50.md
@@ -47,3 +47,4 @@ Relays SHOULD exclude spam from search results by default if they support some f
 
 Relay MAY support these extensions:
 - `include:spam` - turn off spam filtering, if it was enabled by default
+- `domain:<domain>` - include events from users whose valid nip05 domain matches the domain


### PR DESCRIPTION
Add a search extension to NIP-50 like `domain:gleasonator.dev` to include only events from users with a valid nip05 name on the domain `gleasonator.dev`