### PR TITLE
Add `other` category to reports

### DIFF
--- a/56.md
+++ b/56.md
@@ -28,6 +28,7 @@ being reported, which consists of the following report types:
 - `illegal` - something which may be illegal in some jurisdiction
 - `spam` - spam
 - `impersonation` - someone pretending to be someone else
+- `other` - for reports that don't fit in the above categories
 
 Some report tags only make sense for profile reports, such as `impersonation`
 


### PR DESCRIPTION
This adds an `other` category alongside the 5 others listed in this NIP. At Nos we add NIP-32 labels to our reports so we often have users publishing reports for things that don't fall into the five buckets listed in this NIP (nudity, profanity, illegal, spam, impersonation). For example, if I report a note from Nos that shows nsfw gore what should we put in the `report type`? Other apps like Amethyst will show this report using only the `report type` so we don't want it to be wrong. Hence the need for an `other` category.

This is something we've been using in production for over 6 months now, I imagine other apps will/do want this, and we would like to see support for it in some of the libraries we use (like [this](https://github.com/rust-nostr/nostr/blob/bef044f5fed68256393094568219d1aa890e0cc9/bindings/nostr-ffi/src/event/tag.rs#L64-L77)), hence the PR.