### PR TITLE
NIP-01: filters can query any tag

### DIFF
--- a/01.md
+++ b/01.md
@@ -124,7 +124,7 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
   "ids": <a list of event ids>,
   "authors": <a list of lowercase pubkeys, the pubkey of an event must be one of these>,
   "kinds": <a list of a kind numbers>,
-  "#<single-letter (a-zA-Z)>": <a list of tag values, for #e — a list of event ids, for #p — a list of pubkeys, etc.>,
+  "#<tag>": <a list of tag values, for #e — a list of event ids, for #p — a list of pubkeys, etc.>,
   "since": <an integer unix timestamp in seconds, events must be newer than this to pass>,
   "until": <an integer unix timestamp in seconds, events must be older than this to pass>,
   "limit": <maximum number of events relays SHOULD return in the initial query>


### PR DESCRIPTION
Filters such as `{ "#proxy": ["https://example.com/123"] }` are valid. It doesn't mean the relay will index them - this is never a guarantee (regardless of whether the tag is single-letter or not).