### PR TITLE
Add used fields to Calendar Time Event in NIP-52

### DIFF
--- a/52.md
+++ b/52.md
@@ -90,7 +90,7 @@ The list of tags are as follows:
 * `end` (optional) exclusive end Unix timestamp in seconds. If omitted, the calendar event ends instantaneously.
 * `start_tzid` (optional) time zone of the start timestamp, as defined by the IANA Time Zone Database. e.g., `America/Costa_Rica`
 * `end_tzid` (optional) time zone of the end timestamp, as defined by the IANA Time Zone Database. e.g., `America/Costa_Rica`. If omitted and `start_tzid` is provided, the time zone of the end timestamp is the same as the start timestamp.
-* `about` (optional) description of the calendar event
+* `summary` (optional) brief description of the calendar event
 * `image` (optional) url of an image to use for the event
 * `location` (optional, repeated) location of the calendar event. e.g. address, GPS coordinates, meeting room name, link to video call
 * `g` (optional) [geohash](https://en.wikipedia.org/wiki/Geohash) to associate calendar event with a searchable physical location
@@ -113,7 +113,7 @@ The following tags are deprecated:
     ["d", "<UUID>"],
 
     ["title", "<title of calendar event>"],
-    ["about", "<details of the calendar event>"],
+    ["summary", "<brief description of the calendar event>"],
     ["image", "<string with image URI>"],
 
     // Timestamps

--- a/52.md
+++ b/52.md
@@ -90,10 +90,12 @@ The list of tags are as follows:
 * `end` (optional) exclusive end Unix timestamp in seconds. If omitted, the calendar event ends instantaneously.
 * `start_tzid` (optional) time zone of the start timestamp, as defined by the IANA Time Zone Database. e.g., `America/Costa_Rica`
 * `end_tzid` (optional) time zone of the end timestamp, as defined by the IANA Time Zone Database. e.g., `America/Costa_Rica`. If omitted and `start_tzid` is provided, the time zone of the end timestamp is the same as the start timestamp.
+* `about` (optional) description of the calendar event
+* `image` (optional) url of an image to use for the event
 * `location` (optional, repeated) location of the calendar event. e.g. address, GPS coordinates, meeting room name, link to video call
 * `g` (optional) [geohash](https://en.wikipedia.org/wiki/Geohash) to associate calendar event with a searchable physical location
 * `p` (optional, repeated) 32-bytes hex pubkey of a participant, optional recommended relay URL, and participant's role in the meeting
-* `t` (optional, repeated) hashtag to categorize calendar event
+* `t` (optional, repeated) hashtag to categorize calendar event. e.g. `audiospace` to denote a scheduled event from an live audio space implementation such as cornychat.com
 * `r` (optional, repeated) references / links to web pages, documents, video calls, recorded videos, etc.
 
 The following tags are deprecated:
@@ -110,6 +112,8 @@ The following tags are deprecated:
     ["d", "<UUID>"],
 
     ["title", "<title of calendar event>"],
+    ["about", "<details of the calendar event>"],
+    ["image", "<string with image URI>"],
 
     // Timestamps
     ["start", "<Unix timestamp in seconds>"],

--- a/52.md
+++ b/52.md
@@ -95,7 +95,8 @@ The list of tags are as follows:
 * `location` (optional, repeated) location of the calendar event. e.g. address, GPS coordinates, meeting room name, link to video call
 * `g` (optional) [geohash](https://en.wikipedia.org/wiki/Geohash) to associate calendar event with a searchable physical location
 * `p` (optional, repeated) 32-bytes hex pubkey of a participant, optional recommended relay URL, and participant's role in the meeting
-* `t` (optional, repeated) hashtag to categorize calendar event. e.g. `audiospace` to denote a scheduled event from an live audio space implementation such as cornychat.com
+* `l` (optional, repeated) label to categorize calendar event. e.g. `audiospace` to denote a scheduled event from a live audio space implementation such as cornychat.com
+* `t` (optional, repeated) hashtag to categorize calendar event
 * `r` (optional, repeated) references / links to web pages, documents, video calls, recorded videos, etc.
 
 The following tags are deprecated:
@@ -129,6 +130,10 @@ The following tags are deprecated:
     // Participants
     ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "<role>"],
     ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>", "<role>"],
+
+    // Labels (example using com.cornychat namespace denoting the event as an audiospace)
+    ["L", "com.cornychat"],
+    ["l", "audiospace", "com.cornychat"],
 
     // Hashtags
     ["t", "<tag>"],


### PR DESCRIPTION
Cornychat.com relies on a `t` tag of `audiospace` for filtering.  Flockstr.com relies on optional and previously undocumented `audio` and `image` tags for rendering.