### PR TITLE
Nip88: Adding dtag, 7001 etag

### DIFF
--- a/88.md
+++ b/88.md
@@ -45,6 +45,9 @@ A pubkey that wants to provide others the ability to subscribe to them can creat
         // Relay and payment-verification
         [ "r", "wss://my-subscribers-only-relay.com" ],
         [ "p", "<payment-verifier-pubkey>" ],
+
+        // A unique identifier
+        [ "d", "<random-id>" ],
     ]
 }
 ```
@@ -77,7 +80,7 @@ Zero or more `p` tags can be included to specify a pubkey that is trusted by the
     "content": "<optional-message>",
     "tags": [
         [ "p", "<recipient-pubkey>" ],
-        [ "a", "<supporting-tier-event-id>" ],
+        [ "e", "<supporting-tier-event-id>" ],
         [ "event", "<stringied-event-subscribed-to>" ],
         [ "amount", "<amount-in-base-unit>", "<currency>", "<cadence>" ],
 
@@ -92,7 +95,7 @@ When a user wants to subscribe to support a user they create a `kind:7001` event
 
 * `.content` is an optional message the supporter can write.
 * The `p` tag MUST tag the pubkey being supported.
-* The `a` tag is optional; it should point to a `kind:37001` support tier event. There MUST be exactly 0 or 1 `a` tag.
+* The `e` tag is optional; it should point to a `kind:37001` support tier event. There MUST be exactly 0 or 1 `e` tag.
 * The `event` tag is optional; subscribers can opt to keep the version of the event they subscribed to. There MUST be exactly 0 or 1 `event` tag.
 * The `amount` tag specifies what the supporters is committing to pay to the supported pubkey and the cadence. MUST be equal to one of the amounts specified in the
 `kind:37001` event if one is tagged. There MUST be exactly 1 `amount` tag.
@@ -113,6 +116,7 @@ The supporting user should create a zap `p`-tagging the receiver and e-tagging t
         [ "p", "<recipient-pubkey>" ],
         [ "e", "<kind-7001-event-id>" ]
     ]
+}
 ```
 
 Clients supporting this NIP can check for zaps e-tagging the `kind:7001` event to find the pubkeys that have a valid, paid subscriptions at each different period.


### PR DESCRIPTION
- A kind 37001 dtag is referenced in the 7003 description, but was missing in the example

- An  e tag is referenced in the  kind 7001 description but an a tag was referenced in the example. I think e tag would be correct