### PR TITLE
NIP-95 Revisit

### DIFF
--- a/95.md
+++ b/95.md
@@ -131,4 +131,8 @@ These two tag values can instead be encoded on an `nfile`.
 Upon seeing such tags, in order to download the file, client should search for `kind:1195` events
 by author (`f` tag value) on the `nip95u` uploader's "file relays".
 
+Filter example:
+
+`{ authors: ["<same-random-pubkey-for-all-event-chunks>"], kinds: [1195] }`
+
 It must join the `.content` values from all the `kind:1195` events then convert it to bytes to recreate the file.

--- a/95.md
+++ b/95.md
@@ -24,7 +24,7 @@ into multiple chunks or use a single event.
 The event `.pubkey` is NOT the uploader's one but a randomly generated pubkey. All chunks
 use the same pubkey. The pubkey MUST NOT be reused on events other than the
 `kind:1195` event set of a single file.
-**The pubkey is what is used to uniquely identify the file made of a set of chunk events**
+**The pubkey is what is used to uniquely identify the set of chunk events that make up the file**
 
 The event `.content` is the base64-encoded file data.
 
@@ -70,10 +70,29 @@ Before uploading `kind:1195` events of a specifc file,
 user MUST publish a single `kind:1095` "Uploader" event,
 which is an event authored by the **user's main pubkey**,
 with empty `.content` and an `f` tag referencing the `kind:1195`
-event set (the `kind:1195` event(s) `.pubkey`).
+event set (the `kind:1195` event(s) `.pubkey`). It also
+has a `x` tag with the full file's hex-encoded sha256 hash that the
+file relay may later validate.
 
 Its purpose is to register the user as an uploader of the file on a specific relay and to request permission
 for uploading the file chunks.
+
+Example:
+
+```js
+{
+  "id": "<id>",
+  "pubkey": "<user's-main-pubkey>"
+  "kind": 1095,
+  "tags": [
+    ["f", "<same-random-pubkey-for-all-event-chunks>"],
+    ["x", "<Hash SHA-256>"]
+  ],
+  "content": "",
+  "created_at": <timestamp>,
+  "sig": "<signature>"
+}
+```
 
 When receiving the `kind:1095` event, relay may answer with one of the following messages and prefixes:
 
@@ -98,14 +117,14 @@ Clients may download `kind:1095` events from user's file relays to list all user
 A [NIP-19](19.md) `nfile` bech32-encoded entity may be embedded directly on notes using a [NIP-21](21.md) URL.
 It translates to two values:
 
-1) The `kind:1195` set's pubkey, identifying the file;
+1) The `kind:1195` set's pubkey, that is the address of the file chunks;
 2) The uploader's pubkey, to be able to find the right "file relays" to download the file from.
 
 ## Download
 
-This NIP introduces an `f` tag filled with the `kind:1195` pubkey, uniquely identifying the file,
+This NIP introduces an `f` tag filled with the `kind:1195` pubkey, uniquely identifying the file chunk set,
 and a `nip95u` tag set to the pubkey of the user who uploaded the file. Both are to
-be present if using thee NIP-94-like `kind:1094` event (instead of the `url` tag).
+be present if using the NIP-94-like `kind:1094` event (instead of the `url` tag).
 
 These two tag values can instead be encoded on an `nfile`.
 

--- a/95.md
+++ b/95.md
@@ -19,16 +19,17 @@ The chunk events may be sent on separate websockets connections for parallel upl
 ## Event
 
 An event of `kind:1195` represents a file chunk. A client may choose to split a file
-into multiple chunks or use a single event.
+into multiple chunks or use a single event. If using chunks, all of them MUST
+have the same size, except for the last one.
 
