### PR TITLE
NIP-46, NIP-90: "encrypted" tag to indicate the encryption method used

### DIFF
--- a/46.md
+++ b/46.md
@@ -56,7 +56,7 @@ nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata
 {
     "kind": 24133,
     "pubkey": "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86",
-    "content": nip04({
+    "content": encrypt({
         "id": <random_string>,
         "method": "sign_event",
         "params": [json_stringified(<{
@@ -66,7 +66,10 @@ nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata
             created_at: 1714078911
         }>)]
     }),
-    "tags": [["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"]], // p-tags the remote user pubkey
+    "tags": [
+        ["p", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52"], // p-tags the remote user pubkey
+        ["encrypted", "nip04"] // specifies the encryption used
+    ],
 }
 ```
 
@@ -76,13 +79,32 @@ nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata
 {
     "kind": 24133,
     "pubkey": "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52",
-    "content": nip04({
+    "content": encrypt({
         "id": <random_string>,
         "result": json_stringified(<signed-event>)
     }),
-    "tags": [["p", "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86"]], // p-tags the local keypair pubkey
+    "tags": [
+        ["p", "eff37350d839ce3707332348af4549a96051bd695d3223af4aabce4993531d86"], // p-tags the local keypair pubkey
+        ["encrypted", "nip04"], // specifies the encryption used
+    ]
 }
 ```
+
+#### Encryption
+
+An `encrypted` tag MAY be included in kind 24133 events to specify the encryption method used.
+The tag is in the form:
+
+```
+["encrypted", "<encryption>"]
+```
+
+Where encryption is one of:
+
+- `nip04` - NIP-04 encryption
+- `nip44` - NIP-44 encryption
+
+If the tag is not included, the encryption method is assumed to be NIP-04 for backwards-compatibility.
 
 #### Diagram
 
@@ -95,8 +117,11 @@ nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata
     "id": <id>,
     "kind": 24133,
     "pubkey": <local_keypair_pubkey>,
-    "content": <nip04(<request>)>,
-    "tags": [["p", <remote_user_pubkey>]], // NB: in the `create_account` event, the remote signer pubkey should be `p` tagged.
+    "content": <encrypt(<request>)>,
+    "tags": [
+        ["p", <remote_user_pubkey>], // NB: in the `create_account` event, the remote signer pubkey should be `p` tagged.
+        ["encrypted", "nip04"]
+    ],
     "created_at": <unix timestamp in seconds>
 }
 ```
@@ -142,8 +167,8 @@ The `connect` method may be provided with `optional_requested_permissions` for u
     "id": <id>,
     "kind": 24133,
     "pubkey": <remote_signer_pubkey>,
-    "content": <nip04(<response>)>,
-    "tags": [["p", <local_keypair_pubkey>]],
+    "content": <encrypt(<response>)>,
+    "tags": [["p", <local_keypair_pubkey>], ["encrypted", "nip04"]],
     "created_at": <unix timestamp in seconds>
 }
 ```

--- a/90.md
+++ b/90.md
@@ -69,7 +69,15 @@ All tags are optional.
 
 ## Encrypted Params
 
-If the user wants to keep the input parameters a secret, they can encrypt the `i` and `param` tags with the service provider's 'p' tag and add it to the content field. Add a tag `encrypted` as tags. Encryption for private tags will use [NIP-04 - Encrypted Direct Message encryption](https://github.com/nostr-protocol/nips/blob/master/04.md), using the user's private and service provider's public key for the shared secret
+If the user wants to keep the input parameters a secret, they can encrypt the `i` and `param` tags with the service provider's 'p' tag and add it to the content field.
+
+Requests with encrypted content should include a tag like `["encrypted", <encryption>]`, where encryption is one of:
+
+- `nip04` for [NIP-04](https://github.com/nostr-protocol/nips/blob/master/04.md)
+- `nip44` for [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md)
+- if not provided (eg `["encrypted"]`), the encryption method is assumed to be `nip04` for backwards-compatibility.
+
+Encryption for private tags will use the user's private and service provider's public key for the shared secret.
 
 ```json
 [
@@ -91,7 +99,7 @@ This param data will be encrypted and added to the `content` field and `p` tag s
   "content": "BE2Y4xvS6HIY7TozIgbEl3sAHkdZoXyLRRkZv4fLPh3R7LtviLKAJM5qpkC7D6VtMbgIt4iNcMpLtpo...",
   "tags": [
     ["p", "04f74530a6ede6b24731b976b8e78fb449ea61f40ff10e3d869a3030c4edc91f"],
-    ["encrypted"]
+    ["encrypted", "nip04"]
   ],
   ...
 }
@@ -137,7 +145,7 @@ Add a tag encrypted to mark the output content as `encrypted`
     ["e", "<job-request-id>", "<relay-hint>"],
     ["p", "<customer's-pubkey>"],
     ["amount", "requested-payment-amount", "<optional-bolt11>"],
-    ["encrypted"]
+    ["encrypted", "nip04"]
   ],
   ...
 }


### PR DESCRIPTION
I remembered that NIP-90 has an "encrypted" tag with no value, and it got me thinking we could utilize that tag as a more general-purpose "hey the thing in the content is encrypted" indicator, for events that may or may not have encrypted data.

Then I realized, since it has no value, we could add a `"nip04" | "nip44"` to indicate the type of encryption used.

Then I realized we could also use this tag on NIP-46 to help ease the transition in https://github.com/nostr-protocol/nips/issues/1095 https://github.com/nostr-protocol/nips/pull/1248

As I'm typing this I realize, that we could also use this on NIP-51 lists which also have an "optionally encrypted" criteria, and might also want to benefit from knowing which encryption is used.

So basically it's one simple idea that solves a lot of problems.