### PR TITLE
Add open-ended hint mechanism

### DIFF
--- a/xx.md
+++ b/xx.md
@@ -16,26 +16,24 @@ This NIP introduces the `~` tag, used to recommend durable indexes which can be 
 
 Indexes may directly provide events published by a given pubkey, or references to other indexes. An index's content is a JSON-encoded object with the following properties optionally defined:
 
-- `events`: an object mapping pubkeys to arrays of events signed by that pubkey. Indexes MAY include as many events as desired, but SHOULD prioritize kind 0 and kind 3.
+- `events`: an array of events. Indexes MAY include as many events as desired, but SHOULD prioritize kind 0, 3, and 10002 so that profiles can be loaded quickly while clients fetch additional events from relays directly.
 - `indexes`: an object referring to additional indexes, keys of which are index types, and values are arrays of index addresses.
 
 Example:
 
 ```
 {
-  "events": {
-    "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9": [
-      {
-        "kind": 3,
-        "content": "Hello",
-        "tags": [],
-        "created_at": 1710607821,
-        "pubkey": "8382758c082756265f88b726ca3679a8f91cf4d4e1e9b34d4fdcb1bc814fd8f7",
-        "id": "9fca770c84daba9caa72426443488e269e7ede6aa8c4bfef97f5b05b1bfe2f25",
-        "sig": "14b31fff964eab7ad77f03647001ad644ced0b265e46b8be5b21f4e01ec77949c129ef0e4875726e7d33ae55eb4b814ba9d73148d1adcee78b87b5a8760a08a5"
-      }
-    ]
-  },
+  "events": [
+    {
+      "kind": 1,
+      "content": "Hello",
+      "tags": [],
+      "created_at": 1710607821,
+      "pubkey": "8382758c082756265f88b726ca3679a8f91cf4d4e1e9b34d4fdcb1bc814fd8f7",
+      "id": "9fca770c84daba9caa72426443488e269e7ede6aa8c4bfef97f5b05b1bfe2f25",
+      "sig": "14b31fff964eab7ad77f03647001ad644ced0b265e46b8be5b21f4e01ec77949c129ef0e4875726e7d33ae55eb4b814ba9d73148d1adcee78b87b5a8760a08a5"
+    }
+  ],
   "indexes": {
     "nip05": ["username@example.com", "othername@example2.com"],
     "gundb": ["b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9", "b0635d6a"]
@@ -67,4 +65,6 @@ Example:
 
 # Additional considerations
 
-In general, indexes are not built by the users referred to, so care should be taken to consult multiple indexes if needed, and to validate event signatures to avoid forgery and censorship. Certain index types (e.g. `gundb`) can be written to by anyone, so care should be taken to defend against overly large index files, malformed data, or other malicious indexes.
+In general, indexes are not built by the users referred to, so care should be taken to consult multiple indexes if needed, and to validate event signatures to avoid forgery and censorship.
+
+Certain index types (e.g. `gundb`) can be written to by anyone, so care should be taken to defend against overly large index files, malformed data, or other malicious indexes.

--- a/xx.md
+++ b/xx.md
@@ -1,0 +1,71 @@
+NIP-01
+======
+
+Pubkey-based routing hints
+--------------------------
+
+`draft` `optional`
+
+This NIP introduces the `~` tag, used to indicate authors of related data, and where to find their notes. The first argument is a hex pubkey, the second argument is an index type, and the third a an index address, for example:
+
+```json
+["~", "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9", "gundb", "b0635d6a985"]
+```
+
+# Indexes
+
+Indexes may directly provide events published by a given pubkey, or references to other indexes. In any case, an index value is a JSON-encoded object, each value of which is an object mapping pubkeys to values as defined below. The following keys are defined (all keys are optional):
+
+- `relays`: an object mapping pubkeys to arrays of relay urls. This SHOULD match the user's `write` relays as defined by [NIP 65](./65.md).
+- `events`: an object mapping pubkeys to arrays of events signed by that pubkey.
+- `indexes`: an object referring to additional indexes, keys of which are index types, and values are objects mapping pubkeys to an array of index addresses.
+
+Example:
+
+```
+{
+  "relays": {
+    "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9": [
+      "wss://example.com",
+      "wss://example2.com"
+    ]
+  },
+  "events": {
+    "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9": [
+      {
+        "kind": 1,
+        "content": "Hello",
+        "tags": [],
+        "created_at": 1710607821,
+        "pubkey": "8382758c082756265f88b726ca3679a8f91cf4d4e1e9b34d4fdcb1bc814fd8f7",
+        "id": "9fca770c84daba9caa72426443488e269e7ede6aa8c4bfef97f5b05b1bfe2f25",
+        "sig": "14b31fff964eab7ad77f03647001ad644ced0b265e46b8be5b21f4e01ec77949c129ef0e4875726e7d33ae55eb4b814ba9d73148d1adcee78b87b5a8760a08a5"
+      }
+    ]
+  },
+  "indexes": {
+    "nip05": {
+      "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9": [
+        "https://example.com/.well-known/nostr.json?name=username",
+        "https://example2.com/.well-known/nostr.json?name=othername"
+      ]
+    },
+    "gundb": {
+      "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9": [
+        "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9",
+        "b0635d6a"
+      ]
+    }
+  }
+}
+```
+
+# Index types
+
+## `nip05`
+
+[NIP 05](./05.md) is the original indexing scheme, and may be used as described in this NIP if supported, or used as described in NIP 05 as a fallback. Index addresses should use the following pattern: `https://example.com/.well-known/nostr.json?name=username`
+
+## `gundb`
+
+[GunDB](https://gun.eco/) is an implementation of a DHT, and can be used to provide an index. A gundb index address may be any string.

--- a/xx.md
+++ b/xx.md
@@ -12,7 +12,7 @@ This NIP introduces the `~` tag, used to recommend durable indexes which can be 
 ["~", "b0635d6a9851", "gundb"]
 ```
 
-# Indexes
+# Index data file
 
 Indexes may directly provide events published by a given pubkey, or references to other indexes. An index's content is a JSON-encoded object with the following properties optionally defined:
 
@@ -41,7 +41,21 @@ Example:
 }
 ```
 
+Unless specified otherwise below, indexes should adhere to this data format.
+
 # Index types
+
+## `relay`
+
+This is an alternative to inline relay hints, and simply refer to a relay url where related events may be found. Relays need not adhere to the data format above, since they already provide events using a standard interface.
+
+Note: these are not generally recommended, as they're currently less-well supported than regular relay hints, and are redundant with them.
+
+Example:
+
+```json
+["~", "wss://relay.example.com", "relay"]
+```
 
 ## `nip05`
 

--- a/xx.md
+++ b/xx.md
@@ -1,39 +1,32 @@
-NIP-01
+NIP-xx
 ======
 
-Pubkey-based routing hints
---------------------------
+Indexes
+-------
 
 `draft` `optional`
 
-This NIP introduces the `~` tag, used to indicate authors of related data, and where to find their notes. The first argument is a hex pubkey, the second argument is an index type, and the third a an index address, for example:
+This NIP introduces the `~` tag, used to recommend durable indexes which can be used to find relevant notes. The first argument is an index address (dependent on index type, described below), and the second argument is an index type.
 
 ```json
-["~", "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9", "gundb", "b0635d6a985"]
+["~", "b0635d6a9851", "gundb"]
 ```
 
 # Indexes
 
-Indexes may directly provide events published by a given pubkey, or references to other indexes. In any case, an index value is a JSON-encoded object, each value of which is an object mapping pubkeys to values as defined below. The following keys are defined (all keys are optional):
+Indexes may directly provide events published by a given pubkey, or references to other indexes. An index's content is a JSON-encoded object with the following properties optionally defined:
 
-- `relays`: an object mapping pubkeys to arrays of relay urls. This SHOULD match the user's `write` relays as defined by [NIP 65](./65.md).
-- `events`: an object mapping pubkeys to arrays of events signed by that pubkey.
-- `indexes`: an object referring to additional indexes, keys of which are index types, and values are objects mapping pubkeys to an array of index addresses.
+- `events`: an object mapping pubkeys to arrays of events signed by that pubkey. Indexes MAY include as many events as desired, but SHOULD prioritize kind 0 and kind 3.
+- `indexes`: an object referring to additional indexes, keys of which are index types, and values are arrays of index addresses.
 
 Example:
 
 ```
 {
-  "relays": {
-    "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9": [
-      "wss://example.com",
-      "wss://example2.com"
-    ]
-  },
   "events": {
     "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9": [
       {
-        "kind": 1,
+        "kind": 3,
         "content": "Hello",
         "tags": [],
         "created_at": 1710607821,
@@ -44,18 +37,8 @@ Example:
     ]
   },
   "indexes": {
-    "nip05": {
-      "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9": [
-        "https://example.com/.well-known/nostr.json?name=username",
-        "https://example2.com/.well-known/nostr.json?name=othername"
-      ]
-    },
-    "gundb": {
-      "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9": [
-        "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9",
-        "b0635d6a"
-      ]
-    }
+    "nip05": ["username@example.com", "othername@example2.com"],
+    "gundb": ["b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9", "b0635d6a"]
   }
 }
 ```
@@ -64,8 +47,24 @@ Example:
 
 ## `nip05`
 
-[NIP 05](./05.md) is the original indexing scheme, and may be used as described in this NIP if supported, or used as described in NIP 05 as a fallback. Index addresses should use the following pattern: `https://example.com/.well-known/nostr.json?name=username`
+[NIP 05](./05.md) is the original indexing scheme, and may be used as described in this NIP if supported, or used as described in NIP 05 as a fallback.
+
+Example:
+
+```json
+["~", "user@example.com", "nip05"]
+```
 
 ## `gundb`
 
 [GunDB](https://gun.eco/) is an implementation of a DHT, and can be used to provide an index. A gundb index address may be any string.
+
+Example:
+
+```json
+["~", "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9", "gundb"]
+```
+
+# Additional considerations
+
+In general, indexes are not built by the users referred to, so care should be taken to consult multiple indexes if needed, and to validate event signatures to avoid forgery and censorship. Certain index types (e.g. `gundb`) can be written to by anyone, so care should be taken to defend against overly large index files, malformed data, or other malicious indexes.


### PR DESCRIPTION
This introduces the `~` tag, which allows events to refer to indexes where clients might be able to find additional related events.

This is purposely open-ended, since many types of indexes can be created, but the main goal is to replace or complement existing relay hints with redundant indexes that are less prone to link rot. In other words, if damus' relay goes down, many relay hints will become dead and can't be updated. Index hints allow for pointing to other sources than relays for fetching events, which may have different trade offs (for example, gundb indexes are publicly writable, and so prone to attack, but also maintainable by anyone).

The main events recommended are kind 0/3/10002, so that clients can find user relay preferences and profiles and then load events directly from relays, but other use cases are possible. For example, it is currently hard to find reply parents if the relay hint is unhelpful. Ad-hoc indexes can be created by clients which contain just the ancestors of a given note.

For example, for an event with the following tags:

```json
"tags": [
  ["e", "<event_id>", "wss://relay.example.com", "root"],
  ["~", "<event_id>", "gundb"]
]
```

If `event_id` is not found on `relay.example.com`, it may be found at `gun.get("<event_id>")`, which would return an index with a single event (the parent event).

Other index types will have different trade-offs from relays, which is a good thing. For example, gundb keys are publicly writable, so they can be both attacked and maintained by anyone. Other index types that are authenticated-write could be created though.