### PR TITLE
NIP-46: "error" property of response is optional

### DIFF
--- a/46.md
+++ b/46.md
@@ -159,7 +159,7 @@ The `content` field is a JSON-RPC-like message that is [NIP-04](https://github.c
 
 - `id` is the request ID that this response is for.
 - `results` is a string of the result of the call (this can be either a string or a JSON stringified object)
-- `error` is an error in string form, if any. Its presence indicates an error with the request.
+- `error`, _optionally_, it is an error in string form, if any. Its presence indicates an error with the request.
 
 ### Auth Challenges
 

--- a/46.md
+++ b/46.md
@@ -153,13 +153,13 @@ The `content` field is a JSON-RPC-like message that is [NIP-04](https://github.c
 {
     "id": <request_id>,
     "result": <results_string>,
-    "error": <error_string>
+    "error": <optional_error_string>
 }
 ```
 
 - `id` is the request ID that this response is for.
 - `results` is a string of the result of the call (this can be either a string or a JSON stringified object)
-- `error` is an error in string form.
+- `error` is an error in string form, if any. It's presence indicates an error with the request.
 
 ### Auth Challenges
 

--- a/46.md
+++ b/46.md
@@ -159,7 +159,7 @@ The `content` field is a JSON-RPC-like message that is [NIP-04](https://github.c
 
 - `id` is the request ID that this response is for.
 - `results` is a string of the result of the call (this can be either a string or a JSON stringified object)
-- `error` is an error in string form, if any. It's presence indicates an error with the request.
+- `error` is an error in string form, if any. Its presence indicates an error with the request.
 
 ### Auth Challenges
 


### PR DESCRIPTION
The `error` property of NIP-46 responses is optional.

nsecbunker [marks it optional](https://github.com/nostr-dev-kit/ndk/blob/44ab157ccf46297700a7b159d5343bcd31536e8a/ndk/src/signers/nip46/rpc.ts#L26) and only returns it [conditionally](https://github.com/nostr-dev-kit/ndk/blob/44ab157ccf46297700a7b159d5343bcd31536e8a/ndk/src/signers/nip46/rpc.ts#L103) if an error exists.