### PR TITLE
NIP-46 : Fix use of confusing ambiguous term

### DIFF
--- a/46.md
+++ b/46.md
@@ -25,7 +25,7 @@ This is most common in a situation where you have your own nsecbunker or other t
 The remote signer would provide a connection token in the form:
 
 ```
-bunker://<remote-pubkey>?relay=<wss://relay-to-connect-on>&relay=<wss://another-relay-to-connect-on>&secret=<optional-secret-value>
+bunker://<remote-user-pubkey>?relay=<wss://relay-to-connect-on>&relay=<wss://another-relay-to-connect-on>&secret=<optional-secret-value>
 ```
 
 This token is pasted into the client by the user and the client then uses the details to connect to the remote signer via the specified relay(s).


### PR DESCRIPTION
It's very confusing as to whether `<remote-pubkey>` refers to remote user pubkey vs remote signer pubkey. This is complicated further by the typo in the explanation of "remote signer pubkey", which makes it hard to infer which would be used. Can we just be explicit here?