### PR TITLE
NIP-61: Danmaku

### DIFF
--- a/61.md
+++ b/61.md
@@ -1,0 +1,36 @@
+NIP-61
+======
+
+Danmaku
+-------
+
+`draft` `optional`
+
+This NIP defines a new kind of event, `2333`, for danmaku.
+
+Danmaku (弾幕 だんまく; 弹幕; literally translated as "bullet curtain" and figuratively as "barrage") is a subtitle system in online video platforms that originates from Japan and popularised in Mainland China. Such system allows user to post moving comments onto a playing video that are synchronized to the video timeline. The comments are typically presented as “shooting” across the screen, resembling a barrage.
+
+### Format
+
+The format uses a regular event kind `2333`.
+
+The `.content` of these events is the content of the danmaku comment.
+
+The list of tags are as follows:
+* `i` (required) universally unique identifier of the video. The format is `<platform (lowercase)>:<identity>` where `<platform>` is the platform of the video and `<identity>` is the unique identifier of the video on that platform. For example, a YouTube video with the identifier `aA-jiiepOrE` would have the identifier `youtube:aA-jiiepOrE`.
+* `time` (required) the time of the video when the danmaku comment is sent in seconds.
+
+```jsonc
+{
+  "id": "<...>",
+  "pubkey": "<...>",
+  "kind": 2333,
+  "tags": [
+    ["i", "youtube:aA-jiiepOrE"],
+    ["time", "3.018597"]
+  ],
+  "content": "Hello Nostr!",
+  "sig": "<...>",
+  "created_at": 1713368851
+}
+```

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-57: Lightning Zaps](57.md)
 - [NIP-58: Badges](58.md)
 - [NIP-59: Gift Wrap](59.md)
+- [NIP-61: Danmaku](61.md)
 - [NIP-65: Relay List Metadata](65.md)
 - [NIP-72: Moderated Communities](72.md)
 - [NIP-75: Zap Goals](75.md)
@@ -117,6 +118,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `1971`        | Problem Tracker            | [nostrocket][nostrocket] |
 | `1984`        | Reporting                  | [56](56.md)              |
 | `1985`        | Label                      | [32](32.md)              |
+| `2333`        | Danmaku                    | [61](61.md)              |
 | `4550`        | Community Post Approval    | [72](72.md)              |
 | `5000`-`5999` | Job Request                | [90](90.md)              |
 | `6000`-`6999` | Job Result                 | [90](90.md)              |
@@ -214,7 +216,7 @@ Please update these lists when proposing NIPs introducing new event kinds.
 | `a`               | coordinates to an event              | relay URL            | [01](01.md)                           |
 | `d`               | identifier                           | --                   | [01](01.md)                           |
 | `g`               | geohash                              | --                   | [52](52.md)                           |
-| `i`               | identity                             | proof                | [39](39.md)                           |
+| `i`               | identity                             | proof                | [39](39.md), [61](61.md)              |
 | `k`               | kind number (string)                 | --                   | [18](18.md), [25](25.md), [72](72.md) |
 | `l`               | label, label namespace               | annotations          | [32](32.md)                           |
 | `L`               | label namespace                      | --                   | [32](32.md)                           |


### PR DESCRIPTION
Danmaku (弾幕 だんまく; 弹幕; literally translated as "bullet curtain" and figuratively as "barrage") is a subtitle system in online video platforms that originates from Japan and popularised in Mainland China. Such system allows user to post moving comments onto a playing video that are synchronized to the video timeline. The comments are typically presented as “shooting” across the screen, resembling a barrage.

This NIP is being implemented and experimented with in [danmakustr](https://github.com/CodyTseng/danmakustr), but it's still a work in progress. Feedback is welcome

![WechatIMG40](https://github.com/nostr-protocol/nips/assets/64680921/b9aa5518-c6bb-4430-97b1-a923d2e7ebc8)