### PR TITLE
Update NIP-23 to define encrypted long form content

### DIFF
--- a/23.md
+++ b/23.md
@@ -6,21 +6,19 @@ Long-form Content
 
 `draft` `optional`
 
-This NIP defines `kind:30023` (a _parameterized replaceable event_) for long-form text content, generally referred to as "articles" or "blog posts". `kind:30024` has the same structure as `kind:30023` and is used to save long form drafts.
+This NIP defines `kind:30023` (a _parameterized replaceable event_) for long-form text content, generally referred to as "articles" or "blog posts". `kind:30024` has the same structure as `kind:30023` and is used to save long form drafts. `kind:30025` is used for encryped long form content and also has the same structure as `kind:30023` with the difference being that the content is encrypted via NIP-44 encryption.
 
 "Social" clients that deal primarily with `kind:1` notes should not be expected to implement this NIP.
 
 ### Format
 
-The `.content` of these events should be a string text in Markdown syntax. To maximize compatibility and readability between different clients and devices, any client that is creating long form notes:
+The `.content` of these events should be a string text in Markdown syntax wether encrypted or not. To maximize compatibility and readability between different clients and devices, any client that is creating long form notes:
 
 - MUST NOT hard line-break paragraphs of text, such as arbitrary line breaks at 80 column boundaries.
 
 - MUST NOT support adding HTML to Markdown.
 
-- MUST include the `encrypted` tag for encrypted Markdown content.
-
-- MUST use NIP-44 definition for encrypted Markdown content.
+- MUST use the NIP-44 definition for encrypted Markdown content.
 
 ### Metadata
 
@@ -69,7 +67,7 @@ References to other Nostr notes, articles or profiles must be made according to 
 
 ```json
 {
-  "kind": 30023,
+  "kind": 30025,
   "created_at": 1675642635,
   "content": "AqBCdwoS7/tPK+QGkPCadJTn8FxGkd24iApo3BR9/M0uw6n4RFAFSPAKKMgkzVMoRyR3ZS/aqATDFvoZJOkE9cPG/TAzmyZvr/WUIS8kLmuI1dCA+itFF6+ULZqbkWS0YcVU0j6UDvMBvVlGTzHz+UHzWYJLUq2LnlynJtFap5k8560+tBGtxi9Gx2NIycKgbOUv0gEqhfVzAwvg1IhTltfSwOeZXvDvd40rozONRxwq8hjKy+4DbfrO0iRtlT7G/eVEO9aJJnqagomFSkqCscttf/o6VeT2+A9JhcSxLmjcKFG3FEK3Try/WkarJa1jM3lMRQqVOZrzHAaLFW/5sXano6DqqC5ERD6CcVVsrny0tYN4iHHB8BHJ9zvjff0NjLGG/v5Wsy31+BwZA8cUlfAZ0f5EYRo9/vKSd8TV0wRb9DQ=",
   "tags": [
@@ -78,8 +76,7 @@ References to other Nostr notes, articles or profiles must be made according to 
     ["published_at", "1296962229"],
     ["t", "placeholder"],
     ["e", "b3e392b11f5d4f28321cedd09303a748acfd0487aea5a7450b3481c60b6e4f87", "wss://relay.example.com"],
-    ["a", "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum", "wss://relay.nostr.org"],
-    ["encrypted"]
+    ["a", "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum", "wss://relay.nostr.org"]
   ],
   "pubkey": "...",
   "id": "..."

--- a/23.md
+++ b/23.md
@@ -12,7 +12,7 @@ This NIP defines `kind:30023` (a _parameterized replaceable event_) for long-for
 
 ### Format
 
-The `.content` of these events should be a string text in Markdown syntax wether encrypted or not. To maximize compatibility and readability between different clients and devices, any client that is creating long form notes:
+The `.content` of these events should be a string text in Markdown syntax whether encrypted or not. To maximize compatibility and readability between different clients and devices, any client that is creating long form notes:
 
 - MUST NOT hard line-break paragraphs of text, such as arbitrary line breaks at 80 column boundaries.
 

--- a/23.md
+++ b/23.md
@@ -18,6 +18,10 @@ The `.content` of these events should be a string text in Markdown syntax. To ma
 
 - MUST NOT support adding HTML to Markdown.
 
+- MUST include the `encrypted` tag for encrypted Markdown content.
+
+- MUST use NIP-44 definition for encrypted Markdown content.
+
 ### Metadata
 
 For the date of the last update the `.created_at` field should be used, for "tags"/"hashtags" (i.e. topics about which the event might be of relevance) the `t` tag should be used, as per NIP-12.
@@ -55,6 +59,27 @@ References to other Nostr notes, articles or profiles must be made according to 
     ["t", "placeholder"],
     ["e", "b3e392b11f5d4f28321cedd09303a748acfd0487aea5a7450b3481c60b6e4f87", "wss://relay.example.com"],
     ["a", "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum", "wss://relay.nostr.org"]
+  ],
+  "pubkey": "...",
+  "id": "..."
+}
+```
+
+## Example Encrypted Event
+
+```json
+{
+  "kind": 30023,
+  "created_at": 1675642635,
+  "content": "AqBCdwoS7/tPK+QGkPCadJTn8FxGkd24iApo3BR9/M0uw6n4RFAFSPAKKMgkzVMoRyR3ZS/aqATDFvoZJOkE9cPG/TAzmyZvr/WUIS8kLmuI1dCA+itFF6+ULZqbkWS0YcVU0j6UDvMBvVlGTzHz+UHzWYJLUq2LnlynJtFap5k8560+tBGtxi9Gx2NIycKgbOUv0gEqhfVzAwvg1IhTltfSwOeZXvDvd40rozONRxwq8hjKy+4DbfrO0iRtlT7G/eVEO9aJJnqagomFSkqCscttf/o6VeT2+A9JhcSxLmjcKFG3FEK3Try/WkarJa1jM3lMRQqVOZrzHAaLFW/5sXano6DqqC5ERD6CcVVsrny0tYN4iHHB8BHJ9zvjff0NjLGG/v5Wsy31+BwZA8cUlfAZ0f5EYRo9/vKSd8TV0wRb9DQ=",
+  "tags": [
+    ["d", "lorem-ipsum"],
+    ["title", "Lorem Ipsum"],
+    ["published_at", "1296962229"],
+    ["t", "placeholder"],
+    ["e", "b3e392b11f5d4f28321cedd09303a748acfd0487aea5a7450b3481c60b6e4f87", "wss://relay.example.com"],
+    ["a", "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum", "wss://relay.nostr.org"],
+    ["encrypted"]
   ],
   "pubkey": "...",
   "id": "..."


### PR DESCRIPTION
**Overview**

This change updates an existing protocol definition to allow for encrypted long form content.

> Considering that we currently have applications utilizing the event kind `30024` for long form content and to avoid clients accidentally being presented with encrypted strings it may be preferable to replace the `encrypted` tag for another event kind all together e.g. event `30025` to represent encrypted long form content.

**Potential use cases**

 - Article paywalls: utilizing [NIP-46](/nostr-protocol/nips/blob/master/46.md) authors can selectively allow decryption acces to private / premium content
 - Private journaling: utilizing relays to distribute and access private journal entries to be viewed and edited via multiple clients.
 - DVM Publication: users may request that DVM's ( [NIP-90](/nostr-protocol/nips/blob/master/90.md) ) output their content to Nostr as a private article.
 
 **Relates to**
 
 https://github.com/nostr-protocol/nips/issues/1183
 https://github.com/nostr-protocol/nips/issues/1139
 https://github.com/nostr-protocol/nips/issues/583