### PR TITLE
NIP-11, add `supported_nips_at` field

### DIFF
--- a/11.md
+++ b/11.md
@@ -49,6 +49,18 @@ An alternative contact may be listed under the `contact` field as well, with the
 
 As the Nostr protocol evolves, some functionality may only be available by relays that implement a specific `NIP`.  This field is an array of the integer identifiers of `NIP`s that are implemented in the relay.  Examples would include `1`, for `"NIP-01"` and `9`, for `"NIP-09"`.  Client-side `NIPs` SHOULD NOT be advertised, and can be ignored by clients.
 
+In addition, over time some `NIP`s are combined into other `NIP`s. For example, `NIP-01` now contains the features which were previously described separately by `NIP`s `12`, `16`, `20`, `22`, and `33`.
+
+To clarify which versions of which `NIP`s a relay implements, the response MAY list a `supported_nips_at` field. If present, it MUST contain a unix timestamp in seconds as defined in [NIP-01](01.md). Changes to NIPs in the [nostr-protocol/nips](https://github.com/nostr-protocol/nips) repository after this time may not be supported.
+
+```json
+{
+  ...
+  "supported_nips": [1, 11, 20],
+  "supported_nips_at": 1690848000,
+}
+```
+
 ### Software
 
 The relay server implementation MAY be provided in the `software` attribute.  If present, this MUST be a URL to the project's homepage.


### PR DESCRIPTION
Adding an optional `supported_nips_at` field to NIP-11 server metadata response. This allows relays to declare which version of the NIPs they support.

Many relays currently declare support for NIPs which no longer exist. For example, here's a recent response from `nos.lol`:

```json
{
  "contact":"unset",
  "description":"Generally accepts notes, except spammy ones.",
  "name":"nos.lol",
  "software":"git+https://github.com/hoytech/strfry.git",
  "supported_nips": [1,2,4,9,11,12,16,20,22,28,33,40],
  "version":"0.9.6"
}
```

Note that it declares support for non-existent `NIP`s 12, 16, 20, 22 and 33.

Adding a `supported_nips_at` field would allow relays to clarify that they support these `NIP`s as of a specific time in the past. This will become more important over time as `NIP`s continue to change.