### PR TITLE
rename "parameterized replaceable event" to "tagged-replaceable event"

### DIFF
--- a/01.md
+++ b/01.md
@@ -77,9 +77,9 @@ This NIP defines 3 standard tags that can be used across all event kinds with th
 
 - The `e` tag, used to refer to an event: `["e", <32-bytes lowercase hex of the id of another event>, <recommended relay URL, optional>]`
 - The `p` tag, used to refer to another user: `["p", <32-bytes lowercase hex of a pubkey>, <recommended relay URL, optional>]`
-- The `a` tag, used to refer to a (maybe parameterized) replaceable event
-    - for a parameterized replaceable event: `["a", <kind integer>:<32-bytes lowercase hex of a pubkey>:<d tag value>, <recommended relay URL, optional>]`
-    - for a non-parameterized replaceable event: `["a", <kind integer>:<32-bytes lowercase hex of a pubkey>:, <recommended relay URL, optional>]`
+- The `a` tag, used to refer to a (maybe tagged) replaceable event
+    - for a tagged-replaceable event: `["a", <kind integer>:<32-bytes lowercase hex of a pubkey>:<d tag value>, <recommended relay URL, optional>]`
+    - for a non-tagged-replaceable event: `["a", <kind integer>:<32-bytes lowercase hex of a pubkey>:, <recommended relay URL, optional>]`
 
 As a convention, all single-letter (only english alphabet letters: a-z, A-Z) key tags are expected to be indexed by relays, such that it is possible, for example, to query or subscribe to events that reference the event `"5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36"` by using the `{"#e": ["5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36"]}` filter.
 
@@ -95,7 +95,7 @@ And also a convention for kind ranges that allow for easier experimentation and 
 - for kind `n` such that `1000 <= n < 10000`, events are **regular**, which means they're all expected to be stored by relays.
 - for kind `n` such that `10000 <= n < 20000 || n == 0 || n == 3`, events are **replaceable**, which means that, for each combination of `pubkey` and `kind`, only the latest event MUST be stored by relays, older versions MAY be discarded.
 - for kind `n` such that `20000 <= n < 30000`, events are **ephemeral**, which means they are not expected to be stored by relays.
-- for kind `n` such that `30000 <= n < 40000`, events are **parameterized replaceable**, which means that, for each combination of `pubkey`, `kind` and the `d` tag's first value, only the latest event MUST be stored by relays, older versions MAY be discarded.
+- for kind `n` such that `30000 <= n < 40000`, events are **tagged-replaceable**, which means that, for each combination of `pubkey`, `kind` and the `d` tag's first value, only the latest event MUST be stored by relays, older versions MAY be discarded.
 
 In case of replaceable events with the same timestamp, the event with the lowest id (first in lexical order) should be retained, and the other discarded.
 

--- a/15.md
+++ b/15.md
@@ -300,7 +300,7 @@ This event leverages naddr to enable comprehensive customization and sharing of 
 Bids are simply events of kind `1021` with a `content` field specifying the amount, in the currency of the auction. Bids must reference an auction.
 
 > [!NOTE]
-> Auctions can be edited as many times as desired (they are "parameterized replaceable events") by the author - even after the start_date, but they cannot be edited after they have received the first bid! This is enforced by the fact that bids reference the event ID of the auction (rather than the product UUID), which changes with every new version of the auctioned product. So a bid is always attached to one "version". Editing the auction after a bid would result in the new product losing the bid!
+> Auctions can be edited as many times as desired (they are "tagged-replaceable events") by the author - even after the start_date, but they cannot be edited after they have received the first bid! This is enforced by the fact that bids reference the event ID of the auction (rather than the product UUID), which changes with every new version of the auctioned product. So a bid is always attached to one "version". Editing the auction after a bid would result in the new product losing the bid!
 
 ### Event `1022`: Bid confirmation
 

--- a/19.md
+++ b/19.md
@@ -44,7 +44,7 @@ These possible standardized `TLV` types are indicated here:
     - for `nprofile` it will be the 32 bytes of the profile public key
     - for `nevent` it will be the 32 bytes of the event id
     - for `nrelay`, this is the relay URL
