### PR TITLE
potentially superfluous/erroneous colon ":" character in NIP-01 non-parameterized replaceable-event "a" tag specfication

### DIFF
--- a/01.md
+++ b/01.md
@@ -79,7 +79,7 @@ This NIP defines 3 standard tags that can be used across all event kinds with th
 - The `p` tag, used to refer to another user: `["p", <32-bytes lowercase hex of a pubkey>, <recommended relay URL, optional>]`
 - The `a` tag, used to refer to a (maybe parameterized) replaceable event
     - for a parameterized replaceable event: `["a", <kind integer>:<32-bytes lowercase hex of a pubkey>:<d tag value>, <recommended relay URL, optional>]`
-    - for a non-parameterized replaceable event: `["a", <kind integer>:<32-bytes lowercase hex of a pubkey>:, <recommended relay URL, optional>]`
+    - for a non-parameterized replaceable event: `["a", <kind integer>:<32-bytes lowercase hex of a pubkey>, <recommended relay URL, optional>]`
 
 As a convention, all single-letter (only english alphabet letters: a-z, A-Z) key tags are expected to be indexed by relays, such that it is possible, for example, to query or subscribe to events that reference the event `"5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36"` by using the `{"#e": "5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36"}` filter.
 


### PR DESCRIPTION
**_non-parameterized_** replaceable-event "a" tag specification contains (potentially) superfluous/erroneous colon ":" character after hex pubkey and prior to field separator ","

```java
["a", <kind integer>:<32-bytes lowercase hex of a pubkey>:, <recommended relay URL, optional>]
                                                         ↑
                                          superfluous/erroneous inclusion
```

in contrast, **_parameterized_** replaceable event, _correctly_ specifies colon ":" character, as it is necessarily followed by a `<d tag value>`

```java
["a", <kind integer>:<32-bytes lowercase hex of a pubkey>:<d tag value>, <recommended relay URL, optional>]
                                                         ↑
                                                necessary inclusion
```