### PR TITLE
Add optional `&clientkey=...` to NIP-46

### DIFF
--- a/46.md
+++ b/46.md
@@ -25,7 +25,7 @@ This is most common in a situation where you have your own nsecbunker or other t
 The remote signer would provide a connection token in the form:
 
 ```
-bunker://<remote-pubkey>?relay=<wss://relay-to-connect-on>&relay=<wss://another-relay-to-connect-on>&secret=<optional-secret-value>
+bunker://<remote-pubkey>?relay=<wss://relay-to-connect-on>&relay=<wss://another-relay-to-connect-on>&secret=<optional-secret-value>&clientkey=<optional-hex-key-to-use-as-the-clients-key>
 ```
 
 This token is pasted into the client by the user and the client then uses the details to connect to the remote signer via the specified relay(s).


### PR DESCRIPTION
This allows a single bunker://... string to be self-contained, storeable and pre-authorized.

closes https://github.com/nostr-protocol/nips/issues/1106