-The event `.pubkey` is NOT the uploader's one but a randomly generated pubkey. All chunks
-use the same pubkey. The pubkey MUST NOT be reused on events other than the
-`kind:1195` event set of a single file.
-**The pubkey is what is used to uniquely identify the set of chunk events that make up the file**
+The event `.pubkey` may be the uploader's one or a randomly generated pubkey.
+
+All chunks share the same [NIP-61](61.md) unbound list `n` tag that is set to `"<toHex(sha256(full-file))>-<chunk-byte-size>"`
+(here the chunk size is always the greater one, because the last chunk size may be smaller than the others).
 
 The event `.content` is the base64-encoded file data.
 
-It has a `c` tag. Its first falue is the chunk number while the second one is the total number of chunks.
+It has a `c` tag. Its first value is the chunk number while the second one is the total number of chunks.
 The client can use the `c` tag to ask for missing chunks when resuming a download.
 
 Example:
@@ -36,9 +37,10 @@ Example:
 ```js
 {
   "id": "<id>",
-  "pubkey": "<same-random-pubkey-for-all-event-chunks>"
+  "pubkey": "<pubkey>"
   "kind": 1195,
   "tags": [
+    ["n", "<toHex(sha256(full-file))>-<chunk-byte-size>"],
     ["c", "5", "20"] // required; this is the 5th chunk of a total of 20
   ],
   "content": "<base64-chunk>",
@@ -50,19 +52,24 @@ Example:
 ## Metadata
 
 Metadata should be added using [NIP-94](94.md) or other metadata-related NIP.
-If using NIP-94, instead of `kind:1063`, use `kind:1094` with the exact same format.
-See [download section](#download) that adds two tags to be used in place of the `url` tag
-on `kind:1094` events.
+If using NIP-94, instead of `kind:1063`, use `kind:1094` with the exact same format
+and instead of `url` tags(s) use NIP-61 `u` tags to reference the file chunk set,
+including the uploader's pubkey as second value, as follows:
+
+`["u", "<pubkey>:<n-tag-value>", "<uploader's-pubkey>"]`
+
+The uploader's NIP-65 "file relays" are where clients should search for the file.
 
 ## File Relay
 
-Client should upload to user's "file relays", which use the [NIP-65](65.md) `f` flag.
-When downloading a file uploaded with this NIP, it should search on the uploader's "file relays".
+Client should upload to user's "file relays", which use the [NIP-65](65.md) `f` flag
+and follow the behavior described here and on the [Pre-Upload section](#pre-upload).
+When downloading a file uploaded with this NIP, client should search on the uploader's "file relays".
 
-**Relays must NOT honor `kind:5` deletion events referencing file chunk events.**
+**File relays must NOT honor `kind:5` deletion events referencing file chunk events.**
 This is because the same file chunk set may be in use by other "uploaders".
-Deletion of all file chunks is expected to be automatic when there is no registered uploader left on the file relay
-(see [Pre-Upload](#pre-upload) section to learn how to register an uploader).
+Deletion of all file chunks is expected to be automatic when there is no registered uploader left on the "file relay"
+(see [Pre-Upload section](#pre-upload) to learn how to register an uploader).
 
 If an user wants to make sure a file won't be deleted, it
 should become an uploader of that file.
@@ -72,24 +79,28 @@ should become an uploader of that file.
 Before uploading `kind:1195` events of a specifc file,
 user MUST publish a single `kind:1095` "Uploader" event,
 which is an event authored by the **user's main pubkey**,
-with empty `.content` and an `f` tag referencing the `kind:1195`
-event set (the `kind:1195` event(s) `.pubkey`). It also
-has a `x` tag with the full file's hex-encoded sha256 hash that the
-file relay may later validate.
+with empty `.content` and an `u` tag referencing the NIP-61 unbound list of `kind:1195`
+events.
 
-Its purpose is to register the user as an uploader of the file on a specific relay and to request permission
-for uploading the file chunks.
+The second part of the `u` tag contains the full file hash and the chosen chunk size
+(used on the `kind:1195` event(s)) that the relay should validate after upload is finished.
+
+There is an `x` tag set to the full file hash to help find uploaders of a file and
+also, consequently, find out if there are already stored chunks of a file on a file relay.
+
+The `kind:1095` event purpose is to register the user as an uploader of the file on a specific
+file relay and to request permission for uploading the file chunks.
 
 Example:
 
 ```js
 {
   "id": "<id>",
-  "pubkey": "<user's-main-pubkey>"
+  "pubkey": "<user's-main-pubkey>" // uploader's pubkey
   "kind": 1095,
   "tags": [
-    ["f", "<same-random-pubkey-for-all-event-chunks>"],
-    ["x", "<Hash SHA-256>"]
+    ["u", "<pubkey>:<n-tag-value>"],
+    ["x", "<toHex(sha256(full-file))>"]
   ],
   "content": "",
   "created_at": <timestamp>,
@@ -97,45 +108,51 @@ Example:
 }
 ```
 
-When receiving the `kind:1095` event, relay may answer with one of the following messages and prefixes:
+When receiving the `kind:1095` event, the "file relay" may answer with one of the following messages and prefixes:
 
 - `["OK", "<kind:1095-event-id>", false, "auth-required: ..."]`: Authentication is required to register an uploader;
 - `["OK", "<kind:1095-event-id>", true, "uploaded: ..."]`: The corresponding `kind:1195` file chunks are already uploaded, trying to re-upload them will fail;
 - `["OK", "<kind:1095-event-id>", true, "upload: Missing chunks 1, 2, 7, 10"]`: File isn't uploaded yet or incomplete, user is allowed to upload it on this ws connection;
 
 Trying to send a `kind:1195` event before a `kind:1095` one should fail.
-Sending `kind:1095` events with an identifier (pubkey) different from the previously sent `kind:1195`'s `f` tag should fail.
+Sending `kind:1095` events with an `u` tag identifier
+different from the previously sent `kind:1195`'s corresponding values (`pubkey` and `n` tag) should fail.
 
-A `kind:5` deletion event referencing a `kind:1095` event is used to unregister the user as an uploader.
+A `kind:5` deletion event referencing a `kind:1095` event is used to **un**register the user as an uploader.
 
-Relay may split the burden of a single file by the multiple registered uploaders. For example, when there are 2 uploaders,
-a file relay may charge each of them half of the costs to host the file.
+The "file relay" may split the burden of a single file by the multiple registered uploaders. For example, when there are 2 uploaders,
+a "file relay" may charge each of them half of the costs to host the file.
 
-Relay should delete the `kind:1095` event if no corresponding `kind:1195` event is uploaded within a reasonable period.
+"File relay" should delete the `kind:1095` event if no corresponding `kind:1195` event is uploaded within a reasonable period.
 
-Clients may download `kind:1095` events from user's file relays to list all user files.
+Clients may download `kind:1095` events from user's "file relays" to list all user files.
 
 ## nfile Entity
 
 A [NIP-19](19.md) `nfile` bech32-encoded entity may be embedded directly on notes using a [NIP-21](21.md) URL.
-It translates to two values:
 
-1) The `kind:1195` set's pubkey, that is the address of the file chunks;
-2) The uploader's pubkey, to be able to find the right "file relays" to download the file from.
+It translates to:
+
+1) the unbound list (file chunk set) author's pubkey;
+2) the unbound list name (`n` tag value);
+3) and the uploader's pubkey (to locate the list using uploader's NIP-65 "file relays").
+
+The event kind number `1195` is implicit.
+
+It should have atleast inlined MIME type
+to help clients choose to download it depending on MIME type support.
+
+For example:
+
+`nostr:nfile1qqstn...794234d#m=image%2Fjpeg&dim=3024x4032`
 
 ## Download
 
