### PR TITLE
add kind 10033 private follows list

### DIFF
--- a/51.md
+++ b/51.md
@@ -20,18 +20,19 @@ Standard lists use non-parameterized replaceable events, meaning users may only 
 
 For example, _mute list_ can contain the public keys of spammers and bad actors users don't want to see in their feeds or receive annoying notifications from.
 
-| name           | kind  | description                                                 | expected tag items                                                                |
-| ---            | ---   | ---                                                         | ---                                                                               |
-| Mute list      | 10000 | things the user doesn't want to see in their feeds          | `"p"` (pubkeys), `"t"` (hashtags), `"word"` (lowercase string), `"e"` (threads)   |
-| Pinned notes   | 10001 | events the user intends to showcase in their profile page   | `"e"` (kind:1 notes)                                                              |
-| Bookmarks      | 10003 | uncategorized, "global" list of things a user wants to save | `"e"` (kind:1 notes), `"a"` (kind:30023 articles), `"t"` (hashtags), `"r"` (URLs) |
-| Communities    | 10004 | [NIP-72](72.md) communities the user belongs to             | `"a"` (kind:34550 community definitions)                                          |
-| Public chats   | 10005 | [NIP-28](28.md) chat channels the user is in                | `"e"` (kind:40 channel definitions)                                               |
-| Blocked relays | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                            |
-| Search relays  | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                            |
-| Simple groups  | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group ids + mandatory relay URL)                       |
-| Interests      | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a"` (kind:30015 interest set)                              |
-| Emojis         | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                  |
+| name            | kind  | description                                                 | expected tag items                                                                |
+| ---             | ---   | ---                                                         | ---                                                                               |
+| Mute list       | 10000 | things the user doesn't want to see in their feeds          | `"p"` (pubkeys), `"t"` (hashtags), `"word"` (lowercase string), `"e"` (threads)   |
+| Pinned notes    | 10001 | events the user intends to showcase in their profile page   | `"e"` (kind:1 notes)                                                              |
+| Bookmarks       | 10003 | uncategorized, "global" list of things a user wants to save | `"e"` (kind:1 notes), `"a"` (kind:30023 articles), `"t"` (hashtags), `"r"` (URLs) |
+| Communities     | 10004 | [NIP-72](72.md) communities the user belongs to             | `"a"` (kind:34550 community definitions)                                          |
+| Public chats    | 10005 | [NIP-28](28.md) chat channels the user is in                | `"e"` (kind:40 channel definitions)                                               |
+| Blocked relays  | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                            |
+| Search relays   | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                            |
+| Simple groups   | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group ids + mandatory relay URL)                       |
+| Interests       | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a"` (kind:30015 interest set)                              |
+| Emojis          | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                  |
+| Private follows | 10033 | the follow list who is encrypted and can't be seem by others| `"e"` (kind:1 notes), `"a"` (kind:30023 articles), `"t"` (hashtags), `"r"` (URLs) |
 
 ## Sets
 


### PR DESCRIPTION
Add kind 10033 private follows list who shoud be encrypted and put in to the event content. When querying feeds, we should mix these private follows list with the kind 3's list.

The things we put into private follows list's what we want to follow and don't want others know.