### PR TITLE
NIP-07 command queue

### DIFF
--- a/07.md
+++ b/07.md
@@ -24,6 +24,35 @@ async window.nostr.nip44.encrypt(pubkey, plaintext): string // returns ciphertex
 async window.nostr.nip44.decrypt(pubkey, ciphertext): string // takes ciphertext as specified in nip-44
 ```
 
+## Command Queue
+
+In order to avoid race conditions the object SHOULD have a `cmd` property.
+This object is defined as follows
+
+```ts
+window.nostr.cmd: (() => void)[]
+```
+
+Browsers or extensions SHOULD invoke all callbacks queued once it has finished loading.
+After that it should shadow the `push` method on `cmd`
+to immediately invoke subsequent queues
+
+This allows consumers to queue up calls to the NIP-07 providers even before
+it is present.
+
+### Examples
+
+Queue a command
+
+```js
+window.nostr = window.nostr || { cmd: [] };
+
+window.nostr.cmd.push(() => {
+  const pk = window.nostr.getPublicKey();
+  // do something with pk
+});
+```
+
 ### Implementation
 
 See https://github.com/aljazceru/awesome-nostr#nip-07-browser-extensions.


### PR DESCRIPTION
This addition to NIP-07 introduces a command queue. This is a common technique in Javascript libraries that are loaded asynchronously from a CDN. It allows API consumers to queue up calls even before the library (or in this case) the provider is present on the page and avoids all race conditions.

Once the provider has been loaded and initialized it invokes all queued callbacks and replaces the `push`method to instantly invoke future calls to the queue:

```ts
// Setup code here
// ...

for (let i = 0; i < window.nostr.cmd.length; i++) {
  window.nostr.cmd[i]();
}

window.nostr.cmd.push = cb => cb();
```