### PR TITLE
NIP-09: clarify "a" tag deletions

### DIFF
--- a/09.md
+++ b/09.md
@@ -32,6 +32,8 @@ Relays SHOULD delete or stop publishing any referenced events that have an ident
 
 Relays SHOULD continue to publish/share the deletion events indefinitely, as clients may already have the event that's intended to be deleted. Additionally, clients SHOULD broadcast deletion events to other relays which don't have it.
 
+When an `a` tag is used, relays SHOULD delete all versions of the replaceable event up to the `created_at` timestamp of the deletion event.
+
 ## Client Usage
 
 Clients MAY choose to fully hide any events that are referenced by valid deletion events.  This includes text notes, direct messages, or other yet-to-be defined event kinds.  Alternatively, they MAY show the event along with an icon or other indication that the author has "disowned" the event.  The `content` field MAY also be used to replace the deleted events' own content, although a user interface should clearly indicate that this is a deletion reason, not the original content.


### PR DESCRIPTION
Deleting a replaceable event is not well defined. It should delete all versions of the event up to the created_at timestamp of the deletion event itself, to allow the author to publish that kind of event in the future.