### PR TITLE
Changes reactions to not include the entire thread as e-tags. 

### DIFF
--- a/25.md
+++ b/25.md
@@ -25,11 +25,14 @@ consider it a "+".
 Tags
 ----
 
-The reaction event SHOULD include `e` and `p` tags pointing to the note the user is
+The reaction event SHOULD include `a`, `e` and `p` tags pointing to the note the user is
 reacting to. The `p` tag allows authors to be notified. The `e` tags enables clients 
-to pull all the reactions to individual posts.
+to pull all the reactions to individual events and `a` tags enables clients to seek reactions
+for all versions of a replaceable event. 
 
 The `e` tag MUST be the `id` of the note that is being reacted to. 
+
+The `a` tag MUST contain the coordinates (`kind:pubkey:d-tag`) of the replaceable being reacted to. 
 
 The `p` tag MUST be the `pubkey` of the event being reacted to.
 

--- a/25.md
+++ b/25.md
@@ -25,14 +25,13 @@ consider it a "+".
 Tags
 ----
 
-The reaction event SHOULD include `e` and `p` tags from the note the user is
-reacting to. This allows users to be notified of reactions to posts they were
-mentioned in. Including the `e` tags enables clients to pull all the reactions
-associated with individual posts or all the posts in a thread.
+The reaction event SHOULD include `e` and `p` tags pointing to the note the user is
+reacting to. The `p` tag allows authors to be notified. The `e` tags enables clients 
+to pull all the reactions to individual posts.
 
-The last `e` tag MUST be the `id` of the note that is being reacted to. 
+The `e` tag MUST be the `id` of the note that is being reacted to. 
 
-The last `p` tag MUST be the `pubkey` of the event being reacted to.
+The `p` tag MUST be the `pubkey` of the event being reacted to.
 
 The reaction event MAY include a `k` tag with the stringified kind number
 of the reacted event as its value.
@@ -41,9 +40,6 @@ Example code
 
 ```swift
 func make_like_event(pubkey: String, privkey: String, liked: NostrEvent) -> NostrEvent {
-    var tags: [[String]] = liked.tags.filter { 
-    	tag in tag.count >= 2 && (tag[0] == "e" || tag[0] == "p") 
-    }
     tags.append(["e", liked.id])
     tags.append(["p", liked.pubkey])
     tags.append(["k", liked.kind])


### PR DESCRIPTION
Current guidance recommends including all `e` tags and `p` tags, but no other tags, from the liked post in the reaction event. I believe this is a relic of the past and should be deprecated. 

There is no need to index the entire thread in every single reaction. The indexing burden in popular threads is real. I would argue reactions should only point to the note receiving the reaction and nothing else. 

Reasons for the change: 
1. Indexing burden: Indexing entire threads for every single reaction has quadratic costs on the thread's popularity. 
2. Data consumption: requesting reactions to posts in the feed downloads all reactions to all replies in that thread, which is not necessary. 
3. No consistency: We now use NIP-10 markers instead of positional `e` tags for the entire thread. This means that some reactions include the `e` tags for the entire thread while others only include `root` and `reply`, and others only include the `reply` without the marker. Since we also have `mention` and `q` tags, `mention`s are added to the reaction's tag array while `q` tags are not. Conclusion: there is no consistency for reaction counters that are not the reacted event. 
4. No addresses: The recommendation was from before `a` tags existed, so `a` tags are not even included.
5. It's unnecessary: No one reassembles a thread from a reaction event, so there is really no need to have all the tags there. 
6. Zaps and replies don't follow the same rule: We don't include the entire thread on zaps, replies, and quotes. Not even on reports. This only exists on reactions. 