-This NIP introduces an `f` tag filled with the `kind:1195` pubkey, uniquely identifying the file chunk set,
-and a `nip95u` tag set to the pubkey of the user who uploaded the file. Both are to
-be present if using the NIP-94-like `kind:1094` event (instead of the `url` tag).
-
-These two tag values can instead be encoded on an `nfile`.
-
-Upon seeing such tags, in order to download the file, client should search for `kind:1195` events
-by author (`f` tag value) on the `nip95u` uploader's "file relays".
+In order to download the file, client should search for `kind:1195` events
+by unbound list's name and author on the uploader's "file relays".
 
 Filter example:
 
-`{ authors: ["<same-random-pubkey-for-all-event-chunks>"], kinds: [1195] }`
+`{ "authors": ["<pubkey>"], "#n": ["<toHex(sha256(full-file))>|<chunk-size>"], "kinds": [1195] }`
 
-It must join the `.content` values from all the `kind:1195` events then convert it to bytes to recreate the file.
+It must join the `.content` values from all the `kind:1195` events then convert it back to bytes to recreate the file.

--- a/95.md
+++ b/95.md
@@ -27,7 +27,11 @@ The event `.pubkey` may be the uploader's one or a randomly generated pubkey.
 All chunks share the same [NIP-61](61.md) unbound list `n` tag that is set to `"<toHex(sha256(full-file))>-<chunk-byte-size>"`
 (here the chunk size is always the greater one, because the last chunk size may be smaller than the others).
 
