### PR TITLE
NIP-10: pubkey arg

### DIFF
--- a/10.md
+++ b/10.md
@@ -38,13 +38,14 @@ They are citing from this event.  `root-id` and `reply-id` are as above.
 >This scheme is deprecated because it creates ambiguities that are difficult, or impossible to resolve when an event references another but is not a reply.
 
 ## Marked "e" tags (PREFERRED)
-`["e", <event-id>, <relay-url>, <marker>]`
+`["e", <event-id>, <relay-url>, <marker>, <pubkey>]`
 
 Where:
 
  * `<event-id>` is the id of the event being referenced.
  * `<relay-url>` is the URL of a recommended relay associated with the reference. Clients SHOULD add a valid `<relay-URL>` field, but may instead leave it as `""`.
  * `<marker>` is optional and if present is one of `"reply"`, `"root"`, or `"mention"`.
+ * `<pubkey>` is optional, SHOULD be the pubkey of the author of the referenced event
 
 Those marked with `"reply"` denote the id of the reply event being responded to.  Those marked with `"root"` denote the root id of the reply thread being responded to. For top level replies (those replying directly to the root event), only the `"root"` marker should be used. Those marked with `"mention"` denote a quoted or reposted event id.
 
@@ -52,6 +53,7 @@ A direct reply to the root of a thread should have a single marked "e" tag of ty
 
 >This scheme is preferred because it allows events to mention others without confusing them with `<reply-id>` or `<root-id>`.
 
+`<pubkey>` SHOULD be the pubkey of the author of the `e` tagged event, this is used in the outbox model to search for that event from the authors write relays where relay hints did not resolve the event.
 
 ## The "p" tag
 Used in a text event contains a list of pubkeys used to record who is involved in a reply thread.


### PR DESCRIPTION
I have found that sometimes relay hints are not enough, and it would be much easier to find replies in a thread if that thread added the pubkey of the author as an additional argument to the `e` tag