### PR TITLE
Resumes

### DIFF
--- a/55.md
+++ b/55.md
@@ -8,8 +8,6 @@ Structured Resumes
 
 This NIP defines event kind `11000` as the pubkey's resume. Life acomplishments are described as tags and a mini bio is written in `.content`. 
 
-
-
 ```jsonc
 {
   "kind": 11000,

--- a/55.md
+++ b/55.md
@@ -1,0 +1,71 @@
+NIP-55
+======
+
+Structured Resumes
+------------------
+
+`optional`
+
+This NIP defines event kind `11000` as the pubkey's resume. Life acomplishments are described as tags and a mini bio is written in `.content`. 
+
+
+
+```jsonc
+{
+  "kind": 11000,
+  "tags": [
+    ["headline", "<short single-line descriptor of the candidate>"],
+    ["location", "<city>, <state>, <country>"],
+    ["featured", "<image or video url>", "<title>", "<summary>"],
+    [
+      "w",  // work / experience
+      "<company's public key>",  // can be blank if not on Nostr yet.
+      "<company name>", "<city>, <state>, <country>", "<more info url>",
+      "<job title>", "<full-time,part-time>", "<on-site, hybrid, remote>", 
+      "<start unix timestamp>", "<end unix timestamp>", // blank if currently working there.
+      "<work summary>"
+    ],
+    [
+      "s", // education / courses
+      "<school's public key>",  // can be blank if not on Nostr yet.
+      "<school name>", "<city>, <state>, <country>", "<more info url>",
+      "<degree>", "<field of study>", "<grade>", "<on-site, hybrid, remote>", 
+      "<start unix timestamp>", "<end unix timestamp>", // blank if currently studying there.
+      "<work summary>"
+    ],
+    [
+      "n", // patents and publications
+      "<patent number or application number>", 
+      "<title>", "<patent url>", "<issued, pending>", 
+      "<issue date unix timestamp>", 
+      "<patent summary>"
+    ],
+    [
+      "h", // certifications, honors and awards
+      "<issuer's public key>",  // can be blank if not on Nostr yet.
+      "<issuer name>", "<city>, <state>, <country>", "<more info url>",
+      "<title>", "<image or video url>", 
+      "<issue date unix timestamp>", 
+      "<patent summary>"
+    ],
+    [
+      "u", // languages
+      "<two letter ISO 639-1 language code>",  
+      "<elementary, intermediate, fluent, native>", 
+    ],
+    [
+      "v", // volunteering & memberships
+      "<organization's public key>",  // can be blank if not on Nostr yet.
+      "<organization name>", "<city>, <state>, <country>", "<more info url>",
+      "<position>", 
+      "<start unix timestamp>", "<end unix timestamp>", // blank if currently working there.
+      "<volunteer summary>"
+    ],
+    ["t", "<skill>"],
+  ],
+  "content": "<summary or mini bio>",
+  //...
+}
+```
+
+All tags can happen more than once. 


### PR DESCRIPTION
Adds kind 11000 as the pubkey's resume. It uses a structure format that Clients can render in any way they see fit. 

Read [here](https://github.com/vitorpamplona/nips/blob/resume/55.md)