### PR TITLE
Relational Databases

### DIFF
--- a/41.md
+++ b/41.md
@@ -1,0 +1,37 @@
+NIP-41
+======
+
+Relational Database
+-------------------
+
+`draft` `optional`
+
+This NIP offers a plug-and-play method to export/sync information from existing systems using relational databases into Nostr. 
+
+Event kind `31200` represents a row in a database. Each value of the row is added as a tag whose name is the column's name. 
+
+Values can be public or encrypted to the user. 
+
+```js
+{
+  "kind": 31200,
+  "tags": [
+    ["d", "<row-private-key>"]
+    ["n", "<table-name>"]
+    ["u", "<database-name>"]
+    ["<column-name>", "<column-row-value>"]
+    // other public columns
+  ],
+  "content": nip44Encrypt(JSON.stringify((
+    [
+      ["<column-name>", "<column-row-value>"]
+      // other private columns
+    ]
+  )),
+  // .. other fields
+}
+```
+
+Inserts and updates are supported via Nostr's regular signing operations and deletions via [NIP-09](09.md).
+
+The pubkey MAY be own by the system and represent several users from that system. 


### PR DESCRIPTION
This NIP offers a plug-and-play method to export/sync information from existing systems using relational databases into Nostr. It describes a generic `ROW` event type to be used by all tables and all database types. 

Read [here](https://github.com/vitorpamplona/nips/blob/relational-database/41.md)