### PR TITLE
Cashu Ecash Reaction

### DIFF
--- a/25.md
+++ b/25.md
@@ -73,3 +73,18 @@ content as an emoji if shortcode is specified.
 ```
 
 The content can be set only one `:shortcode:`. And emoji tag should be one.
+
+Cashu Ecash Reaction
+---------------------
+
+The client may also specify a Cashu Ecash token `cashu***` in the reaction content. This Ecash token should utilize P2PK ([NUT-11](https://github.com/cashubtc/nuts/blob/main/11.md)) and lock the token to the `pubkey` associated with the event being reacted to. Upon receiving the reaction content, the client is required to validate the DLEQ proof ([NUT-12](https://github.com/cashubtc/nuts/blob/main/12.md)).
+
+
+```json
+{
+  "kind": 7,
+  "content": "cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHBzOi8vODMzMy5zcGFjZTozMzM4IiwicHJvb2ZzIjpbeyJhbW91bnQiOjIsImlkIjoiMDA5YTFmMjkzMjUzZTQxZSIsInNlY3JldCI6IjQwNzkxNWJjMjEyYmU2MWE3N2UzZTZkMmFlYjRjNzI3OTgwYmRhNTFjZDA2YTZhZmMyOWUyODYxNzY4YTc4MzciLCJDIjoiMDJiYzkwOTc5OTdkODFhZmIyY2M3MzQ2YjVlNDM0NWE5MzQ2YmQyYTUwNmViNzk1ODU5OGE3MmYwY2Y4NTE2M2VhIn0seyJhbW91bnQiOjgsImlkIjoiMDA5YTFmMjkzMjUzZTQxZSIsInNlY3JldCI6ImZlMTUxMDkzMTRlNjFkNzc1NmIwZjhlZTBmMjNhNjI0YWNhYTNmNGUwNDJmNjE0MzNjNzI4YzcwNTdiOTMxYmUiLCJDIjoiMDI5ZThlNTA1MGI4OTBhN2Q2YzA5NjhkYjE2YmMxZDVkNWZhMDQwZWExZGUyODRmNmVjNjlkNjEyOTlmNjcxMDU5In1dfV0sInVuaXQiOiJzYXQiLCJtZW1vIjoiVGhhbmsgeW91LiJ9",
+  "pubkey": "79c2cae114ea28a981e7559b4fe7854a473521a8d22a66bbab9fa248eb820ff6",
+  "created_at": 1682790000
+}
+```


### PR DESCRIPTION
I propose adding Cashu ecash reaction to NIP25.

With ecash reaction, you can directly send Cashu ecash token to achieve a similar effect as Zap, and it's even simpler than Zap.

a) You don't need to set up a Lightning address.
b) You don't need a complex Zap flow.
c) And you don't rely on Lightning wallets to send Receipt events.

Any thoughts?

Cashu Ecash Reaction
---------------------

The client may also specify a Cashu Ecash token `cashu***` in the reaction content. This Ecash token should utilize P2PK ([NUT-11](https://github.com/cashubtc/nuts/blob/main/11.md)) and lock the token to the `pubkey` associated with the event being reacted to. Upon receiving the reaction content, the client is required to validate the DLEQ proof ([NUT-12](https://github.com/cashubtc/nuts/blob/main/12.md)).

```json
{
  "kind": 7,
  "content": "cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHBzOi8vODMzMy5zcGFjZTozMzM4IiwicHJvb2ZzIjpbeyJhbW91bnQiOjIsImlkIjoiMDA5YTFmMjkzMjUzZTQxZSIsInNlY3JldCI6IjQwNzkxNWJjMjEyYmU2MWE3N2UzZTZkMmFlYjRjNzI3OTgwYmRhNTFjZDA2YTZhZmMyOWUyODYxNzY4YTc4MzciLCJDIjoiMDJiYzkwOTc5OTdkODFhZmIyY2M3MzQ2YjVlNDM0NWE5MzQ2YmQyYTUwNmViNzk1ODU5OGE3MmYwY2Y4NTE2M2VhIn0seyJhbW91bnQiOjgsImlkIjoiMDA5YTFmMjkzMjUzZTQxZSIsInNlY3JldCI6ImZlMTUxMDkzMTRlNjFkNzc1NmIwZjhlZTBmMjNhNjI0YWNhYTNmNGUwNDJmNjE0MzNjNzI4YzcwNTdiOTMxYmUiLCJDIjoiMDI5ZThlNTA1MGI4OTBhN2Q2YzA5NjhkYjE2YmMxZDVkNWZhMDQwZWExZGUyODRmNmVjNjlkNjEyOTlmNjcxMDU5In1dfV0sInVuaXQiOiJzYXQiLCJtZW1vIjoiVGhhbmsgeW91LiJ9",
  "pubkey": "79c2cae114ea28a981e7559b4fe7854a473521a8d22a66bbab9fa248eb820ff6",
  "created_at": 1682790000
}
```