### PR TITLE
Adds Order of results for NIP-50 Search

### DIFF
--- a/50.md
+++ b/50.md
@@ -26,9 +26,8 @@ Relays SHOULD interpret the query to the best of their ability and return events
 Relays SHOULD perform matching against `content` event field, and MAY perform
 matching against other fields if that makes sense in the context of a specific kind. 
 
-Results SHOULD be returned in the order of their matching score, not by the usual `.created_at`. 
-The `limit` filter SHOULD be applied after sorting by matching score.
-
+Results SHOULD be returned in descending order by quality of search result (as defined by the implementation),
+not by the usual `.created_at`. The `limit` filter SHOULD be applied after sorting by matching score.
 A query string may contain `key:value` pairs (two words separated by colon), these are extensions, relays SHOULD ignore 
 extensions they don't support.
 

--- a/50.md
+++ b/50.md
@@ -26,6 +26,9 @@ Relays SHOULD interpret the query to the best of their ability and return events
 Relays SHOULD perform matching against `content` event field, and MAY perform
 matching against other fields if that makes sense in the context of a specific kind. 
 
+Results SHOULD be returned in the order of their matching score, not by the usual `.created_at`. 
+The `limit` filter SHOULD be applied after sorting by matching score.
+
 A query string may contain `key:value` pairs (two words separated by colon), these are extensions, relays SHOULD ignore 
 extensions they don't support.
 


### PR DESCRIPTION
Searching for `fiatjaf` right now brings back the `n` most recent metadata changes. If clients limit by 100

```
["REQ", "mysub", {"kinds":[0],"limit":100,"search":"fiatjaf"}]
```

The results don't include @fiatjaf. 

Either NIP-50 relays are returning based on `.created_at` OR the scoring algorithm is not very good.

Pinging NIP-50 operators: @nostrband @nostr-wine @Semisol 