### PR TITLE
tags explanation revision

### DIFF
--- a/01.md
+++ b/01.md
@@ -71,7 +71,7 @@ Each tag is an array of one or more strings, with some conventions around them. 
 }
 ```
 
-The first element of the tag array is referred to as the tag _name_ or _key_, the second as the tag _value_, but the third and subsequent elements do not have conventional names. From the example above, we can say that the tag with the name `a` is set to the value `"30023:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:abcd"`, and has a third unnamed element with the value `"wss://nostr.example.com"`.
+The first element of the tag array is referred to as the tag _name_ or _key_, the second as the tag _value_, but the third and subsequent elements names depend on the type of tag. From the example above, the tag with the name `a` is set to the value `"30023:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:abcd"`, and has a third tag element with the value `"wss://nostr.example.com"`.
 
 This NIP defines 3 standard tags that can be used across all event kinds with the same meaning. They are as follows:
 

--- a/01.md
+++ b/01.md
@@ -71,7 +71,7 @@ Each tag is an array of one or more strings, with some conventions around them. 
 }
 ```
 
-The first element of the tag array is referred to as the tag _name_ or _key_, the second as the tag _value_, but the third and subsequent elements names depend on the type of tag. From the example above, the tag with the name `a` is set to the value `"30023:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:abcd"`, and has a third tag element with the value `"wss://nostr.example.com"`.
+The first element of the tag array is referred to as the tag _name_ or _key_, the second as the tag _value_, and the third and subsequent element names depend on the type of tag. From the example above, the tag with the name `a` is set to the value `"30023:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:abcd"`, and has a third tag element with the value `"wss://nostr.example.com"`.
 
 This NIP defines 3 standard tags that can be used across all event kinds with the same meaning. They are as follows:
 

--- a/01.md
+++ b/01.md
@@ -10,7 +10,7 @@ This NIP defines the basic protocol that should be implemented by everybody. New
 
 ## Events and signatures
 
-Each user has a keypair. Signatures, public key, and encodings are done according to the [Schnorr signatures standard for the curve `secp256k1`](https://bips.xyz/340).
+Each user has a key pair. Signatures, public key, and encodings are done according to the [Schnorr signatures standard for the curve `secp256k1`](https://bips.xyz/340).
 
 The only object type that exists is the `event`, which has the following format on the wire:
 
@@ -71,7 +71,7 @@ Each tag is an array of one or more strings, with some conventions around them. 
 }
 ```
 
-The first element of the tag array is referred to as the tag _name_ or _key_ and the second as the tag _value_. So we can safely say that the event above has an `e` tag set to `"5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36"`, an `alt` tag set to `"reply"` and so on. All elements after the second do not have a conventional name.
+The first element of the tag array is referred to as the tag _name_ or _key_, the second as the tag _value_, but the third and subsequent elements do not have conventional names. From the example above, we can say that the tag with the name `a` is set to the value `"30023:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:abcd"`, and has a third unnamed element with the value `"wss://nostr.example.com"`.
 
 This NIP defines 3 standard tags that can be used across all event kinds with the same meaning. They are as follows:
 


### PR DESCRIPTION
The explanation was a bit "jumpy" going from explaining element names, then to values, then back to names.

I made it clearer and flow better.

Also corrected 'keypair' to 'key pair'