### PR TITLE
External Content IDs

### DIFF
--- a/24.md
+++ b/24.md
@@ -40,4 +40,5 @@ tags
 These tags may be present in multiple event kinds. Whenever a different meaning is not specified by some more specific NIP, they have the following meanings:
 
   - `r`: a web URL the event is referring to in some way
+  - `i`: an external id the event is referring to in some way - see [NIP-XX](XX.md)
   - `title`: title of the event

--- a/XX.md
+++ b/XX.md
@@ -1,0 +1,31 @@
+NIP-XX
+======
+
+External Content IDs
+-------------------------
+
+`draft` `optional`
+
+There are certain established global content identifiers that would be useful to reference in nostr events so that clients can query all events assosiated with these ids.
+
+- Book [ISBNs](https://en.wikipedia.org/wiki/ISBN)
+- Podcast [GUIDs](https://podcastnamespace.org/tag/guid)
+- Movie [EIDRs](https://www.eidr.org)
+
+Since the `i` tag is already used for similar references in kind-0 metadata events it makes sense to use it for these content ids as well.
+
+
+## Supported IDs
+
+### Books:
+
+- Book ISBN: `["i", "book:isbn:123"]`
+
+### Podcasts:
+
+- Podcast Feed GUID: `["i", "podcast:guid:123"]`
+- Podcast Item GUID: `["i", "podcast:item:guid:123"]`
+
+### Movies:
+
+- Movie EIDR: `["i", "movie:eidr:123"]`


### PR DESCRIPTION
There are certain established global content identifiers that would be useful to reference in nostr events so that clients can query all events associated with these ids.

- Book [ISBNs](https://en.wikipedia.org/wiki/ISBN)
- Podcast [GUIDs](https://podcastnamespace.org/tag/guid)
- Movie [EIDRs](https://www.eidr.org)

Formalising the way these ids are referenced in nostr events would make it much easier for developers to build open versions of popular services like IMDB, GoodReads etc. built on nostr.