### PR TITLE
Add NIP-77 for expressing trust

### DIFF
--- a/07.md
+++ b/07.md
@@ -11,7 +11,7 @@ The `window.nostr` object may be made available by web browsers or extensions an
 That object must define the following methods:
 
 ```
-async window.nostr.getPublicKey(): string // returns a public key as hex
+async window.nostr.getPublicKey({optional: bool}): string // returns a public key as hex. If optional is true, don't show popup to user, return pubkey only if permission had been already granted, null otherwise.
 async window.nostr.signEvent(event: { created_at: number, kind: number, tags: string[][], content: string }): Event // takes an event object, adds `id`, `pubkey` and `sig` and returns it
 ```
 


### PR DESCRIPTION
This seems to be the smallest common denominator of what people think about web-of-trust or trusting people.

From here, we can branch out, use this common format in apps, clients, relays, algorithms, DVMs, et cetera.

Two specific branches already exist:
* Tapestry Protocol for creating a language for the context field (https://github.com/wds4/tapestry-protocol/blob/main/guides/grapevineIncorporation/NIP-proposal.md#contexts)
* A NIP for extending relay filters to support querying / filtering based on web-of-trust (https://github.com/lez/nips/blob/nip76/76.md)