### PR TITLE
NIP-71: remove `aes-256-gcm` tag

### DIFF
--- a/71.md
+++ b/71.md
@@ -26,7 +26,6 @@ The list of tags are as follows:
 * `m` a string indicating the data type of the file. The [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) format must be used, and they should be lowercase.
 * `title` (required) title of the video
 * `"published_at"`, for the timestamp in unix seconds (stringified) of the first time the video was published
-* `"aes-256-gcm"` (optional)  key and nonce for AES-GCM encryption with tagSize always 128bits
 * `x` containing the SHA-256 hexencoded string of the file.
 * `size` (optional) size of file in bytes
 * `dim` (optional) size of file in pixels in the form `<width>x<height>`
@@ -62,7 +61,6 @@ The list of tags are as follows:
     ["url",<string with URI of file>],
     ["m", <MIME type>],
     ["x",<Hash SHA-256>],
-    ["aes-256-gcm",<key>, <iv>],
     ["size", <size of file in bytes>],
     ["duration", <duration of video in seconds>],
     ["dim", <size of file in pixels>],


### PR DESCRIPTION
For the same reason as #948.

> 1. No one seems to be using it.
> 2. People who wish to use encryption can now use the new NIP-44 scheme.
> 3. The existence of the tag as is creates more questions than solutions.