### PR TITLE
NIP-13: Fix of otherwise unverifiable example event

### DIFF
--- a/13.md
+++ b/13.md
@@ -35,7 +35,7 @@ Example mined note
   "created_at": 1651794653,
   "kind": 1,
   "tags": [
-    ["nonce", "776797", "21"]
+    ["nonce", "776797", "20"]
   ],
   "content": "It's just me mining my own business",
   "sig": "284622fc0a3f4f1303455d5175f7ba962a3300d136085b9566801bc2e0699de0c7e31e44c81fb40ad9049173742e904713c3594a1da0fc5d2382a25c11aba977"


### PR DESCRIPTION
I'm reverting a change made by @arkin0x in commit: https://github.com/nostr-protocol/nips/commit/6fb9e54f7b4886272f7464aba2f0971543d8df40#diff-cb504c91ef546f76741fb8fd4c13b1f97e4b5ce2a9d78afa545fb6ec799e06c2L39 which renders the example event unverifiable because of a changed hash.

Please compare:
```python
import hashlib
import json

pubkey = "a48380f4cfcc1ad5378294fcac36439770f9c878dd880ffa94bb74ea54a6f243"
created_at = 1651794653
kind = 1
tags = [
    [
        "nonce",
        "776797",
        "20"
    ]
]
content = "It's just me mining my own business"

pre_event = [
    0,
    pubkey,
    created_at,
    kind,
    tags,
    content
]

serialized_event = json.dumps(pre_event, separators=(',', ':')) 
print(serialized_event)
event_hash = hashlib.sha256(serialized_event.encode('utf-8')).digest()
event_id = hashlib.sha256(serialized_event.encode('utf-8')).hexdigest()

print("Event ID: ", event_id)
```

> [0,"a48380f4cfcc1ad5378294fcac36439770f9c878dd880ffa94bb74ea54a6f243",1651794653,1,[["nonce","776797","20"]],"It's just me mining my own business"]
> Event ID:  000006d8c378af1779d2feebc7603a125d99eca0ccf1085959b307f64e5dd358

vs.:

```python
import hashlib
import json

pubkey = "a48380f4cfcc1ad5378294fcac36439770f9c878dd880ffa94bb74ea54a6f243"
created_at = 1651794653
kind = 1
tags = [
    [
        "nonce",
        "776797",
        "21"
    ]
]
content = "It's just me mining my own business"

pre_event = [
    0,
    pubkey,
    created_at,
    kind,
    tags,
    content
]

serialized_event = json.dumps(pre_event, separators=(',', ':')) 
print(serialized_event)
event_hash = hashlib.sha256(serialized_event.encode('utf-8')).digest()
event_id = hashlib.sha256(serialized_event.encode('utf-8')).hexdigest()

print("Event ID: ", event_id)
```

> [0,"a48380f4cfcc1ad5378294fcac36439770f9c878dd880ffa94bb74ea54a6f243",1651794653,1,[["nonce","776797","21"]],"It's just me mining my own business"]
> Event ID:  7a8fbde58cf8d24f1a8aba192636e4085ae085a2bda459fc17202cfe63660487