### PR TITLE
NIP-26: Increase percentage of relays supporting it from 0.01% to 100%

### DIFF
--- a/26.md
+++ b/26.md
@@ -8,11 +8,11 @@ Delegated Event Signing
 
 This NIP defines how events can be delegated so that they can be signed by other keypairs.
 
-Another application of this proposal is to abstract away the use of the 'root' keypairs when interacting with clients. For example, a user could generate new keypairs for each client they wish to use and authorize those keypairs to generate events on behalf of their root pubkey, where the root keypair is stored in cold storage. 
+Another application of this proposal is to abstract away the use of the 'root' keypairs when interacting with clients. For example, a user could generate new keypairs for each client they wish to use and authorize those keypairs to generate events on behalf of their root pubkey, where the root keypair is stored in cold storage.
 
-#### Introducing the 'delegation' tag
+#### Introducing the 'D' tag
 
-This NIP introduces a new tag: `delegation` which is formatted as follows:
+This NIP introduces a new tag: `D` which is formatted as follows:
 
 ```json
 [
@@ -22,6 +22,9 @@ This NIP introduces a new tag: `delegation` which is formatted as follows:
   <delegation token: 64-byte Schnorr signature of the sha256 hash of the delegation string>
 ]
 ```
+
+Note that the `D` tag was formerly named `delegation`. For maximum compatibility, delegated
+events should include both a `D` and a `delegation` tag with the same values.
 
 ##### Delegation Token
 
@@ -87,7 +90,7 @@ The delegatee (477318cf) can now construct an event on behalf of the delegator (
   "kind": 1,
   "tags": [
     [
-      "delegation",
+      "D",
       "8e0d3d3eb2881ec137a11debe736a9086715a8c8beeeda615780064d68bc25dd",
       "kind=1&created_at>1674834236&created_at<1677426236",
       "6f44d7fe4f1c09f3954640fb58bd12bae8bb8ff4120853c4693106c82e920e2b898f1f9ba9bd65449a987c39c0423426ab7b53910c0c6abfb41b30bc16e5f524"
@@ -104,7 +107,5 @@ Clients should display the delegated note as if it was published directly by the
 
 
 #### Relay & Client Support
-
-Relays should answer requests such as `["REQ", "", {"authors": ["A"]}]` by querying both the `pubkey` and delegation tags `[1]` value.
 
 Relays SHOULD allow the delegator (8e0d3d3e) to delete the events published by the delegatee (477318cf).


### PR DESCRIPTION
Currently almost no relay supports NIP-26 (e.g.: nostream removed it and strfry doesn't have it). By renaming `delegation` tag to `D`, all relays automatically have basic support to delegated events.

Minds client (the first and only client implementation?) won't break because they certainly use their own relay (which doesn't need to change) for that.