### PR TITLE
Add custom feeds

### DIFF
--- a/xx.md
+++ b/xx.md
@@ -34,7 +34,7 @@ A `author` feed includes one or more pubkeys to use in an `authors` filter.
 ["author", "d97a7541e4603d393c61eaad810c2e2e72684fb5672bde962c75c023d70e763f"]
 ```
 
-## CreatedAt
+## Created At
 
 A `created_at` feed includes one or more objects describing date ranges for events to fetch.
 These MAY include values `since`, `until`, and `relative`, which may be a list containing
@@ -44,7 +44,7 @@ If included in the `relative` list, `since` and `until` values MUST be interpret
 `seconds before now`. Negative numbers MUST be interpreted as `seconds after now`.
 
 ```json
-["created_at", {"since": 1715293673, "until": 86400, "relative": ["since"]}]
+["created_at", {"since": 1715293673, "until": 86400, "relative": ["until"]}]
 ```
 
 ## DVM
@@ -52,7 +52,7 @@ If included in the `relative` list, `since` and `until` values MUST be interpret
 A `dvm` feed includes one or more objects describing a DVM request. Each object MUST
 have a request `kind`, and MAY have a list of request `tags`, `relays` to send the
 request to, and a list of `mappings` mapping response tags to feeds. If omitted,
-applications SHOULD provide a resonable set of default `mappings`.
+applications SHOULD provide a reasonable set of default `mappings`.
 
 ```json
 [
@@ -67,17 +67,25 @@ applications SHOULD provide a resonable set of default `mappings`.
 
 ## ID
 
-A `id` feed
+A `id` feed includes one or more ids of events to fetch.
+
+```json
+["id", "b1ee83587c4ebab697719fd5bad22319741134e49933b0528b8cca426cafd59e"]
+```
 
 ## Kind
 
-A `kind` feed
+A `kind` feed includes one or more kinds of events to fetch.
+
+```json
+["kind", 1, 30023]
+```
 
 ## List
 
-A `dvm` feed includes one or more objects defining one or more `addresses` and a set of
-`mappings` for how to translate list tags into feeds. If omitted,
-applications SHOULD provide a resonable set of default `mappings`.
+A `list` feed includes one or more objects defining one or more `addresses` and optional
+`mappings` for how to translate list tags into feeds. If omitted, applications SHOULD
+provide a reasonable set of default `mappings`.
 
 ```json
 [
@@ -94,7 +102,7 @@ applications SHOULD provide a resonable set of default `mappings`.
 A `wot` feed includes one or more objects with optional `min` and `max` properties. These
 MUST be between 0 and 1 (inclusive) so that the interpeting application can scale the filter
 to their own web of trust's score range. If empty, `min` MUST be interpreted as `0`, and
-`max` as 1.
+`max` as `1`.
 
 ```json
 ["wot", {"min": 0.3}]
@@ -143,7 +151,7 @@ as standard tag filters.
 
 ## Union
 
-A `union` feed includes two or more feeds. An event may match any feed to match the parent feed.
+A `union` feed includes zero or more feeds. An event may match any feed to match the parent feed.
 
 Example:
 
@@ -157,7 +165,7 @@ Example:
 
 ## Intersection
 
-An `intersection` feed includes two or more feeds. An event must match all given feeds to
+An `intersection` feed includes zero or more feeds. An event must match all given feeds to
 match the parent feed.
 
 Example:
@@ -172,7 +180,7 @@ Example:
 
 ## Difference
 
-A `difference` feed includes a base feed to fetch, and one or more feeds used to exclude
+A `difference` feed MAY include a base feed to fetch, and zero or more feeds used to exclude
 events from the base feed.
 
 Example:
@@ -194,8 +202,8 @@ Example:
 
 ## Symmetric Difference
 
-A `symmetric_difference` feed includes two or more feeds. An event must match only one feed to match
-the parent feed.
+A `symmetric_difference` feed includes zero or more feeds. An event must match only one feed to match
+the base feed.
 
 Example:
 
@@ -220,6 +228,12 @@ Example:
   ]
 ]
 ```
+
+# Implementation notes
+
+If a `union`, `difference`, `intersection`, or `symmetric_difference` feed has no entries, it should
+be treated as an empty feed. Likewise with other feed types that have no arguments; for example
+`["authors"]` should be interprete the same way as a `{"authors": []}` filter.
 
 # Feed Event
 

--- a/xx.md
+++ b/xx.md
@@ -221,10 +221,6 @@ Example:
 ]
 ```
 
-# Feed Tag
-
-Any event MAY use a `feed` tag with a JSON-encoded feed as the value.
-
 # Feed Event
 
 A `kind:31890` event defines a feed in an addressable way. The `content` SHOULD be a human-