-    - for `naddr`, it is the identifier (the `"d"` tag) of the event being referenced. For non-parameterized replaceable events, use an empty string.
+    - for `naddr`, it is the identifier (the `"d"` tag) of the event being referenced. For non-tagged-replaceable events, use an empty string.
 - `1`: `relay`
   - for `nprofile`, `nevent` and `naddr`, _optionally_, a relay in which the entity (profile or event) is more likely to be found, encoded as ascii
   - this may be included multiple times

--- a/23.md
+++ b/23.md
@@ -6,7 +6,7 @@ Long-form Content
 
 `draft` `optional`
 
-This NIP defines `kind:30023` (a _parameterized replaceable event_) for long-form text content, generally referred to as "articles" or "blog posts". `kind:30024` has the same structure as `kind:30023` and is used to save long form drafts.
+This NIP defines `kind:30023` (a _tagged-replaceable event_) for long-form text content, generally referred to as "articles" or "blog posts". `kind:30024` has the same structure as `kind:30023` and is used to save long form drafts.
 
 "Social" clients that deal primarily with `kind:1` notes should not be expected to implement this NIP.
 
@@ -31,7 +31,7 @@ Other metadata fields can be added as tags to the event as necessary. Here we st
 
 ### Editability
 
-These articles are meant to be editable, so they should make use of the parameterized replaceability feature and include a `d` tag with an identifier for the article. Clients should take care to only publish and read these events from relays that implement that. If they don't do that they should also take care to hide old versions of the same article they may receive.
+These articles are meant to be editable, so they should make use of the tagged replaceability feature and include a `d` tag with an identifier for the article. Clients should take care to only publish and read these events from relays that implement that. If they don't do that they should also take care to hide old versions of the same article they may receive.
 
 ### Linking
 

--- a/29.md
+++ b/29.md
@@ -16,7 +16,7 @@ Normally a group will originally belong to one specific relay, but the community
 
 ## Relay-generated events
 
-Relays are supposed to generate the events that describe group metadata and group admins. These are parameterized replaceable events signed by the relay keypair directly, with the group _id_ as the `d` tag.
+Relays are supposed to generate the events that describe group metadata and group admins. These are tagged-replaceable events signed by the relay keypair directly, with the group _id_ as the `d` tag.
 
 ## Group identifier
 

--- a/33.md
+++ b/33.md
@@ -1,8 +1,8 @@
 NIP-33
 ======
 
-Parameterized Replaceable Events
---------------------------------
+Tagged Replaceable Events
+-------------------------
 
 `final` `mandatory`
 

--- a/38.md
+++ b/38.md
@@ -13,7 +13,7 @@ This NIP enables a way for users to share live statuses such as what music they 
 
 ## Live Statuses
 
-A special event with `kind:30315` "User Status" is defined as an *optionally expiring* _parameterized replaceable event_, where the `d` tag represents the status type:
+A special event with `kind:30315` "User Status" is defined as an *optionally expiring* _tagged-replaceable event_, where the `d` tag represents the status type:
 
 For example:
 
@@ -44,7 +44,7 @@ Two common status types are defined: `general` and `music`. `general` represent 
 
 Any other status types can be used but they are not defined by this NIP.
 
-The status MAY include an `r`, `p`, `e` or `a` tag linking to a URL, profile, note, or parameterized replaceable event.
+The status MAY include an `r`, `p`, `e` or `a` tag linking to a URL, profile, note, or tagged-replaceable event.
 
 # Client behavior
 

--- a/51.md
+++ b/51.md
@@ -16,7 +16,7 @@ When new items are added to an existing list, clients SHOULD append them to the 
 
 ## Standard lists
 
