### PR TITLE
Shared replaceables

### DIFF
--- a/68.md
+++ b/68.md
@@ -1,0 +1,86 @@
+NIP-68
+======
+
+Shared Replaceables
+-------------------
+
+`draft` `optional`
+
+This NIP establishes the encoding mechanism to create, filter and reference replaceable events whose ownership are shared among several keys. 
+
+The initial creator adds all owners to the `d` tag, separated by `|`. The presence of `|` with valid keys for each but the last position, directs clients to work with this event as a shared replaceable. 
+
+```js
+{
+  "kind": 3xxxx,
+  "tags": [
+    ["d", "<pubkey1>|<pubkey2>|<pubkey3>|<identifier>"],
+    // ...
+  ],
+  //...
+}
+```
+
+To change owners, users MUST create a new `d` tag with new owners and MAY delete the previous one. 
+
+# Referencing & Indexing
+
+Events that reference the most recent version of a shared replaceable MUST add `a` tags to each owner. 
+
+Reply example:
+
+```jsonc
+{
+  "kind": 1,
+  "tags": [
+    ["a", "3xxxx:<pubkey1>:<pubkey1>|<pubkey2>|<pubkey3>|<identifier>", "<optional-relay-url>", "reply"],
+    ["a", "3xxxx:<pubkey2>:<pubkey1>|<pubkey2>|<pubkey3>|<identifier>", "<optional-relay-url>", "reply"],
+    ["a", "3xxxx:<pubkey3>:<pubkey1>|<pubkey2>|<pubkey3>|<identifier>", "<optional-relay-url>", "reply"]
+  ],
+  "content": "a reply",
+  // ...
+}
+```
+
+## Deletion
+
+Owners can only unilaterally delete their own events: 
+
+```jsonc
+{
+  "pubkey": "<pubkey1>",
+  "kind": 5, 
+  "tags": [
+    ["a", "3xxxx:<pubkey1>:<pubkey1>|<pubkey2>|<pubkey3>|<identifier>", "<optional-relay-url>"],
+  ],
+  "content": "Deletes my versions of this repleceable",
+  // ...
+}
+```
+
+Adding other pubkeys to the `a` tag won't have any effect. 
+
+# Filtering
+
+After parsing the desired `d` tag, clients SHOULD create a filter that includes all `d`-tag pubkeys as authors and use the `limit:1` to get only the latest event. 
+
+```json
+{
+  "authors": ["<pubkey1>", "<pubkey2>", "<pubkey3>"],
+  "kinds": [3xxxx],
+  "#d": ["<pubkey1>|<pubkey2>|<pubkey3>|<identifier>"],
+  "limit": 1
+}
+```
+
+To find all events associated with a given shared replaceable, clients SHOULD search for `a` tags from each of the authors: 
+
+```json
+{
+  "#a": [
+    "3xxxx:<pubkey1>:<pubkey1>|<pubkey2>|<pubkey3>|<identifier>", 
+    "3xxxx:<pubkey2>:<pubkey1>|<pubkey2>|<pubkey3>|<identifier>", 
+    "3xxxx:<pubkey3>:<pubkey1>|<pubkey2>|<pubkey3>|<identifier>"
+  ]
+}
+```


### PR DESCRIPTION
The idea here is to add replaceable events that can be changed only by a list of pre-defined keys without changing relay implementations and without using a separate key to sign the event on behalf of the owners, like how https://github.com/nostr-protocol/nips/pull/1015 suggested. 

Imagine a Google Doc/Spreadsheet that is constantly being updated by a list of users. 

Read [here](https://github.com/vitorpamplona/nips/blob/shared-replaceables/68.md)