### PR TITLE
nip54: change to asciidoc

### DIFF
--- a/54.md
+++ b/54.md
@@ -28,13 +28,13 @@ Articles are identified by lowercase, normalized ascii `d` tags.
 
 ### Content rules
 
-The content should be Markdown, following the same rules as of [NIP-23](23.md), although it takes some extra (optional) metadata tags:
+The content should be Asciidoc, following the same rules as of [NIP-23](23.md), although it takes some extra (optional) metadata tags:
 
   - `title`: for when the display title should be different from the `d` tag.
   - `summary`: for display in lists.
   - `a` and `e`: for referencing the original event a wiki article was forked from.
 
-One extra functionality is added: **wikilinks**. Unlike normal Markdown links `[]()` that link to webpages, wikilinks `[[]]` link to other articles in the wiki. In this case, the wiki is the entirety of Nostr. Clicking on a wikilink should cause the client to ask relays for events with `d` tags equal to the target of that wikilink.
+One extra functionality is added: **wikilinks**. Unlike normal Asciidoc links `[]()` that link to webpages, wikilinks `[[]]` link to other articles in the wiki. In this case, the wiki is the entirety of Nostr. Clicking on a wikilink should cause the client to ask relays for events with `d` tags equal to the target of that wikilink.
 
 Wikilinks can take these two forms:
 
@@ -86,12 +86,12 @@ This is a stronger signal of trust than a `+` reaction.
 
 This marker is useful when a user edits someone else's entry; if the original author includes the editor's changes and the editor doesn't want to keep/maintain an independent version, the `link` tag could effectively be a considered a "deletion" of the editor's version and putting that pubkey's WoT weight behind the original author's version.
 
-Why Markdown?
+Why Asciidoc?
 -------------
 
-If the idea is to make a wiki then the most obvious text format to use is probably the mediawiki/wikitext format used by Wikipedia since it's widely deployed in all mediawiki installations and used for decades with great success. However, it turns out that format is very bloated and convoluted, has way too many features and probably because of that it doesn't have many alternative implementations out there, and the ones that exist are not complete and don't look very trustworthy. Also it is very much a centralized format that can probably be changed at the whims of the Wikipedia owners.
+Wikitext is [garbage](nostr:nevent1qqsqt0gcggry60n72uglhuhypdlmr2dm6swjj69jex5v530gcpazlzsprpmhxue69uhhyetvv9ujumn0wdmksetjv5hxxmmdqy28wumn8ghj7un9d3shjtnyv9kh2uewd9hsygpm7rrrljungc6q0tuh5hj7ue863q73qlheu4vywtzwhx42a7j9n5ueneex) and Markdown is not powerful enough (besides being too freeform and unspecified and prone to generate incompatibilities in the future).
 
-On the other hand, Markdown has proven to work well for small scale wikis and one of the biggest wikis in the planet (which is not very often thought of as a wiki), [StackOverflow](https://stackoverflow.com) and its child sites, and also one of the biggest "personal wiki" software, [Obsidian](https://obsidian.md/). Markdown can probably deliver 95% of the functionality of wikitext. When augmented with tables, diagram generators and MathJax (which are common extensions that exist in the wild and can be included in this NIP) that rate probably goes to 99%, and its simplicity is a huge benefit that can't be overlooked. Wikitext format can also be transpíled into Markdown using Pandoc. Given all that, I think it's a reasonable suspicion that mediawiki is not inherently better than Markdown, the success of Wikipedia probably cannot be predicated on the syntax language choice.
+Asciidoc has a strict spec, multiple implementations in many languages, and support for features that are very much necessary in a wiki article, like _sidebars_, _tables_ (with rich markup inside cells), many levels of _headings_, _footnotes_, _superscript_ and _subscript_ markup and _description lists_. It is also arguably easier to read in its plaintext format than Markdown (and certainly much better than Wikitext).
 
 # Appendix 1: Merge requests
 Users can request other users to get their entries merged into someone else's entry by creating a `kind:818` event.


### PR DESCRIPTION
== Why?

Because Markdown is somewhat of a mess. It's fine when you just use the core features, but when you start to add tables and other stuff it quickly degrades. And there had been talks already of how to add description lists, footnotes, sidebars and tables to these wiki articles so we would not be able to stick to mostly plain text anyway.

Asciidoc has a strict spec, multiple implementations in many languages, and support for features that are very much necessary in a wiki article, like _sidebars_, _tables_ (with rich markup inside cells), many levels of _headings_, _footnotes_, _superscript_ and _subscript_ markup and _description lists_. It is also arguably easier to read in its plaintext format than Markdown.

Read this if you're still not convinced: https://docs.asciidoctor.org/asciidoc/latest/asciidoc-vs-markdown/

Caveat: I don't have much experience with Asciidoc (if I had I might have proposed this NIP with Asciidoc since the beginning anyway).

Caveat: unfortunately Asciidoc is extensible, so it is not guaranteed that implementations will all implement the same extensions and stay compatible forever. However the extensions at least are well-delimited, named and specified and must be added explicitly by the developer (unlike on Markdown world where each library will add ad-hoc extensions by themselves), so that should be less bad. Also it's always clear when an extension is being used since its usage is delimited in tagged blocks in the source text. In any case I think we won't need any extensions for a long time.

== Migration path

Option 1:: Just drop Markdown support and be done with it. Everything will still be readable.
Option 2:: Documents created up to the date this document is merged should still be supported in the existing wiki clients. Documents with a higher timestamp shouldn't. Clients can drop Markdown support entirely in the future when that becomes a more reasonable idea.

@hzrd149 @pablof7z @SilberWitch 