### PR TITLE
NIP-56 to reporting of digital threats

### DIFF
--- a/56.md
+++ b/56.md
@@ -26,6 +26,7 @@ A `report type` string MUST be included as the 3rd entry to the `e` or `p` tag
 being reported, which consists of the following report types:
 
 - `nudity` - depictions of nudity, porn, etc.
+- `malware` - depictions of malware, virus, Trojan Horse, worm, robot, spyware, adware, back door, ransomware, rootkit, kidnapper, etc.
 - `profanity` - profanity, hateful speech, etc.
 - `illegal` - something which may be illegal in some jurisdiction
 - `spam` - spam

--- a/56.md
+++ b/56.md
@@ -26,7 +26,7 @@ A `report type` string MUST be included as the 3rd entry to the `e` or `p` tag
 being reported, which consists of the following report types:
 
 - `nudity` - depictions of nudity, porn, etc.
-- `malware` - depictions of malware, virus, Trojan Horse, worm, robot, spyware, adware, back door, ransomware, rootkit, kidnapper, etc.
+- `malware` - virus, trojan horse, worm, robot, spyware, adware, back door, ransomware, rootkit, kidnapper, etc.
 - `profanity` - profanity, hateful speech, etc.
 - `illegal` - something which may be illegal in some jurisdiction
 - `spam` - spam


### PR DESCRIPTION
A report is a kind 1984 event that signals to users and relays that some referenced content is objectionable. The definition of objectionable is obviously subjective and all agents on the network (users, apps, relays, etc.) may consume and take action on them as they see fit.

The content MAY contain additional information submitted by the entity reporting the content.

## Description
Currently there is Nip 56. But can we include more use cases? Can we include specific tags such as malware(virus, trojan horse, worm, robot, spyware, adware, back door, ransomware, rootkit, kidnapper, etc)?

## Notes for Reviewer
I explained this technical detail here https://gist.github.com/lucasnuic/cf71109d0760542ad7ad2f2d2c260c44 , https://github.com/nostr-protocol/nips/discussions/1212