### PR TITLE
Signed Filters

### DIFF
--- a/63.md
+++ b/63.md
@@ -1,8 +1,8 @@
 NIP-63
 ======
 
-Pre-authed Filters
-------------------
+Signed Filters
+--------------
 
 `draft` `optional`
 

--- a/63.md
+++ b/63.md
@@ -8,7 +8,7 @@ Pre-authed Filters
 
 This NIP declares the use of event kind `33012` to represent one or more Nostr filters. 
 
-The `d` tag represents the subscription id and the `filter` tag describes a (NIP-01)[01.md] filter. 
+The `d` tag represents the subscription id and the `filter` tag contains the JSON-stringified (NIP-01)[01.md] filter. 
 
 Supporting relays interpret the tags of this event as if they were submitted in the `REQ` scheme while automatically authenticating the signer. 
 

--- a/63.md
+++ b/63.md
@@ -1,0 +1,33 @@
+NIP-63
+======
+
+Pre-authed Filters
+------------------
+
+`draft` `optional`
+
+This NIP declares the use of event kind `33012` to represent one or more Nostr filters. 
+
+The `d` tag represents the subscription id and the `filter` tag describes a (NIP-01)[01.md] filter. 
+
+Supporting relays interpret the tags of this event as if they were submitted in the `REQ` scheme while automatically authenticating the signer. 
+
+They are submitted to the relay via `EVENT` messages instead of the usual `REQ` message.
+
+The goal is to be able to support `AUTH` from multiple users in the same connection while removing the usual `AUTH` round trip. 
+
+```json
+{
+  "kind": 33012,
+  "tags": [
+    ["d", "<subscription_id>"],
+    ["filter", "<filters1>"],
+    ["filter", "<filters2>"],
+  ],
+  "content": "",
+  ...other fields
+}
+```
+
+
+


### PR DESCRIPTION
The goal here is 2 fold: 
- Allow subscriptions for multiple users in the same connection. 
- Get rid of the auth round trip

We can use an `AUTHED_REQ` message type as well. 

I don't know if this is the right way to do it, but it is what I am testing at the moment. 