-The event `.content` is the base64-encoded file data.
+**Important**: The chunk byte size used on the `n` tag is the binary one, before conversion to base64.
+
+The event `.content` is the base64-encoded file chunk data. Before storing this field, relays
+may convert it back to binary to reduce its size and then re-encode the field to base64
+before sending the event to clients.
 
 It has a `c` tag. Its first value is the chunk number while the second one is the total number of chunks.
 The client can use the `c` tag to ask for missing chunks when resuming a download.

--- a/95.md
+++ b/95.md
@@ -159,4 +159,5 @@ Filter example:
 
 `{ "authors": ["<pubkey>"], "#n": ["<toHex(sha256(full-file))>|<chunk-size>"], "kinds": [1195] }`
 
-It must join the `.content` values from all the `kind:1195` events then convert it back to bytes to recreate the file.
+The client must convert each `.content` value from all the `kind:1195` events back to bytes
+and concatenate all of them in the correct order to recreate the file.

--- a/95.md
+++ b/95.md
@@ -55,6 +55,40 @@ Metadata should be added using [NIP-94](94.md) or other metadata-related NIP.
 Client should upload to user's "file relays", which use the [NIP-65](65.md) `f` flag.
 When downloading a file uploaded with this NIP, it should search on the uploader's "file relays".
 
