### PR TITLE
Wikilink tags and Trust Rank NIP (and how to apply it to wikis)

### DIFF
--- a/54.md
+++ b/54.md
@@ -31,6 +31,69 @@ The content should be Markdown, following the same rules as of [NIP-23](23.md), 
 
 One extra functionality is added: **wikilinks**. Unlike normal Markdown links `[]()` that link to webpages, wikilinks `[[]]` link to other articles in the wiki. In this case, the wiki is the entirety of Nostr. Clicking on a wikilink should cause the client to ask relays for events with `d` tags equal to the target of that wikilink.
 
+#### Wikilink Tags
+
+The one to two most prevailing wikilink `d` tag references of an article should be set to the `y` and `z` tags.
+The `y` tag is set to the most prevailing one while `z` is set to the least of the two.
+
+A prevalent wikilink is a reference that is able to categorize the article into a specifc topic. These are usually positioned
+on the top of the article on an introductory paragraph.
+
+A Nostr wiki client may try to auto assign those tags. For example, by finding the first wikilink's paragraph on the article
+then considering the up to first two wikilinks on the current paragraph as the prevailing wikilinks.
+
+Example:
+
+```js
+{
+  "kind": 30818,
+  "tags": [
+    [ "d", "john-doe" ],
+    [ "title", "John Doe" ],
+    [ "y", "internet-celebrity" ],
+    [ "z", "nostr" ],
+  ],
+  "content": "# John Doe\n\n" +
+    "John Doe is an [influencer[internet-celebrity]] in the [Nostr[nostr]] scene. He is known for his [memes[meme]].\n" +
+    "# Early Life\n\n" +
+    "He was born in [Los Angeles[los-angeles]] ...",
+  // other fields
+}
+```
+
+Those tags are handy when searching for topics related to an article.
+They may be used as labels to tell two articles with the same `d` tag apart.
+They are also used when [ranking authors](#author-ranking).
+
+#### Author Ranking
+
+When a reader adds a [NIP-25](25.md) reaction to an article,
+the client may help them with adding/updating a [NIP-64](64.md) trust rank
+on the main and related topics regarding the article author.
+
+For example, if an user **likes** the above article, the author may be auto ranked as follows:
+
+```js
+{
+  "kind": 30382,
+  "tags": [
+    ["d", "<wiki-article-author-pubkey>"],
+    // "x" is the marker for the main article topic (its `d` tag "john-doe")
+    ["T", "3:wiki:john-doe", "x"],
+    // even though this wiki article author may not have written about "internet-celebrity" yet (or never will),
+    // this rank may be used to consider the relevance of a "x"-marked trust rank eventually authored
+    // by them (or by someone even deeper, if following another y/z rank) on the "internet-celebrity" topic
+    ["T", "2:wiki:internet-celebrity", "y"],
+    ["T", "1:wiki:nostr", "z"]
+  ],
+  // ...other fields
+}
+```
+
+Note that if later the same user **dislikes** a Nostr wiki article from the same author, the corresponding `T` tag would
+be updated from `["T", "2:wiki:nostr", "z"]` to `["T", "-3:wiki:nostr", "x"]`, overwritting it because
+the "x" marker (meaning main topic) takes precedence over the "z" one (related topic).
+
 ### Merge Requests
 
 Event `kind:818` represents a request to merge from a forked article into the source. It is directed to a pubkey and references the original article and the modified event.
@@ -56,13 +119,20 @@ As there could be many articles for each given name, some kind of prioritization
 
 [NIP-51](51.md) lists of relays can be created with the kind 10102 and then used by wiki clients in order to determine where to query articles first and to rank these differently in relation to other events fetched from other relays.
 
-### Contact lists
+### Follow lists
 
-[NIP-02](02.md) contact lists can form the basis of a recommendation system that is then expanded with relay lists and reaction lists through nested queries. These lists form a good starting point only because they are so widespread.
+[NIP-02](02.md) follow lists can form the basis of a recommendation system that is then expanded with relay lists and reaction lists through nested queries. These lists form a good starting point only because they are so widespread.
 
 ### Wiki-related contact lists
 
 [NIP-51](51.md) lists can also be used to create a list of users that are trusted only in the context of wiki authorship or wiki curationship.
+
+### Trust Rank
+
+As mentioned [above](#author-ranking), article author [NIP-64](64.md) trust ranks can be assigned based on [NIP-25](25.md) reactions (or below [deferences](#deference)).
+An user's follow trust rank event can be used to rank an article version directly by using a "x" marker.
+If an "y" or "z" marker was used instead,
+it may indirectly be linking to the involved author's article on a related topic or another trust rank event on that related topic that depending on the marker can be navigated further until possibly finding a ranked article version.
 
 Forks
 ---------

--- a/54.md
+++ b/54.md
@@ -83,25 +83,27 @@ the author may be ranked as follows:
     ["d", "<wiki-article-author-pubkey>"],
     // Current article topic ("john-doe") is rated 3 and related articles are rated 2 and 1 in the order they are linked on current article
     // (because author is expected to be somewhat knowledgeable on related topics)
-    //
-    // The `d` marker means it is related to the `d` tag of current article
-    // while `r` marker is related to the `r` tag
-    ["T", "3:wiki:john-doe", "d"],
+    ["T", "3:wiki:john-doe"],
     // Even though this "John Doe" wiki article's author may not have written a wiki article about "internet-celebrity" yet
     // (or never will or article was deleted),
-    // they may have rated another person positively on "internet-celebrity" who may have written one or
+    // they may have rated another person positively on "internet-celebrity" topic who may have written one or
     // also may have positively rated someone else and so on
-    ["T", "2:wiki:internet-celebrity", "r"],
-    ["T", "1:wiki:nostr", "r"]
+    ["T", "2:wiki:internet-celebrity"],
+    ["T", "1:wiki:nostr"]
   ],
   // ...other fields
 }
 ```
 
 Note that if later the same user **dislikes** a Nostr wiki article from the same author, the corresponding `T` tag would
-be updated from `["T", "1:wiki:nostr", "r"]` to `["T", "-3:wiki:nostr", "d"]`, overwritting it because
-the "d" marker (meaning main article) takes precedence over the "r" one (related article). Also, newer rating
-from same marker overwrites old one.
+be updated from `["T", "1:wiki:nostr"]` to `["T", "-3:wiki:nostr"]`, overwritting it.
+
+On this recommended setup, a score of 3 or -3 has precedence over other values,
+because they are used when the pubkey is the currently viewed article's author (not a related article).
+
+If updating the rating on the same topic from a positive value to another positive one, the higher one has precedence.
+If updating from a negative value to another negative one, the lower one has precedence.
+Else the newer rating overwrites the old one.
 
 ### Merge Requests
 

--- a/54.md
+++ b/54.md
@@ -67,15 +67,17 @@ They are also used when [ranking authors](#author-ranking).
 
 #### Author Ranking
 
-When a reader adds a [NIP-25](25.md) reaction to an article,
-the client may help them with adding/updating a [NIP-64](64.md) trust rank
+An user reading a wiki article may add/update a [NIP-64](64.md) trust rank
 on the main and related topics regarding the article author.
 
-For example, if an user **likes** the above article, the author may be auto ranked as follows:
+For example, if an user **likes** the above article
+(by clicking a thumbs up button positioned next to the question "Is this article correct?", for example),
+the author may be ranked as follows:
 
 ```js
 {
   "kind": 30382,
+  "pubkey": "<user-pubkey>",
   "tags": [
     ["d", "<wiki-article-author-pubkey>"],
     // "x" is the marker for the main article topic (its `d` tag "john-doe")
@@ -129,7 +131,8 @@ As there could be many articles for each given name, some kind of prioritization
 
 ### Trust Rank
 
-As mentioned [above](#author-ranking), article author [NIP-64](64.md) trust ranks can be assigned based on [NIP-25](25.md) reactions (or below [deferences](#deference)).
+As mentioned [above](#author-ranking), article author [NIP-64](64.md) trust ranks can be easily assigned by
+clicking a thumb up/down button or when making below [deferences](#deference)).
 An user's follow trust rank event can be used to rank an article version directly by using a "x" marker.
 If an "y" or "z" marker was used instead,
 it may indirectly be linking to the involved author's article on a related topic or another trust rank event on that related topic that depending on the marker can be navigated further until possibly finding a ranked article version.

--- a/54.md
+++ b/54.md
@@ -31,16 +31,17 @@ The content should be Markdown, following the same rules as of [NIP-23](23.md), 
 
 One extra functionality is added: **wikilinks**. Unlike normal Markdown links `[]()` that link to webpages, wikilinks `[[]]` link to other articles in the wiki. In this case, the wiki is the entirety of Nostr. Clicking on a wikilink should cause the client to ask relays for events with `d` tags equal to the target of that wikilink.
 
-#### Wikilink Tags
+#### Closely Related Article Tags
 
-The one to two most prevailing wikilink `d` tag references of an article should be set to the `y` and `z` tags.
-The `y` tag is set to the most prevailing one while `z` is set to the least of the two.
+The most prevailing wikilinks of an article should be set to `r` (related article) tags and should
+be limited in number.
 
-A prevalent wikilink is a reference that is able to categorize the article into a specifc topic. These are usually positioned
+Prevalent wikilinks are references to articles on topics that have high
+level of relationship with the current article. These are usually positioned
 on the top of the article on an introductory paragraph.
 
 A Nostr wiki client may try to auto assign those tags. For example, by finding the first wikilink's paragraph on the article
-then considering the up to first two wikilinks on the current paragraph as the prevailing wikilinks.
+then considering the up to the first two wikilinks on the current paragraph as the prevailing wikilinks.
 
 Example:
 
@@ -50,8 +51,8 @@ Example:
   "tags": [
     [ "d", "john-doe" ],
     [ "title", "John Doe" ],
-    [ "y", "internet-celebrity" ],
-    [ "z", "nostr" ],
+    [ "r", "internet-celebrity" ],
+    [ "r", "nostr" ],
   ],
   "content": "# John Doe\n\n" +
     "John Doe is an [influencer[internet-celebrity]] in the [Nostr[nostr]] scene. He is known for his [memes[meme]].\n" +
@@ -61,7 +62,7 @@ Example:
 }
 ```
 
-Those tags are handy when searching for topics related to an article.
+Those tags are handy when searching for articles closely related to another article.
 They may be used as labels to tell two articles with the same `d` tag apart.
 They are also used when [ranking authors](#author-ranking).
 
@@ -80,21 +81,21 @@ the author may be ranked as follows:
   "pubkey": "<user-pubkey>",
   "tags": [
     ["d", "<wiki-article-author-pubkey>"],
-    // "x" is the marker for the main article topic (its `d` tag "john-doe")
-    ["T", "3:wiki:john-doe", "x"],
+    // "d" is the marker for the main article topic (its `d` tag "john-doe")
+    ["T", "3:wiki:john-doe", "d"],
     // even though this wiki article author may not have written about "internet-celebrity" yet (or never will),
-    // this rank may be used to consider the relevance of a "x"-marked trust rank eventually authored
-    // by them (or by someone even deeper, if following another y/z rank) on the "internet-celebrity" topic
-    ["T", "2:wiki:internet-celebrity", "y"],
-    ["T", "1:wiki:nostr", "z"]
+    // this rank may be used to consider the relevance of a "d"-marked trust rank eventually assigned
+    // by them (or by someone even deeper, if following another "r" rank) on the "internet-celebrity" topic
+    ["T", "2:wiki:internet-celebrity", "r"],
+    ["T", "1:wiki:nostr", "r"]
   ],
   // ...other fields
 }
 ```
 
 Note that if later the same user **dislikes** a Nostr wiki article from the same author, the corresponding `T` tag would
-be updated from `["T", "2:wiki:nostr", "z"]` to `["T", "-3:wiki:nostr", "x"]`, overwritting it because
-the "x" marker (meaning main topic) takes precedence over the "z" one (related topic).
+be updated from `["T", "1:wiki:nostr", "r"]` to `["T", "-3:wiki:nostr", "d"]`, overwritting it because
+the "d" marker (meaning main article) takes precedence over the "r" one (related article).
 
 ### Merge Requests
 
@@ -133,8 +134,8 @@ As there could be many articles for each given name, some kind of prioritization
 
 As mentioned [above](#author-ranking), article author [NIP-64](64.md) trust ranks can be easily assigned by
 clicking a thumb up/down button or when making below [deferences](#deference)).
-An user's follow trust rank event can be used to rank an article version directly by using a "x" marker.
-If an "y" or "z" marker was used instead,
+An user follow's trust rank event can be used to rank an article version directly if it has a "d" marker.
+If a "r" marker was used instead,
 it may indirectly be linking to the involved author's article on a related topic or another trust rank event on that related topic that depending on the marker can be navigated further until possibly finding a ranked article version.
 
 Forks

--- a/54.md
+++ b/54.md
@@ -81,11 +81,16 @@ the author may be ranked as follows:
   "pubkey": "<user-pubkey>",
   "tags": [
     ["d", "<wiki-article-author-pubkey>"],
-    // "d" is the marker for the main article topic (its `d` tag "john-doe")
+    // Current article topic ("john-doe") is rated 3 and related articles are rated 2 and 1 in the order they are linked on current article
+    // (because author is expected to be somewhat knowledgeable on related topics)
+    //
+    // The `d` marker means it is related to the `d` tag of current article
+    // while `r` marker is related to the `r` tag
     ["T", "3:wiki:john-doe", "d"],
-    // even though this wiki article author may not have written about "internet-celebrity" yet (or never will),
-    // this rank may be used to consider the relevance of a "d"-marked trust rank eventually assigned
-    // by them (or by someone even deeper, if following another "r" rank) on the "internet-celebrity" topic
+    // Even though this "John Doe" wiki article's author may not have written a wiki article about "internet-celebrity" yet
+    // (or never will or article was deleted),
+    // they may have rated another person positively on "internet-celebrity" who may have written one or
+    // also may have positively rated someone else and so on
     ["T", "2:wiki:internet-celebrity", "r"],
     ["T", "1:wiki:nostr", "r"]
   ],
@@ -95,7 +100,8 @@ the author may be ranked as follows:
 
 Note that if later the same user **dislikes** a Nostr wiki article from the same author, the corresponding `T` tag would
 be updated from `["T", "1:wiki:nostr", "r"]` to `["T", "-3:wiki:nostr", "d"]`, overwritting it because
-the "d" marker (meaning main article) takes precedence over the "r" one (related article).
+the "d" marker (meaning main article) takes precedence over the "r" one (related article). Also, newer rating
+from same marker overwrites old one.
 
 ### Merge Requests
 
@@ -130,13 +136,19 @@ As there could be many articles for each given name, some kind of prioritization
 
 [NIP-51](51.md) lists can also be used to create a list of users that are trusted only in the context of wiki authorship or wiki curationship.
 
-### Trust Rank
+### Trust Ranks
 
 As mentioned [above](#author-ranking), article author [NIP-64](64.md) trust ranks can be easily assigned by
-clicking a thumb up/down button or when making below [deferences](#deference)).
-An user follow's trust rank event can be used to rank an article version directly if it has a "d" marker.
-If a "r" marker was used instead,
-it may indirectly be linking to the involved author's article on a related topic or another trust rank event on that related topic that depending on the marker can be navigated further until possibly finding a ranked article version.
+clicking a thumb up/down button or when making below [deferences](#deference)) (article author when deferencing
+may sign a trust rank favoring another pubkey on the same topic).
+
+If me or my follow has positively rated `pubkey A` on "wiki:internet-celebrity",
+chances are `pubkey A` has written a good article on the topic or have themselves rated `pubkey B` on the same topic.
+
+Then `pubkey B` also may have written a good article on the topic or have themselves rated `pubkey C` on the same topic and so on.
+
+This way from an user and their follows it is possible to reach good article versions (written by well rated authors)
+on a specifc topic.
 
 Forks
 ---------

--- a/64.md
+++ b/64.md
@@ -39,3 +39,13 @@ a wiki client will only add/update/remove `T` tags with topic names starting wit
 |trusted a lot|somewhat trusted|a bit trusted|neutral|a bit untrusted|somewhat untrusted|untrusted a lot|
 |-|-|-|-|-|-|-|
 |3|2|1|0|-1|-2|-3|
+
+### Filtering
+
+The reason why the rating score (integer value) has few possible values and is placed together with the topic name
+is for letting client filter by both data.
+
+Example filters:
+
+- Good drivers: `{ "kinds": [30382], "#T": ["3:driver", "2:driver", "1:driver"] }`
+- Best merchants: `{ "kinds": [30382], "#T": ["3:seller"] }`

--- a/64.md
+++ b/64.md
@@ -22,7 +22,7 @@ Example:
   "kind": 30382,
   "tags": [
     ["d", "<pubkey>"],
-    ["T", "3:wiki:role-playing-video-game", "x"], // has written a based wiki article about RPG
+    ["T", "3:wiki:role-playing-video-game", "d"], // has written a based wiki article about RPG
     ["T", "2:driver"], // polite and skilled driver but doesn't turn the air conditioner on
     ["T", "3:buyer"], // no problems when selling to this person
     ["T", "-2:seller"] // had a bad experience when buying from this person or company
@@ -30,6 +30,9 @@ Example:
   // ...other fields
 }
 ```
+
+If a client doesn't recognize a topic name, it should leave the corresponding `T` tag untouched. For example,
+a wiki client will only add/update/remove `T` tags with topic names starting with `wiki:`.
 
 ## Trust by Rank Value
 

--- a/64.md
+++ b/64.md
@@ -1,0 +1,38 @@
+NIP-64
+======
+
+Trust Rank
+----------
+
+`draft` `optional`
+
+A trust rank is a public way to individually assign a quantifiable level of trust on specifc topics to a nostr identity.
+Ranks can be used to discover trusted people or content on a common topic.
+
+## Event Structure
+
+The `kind:30382` is used to assign public relationship statuses between the event author and a pubkey set to the `d` tag.
+This NIP assigns one or more trust ranks by adding `T` tags with different topic names to such event
+using the following structure: `["T", "<int_value_ranging_from_-3_to_3>:<topic-name>", "<context_dependent_marker>"]`.
+
+Example:
+
+```js
+{
+  "kind": 30382,
+  "tags": [
+    ["d", "<pubkey>"],
+    ["T", "3:wiki:role-playing-video-game", "x"], // has written a based wiki article about RPG
+    ["T", "2:driver"], // polite and skilled driver but doesn't turn the air conditioner on
+    ["T", "3:buyer"], // no problems when selling to this person
+    ["T", "-2:seller"] // had a bad experience when buying from this person or company
+  ],
+  // ...other fields
+}
+```
+
+## Trust by Rank Value
+
+|trusted a lot|somewhat trusted|a bit trusted|neutral|a bit untrusted|somewhat untrusted|untrusted a lot|
+|-|-|-|-|-|-|-|
+|3|2|1|0|-1|-2|-3|

--- a/64.md
+++ b/64.md
@@ -13,7 +13,7 @@ Ranks can be used to discover trusted people or content on a common topic.
 
 The `kind:30382` is used to assign public relationship statuses between the event author and a pubkey set to the `d` tag.
 This NIP assigns one or more trust ranks by adding `T` tags with different topic names to such event
-using the following structure: `["T", "<int_value_ranging_from_-3_to_3>:<topic-name>", "<context_dependent_marker>"]`.
+using the following structure: `["T", "<int_value_ranging_from_-3_to_3>:<topic-name>"]`.
 
 Example:
 
@@ -22,7 +22,7 @@ Example:
   "kind": 30382,
   "tags": [
     ["d", "<pubkey>"],
-    ["T", "3:wiki:role-playing-video-game", "d"], // has written a based wiki article about RPG
+    ["T", "3:wiki:role-playing-video-game"], // has written a based wiki article about RPG
     ["T", "2:driver"], // polite and skilled driver but doesn't turn the air conditioner on
     ["T", "3:buyer"], // no problems when selling to this person
     ["T", "-2:seller"] // had a bad experience when buying from this person or company
@@ -32,7 +32,7 @@ Example:
 ```
 
 If a client doesn't recognize a topic name, it should leave the corresponding `T` tag untouched. For example,
-a wiki client will only add/update/remove `T` tags with topic names starting with `wiki:`.
+a wiki client will only add/update/remove `T` tags with topic names starting with `wiki:`, as explained on [NIP-54](#54.md).
 
 ## Trust by Rank Value
 


### PR DESCRIPTION
Edited TLDR:

When user gives a thumbs up/down to an article, wiki client auto sets the trust rank for the wiki author relative to the said article (and to some other closely related articles; most likely the first two article links).

By looking at an user network (him and his follows) of trust metrics, client can figure out the best article version to show.