### PR TITLE
Added bot field to denote automated npubs

### DIFF
--- a/24.md
+++ b/24.md
@@ -16,6 +16,7 @@ These are extra fields not specified in NIP-01 that may be present in the string
   - `display_name`: an alternative, bigger name with richer characters than `name`. `name` should always be set regardless of the presence of `display_name` in the metadata.
   - `website`: a web URL related in any way to the event author.
   - `banner`: an URL to a wide (~1024x768) picture to be optionally displayed in the background of a profile screen.
+  - `bot`: a boolean to clarify that the content is entirely or partially the result of automation, such as with chatbots or newsfeeds.
 
 ### Deprecated fields
 


### PR DESCRIPTION
This is an extension of the Kind 0 fields, to allow profiles to self-indicate if they are a bot.

## Description

There are an increasing number of automated npubs that are simply newsfeeds or cross-posting from other places, such as RSS or Twitter. This is completely legitimate and many users find them helpful, to consolidate their various reading lists, but it creates confusion when there are two npubs with the same name (one human, one automated), or when people try to respond to these bots, as if they were humans.

There are also an increasing number of chatbots, infobots, DVMs, etc. that could make their status more clear to users and clients.

Until now, profiles denote this status in freetext descriptions, but that makes it difficult to query or filter, and limits the ability to easily create clients with newsfeeds or bot-labels.

## Notes for Reviewer
Closes #624 