### PR TITLE
Adds Topical Notes

### DIFF
--- a/54.md
+++ b/54.md
@@ -1,0 +1,60 @@
+NIP-54
+======
+
+Topical Notes
+-------------
+
+`draft` `optional`
+
+This NIP enables authors to post exclusively into topics, without polluting their main feed. Authors can post to locations, hashtags, labels, and urls in a way that only followers of those topics will receive their posts. 
+
+## Topical Note Kind
+
+Kind `21` defines a `kind:1`-equivalent event that MUST NOT be displayed unless the user follows one of the `g`, `t`, `r` or `l` tags. 
+
+```jsonc
+{
+  "kind": 21,
+  "tags": [
+    ["g", "<geohash>"],
+    ["t", "<hashtag>"],
+    ["r", "<url>"],
+    //.. 
+    ["L", "<label namespace>"],
+    ["l", "<label>", "<label namespace>"],
+  ],
+  "content": "This is a note for followers of the hashtag, location OR url. My followers should not see this.",
+  //...
+}
+```
+
+`.content` MUST be plain text and tags that mention, quote and assemble threading structures MUST follow [NIP-10](10.md).
+
+## Topical Relay Setup
+
+Kind `30021` defines a topic follower. It registers a list of relays to aggregate events for each topic. 
+
+The `d` tag of this kind is equal to `name:value` of the topics used in kind `21`. 
+
+```js
+{
+  "kind": 30021,
+  "tags": [
+    ["d", "g:<my city's geohash>"],
+    ["r", "wss://my-city-owned-relay"],
+    ["r", "wss://independent-but-city-based-relay"],
+    // ... other tags
+    ["title", "Name of this topic"]
+  ],
+  "content": nip44Encrypt([
+    ["r", "wss://my-city-owned-relay2"], // private relay
+    ["title", "Name of this topic"] // private topic title
+    // ... other tags
+  ]),
+  //...other fields
+}
+```
+
+The `.content` contains a list of private tags.
+
+Clients MUST seek and broadcast events from and to the relays defined for each topic. 

--- a/54.md
+++ b/54.md
@@ -28,27 +28,33 @@ Kind `21` defines a `kind:1`-equivalent event that MUST NOT be displayed unless 
 }
 ```
 
+Clients MUST include at least one `g`, `t`, `r` or `l` tags.
+
 `.content` MUST be plain text and tags that mention, quote and assemble threading structures MUST follow [NIP-10](10.md).
 
 ## Topical Relay Setup
 
-Kind `30021` defines a topic follower. It registers a list of relays to aggregate events for each topic. 
+Kind `30021` defines a following topic. It registers a list of relays to aggregate events for the list of topics. 
 
-The `d` tag of this kind is equal to `name:value` of the topics used in kind `21`. 
+The `d` tag of this kind is a simple `UUID`. 
 
 ```js
 {
   "kind": 30021,
   "tags": [
-    ["d", "g:<my city's geohash>"],
-    ["r", "wss://my-city-owned-relay"],
-    ["r", "wss://independent-but-city-based-relay"],
+    ["d", "<UUID>"],
+    ["g", "<geohash>"],
+    ["t", "<hashtag>"],
+    ["r", "<url>"],
+    ["relay", "wss://my-city-owned-relay"],
+    ["relay", "wss://independent-but-city-based-relay"],
     // ... other tags
     ["title", "Name of this topic"]
   ],
   "content": nip44Encrypt([
-    ["r", "wss://my-city-owned-relay2"], // private relay
+    ["relay", "wss://my-city-owned-relay2"], // private relay
     ["title", "Name of this topic"] // private topic title
+    ["t", "<hashtag>"], // private follows of tags.
     // ... other tags
   ]),
   //...other fields

--- a/54.md
+++ b/54.md
@@ -10,7 +10,7 @@ This NIP enables authors to post exclusively into topics, without polluting thei
 
 ## Topical Note Kind
 
-Kind `21` defines a `kind:1`-equivalent event that MUST NOT be displayed unless the user follows one of the `g`, `t`, `r` or `l` tags. 
+Kind `21` defines a `kind:1`-equivalent event that MUST NOT be displayed unless the user follows one of the `g`, `t`, `r`, or `l` tags. 
 
 ```jsonc
 {
@@ -23,12 +23,12 @@ Kind `21` defines a `kind:1`-equivalent event that MUST NOT be displayed unless 
     ["L", "<label namespace>"],
     ["l", "<label>", "<label namespace>"],
   ],
-  "content": "This is a note for followers of the hashtag, location OR url. My followers should not see this.",
+  "content": "This is a note for followers of the hashtag, location, OR url. My followers should not see this.",
   //...
 }
 ```
 
-Clients MUST include at least one `g`, `t`, `r` or `l` tags.
+Clients MUST include at least one `g`, `t`, `r`, or `l` tags.
 
 `.content` MUST be plain text and tags that mention, quote and assemble threading structures MUST follow [NIP-10](10.md).
 
@@ -36,7 +36,7 @@ Clients MUST include at least one `g`, `t`, `r` or `l` tags.
 
 Kind `30021` defines a following topic. It registers a list of relays to aggregate events for the list of topics. 
 
-The `d` tag of this kind is a simple `UUID`. 
+The `d` tag of this kind is a simple `UUID`. `g`, `t`, `r`, or `l` tags define the topics to be followed and the `relay` tag specifies which relays to use for those topics. The `title` tag adds a name for the topic. 
 
 ```js
 {


### PR DESCRIPTION
The goal here is to create Notes that are only displayed if you follow certain topics from certain relays. 

With this, users can post into their City's relays or into a Hashtag's relays without polluting their main feed. 

Solves #1170 

Read [here](https://github.com/vitorpamplona/nips/blob/location-based-kind1/54.md)