-Standard lists use non-parameterized replaceable events, meaning users may only have a single list of each kind. They have special meaning and clients may rely on them to augment a user's profile or browsing experience.
+Standard lists use non-tagged-replaceable events, meaning users may only have a single list of each kind. They have special meaning and clients may rely on them to augment a user's profile or browsing experience.
 
 For example, _mute list_ can contain the public keys of spammers and bad actors users don't want to see in their feeds or receive annoying notifications from.
 

--- a/52.md
+++ b/52.md
@@ -6,7 +6,7 @@ Calendar Events
 
 `draft` `optional`
 
-This specification defines calendar events representing an occurrence at a specific moment or between moments. These calendar events are _parameterized replaceable_ and deletable per [NIP-09](09.md).
+This specification defines calendar events representing an occurrence at a specific moment or between moments. These calendar events are _tagged-replaceable_ and deletable per [NIP-09](09.md).
 
 Unlike the term `calendar event` specific to this NIP, the term `event` is used broadly in all the NIPs to describe any Nostr event. The distinction is being made here to discern between the two terms.
 
@@ -20,7 +20,7 @@ This kind of calendar event starts on a date and ends before a different date in
 
 #### Format
 
-The format uses a parameterized replaceable event kind `31922`.
+The format uses a tagged-replaceable event kind `31922`.
 
 The `.content` of these events should be a detailed description of the calendar event. It is required but can be an empty string.
 
@@ -79,7 +79,7 @@ This kind of calendar event spans between a start time and end time.
 
 #### Format
 
-The format uses a parameterized replaceable event kind `31923`.
+The format uses a tagged-replaceable event kind `31923`.
 
 The `.content` of these events should be a detailed description of the calendar event. It is required but can be an empty string.
 
@@ -180,7 +180,7 @@ This NIP is also intentionally not defining what happens if a calendar event cha
 
 ### Format
 
-The format uses a parameterized replaceable event kind `31925`.
+The format uses a tagged-replaceable event kind `31925`.
 
 The `.content` of these events is optional and should be a free-form note that adds more context to this calendar event response.
 

--- a/53.md
+++ b/53.md
@@ -12,7 +12,7 @@ Service providers want to offer live activities to the Nostr network in such a w
 
 ### Live Event
 
-A special event with `kind:30311` "Live Event" is defined as a _parameterized replaceable event_ of public `p` tags. Each `p` tag SHOULD have a **displayable** marker name for the current role (e.g. `Host`, `Speaker`, `Participant`) of the user in the event and the relay information MAY be empty. This event will be constantly updated as participants join and leave the activity.
+A special event with `kind:30311` "Live Event" is defined as a _tagged-replaceable event_ of public `p` tags. Each `p` tag SHOULD have a **displayable** marker name for the current role (e.g. `Host`, `Speaker`, `Participant`) of the user in the event and the relay information MAY be empty. This event will be constantly updated as participants join and leave the activity.
 
 For example:
 

--- a/54.md
+++ b/54.md
@@ -6,7 +6,7 @@ Wiki
 
 `draft` `optional`
 
-This NIP defines `kind:30818` (a _parameterized replaceable event_) for long-form text content similar to [NIP-23](23.md), but with one important difference: articles are meant to be descriptions, or encyclopedia entries, of particular subjects, and it's expected that multiple people will write articles about the exact same subjects, with either small variations or completely independent content.
+This NIP defines `kind:30818` (a _tagged-replaceable event_) for long-form text content similar to [NIP-23](23.md), but with one important difference: articles are meant to be descriptions, or encyclopedia entries, of particular subjects, and it's expected that multiple people will write articles about the exact same subjects, with either small variations or completely independent content.
 
 Articles are identified by lowercase, normalized ascii `d` tags.
 

--- a/57.md
+++ b/57.md
@@ -36,7 +36,7 @@ A `zap request` is an event of kind `9734` that is _not_ published to relays, bu
 In addition, the event MAY include the following tags:
 
 - `e` is an optional hex-encoded event id. Clients MUST include this if zapping an event rather than a person.
-- `a` is an optional event coordinate that allows tipping parameterized replaceable events such as NIP-23 long-form notes.
+- `a` is an optional event coordinate that allows tipping tagged-replaceable events such as NIP-23 long-form notes.
 
 Example:
 

