### PR TITLE
nip46: abandon nip04 entirely and just use nip44

### DIFF
--- a/46.md
+++ b/46.md
@@ -72,12 +72,12 @@ _user_ passes this token to _remote-signer_, which then sends `connect` *respons
 {
     "kind": 24133,
     "pubkey": <local_keypair_pubkey>,
-    "content": <nip04(<request>)>,
+    "content": <nip44(<request>)>,
     "tags": [["p", <remote-signer-pubkey>]],
 }
 ```
 
-The `content` field is a JSON-RPC-like message that is [NIP-04](04.md) encrypted and has the following structure:
+The `content` field is a JSON-RPC-like message that is [NIP-44](44.md) encrypted and has the following structure:
 
 ```jsonc
 {
@@ -109,7 +109,7 @@ Each of the following are methods that the _client_ sends to the _remote-signer_
 
 ### Requested permissions
 
-The `connect` method may be provided with `optional_requested_permissions` for user convenience. The permissions are a comma-separated list of `method[:params]`, i.e. `nip04_encrypt,sign_event:4` meaning permissions to call `nip04_encrypt` and to call `sign_event` with `kind:4`. Optional parameter for `sign_event` is the kind number, parameters for other methods are to be defined later. Same permission format may be used for `perms` field of `metadata` in `nostrconnect://` string.
+The `connect` method may be provided with `optional_requested_permissions` for user convenience. The permissions are a comma-separated list of `method[:params]`, i.e. `nip44_encrypt,sign_event:4` meaning permissions to call `nip44_encrypt` and to call `sign_event` with `kind:4`. Optional parameter for `sign_event` is the kind number, parameters for other methods are to be defined later. Same permission format may be used for `perms` field of `metadata` in `nostrconnect://` string.
 
 ## Response Events `kind:24133`
 
@@ -118,13 +118,13 @@ The `connect` method may be provided with `optional_requested_permissions` for u
     "id": <id>,
     "kind": 24133,
     "pubkey": <remote-signer-pubkey>,
-    "content": <nip04(<response>)>,
+    "content": <nip44(<response>)>,
     "tags": [["p", <client-pubkey>]],
     "created_at": <unix timestamp in seconds>
 }
 ```
 
-The `content` field is a JSON-RPC-like message that is [NIP-04](04.md) encrypted and has the following structure:
+The `content` field is a JSON-RPC-like message that is [NIP-44](44.md) encrypted and has the following structure:
 
 ```json
 {
@@ -150,7 +150,7 @@ The `content` field is a JSON-RPC-like message that is [NIP-04](04.md) encrypted
 {
     "kind": 24133,
     "pubkey": "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86",
-    "content": nip04({
+    "content": nip44({
         "id": <random_string>,
         "method": "sign_event",
         "params": [json_stringified(<{
@@ -170,7 +170,7 @@ The `content` field is a JSON-RPC-like message that is [NIP-04](04.md) encrypted
 {
     "kind": 24133,
     "pubkey": "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
-    "content": nip04({
+    "content": nip44({
         "id": <random_string>,
         "result": json_stringified(<signed-event>)
     }),
@@ -224,4 +224,4 @@ The `<remote-signer-app-pubkey>` MAY be used to verify the domain from _remote-s
 
 _remote-signer_ MAY publish a NIP-89 `kind: 31990` event with `k` tag of `24133`, which MAY also include one or more `relay` tags and MAY include `nostrconnect_url` tag. The semantics of `relay` and `nostrconnect_url` tags are the same as in the section above.
 
-_client_ MAY improve UX by discovering _remote-signers_ using their `kind: 31990` events. _client_ MAY then pre-generate `nostrconnect://` strings for the _remote-signers_, and SHOULD in that case verify that `kind: 31990` event's author is mentioned in signer's `nostr.json?name=_` file as `<remote-signer-app-pubkey>`. 
+_client_ MAY improve UX by discovering _remote-signers_ using their `kind: 31990` events. _client_ MAY then pre-generate `nostrconnect://` strings for the _remote-signers_, and SHOULD in that case verify that `kind: 31990` event's author is mentioned in signer's `nostr.json?name=_` file as `<remote-signer-app-pubkey>`.


### PR DESCRIPTION
this is a placeholder PR that should only be merged once the full transition has happened.

| nip44 support   | decrypt | encrypt |
|-----------------|---------|---------|
| gossip          | ✔️      |  ✔️      |
| amethyst          | ✔️      |  ✔️      |
| highlighter          |✔️      |         | 
| snort          | ✔️      | ✔️        | 
| coracle          | ✔️    | ✔️     |
| flotilla          | ✔️    | ✔️     |
| welshman          | ✔️    | ✔️     |
| ndk             | ✔️       | ✔️       |
| nostrify          | ✔️      | ✔️        | 
| nostr-tools     | ✔️      |         |
| go-nostr        |  ✔️     |         |
| rust-nostr      | ✔️      |  ✔️      |
| nak             | ✔️       |         |
| nostr-login     | ✔️       |         |
| window.nostr.js | ✔️      |         |
| ditto           | ✔️      |         |
| amber        | ✔️      |  ✔️      |
| nsec.app | | |

can you edit this comment and include your library/app/etc?