### PR TITLE
NIP-57: Clarify description tag

### DIFF
--- a/57.md
+++ b/57.md
@@ -131,7 +131,7 @@ The following should be true of the `zap receipt` event:
 - The `created_at` date SHOULD be set to the invoice `paid_at` date for idempotency.
 - `tags` MUST include the `p` tag (zap recipient) AND optional `e` tag from the `zap request` AND optional `a` tag from the `zap request` AND optional `P` tag from the pubkey of the zap request (zap sender).
 - The `zap receipt` MUST have a `bolt11` tag containing the description hash bolt11 invoice.
-- The `zap receipt` MUST contain a `description` tag which is the JSON-encoded invoice description.
+- The `zap receipt` MUST contain a `description` tag which is the JSON-encoded zap request.
 - `SHA256(description)` MUST match the description hash in the bolt11 invoice.
 - The `zap receipt` MAY contain a `preimage` tag to match against the payment hash of the bolt11 invoice. This isn't really a payment proof, there is no real way to prove that the invoice is real or has been paid. You are trusting the author of the `zap receipt` for the legitimacy of the payment.
 


### PR DESCRIPTION
The `description` tag includes the 9734 zap request event, writing "_JSON-encoded invoice description_" as it is seems confusing.