--- a/xx.md
+++ b/xx.md
@@ -47,18 +47,6 @@ become `ids`, and `t` tags become `#t` entries. `a` tags should be used to infor
 ["list", "10001:4d7600c1da0b69185fcbcb6b86cbaa010c9ea137fa83a3f4be4c713e1f217dad:"]
 ```
 
-## List of Lists
-
-A `lol` feed includes one or more list addresses. These lists should be fetched, and each `a`
-entry should in turn be fetched and parsed to build a standard nostr filter as described in the
-`list` type above.
-
-Example:
-
-```json
-["lol", "30085:4d7600c1da0b69185fcbcb6b86cbaa010c9ea137fa83a3f4be4c713e1f217dad:12983740"]
-```
-
 ## DVM
 
 A `dvm` feed includes one or more DVM request objects. Each request MUST have a `kind`, and
@@ -119,7 +107,7 @@ Example:
 [
   "intersection",
   ["list", "10001:4d7600c1da0b69185fcbcb6b86cbaa010c9ea137fa83a3f4be4c713e1f217dad:"],
-  ["lol", "30084:039f4899c97734bb1503ce437784ac2131d552e1ef909e8f9775df7c843d0df8:983243"],
+  ["filter", {"#t": ["nostr"], "since_ago": 86400}]
 ]
 ```
 

