### PR TITLE
NIP-47: fix NWC connection string example

### DIFF
--- a/47.md
+++ b/47.md
@@ -95,7 +95,7 @@ The **client** should then store this connection and use it when the user wants 
 
 ### Example connection string
 ```sh
-nostr+walletconnect:b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4?relay=wss%3A%2F%2Frelay.damus.io&secret=71a8c14c1407c113601079c4302dab36460f0ccd0ad506f1f2dc73b5100e4f3c
+nostr+walletconnect://b889ff5b1513b641e2a139f661a661364979c5beee91842f8f0ef42ab558e9d4?relay=wss%3A%2F%2Frelay.damus.io&secret=71a8c14c1407c113601079c4302dab36460f0ccd0ad506f1f2dc73b5100e4f3c
 ```
 
 ## Commands


### PR DESCRIPTION
The format in the example given doesn't work with any of the Alby NWC tools.