### PR TITLE
Mark Key NIPs for Social Feeds as `final`

### DIFF
--- a/01.md
+++ b/01.md
@@ -4,7 +4,7 @@ NIP-01
 Basic protocol flow description
 -------------------------------
 
-`draft` `mandatory`
+`final` `mandatory`
 
 This NIP defines the basic protocol that should be implemented by everybody. New NIPs may add new optional (or mandatory) fields and messages and features to the structures and flows described here.
 

--- a/07.md
+++ b/07.md
@@ -4,7 +4,7 @@ NIP-07
 `window.nostr` capability for web browsers
 ------------------------------------------
 
-`draft` `optional`
+`final` `optional`
 
 The `window.nostr` object may be made available by web browsers or extensions and websites or web-apps may make use of it after checking its availability.
 

--- a/10.md
+++ b/10.md
@@ -5,7 +5,7 @@ NIP-10
 On "e" and "p" tags in Text Events (kind 1).
 --------------------------------------------
 
-`draft` `optional`
+`final` `optional`
 
 ## Abstract
 This NIP describes how to use "e" and "p" tags in text events, especially those that are replies to other text events.  It helps clients thread the replies into a tree rooted at the original event.

--- a/18.md
+++ b/18.md
@@ -4,7 +4,7 @@ NIP-18
 Reposts
 -------
 
-`draft` `optional`
+`final` `optional`
 
 A repost is a `kind 6` event that is used to signal to followers
 that a `kind 1` text note is worth reading.

--- a/21.md
+++ b/21.md
@@ -4,7 +4,7 @@ NIP-21
 `nostr:` URI scheme
 -------------------
 
-`draft` `optional`
+`final` `optional`
 
 This NIP standardizes the usage of a common URI scheme for maximum interoperability and openness in the network.
 

--- a/23.md
+++ b/23.md
@@ -4,7 +4,7 @@ NIP-23
 Long-form Content
 -----------------
 
-`draft` `optional`
+`final` `optional`
 
 This NIP defines `kind:30023` (a _parameterized replaceable event_) for long-form text content, generally referred to as "articles" or "blog posts". `kind:30024` has the same structure as `kind:30023` and is used to save long form drafts.
 

--- a/25.md
+++ b/25.md
@@ -5,7 +5,7 @@ NIP-25
 Reactions
 ---------
 
-`draft` `optional`
+`final` `optional`
 
 A reaction is a `kind 7` event that is used to react to other events.
 

--- a/36.md
+++ b/36.md
@@ -4,7 +4,7 @@ NIP-36
 Sensitive Content / Content Warning
 -----------------------------------
 
-`draft` `optional`
+`final` `optional`
 
 The `content-warning` tag enables users to specify if the event's content needs to be approved by readers to be shown.
 Clients can hide the content until the user acts on it.

--- a/38.md
+++ b/38.md
@@ -5,7 +5,7 @@ NIP-38
 User Statuses
 --------------
 
-`draft` `optional`
+`final` `optional`
 
 ## Abstract
 

--- a/57.md
+++ b/57.md
@@ -4,7 +4,7 @@ NIP-57
 Lightning Zaps
 --------------
 
-`draft` `optional`
+`final` `optional`
 
 This NIP defines two new event types for recording lightning payments between users. `9734` is a `zap request`, representing a payer's request to a recipient's lightning wallet for an invoice. `9735` is a `zap receipt`, representing the confirmation by the recipient's lightning wallet that the invoice issued in response to a `zap request` has been paid.
 


### PR DESCRIPTION
The long-term success of Nostr as a social protocol depends on stability.  To that end, I am proposing we mark as `final` NIPs that define core social features.

## Description

Many widely-implemented NIPs, including NIP-01 (the only mandatory part of the protocol), are still in a `draft` state.  Of these, there are several widely-implemented NIPs that have not changed in several months, and can safely be marked as `final`.

The net result will be to provide developers, especially developers of social clients, an "island of stability" among the NIPs where they can be more confident of long-term compatibility with other clients.  This frees developers to focus their efforts on new social features or on the "other stuff" without worrying that sudden changes to draft NIPs will render their clients incompatible.

This also increases the long-term stability of older clients that are not actively developed, or that only see infrequent updates, providing for a smoother user experience across a wider range of clients.

The NIPs I am proposing we mark as `final` are:

- NIP-01: Almost two years in, the basic protocol flow and event structure should be stabilized.
- NIP-07: There are a plethora of browser extensions that offer Nostr signing; we should ensure they won't suddenly break due to a protocol change.
- NIP-10: The `e` and `p` tags are widely used across Nostr's social feeds, and are not likely to change anytime soon.
- NIP-18: Like NIP-10, reposts are a staple and not likely to change.
- NIP-21: A very simple NIP, and widely agreed upon among clients.
- NIP-23: There are several fairly mature clients for long-form content, and many social media clients render long-form articles; we should ensure their stability.
- NIP-25: A simple and widely-used feature.
- NIP-36: Sensitive content tags are a critical part of a good user experience, and quite simply defined; they should be marked `final`.
- NIP-38: Another simple and well-loved NIP.
- NIP-57: Zaps have become a core part of the Nostr experience; we should mark this NIP as `final` so it is as easy as possible for new clients to add zap support.

## Notes for Reviewer

Any suggestions to add or remove NIPs from the list above are welcome.  I'd love to hear thoughts on protocol stability from other Nostr devs.