### PR TITLE
Adds key aliases to NIP-17

### DIFF
--- a/17.md
+++ b/17.md
@@ -108,6 +108,50 @@ It's advisable that users choose relays that conform to these practices.
 
 Clients SHOULD guide users to keep `kind:10050` lists small (1-3 relays) and SHOULD spread it to as many relays as viable.
 
+## Key Aliases
+
+Key Aliases hide the user's main key from the public gift wrap. 
+
+Key Alias Events use `kind:10059` replaceable events to privately inform peers of the set of pub keys a user is ALSO subscribing their GiftWrap filters with. The event MUST include a `p` tag for each active public key with an optional relay url to be used with that key. These keys work in addition to the user's main public key. The `relay` url MAY or MAY NOT be included in the user's private inbox relay list (i.e. kind `10050`),
+
+```js
+{
+  "pubkey": "<Author's Main PubKey>",
+  "kind": 10059,
+  "created_at": now(),
+  "tags": [
+    ["p", "<Pubkey Alias 1>", "<preferred relay url for alias 1>"]
+    ["p", "<Pubkey Alias 2>", "<preferred relay url for alias 2>"]
+    ["p", "<Pubkey Alias 3>", "<preferred relay url for alias 3>"]
+    ["expiration", "1600000000"] // optional
+  ]
+}
+```
+
+`kind:10059` MUST be unsigned, sealed, and gift-wrapped to each receiver individually. They MAY or MAY NOT contain the same aliases for every receiver.
+
+Receiving Clients SHOULD pick one of the keys listed as `p` tags in this event to use as `receiverPublicKey`. Both the wrap and the seal SHOULD be encrypted with this key.
+
+Receiving Clients SHOULD expect a rotation of these aliases and MUST not store past versions of this event.
+
+In order to decrypt incoming wraps, Sending Clients SHOULD store the private key for all pubkey aliases in an encrypted kind `10058` event. 
+
+```js
+{
+  "kind": 10058,
+  "tags": [],
+  "content": nip44Encrypt(JSON.stringify([
+    ["p", "<Pubkey Alias 1>", "<preferred relay url for alias 1>", "<Alias 1 private key in kex>"]
+    ["p", "<Pubkey Alias 2>", "<preferred relay url for alias 2>", "<Alias 2 private key in kex>"]
+    ["p", "<Pubkey Alias 3>", "<preferred relay url for alias 3>", "<Alias 3 private key in kex>"]
+    ["p", "<Pubkey Alias 4>", "<preferred relay url for alias 4>", "<Alias 4 private key in kex>"]
+    ["p", "<Pubkey Alias 5>", "<preferred relay url for alias 5>", "<Alias 5 private key in kex>"]
+  ]))
+}
+```
+
+Private tags are JSON Stringified, NIP-44-encrypted to the signer's keys and placed inside the `.content` of the event.
+
 ## Benefits & Limitations
 
 This NIP offers the following privacy and security features:


### PR DESCRIPTION
A simple way to: 
1. Remove the final metadata leak from NIP-17 (the public key of the receiver)
2. Distribute a stream of messages through multiple relays that are not publically advertised by the user. 
3. Control disappearing messages from others to you (just delete/rotate the alias private key). You can already control disappearing messages from you to others by adding the `expiration` tag to wraps.

Questions: 
- Should we add this to all Gift Wraps or just DMs?
- Should we offer more relay URL options per key or is one enough?