### PR TITLE
Add previous tag

### DIFF
--- a/01.md
+++ b/01.md
@@ -99,6 +99,8 @@ And also a convention for kind ranges that allow for easier experimentation and 
 
 In case of replaceable events with the same timestamp, the event with the lowest id (first in lexical order) should be retained, and the other discarded.
 
+When the `previous` tag exists on a replaceable event relays SHOULD use this id as the id of the version the client wishes to replace, if the id does not match the stored version, relays MUST reject the update.
+
 When answering to `REQ` messages for replaceable events such as `{"kinds":[0],"authors":[<hex-key>]}`, even if the relay has more than one version stored, it SHOULD return just the latest one.
 
 These are just conventions and relay implementations may differ.


### PR DESCRIPTION
Add a previous tag to replaceable events which prevents updates when the id does not match.