### PR TITLE
nip-64: inbox model

### DIFF
--- a/64.md
+++ b/64.md
@@ -1,0 +1,65 @@
+NIP-64
+======
+
+Inbox model
+-----------
+
+`draft` `optional`
+
+Suppose **Sarah** wants to subscribe to the notes **Walter** writes.
+
+She must let Walter know she is following him. The first step is to find Walter's _inbox list_:
+
+```jsonc
+{
+  "kind": 10064,
+  "pubkey": "<walter>",
+  "tags": [
+    ["relay", "wss://walter.inbox"]
+  ]
+}
+```
+
+Now Sarah can publish a `kind:6401` _follow intent_ to `wss://walter.inbox` tagging Walter:
+
+```jsonc
+{
+  "kind": 6401,
+  "pubkey": "<sarah>"
+  "tags": [
+    ["p", "<walter>"],
+    ["relay", "wss://sarah.inbox"],
+    ["relay", "wss://other.inbox"]
+  ]
+}
+```
+
+Sarah also publishes these to her own inbox relays (`wss://sarah.inbox` and `wss://other.inbox`) so they are aware.
+
+From the Walter side, whenever he is about to publish a note, he downloads all the `kind:6401` events from his inbox relays and sends his note to all the relays he finds in these.
+
+Whenever Sarah's inbox relay receive a note from Walter, they will know that Sarah is following him, so they index that note in a way that it is associated with Sarah. If the relays receive a note from someone else they can simply reject the note.
+
+When Sarah turns on her client she will connect to her inbox relay, perform [NIP-42](42.md) `AUTH` and create a subscription that doesn't specify `"authors"` (for example, `["REQ", "_", {}]`). The relays, aware of who she is and who she is following, can deliver to her just Walter's notes.
+
+If Sarah ever decides to stop following Walter, she can send a `kind:6402` _unfollow intent_ to both Walter's relays and her own, so her relay can start rejecting (and maybe delete previous) Walter's notes, and Walter can know to not send her his notes anymore. As an optimization, Walter's inbox relay can just delete Sarah's `kind:6401` upon receiving a `kind:6402`.
+
+```jsonc
+{
+  "kind": 6402,
+  "pubkey": "<sarah>"
+  "tags": [
+    ["p", "<walter>"]
+  ]
+}
+```
+
+---
+
+The approach described in this NIP doesn't replace any of the other models for following people that are already in use in Nostr, and doesn't claim to be strictly superior to the Outbox Model, but just provides an alternative way to do things.
+
+In reality, clients should implement both approaches and can never assume others will implement this.
+
+For example, if Sarah wanted to follow Wesley and he didn't have a `kind:10064` she would have to do the normal "outbox" approach of subscribing to his relays and fetching his notes from there.
+
+In the same vein, if for any reason Sarah noticed that she had stopped receiving notes from Walter for a long time (~7 days) it would make sense for her to go to his relays (obtained from [NIP-65](65.md), [NIP-05](05.md), relay hints or other means) and check if he is publishing to these. In the affirmative case, she would turn Walter into an "outbox follow" instead of an "inbox follow".


### PR DESCRIPTION
read here: https://github.com/nostr-protocol/nips/blob/inbox-model/64.md

from the text:

> The approach described in this NIP doesn't replace any of the other models for following people that are already in use in Nostr, and doesn't claim to be strictly superior to the Outbox Model, but just provides an alternative way to do things.

> In reality, clients should implement both approaches and can never assume others will implement this.

based on https://github.com/nostr-protocol/nips/discussions/1134