### PR TITLE
Local Relay list

### DIFF
--- a/51.md
+++ b/51.md
@@ -50,9 +50,16 @@ Aside from their main identifier, the `"d"` tag, sets can optionally have a `"ti
 | Bookmark sets | 30003 | user-defined bookmarks categories , for when bookmarks must be in labeled separate groups    | `"e"` (kind:1 notes), `"a"` (kind:30023 articles), `"t"` (hashtags), `"r"` (URLs) |
 | Curation sets | 30004 | groups of articles picked by users as interesting and/or belonging to the same category      | `"a"` (kind:30023 articles), `"e"` (kind:1 notes)                                 |
 | Curation sets | 30005 | groups of videos picked by users as interesting and/or belonging to the same category        | `"a"` (kind:34235 videos)                                                         |
+| Local Relays  | 30006 | device-based relay list                                                                      | `"relay"` (relay URLs), `"d"` sha256(DeviceID)                                    |
 | Interest sets | 30015 | interest topics represented by a bunch of "hashtags"                                         | `"t"` (hashtags)                                                                  |
 | Emoji sets    | 30030 | categorized emoji groups                                                                     | `"emoji"` (see [NIP-30](30.md))                                                   |
 | Release artifact sets | 30063 | groups of files of a software release  | `"e"` (kind:1063 [file metadata](94.md) events), `"i"` (application identifier, typically reverse domain notation), `"version"`  |
+
+Kind `30006`'s `d` tag is dependent on the operating system. The tag should be the `sha256` of the string as UTF-8 bytes from:
+- Win32/64: `MachineGuid` at registry `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography`
+- OSx: `IOPlatformUUID`
+- Linux: `/var/lib/dbus/machine-id`
+- Android: `Secure.ANDROID_ID`
 
 ## Deprecated standard lists
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `30002`       | Relay sets                 | [51](51.md)              |
 | `30003`       | Bookmark sets              | [51](51.md)              |
 | `30004`       | Curation sets              | [51](51.md)              |
-| `30005`       | Video sets              | [51](51.md)              |
+| `30005`       | Video sets                 | [51](51.md)              |
+| `30006`       | Local relay list           | [51](51.md)              |
 | `30008`       | Profile Badges             | [58](58.md)              |
 | `30009`       | Badge Definition           | [58](58.md)              |
 | `30015`       | Interest sets              | [51](51.md)              |


### PR DESCRIPTION
Adds a local relay list anchored by the device ID from each OS. Ideally, all apps installed on the same device/user can access that relay. 