### PR TITLE
NIP-50: add event classification extensions

### DIFF
--- a/50.md
+++ b/50.md
@@ -48,7 +48,6 @@ Relays SHOULD exclude spam from search results by default if they support some f
 Relay MAY support these extensions:
 - `include:spam` - turn off spam filtering, if it was enabled by default
 - `domain:<domain>` - include only events from users whose valid nip05 domain matches the domain
-- `topic:<topic>` - include only events within a classified topic (short string, one to two words)
 - `language:<two letter ISO 639-1 language code>` - include only events of a specified language
 - `sentiment:<negative/neutral/positive>` - include only events of a specific sentiment
 - `nsfw:<true/false>` - include or exclude nsfw events (default: true)

--- a/50.md
+++ b/50.md
@@ -47,4 +47,8 @@ Relays SHOULD exclude spam from search results by default if they support some f
 
 Relay MAY support these extensions:
 - `include:spam` - turn off spam filtering, if it was enabled by default
-- `domain:<domain>` - include events from users whose valid nip05 domain matches the domain
+- `domain:<domain>` - include only events from users whose valid nip05 domain matches the domain
+- `topic:<topic>` - include only events within a classified topic (short string, one to two words)
+- `language:<two letter ISO 639-1 language code>` - include only events of a specified language
+- `sentiment:<negative/neutral/positive>` - include only events of a specific sentiment
+- `nsfw:<true/false>` - include or exclude nsfw events (default: true)


### PR DESCRIPTION
As previously discussed in the other NIP-50 PR with @alexgleason and @fiatjaf...

We have recently started experimenting with event classification (https://docs.nostr.wine/api/classification) on our nostr.wine relay. 

I've added language, sentiment, and nsfw to extensions. I also updated the wording of the domain: extension to include ONLY events from users instead of just "include events". Let me know if I'm misunderstanding that.

I'm not sure of the best format for everything (is ISO 639-1 a good choice for language codes?) but wanted to get something started.
