### PR TITLE
Clarifies which relays to put in the zap request

### DIFF
--- a/57.md
+++ b/57.md
@@ -28,7 +28,7 @@ Having lightning receipts on nostr allows clients to display lightning payments 
 
 A `zap request` is an event of kind `9734` that is _not_ published to relays, but is instead sent to a recipient's lnurl pay `callback` url. This event's `content` MAY be an optional message to send along with the payment. The event MUST include the following tags:
 
-- `relays` is a list of relays the recipient's wallet should publish its `zap receipt` to. Note that relays should not be nested in an additional list, but should be included as shown in the example below.
+- `relays` is a list of relays the recipient's wallet should publish its `zap receipt` to. The list SHOULD include the recipient's READ relays from [NIP-65](65.md) as well as the post author's READ relays if they differ (e.g when paying zap splits)
 - `amount` is the amount in _millisats_ the sender intends to pay, formatted as a string. This is recommended, but optional.
 - `lnurl` is the lnurl pay url of the recipient, encoded using bech32 with the prefix `lnurl`. This is recommended, but optional.
 - `p` is the hex-encoded pubkey of the recipient.


### PR DESCRIPTION
When paying zap splits, the relay list of the zap request should include the post author so that the amount of received zaps can be counted as well as the inbox relays from each of the recipients so that they can receive notifications. 