+**Relays must NOT honor `kind:5` deletion events referencing file chunk events.** Deletion
+is expected to be automatic when no uploader is registered (see [Pre-Upload](#pre-upload) section
+to learn how to register an uploader). If an user wants to make sure a file won't be deleted, it
+should become an uploader of that file.
+
+## Pre-Upload
+
+Before uploading `kind:1064` events of a specifc file,
+user MUST publish a single `kind:1065` "Uploader" event,
+which is an event authored by the **user's main pubkey**,
+with empty `.content` and an `f` tag referencing the `kind:1064`
+event set (the `kind:1064` event(s) `.pubkey`).
+
+Its purpose is to register the user as an uploader of the file on a specific relay and to request permission
+for uploading the file chunks.
+
+When receiving the `kind:1065` event, relay may answer with one of the following messages and prefixes:
+
+- `["OK", "<kind:1065-event-id>", false, "auth-required: ..."]`: Authentication is required to register an uploader;
+- `["OK", "<kind:1065-event-id>", true, "uploaded: ..."]`: The corresponding `kind:1064` file chunks are already uploaded, trying to re-upload them will fail;
+- `["OK", "<kind:1065-event-id>", true, "upload: Missing chunks 1, 2, 7, 10"]`: File isn't uploaded yet or incomplete, user is allowed to upload it on this ws connection;
+
+Trying to send a `kind:1064` event before a `kind:1065` one should fail.
+Sending `kind:1065` events with an identifier (pubkey) different from the previously sent `kind:1064`'s `f` tag should fail.
+
+A `kind:5` deletion event referencing a `kind:1065` event is used to unregister the user as an uploader.
+
+Relay may split the burden of a single file by the multiple registered uploaders. For example, when there are 2 uploaders,
+a file relay may charge each of them half of the costs to host the file.
+
+Relay should delete the `kind:1065` event if no corresponding `kind:1064` event is uploaded within a reasonable period.
+
+Clients may download `kind:1065` events from user's file relays to list all user files.
+
 ## Download
 
 This NIP introduces a NIP-94 `f` tag filled with the `kind:1064` pubkey, uniquely identifying the file,

--- a/95.md
+++ b/95.md
@@ -10,7 +10,8 @@ This NIP defines a way to store binary data on relays. It supports parallel uplo
 
 ## Upload
 
-To upload a file, first client must convert its bytes to base64. It may do it in chunks made of multiples of 3 bytes or in one go.
+To upload a file, first client must convert its bytes to base64. It may do it in chunks which sizes are multiples of 3 bytes
+(250000 bytes per chunk, for example) or in one go.
 The base64 data will be used on the `.content` field of one or more `kind:1064` events to be uploaded to a relay.
 
 The chunk events may be sent on separate websockets connections for parallel uploads.

--- a/95.md
+++ b/95.md
@@ -1,0 +1,74 @@
+NIP-95
+======
+
+Relay File Storage
+------------------
+
+`draft` `optional`
+
+This NIP defines a way to store binary data on relays. It supports parallel uploads and resumable downloads.
+
+## Upload
+
+To upload a file, first client must convert its bytes to base64. It may do it in chunks made of multiples of 3 bytes or in one go.
+The base64 data will be used on the `.content` field of one or more `kind:1064` events to be uploaded to a relay.
+
+The chunk events may be sent on separate websockets connections for parallel uploads.
+
+## Event
+
+An event of `kind:1064` represents a file chunk. A client may choose to split a file
+into multiple chunks or use a single event.
+
+The event `.pubkey` is NOT the uploader's one but a randomly generated pubkey. All chunks
+use the same pubkey. The pubkey MUST NOT be reused on events other than the
+`kind:1064` event set of a single file.
+**The pubkey is what is used to uniquely identify the file made of a set of chunk events**
+
+The event `.content` is the base64-encoded file data.
+
+It has a `c` tag. Its first falue is the chunk number while the second one is the total number of chunks.
+The client can use the `c` tag to ask for missing chunks when resuming a download.
+
+Example:
+
+```js
+{
+  "id": "<id>",
+  "pubkey": "<same-random-pubkey-for-all-event-chunks>"
+  "kind": 1064,
+  "tags": [
+    ["c", "5", "20"] // required; this is the 5th chunk of a total of 20
+  ],
+  "content": "<base64-chunk>",
+  "created_at": <timestamp>,
+  "sig": "<signature>"
+}
+```
+
+## Metadata
+
+Metadata should be added using [NIP-94](94.md) or other metadata-related NIP.
+
+## File Relay
+
+Client should upload to user's "file relays", which use the [NIP-65](65.md) `f` flag.
+When downloading a file uploaded with this NIP, it should search on the uploader's "file relays".
+
+## Download
+
+This NIP introduces a NIP-94 `f` tag filled with the `kind:1064` pubkey, uniquely identifying the file,
+and a `nip95u` tag set to the pubkey of the user who uploaded the file.
+
+Upon seeing such tags, in order to download the file, client should search for `kind:1064` events
+by author (`f` tag value) on the `nip95u` uploader's "file relays".
+
+It must join the `.content` values from all the `kind:1064` events then convert it to bytes to recreate the file.
+
+## nfile Entity
+
+A [NIP-19](19.md) `nfile` bech32-encoded entity may be embedded directly on notes using a [NIP-21](21.md) URL.
+It translates to two values:
+
+1) The `kind:1064` set's pubkey, identifying the file;
+2) The uploader's pubkey, to be able to find the right "file relays" to download the file from.

