### PR TITLE
relax requirements for NIP 32 L tags

### DIFF
--- a/32.md
+++ b/32.md
@@ -20,7 +20,7 @@ Label Namespace Tag
 An `L` tag can be any string, but publishers SHOULD ensure they are unambiguous by using a well-defined namespace
 (such as an ISO standard) or reverse domain name notation.
 
-`L` tags are REQUIRED in order to support searching by namespace rather than by a specific tag. The special `ugc`
+`L` tags are RECOMMENDED in order to support searching by namespace rather than by a specific tag. The special `ugc`
 ("user generated content") namespace MAY be used when the label content is provided by an end user.
 
 `L` tags starting with `#` indicate that the label target should be associated with the label's value.
@@ -29,7 +29,7 @@ This is a way of attaching standard nostr tags to events, pubkeys, relays, urls,
 Label Tag
 ----
 
-An `l` tag's value can be any string. `l` tags MUST include a `mark` matching an `L` tag value in the same event.
+An `l` tag's value can be any string. If using an `L` tag, `l` tags MUST include a `mark` matching an `L` tag value in the same event.
 
 Label Target
 ----
@@ -42,7 +42,7 @@ or topics respectively. As with NIP-01, a relay hint SHOULD be included when usi
 Content
 -------
 
-Labels should be short, meaningful strings. Longer discussions, such as for a review, or an
+Labels should be short, meaningful strings. Longer discussions, such as for an
 explanation of why something was labeled the way it was, should go in the event's `content` field.
 
 Self-Reporting

--- a/32.md
+++ b/32.md
@@ -29,7 +29,9 @@ This is a way of attaching standard nostr tags to events, pubkeys, relays, urls,
 Label Tag
 ----
 
-An `l` tag's value can be any string. If using an `L` tag, `l` tags MUST include a `mark` matching an `L` tag value in the same event.
+An `l` tag's value can be any string. If using an `L` tag, `l` tags MUST include a mark matching an `L`
+tag value in the same event. If no `L` tag is included, a mark SHOULD still be included. If none is
+included, `ugc` is implied.
 
 Label Target
 ----


### PR DESCRIPTION
`l` tags are really useful as a general-purpose indexable value. Adding `L` in many cases doesn't really help anything, and is quite ugly. Use cases:

- Language: `["l", "en-US"]`
- Indexing 31337 creator: `["l", "Ainsley Costello"]`