### PR TITLE
NIP-46: restore original types

### DIFF
--- a/46.md
+++ b/46.md
@@ -59,11 +59,11 @@ nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata
     "content": nip04({
         "id": <random_string>,
         "method": "sign_event",
-        "params": [json_stringified(<{
+        "params": [{
             content: "Hello, I'm signing remotely",
             pubkey: "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
             // ...the rest of the event data
-        }>)]
+        }]
     }),
     "tags": [["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"]], // p-tags the remote user pubkey
 }
@@ -77,7 +77,7 @@ nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata
     "pubkey": "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
     "content": nip04({
         "id": <random_string>,
-        "result": json_stringified(<signed-event>)
+        "result": <signed-event>
     }),
     "tags": [["p", "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86"]], // p-tags the local keypair pubkey
 }
@@ -106,7 +106,7 @@ The `content` field is a JSON-RPC-like message that is [NIP-04](https://github.c
 {
     "id": <random_string>,
     "method": <method_name>,
-    "params": [array_of_strings]
+    "params": [<param1>, <param2>, ...]
 }
 ```
 
@@ -121,9 +121,9 @@ Each of the following are methods that the client sends to the remote signer.
 | Command                  | Params                                            | Result                                                                 |
 | ------------------------ | ------------------------------------------------- | ---------------------------------------------------------------------- |
 | `connect`                | `[<remote_user_pubkey>, <optional_secret>, <optional_requested_permissions>]`       | "ack"                                                                  |
-| `sign_event`             | `[<json_stringified_event_to_sign>]`              | `json_stringified(<signed_event>)`                                     |
+| `sign_event`             | `[<event_to_sign>]`              | `<signed_event>`                                     |
 | `ping`                   | `[]`                                              | "pong"                                                                 |
-| `get_relays`             | `[]`                                              | `json_stringified({<relay_url>: {read: <boolean>, write: <boolean>}})` |
+| `get_relays`             | `[]`                                              | `{<relay_url>: {read: <boolean>, write: <boolean>}}` |
 | `get_public_key`         | `[]`                                              | `<hex-pubkey>`                                                         |
 | `nip04_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`  | `<nip04_ciphertext>`                                                   |
 | `nip04_decrypt`          | `[<third_party_pubkey>, <nip04_ciphertext_to_decrypt>]` | `<plaintext>`                                                    |
@@ -152,7 +152,7 @@ The `content` field is a JSON-RPC-like message that is [NIP-04](https://github.c
 ```json
 {
     "id": <request_id>,
-    "result": <results_string>,
+    "result": <any>,
     "error": <error_string>
 }
 ```


### PR DESCRIPTION
In https://github.com/nostr-protocol/nips/pull/1047 we agreed to leave the protocol the same, and just clarify its usage. However a change slipped through, which I think wasn't intentional, because nobody building existing NIP-46 apps has updated AFAIK, and I don't think they knew they were supposed to.

Fixes https://github.com/nostr-protocol/nips/issues/1154