### PR TITLE
Adds Proxy and Broadcasting relay lists.

### DIFF
--- a/74.md
+++ b/74.md
@@ -1,0 +1,41 @@
+NIP-74
+======
+
+Proxy and Broadcasting Relay Lists
+----------------------------------
+
+`draft` `optional`
+
+Kind `10017` indicates the user's preferred relays for proxy downloads. Such services save the user's bandwidth by utilizing a single connection to a proxy relay which reaches out to all of the other relays. 
+
+Kind `10018` indicates the user's preferred relays for broadcasting relays. Such services improve the user's privacy by utilizing a broadcasting relay to distribute an event to all of the appropriate relays without requiring the user to connect with each of those relays.
+
+Both events MUST include a list of `relay` URLs in private tags. Private tags are JSON Stringified, NIP-44-encrypted to the signer's keys and placed inside the `.content` of the event.
+
+```js
+{
+  "kind": 10017,
+  "tags": [],
+  "content": nip44Encrypt(JSON.stringify([
+    ["relay", "wss://myproxy.relay.com"]
+  ]))
+  //...other fields
+}
+```
+
+```js
+{
+  "kind": 10018,
+  "tags": [],
+  "content": nip44Encrypt(JSON.stringify([
+    ["relay", "wss://mybroadcaster.relay.com"]
+  ]))
+  //...other fields
+}
+```
+
+Clients SHOULD use proxy relays to download events before using it's native event-finding method.
+
+Clients SHOULD use broadcasting relays instead of the Client's own event publishing algorithms. 
+
+Clients SHOULD publish kind `10017` and `10018` events to the author's [NIP-65](65.md) `write` relays. 


### PR DESCRIPTION
Adds lists for specific proxy/broadcasting relays and guides clients on how to work with them. 

Read [here](https://github.com/vitorpamplona/nips/blob/broadcasting-proxy-relay-lists/74.md)