### PR TITLE
Clarifies relays to be used for NIP-28

### DIFF
--- a/28.md
+++ b/28.md
@@ -23,11 +23,11 @@ Client-centric moderation gives client developers discretion over what types of 
 
 Create a public chat channel.
 
-In the channel creation `content` field, Client SHOULD include basic channel metadata (`name`, `about`, `picture` as specified in kind 41).
+In the channel creation `content` field, Client SHOULD include basic channel metadata (`name`, `about`, `picture` and `relays` as specified in kind 41).
 
 ```json
 {
-  "content": "{\"name\": \"Demo Channel\", \"about\": \"A test channel.\", \"picture\": \"https://placekitten.com/200/200\"}",
+  "content": "{\"name\": \"Demo Channel\", \"about\": \"A test channel.\", \"picture\": \"https://placekitten.com/200/200\", \"relays\": [\"wss://nos.lol\", \"wss://nostr.mom\"]}",
   ...
 }
 ```
@@ -46,6 +46,7 @@ Clients SHOULD support basic metadata fields:
 - `name` - string - Channel name
 - `about` - string - Channel description
 - `picture` - string - URL of channel picture
+- `relays` - array - List of relays to download and broadcast events to
 
 Clients MAY add additional metadata fields.
 
@@ -53,7 +54,7 @@ Clients SHOULD use [NIP-10](10.md) marked "e" tags to recommend a relay.
 
 ```json
 {
-  "content": "{\"name\": \"Updated Demo Channel\", \"about\": \"Updating a test channel.\", \"picture\": \"https://placekitten.com/201/201\"}",
+  "content": "{\"name\": \"Updated Demo Channel\", \"about\": \"Updating a test channel.\", \"picture\": \"https://placekitten.com/201/201\", \"relays\": [\"wss://nos.lol\", \"wss://nostr.mom\"]}",
   "tags": [["e", <channel_create_event_id>, <relay-url>]],
   ...
 }
@@ -132,12 +133,11 @@ Clients MAY hide event 42s for users other than the user who sent the event 44.
 }
 ```
 
-## NIP-10 relay recommendations
+## Relay recommendations
 
-For [NIP-10](10.md) relay recommendations, clients generally SHOULD use the relay URL of the original (oldest) kind 40 event.
+Clients SHOULD use the relay URLs of the metadata events. 
 
-Clients MAY recommend any relay URL. For example, if a relay hosting the original kind 40 event for a channel goes offline, clients could instead fetch channel data from a backup relay, or a relay that clients trust more than the original relay.
-
+Clients MAY use any relay URL. For example, if a relay hosting the original kind 40 event for a channel goes offline, clients could instead fetch channel data from a backup relay, or a relay that clients trust more than the original relay.
 
 Motivation
 ----------


### PR DESCRIPTION
Choosing relays for NIP-28 has been quite a challenge. With these changes, the owner of the chat can recommend relays in the metadata events. 