--- a/95.md
+++ b/95.md
@@ -12,18 +12,18 @@ This NIP defines a way to store binary data on relays. It supports parallel uplo
 
 To upload a file, first client must convert its bytes to base64. It may do it in chunks which sizes are multiples of 3 bytes
 (250000 bytes per chunk, for example) or in one go.
-The base64 data will be used on the `.content` field of one or more `kind:1064` events to be uploaded to a relay.
+The base64 data will be used on the `.content` field of one or more `kind:1195` events to be uploaded to a relay.
 
 The chunk events may be sent on separate websockets connections for parallel uploads.
 
 ## Event
 
-An event of `kind:1064` represents a file chunk. A client may choose to split a file
+An event of `kind:1195` represents a file chunk. A client may choose to split a file
 into multiple chunks or use a single event.
 
 The event `.pubkey` is NOT the uploader's one but a randomly generated pubkey. All chunks
 use the same pubkey. The pubkey MUST NOT be reused on events other than the
-`kind:1064` event set of a single file.
+`kind:1195` event set of a single file.
 **The pubkey is what is used to uniquely identify the file made of a set of chunk events**
 
 The event `.content` is the base64-encoded file data.
@@ -37,7 +37,7 @@ Example:
 {
   "id": "<id>",
   "pubkey": "<same-random-pubkey-for-all-event-chunks>"
-  "kind": 1064,
+  "kind": 1195,
   "tags": [
     ["c", "5", "20"] // required; this is the 5th chunk of a total of 20
   ],
@@ -50,6 +50,9 @@ Example:
 ## Metadata
 
 Metadata should be added using [NIP-94](94.md) or other metadata-related NIP.
+If using NIP-94, instead of `kind:1063`, use `kind:1094` with the exact same format.
+See [download section](#download) that adds two tags to be used in place of the `url` tag
+on `kind:1094` events.
 
 ## File Relay
 
@@ -63,47 +66,50 @@ should become an uploader of that file.
 
 ## Pre-Upload
 
-Before uploading `kind:1064` events of a specifc file,
-user MUST publish a single `kind:1065` "Uploader" event,
+Before uploading `kind:1195` events of a specifc file,
+user MUST publish a single `kind:1095` "Uploader" event,
 which is an event authored by the **user's main pubkey**,
-with empty `.content` and an `f` tag referencing the `kind:1064`
-event set (the `kind:1064` event(s) `.pubkey`).
+with empty `.content` and an `f` tag referencing the `kind:1195`
+event set (the `kind:1195` event(s) `.pubkey`).
 
 Its purpose is to register the user as an uploader of the file on a specific relay and to request permission
 for uploading the file chunks.
 
-When receiving the `kind:1065` event, relay may answer with one of the following messages and prefixes:
+When receiving the `kind:1095` event, relay may answer with one of the following messages and prefixes:
 
-- `["OK", "<kind:1065-event-id>", false, "auth-required: ..."]`: Authentication is required to register an uploader;
-- `["OK", "<kind:1065-event-id>", true, "uploaded: ..."]`: The corresponding `kind:1064` file chunks are already uploaded, trying to re-upload them will fail;
-- `["OK", "<kind:1065-event-id>", true, "upload: Missing chunks 1, 2, 7, 10"]`: File isn't uploaded yet or incomplete, user is allowed to upload it on this ws connection;
+- `["OK", "<kind:1095-event-id>", false, "auth-required: ..."]`: Authentication is required to register an uploader;
+- `["OK", "<kind:1095-event-id>", true, "uploaded: ..."]`: The corresponding `kind:1195` file chunks are already uploaded, trying to re-upload them will fail;
+- `["OK", "<kind:1095-event-id>", true, "upload: Missing chunks 1, 2, 7, 10"]`: File isn't uploaded yet or incomplete, user is allowed to upload it on this ws connection;
 
-Trying to send a `kind:1064` event before a `kind:1065` one should fail.
-Sending `kind:1065` events with an identifier (pubkey) different from the previously sent `kind:1064`'s `f` tag should fail.
+Trying to send a `kind:1195` event before a `kind:1095` one should fail.
+Sending `kind:1095` events with an identifier (pubkey) different from the previously sent `kind:1195`'s `f` tag should fail.
 
-A `kind:5` deletion event referencing a `kind:1065` event is used to unregister the user as an uploader.
+A `kind:5` deletion event referencing a `kind:1095` event is used to unregister the user as an uploader.
 
 Relay may split the burden of a single file by the multiple registered uploaders. For example, when there are 2 uploaders,
 a file relay may charge each of them half of the costs to host the file.
 
-Relay should delete the `kind:1065` event if no corresponding `kind:1064` event is uploaded within a reasonable period.
+Relay should delete the `kind:1095` event if no corresponding `kind:1195` event is uploaded within a reasonable period.
 
-Clients may download `kind:1065` events from user's file relays to list all user files.
-
-## Download
-
-This NIP introduces a NIP-94 `f` tag filled with the `kind:1064` pubkey, uniquely identifying the file,
-and a `nip95u` tag set to the pubkey of the user who uploaded the file.
-
-Upon seeing such tags, in order to download the file, client should search for `kind:1064` events
-by author (`f` tag value) on the `nip95u` uploader's "file relays".
-
-It must join the `.content` values from all the `kind:1064` events then convert it to bytes to recreate the file.
+Clients may download `kind:1095` events from user's file relays to list all user files.
 
 ## nfile Entity
 
 A [NIP-19](19.md) `nfile` bech32-encoded entity may be embedded directly on notes using a [NIP-21](21.md) URL.
 It translates to two values:
 
-1) The `kind:1064` set's pubkey, identifying the file;
+1) The `kind:1195` set's pubkey, identifying the file;
 2) The uploader's pubkey, to be able to find the right "file relays" to download the file from.
