### PR TITLE
Update description of NIP-56

### DIFF
--- a/56.md
+++ b/56.md
@@ -4,10 +4,12 @@ NIP-56
 Reporting
 ---------
 
-`draft` `optional`
+`optional`
 
-A report is a `kind 1984` note that is used to report other notes for spam,
-illegal and explicit content.
+A report is a `kind 1984` event that signals to users and relays that 
+some referenced content is objectionable. The definition of objectionable is
+obviously subjective and all agents on the network (users, apps, relays, etc.) 
+may consume and take action on them as they see fit.
 
 The `content` MAY contain additional information submitted by the entity
 reporting the content.


### PR DESCRIPTION
This makes a couple changes to NIP-56 reports to more closely align with how they are being used in production. I know the origins of the NIP are tounge-in-cheek, but it's seeing some real use now which warrants some updates.

I removed the `draft` label from this NIP since it's has been in use for over a year now, and multiple apps (at least Nos and Amethyst) have built moderation systems on top of it.

I rewrote the description at the top to add more detail ("a report is... used to report" struck me as redundant) especially in light of NIP-32 labels which are very similar structurally. When should you use a report instead of a label? I think it's when the content is objectionable. 

I also added some words about the subjective nature of moderation to help distance Nostr reports from reports on traditional platforms. On other platforms a report can mean "this person should be removed from the platform by the admins" where on Nostr they are more like "warning: here is some content you should be careful around". Many Nostr users are particularly sensitive in this area so I think adding this color is helpful. In Nos we are actually discussing dropping the word "report" entirely from our UI, but I think it's here to stay in the NIP.