### PR TITLE
nip46: signer should fill in `pubkey`, `id` and `sig` on `sign_event`

### DIFF
--- a/46.md
+++ b/46.md
@@ -61,8 +61,9 @@ nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata
         "method": "sign_event",
         "params": [json_stringified(<{
             content: "Hello, I'm signing remotely",
-            pubkey: "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
-            // ...the rest of the event data
+            kind: 1,
+            tags: [],
+            created_at: 1714078911
         }>)]
     }),
     "tags": [["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"]], // p-tags the remote user pubkey
@@ -118,21 +119,21 @@ The `content` field is a JSON-RPC-like message that is [NIP-04](https://github.c
 
 Each of the following are methods that the client sends to the remote signer.
 
-| Command                  | Params                                            | Result                                                                 |
-| ------------------------ | ------------------------------------------------- | ---------------------------------------------------------------------- |
-| `connect`                | `[<remote_user_pubkey>, <optional_secret>, <optional_requested_permissions>]`       | "ack"                                                                  |
-| `sign_event`             | `[<json_stringified_event_to_sign>]`              | `json_stringified(<signed_event>)`                                     |
-| `ping`                   | `[]`                                              | "pong"                                                                 |
-| `get_relays`             | `[]`                                              | `json_stringified({<relay_url>: {read: <boolean>, write: <boolean>}})` |
-| `get_public_key`         | `[]`                                              | `<hex-pubkey>`                                                         |
-| `nip04_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`  | `<nip04_ciphertext>`                                                   |
-| `nip04_decrypt`          | `[<third_party_pubkey>, <nip04_ciphertext_to_decrypt>]` | `<plaintext>`                                                    |
-| `nip44_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`  | `<nip44_ciphertext>`                                                   |
-| `nip44_decrypt`          | `[<third_party_pubkey>, <nip44_ciphertext_to_decrypt>]` | `<plaintext>`                                                    |
+| Command                  | Params                                                                        | Result                                                                 |
+| ------------------------ | -------------------------------------------------                             | ---------------------------------------------------------------------- |
+| `connect`                | `[<remote_user_pubkey>, <optional_secret>, <optional_requested_permissions>]` | "ack"                                                                  |
+| `sign_event`             | `[<{kind, content, tags, created_at}>]`                                       | `json_stringified(<signed_event>)`                                     |
+| `ping`                   | `[]`                                                                          | "pong"                                                                 |
+| `get_relays`             | `[]`                                                                          | `json_stringified({<relay_url>: {read: <boolean>, write: <boolean>}})` |
+| `get_public_key`         | `[]`                                                                          | `<hex-pubkey>`                                                         |
+| `nip04_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`                              | `<nip04_ciphertext>`                                                   |
+| `nip04_decrypt`          | `[<third_party_pubkey>, <nip04_ciphertext_to_decrypt>]`                       | `<plaintext>`                                                          |
+| `nip44_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`                              | `<nip44_ciphertext>`                                                   |
+| `nip44_decrypt`          | `[<third_party_pubkey>, <nip44_ciphertext_to_decrypt>]`                       | `<plaintext>`                                                          |
 
 ### Requested permissions
 
-The `connect` method may be provided with `optional_requested_permissions` for user convenience. The permissions are a comma-separated list of `method[:params]`, i.e. `nip04_encrypt,sign_event:4` meaning permissions to call `nip04_encrypt` and to call `sign_event` with `kind:4`. Optional parameter for `sign_event` is the kind number, parameters for other methods are to be defined later. 
+The `connect` method may be provided with `optional_requested_permissions` for user convenience. The permissions are a comma-separated list of `method[:params]`, i.e. `nip04_encrypt,sign_event:4` meaning permissions to call `nip04_encrypt` and to call `sign_event` with `kind:4`. Optional parameter for `sign_event` is the kind number, parameters for other methods are to be defined later.
 
 ## Response Events `kind:24133`
 


### PR DESCRIPTION
This is how it works on NIP-07 and should be how it works on NIP-46 too.