### PR TITLE
NIP-56: allow tagging third-parties in reports

### DIFF
--- a/56.md
+++ b/56.md
@@ -37,6 +37,9 @@ Some report tags only make sense for profile reports, such as `impersonation`
 `l` and `L` tags MAY be also be used as defined in [NIP-32](32.md) to support
 further qualification and querying.
 
+Capital `P` tags MAY also be included on a report to notify third-parties who
+may be able to act upon the report, such as relay admins.
+
 Example events
 --------------
 


### PR DESCRIPTION
When creating a report, `p` tags are used to indicate the user(s) **being reported**.

This change introduces capital `P` tags to **notify third-parties about the report**. These parties are not subjects of the report themselves, but it is rather an indication that the author of this report wants those additional people to know.

I am using `P` tags for a community Nostr relay with a moderation interface, where users can report events to the relay, and then an admin can delete those events from the community relay.

This inclusion has other possible use-cases, such as notifying bots or kicking off webhooks that can trigger other side-effects.