### PR TITLE
More precisely document since/until bounds.

### DIFF
--- a/01.md
+++ b/01.md
@@ -125,7 +125,7 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
   "authors": <a list of lowercase pubkeys, the pubkey of an event must be one of these>,
   "kinds": <a list of a kind numbers>,
   "#<single-letter (a-zA-Z)>": <a list of tag values, for #e — a list of event ids, for #p — a list of pubkeys, etc.>,
-  "since": <an integer unix timestamp in seconds. Events must have a created_at >= this to pass>,
+  "since": <an integer unix timestamp in seconds. Events must have a created_at >= to this to pass>,
   "until": <an integer unix timestamp in seconds. Events must have a created_at <= to this to pass>,
   "limit": <maximum number of events relays SHOULD return in the initial query>
 }

--- a/01.md
+++ b/01.md
@@ -125,8 +125,8 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
   "authors": <a list of lowercase pubkeys, the pubkey of an event must be one of these>,
   "kinds": <a list of a kind numbers>,
   "#<single-letter (a-zA-Z)>": <a list of tag values, for #e — a list of event ids, for #p — a list of pubkeys, etc.>,
-  "since": <an integer unix timestamp in seconds, events must be newer than this to pass>,
-  "until": <an integer unix timestamp in seconds, events must be older than this to pass>,
+  "since": <an integer unix timestamp in seconds. Events must have a created_at >= this to pass>,
+  "until": <an integer unix timestamp in seconds. Events must have a created_at <= this to pass>,
   "limit": <maximum number of events relays SHOULD return in the initial query>
 }
 ```

--- a/01.md
+++ b/01.md
@@ -126,7 +126,7 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
   "kinds": <a list of a kind numbers>,
   "#<single-letter (a-zA-Z)>": <a list of tag values, for #e — a list of event ids, for #p — a list of pubkeys, etc.>,
   "since": <an integer unix timestamp in seconds. Events must have a created_at >= this to pass>,
-  "until": <an integer unix timestamp in seconds. Events must have a created_at <= this to pass>,
+  "until": <an integer unix timestamp in seconds. Events must have a created_at <= to this to pass>,
   "limit": <maximum number of events relays SHOULD return in the initial query>
 }
 ```


### PR DESCRIPTION
Lower in this document, this is expressed as "since <= created_at <= until".

But the English description said that these values had to be "newer than" or "older than".

These two were in conflict. I assume the inclusive behavior is the intended one, since that documentation was added later to clarify. This just makes both cases match.