--- a/xx.md
+++ b/xx.md
@@ -1,0 +1,163 @@
+NIP-32
+======
+
+Custom Feeds
+------------
+
+`draft` `optional`
+
+This NIP introduces a new data structure representing custom nostr feeds. These are to be
+used in the context of an user's session to fetch a list of matching events.
+
+# Data Format
+
+Custom feeds are represented using lists of lists. The first parameter of every list is a `type`,
+which determines the content of subsequent arguments to the feed.
+
+## Filter
+
+A `filter` feed includes one or more `dynamic filter` objects. These are normal `filter` objects
+with the following additional fields:
+
+- `scopes` - a list of scopes to be translated by an application to a filter's `authors` field. May be one of:
+  - `followers` - pubkeys who follow the current user
+  - `follows` - pubkeys the current user follows
+  - `global` - no selection
+  - `network` - pubkeys who the current user does not follow, but which are followed by pubkeys the current user follows.
+  - `self` - the user's own pubkey
+- `min_wot` - a number between 0 and 1 corresponding to pubkeys with a web of trust score greater than `min_wot`% of known pubkeys.
+- `max_wot` - a number between 0 and 1 corresponding to pubkeys with a web of trust score less than `min_wot`% of known pubkeys.
+- `until_ago` - a number of seconds to subtract from the current time to be used in an `until` filter.
+- `since_ago` - a number of seconds to subtract from the current time to be used in a `since` filter.
+
+Example:
+
+```json
+["filter", {"kinds": [1], "scopes": "follows"}, {"kinds": [1], "min_wot": 0.5}]
+```
+
+## List
+
+A `list` feed includes one or more list addresses. These lists should be fetched and parsed
+to build a standard nostr filter. `p` tags from the target lists become `authors`, `e` tags
+become `ids`, and `t` tags become `#t` entries. `a` tags should be used to inform the `authors`,
+`kinds`, and `#d` fields.
+
+```json
+["list", "10001:4d7600c1da0b69185fcbcb6b86cbaa010c9ea137fa83a3f4be4c713e1f217dad:"]
+```
+
+## List of Lists
+
+A `lol` feed includes one or more list addresses. These lists should be fetched, and each `a`
+entry should in turn be fetched and parsed to build a standard nostr filter as described in the
+`list` type above.
+
+Example:
+
+```json
+["lol", "30085:4d7600c1da0b69185fcbcb6b86cbaa010c9ea137fa83a3f4be4c713e1f217dad:12983740"]
+```
+
+## DVM
+
+A `dvm` feed includes one or more DVM request objects. Each request MUST have a `kind`, and
+MAY include an `input` and `pubkey`. Tags returned by the DVM should be used as described for
+[#List](lists).
+
+Example:
+
+```json
+[
+  "dvm",
+  {
+    "kind": 5300,
+    "pubkey": "e64323c026f751c6851cb00c902646ef5f81464d272c62f36569e5d489b749e9"
+  }
+]
+```
+
+## Relay
+
+A `relay` feed includes a list of normalized relay urls, and one or more other feeds. These
+feeds should be handled recursively as described above, but the application should only fetch
+events from the specified relays.
+
+Example:
+
+```json
+[
+  "relay",
+  ["wss://relay.example.com/", "wss://relay2.example.com/"],
+  ["list", "10001:4d7600c1da0b69185fcbcb6b86cbaa010c9ea137fa83a3f4be4c713e1f217dad:"],
+  ["list", "10001:b97111618cef001d2a74cf5f7f62fcdaa51167691a6b338f2aa6a5f4bc847180:"]
+]
+```
+
+## Union
+
+A `union` feed includes two or more other feeds to combine using logical OR.
+
+Example:
+
+```json
+[
+  "union",
+  ["list", "10001:4d7600c1da0b69185fcbcb6b86cbaa010c9ea137fa83a3f4be4c713e1f217dad:"],
+  ["filter", {"#t": ["nostr"], "since_ago": 86400}]
+]
+```
+
+## Intersection
+
+An `intersection` feed includes two or more feeds. An event must match all given feeds to
+match the parent feed.
+
+Example:
+
+```json
+[
+  "intersection",
+  ["list", "10001:4d7600c1da0b69185fcbcb6b86cbaa010c9ea137fa83a3f4be4c713e1f217dad:"],
+  ["lol", "30084:039f4899c97734bb1503ce437784ac2131d552e1ef909e8f9775df7c843d0df8:983243"],
+]
+```
+
+## Difference
+
+A `difference` feed includes a base feed to fetch, and one or more feeds used to exclude
+events from the base feed.
+
+Example:
+
+```json
+[
+  "difference",
+  ["list", "10001:4d7600c1da0b69185fcbcb6b86cbaa010c9ea137fa83a3f4be4c713e1f217dad:"],
+  ["filter", {"max_wot": 0.1}],
+]
+```
+
+## Symmetric Difference
+
+A `symdiff` feed includes two or more feeds. An event must match only one feed to match
+the parent feed.
+
+Example:
+
+```json
+[
+  "symdiff",
+  ["list", "10001:4d7600c1da0b69185fcbcb6b86cbaa010c9ea137fa83a3f4be4c713e1f217dad:"],
+  ["list", "10003:4d7600c1da0b69185fcbcb6b86cbaa010c9ea137fa83a3f4be4c713e1f217dad:"],
+]
+```
+
+# Feed Tag
+
+Any event MAY use a `feed` tag with a JSON-encoded feed as the value.
+
+# Feed Event
+
+A `kind:31890` event defined a feed in an addressable way. The `content` MUST be a JSON-encoded
+feed.

--- a/xx.md
+++ b/xx.md
@@ -231,5 +231,5 @@ A `kind:31890` event defines a feed in an addressable way. The `content` SHOULD 
 readable description of the feed. The following tags SHOULD be included:
 
 - A `d` tag
-- A `name` tag indicating the feed's name
+- A `title` tag indicating the feed's name
 - A `feed` tag whose value is a JSON-encoded feed


### PR DESCRIPTION
This introduces a simple data format for defining custom feeds. It disambiguates between different feed types using keywords, so it's extensible. It extends the normal `filter` data format with some additional keys that can be interpreted using the current user's database to yield a standard filter. It also uses set operators to combine feeds in different ways.

The tricky thing about something like this is the balance between expressiveness and simplicity. For example, the `union` set operator is trivial to implement, but the `symdiff` operator can't be implemented without requesting all events for all feeds first. I've included all four major set operations in the first draft, but it might ultimately be best to rely instead on some external data source to do the heavy lifting for some of these.

For completeness, here are some justifications for novel additions:

- min/max WOT — I'm using numbers from 0 to 1 so that clients can define WOT score any way they choose.
- since/until ago — it would be useful to have a feed pointing to recent or less recent events.
- scopes — this is something Coracle has had for a long time. It allows applications to show different pubkeys to different users based on the user's own follow graph.
- DVM feeds — these are useful for defining any behavior that doesn't end up being possible using vanilla custom feeds.
- List feeds — useful for having a static pointer to a changing list.
- List of list feeds — I'm less sure about this one, but it could be useful for adding a layer of indirection when fetching lists. This could also be accomplished by a more flexible `lists_by_filter` type.
- Union feeds — for example "stuff from this list/dvm but also this pubkey"
- Intersection feeds — for example "stuff from this list/dvm, but with a minimum wot score"
- Difference feeds — for example "stuff from this list/dvm, except for this pubkey"
- Symmetric difference feeds — I've included them for completeness, but they're not very useful and much harder to implement.
- Relay feeds — useful for baking relay selections into any kind of feed in a way that's orthogonal to the other feed types.

One other thing to note is that some feed combinations can be compiled into simpler filters once lists are dereferenced, so the implementation is not as complex as it might seem at first glance.

You can see my initial implementation of this [here](https://github.com/coracle-social/paravel/tree/master/packages/feeds). `core.ts` is the best place to start, since it defines all the data types.