### PR TITLE
Raise bar for NIP implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Please update these lists when proposing NIPs introducing new event kinds.
 
 ## Criteria for acceptance of NIPs
 
-1. They should be implemented in at least two clients and one relay -- when applicable.
+1. They should be fully implemented in at least two clients and one relay -- when applicable.
 2. They should make sense.
 3. They should be optional and backwards-compatible: care must be taken such that clients and relays that choose to not implement them do not stop working when interacting with the ones that choose to.
 4. There should be no more than one way of doing the same thing.


### PR DESCRIPTION
This PR clarifies the "client implementation" requirement. With NUDs, this will no longer really matter, but in the meantime I think it's important to be clear that adding render support for a kind to a popular client does not constitute "implementation".