--- a/58.md
+++ b/58.md
@@ -9,11 +9,11 @@ Badges
 Three special events are used to define, award and display badges in
 user profiles:
 
-1. A "Badge Definition" event is defined as a parameterized replaceable event with kind `30009` having a `d` tag with a value that uniquely identifies the badge (e.g. `bravery`) published by the badge issuer. Badge definitions can be updated.
+1. A "Badge Definition" event is defined as a tagged-replaceable event with kind `30009` having a `d` tag with a value that uniquely identifies the badge (e.g. `bravery`) published by the badge issuer. Badge definitions can be updated.
 
 2. A "Badge Award" event is a kind `8` event with a single `a` tag referencing a "Badge Definition" event and one or more `p` tags, one for each pubkey the badge issuer wishes to award. Awarded badges are immutable and non-transferrable.
 
-3. A "Profile Badges" event is defined as a parameterized replaceable event
+3. A "Profile Badges" event is defined as a tagged-replaceable event
 with kind `30008` with a `d` tag with the value `profile_badges`.
 Profile badges contain an ordered list of pairs of `a` and `e` tags referencing a `Badge Definition` and a `Badge Award` for each badge to be displayed.
 

--- a/75.md
+++ b/75.md
@@ -53,11 +53,11 @@ The following tags are OPTIONAL.
 }
 ```
 
-The goal MAY include an `r` or `a` tag linking to a URL or parameterized replaceable event.
+The goal MAY include an `r` or `a` tag linking to a URL or tagged-replaceable event.
 
 The goal MAY include multiple beneficiary pubkeys by specifying [`zap` tags](57.md#appendix-g-zap-tag-on-other-events).
 
-Parameterized replaceable events can link to a goal by using a `goal` tag specifying the event id and an optional relay hint.
+Tagged-replaceable events can link to a goal by using a `goal` tag specifying the event id and an optional relay hint.
 
 ```json
 {
@@ -77,7 +77,7 @@ Clients MAY display funding goals on user profiles.
 
 When zapping a goal event, clients MUST include the relays in the `relays` tag of the goal event in the zap request `relays` tag.
 
-When zapping a parameterized replaceable event with a `goal` tag, clients SHOULD tag the goal event id in the `e` tag of the zap request.
+When zapping a tagged-replaceable event with a `goal` tag, clients SHOULD tag the goal event id in the `e` tag of the zap request.
 
 ## Use cases
 

--- a/78.md
+++ b/78.md
@@ -12,7 +12,7 @@ Even though interoperability is great, some apps do not want or do not need inte
 
 ## Nostr event
 
-This NIP specifies the use of event kind `30078` (parameterized replaceable event) with a `d` tag containing some reference to the app name and context -- or any other arbitrary string. `content` and other `tags` can be anything or in any format.
+This NIP specifies the use of event kind `30078` (tagged-replaceable event) with a `d` tag containing some reference to the app name and context -- or any other arbitrary string. `content` and other `tags` can be anything or in any format.
 
 ## Some use cases
 

--- a/99.md
+++ b/99.md
@@ -6,7 +6,7 @@ Classified Listings
 
 `draft` `optional`
 
-This NIP defines `kind:30402`: a parameterized replaceable event to describe classified listings that list any arbitrary product, service, or other thing for sale or offer and includes enough structured metadata to make them useful.
+This NIP defines `kind:30402`: a tagged-replaceable event to describe classified listings that list any arbitrary product, service, or other thing for sale or offer and includes enough structured metadata to make them useful.
 
 The category of classifieds includes a very broad range of physical goods, services, work opportunities, rentals, free giveaways, personals, etc. and is distinct from the more strictly structured marketplaces defined in [NIP-15](https://github.com/nostr-protocol/nips/blob/master/15.md) that often sell many units of specific products through very specific channels.
 


### PR DESCRIPTION
Because it's impossible to write and takes two minutes to say that other word, "tagged" is nicer. If you have a better name please let me know.