+
+## Download
+
+This NIP introduces an `f` tag filled with the `kind:1195` pubkey, uniquely identifying the file,
+and a `nip95u` tag set to the pubkey of the user who uploaded the file. Both are to
+be present if using thee NIP-94-like `kind:1094` event (instead of the `url` tag).
+
+These two tag values can instead be encoded on an `nfile`.
+
+Upon seeing such tags, in order to download the file, client should search for `kind:1195` events
+by author (`f` tag value) on the `nip95u` uploader's "file relays".
+
+It must join the `.content` values from all the `kind:1195` events then convert it to bytes to recreate the file.

--- a/95.md
+++ b/95.md
@@ -59,9 +59,12 @@ on `kind:1094` events.
 Client should upload to user's "file relays", which use the [NIP-65](65.md) `f` flag.
 When downloading a file uploaded with this NIP, it should search on the uploader's "file relays".
 
-**Relays must NOT honor `kind:5` deletion events referencing file chunk events.** Deletion
-is expected to be automatic when no uploader is registered (see [Pre-Upload](#pre-upload) section
-to learn how to register an uploader). If an user wants to make sure a file won't be deleted, it
+**Relays must NOT honor `kind:5` deletion events referencing file chunk events.**
+This is because the same file chunk set may be in use by other "uploaders".
+Deletion of all file chunks is expected to be automatic when there is no registered uploader left on the file relay
+(see [Pre-Upload](#pre-upload) section to learn how to register an uploader).
+
+If an user wants to make sure a file won't be deleted, it
 should become an uploader of that file.
 
 ## Pre-Upload


### PR DESCRIPTION
Read [here](https://github.com/arthurfranca/nips/blob/nip-95-revisit/95.md)

I was reading #345 new comments and came up with this spec.

Differences:
- a random pubkey (not the uploader's one) used just once as author of the file event(s) is what identifies the file
- file can be made of multiple chunks, all with the same above pubkey
- new NIP-65 [flag](https://github.com/nostr-protocol/nips/pull/991) to configure user's "file relays" cause most relays won't accept NIP-95 events
- `nfile` entity