### PR TITLE
NIP-60: Record Events

### DIFF
--- a/60.md
+++ b/60.md
@@ -1,0 +1,57 @@
+NIP-60
+======
+
+Record Events
+-------------
+
+`draft` `optional`
+
+This NIP defines a way for users to keep editable records about other people and events.
+
+## Pubkey Record
+
+A pubkey record is a kind 30082 event where the `d` tag points to the pubkey of another user.
+
+```js
+{
+  "kind": 30382,
+  "tags": [
+    ["d", "<pubkey>"],
+    ["n", "colleague"],
+    ["summary", "This is my boss"],
+    // other tags
+  ],
+  // other fields
+}
+```
+
+Any tags can be used. Specific tag uses may be formalized in other NIPs.
+
+The `content` field may be an empty string, or a NIP-44 encrypted tag list of private tags.
+
+## Event Record
+
+An event record is a kind 30083 event where the `d` tag points to the id of another event.
+
+```js
+{
+  "kind": 30383,
+  "tags": [
+    ["d", "<event-id>"],
+    ["k", "1984"],
+    ["p", "<event-pubkey>"],
+    ["n", "open"],
+    // other tags
+  ],
+  // other fields
+}
+```
+
+This event MUST include the following tags:
+
+- `k` - the kind of the referenced event.
+- `p` - the pubkey of the referenced event (for outbox support).
+
+Any other tags can also be used. Specific tag uses may be formalized in other NIPs.
+
+The `content` field may be an empty string, or a NIP-44 encrypted tag list of private tags.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-57: Lightning Zaps](57.md)
 - [NIP-58: Badges](58.md)
 - [NIP-59: Gift Wrap](59.md)
+- [NIP-60: Record Events](60.md)
 - [NIP-65: Relay List Metadata](65.md)
 - [NIP-71: Video Events](71.md)
 - [NIP-72: Moderated Communities](72.md)
@@ -177,6 +178,8 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `30078`       | Application-specific Data  | [78](78.md)              |
 | `30311`       | Live Event                 | [53](53.md)              |
 | `30315`       | User Statuses              | [38](38.md)              |
+| `30382`       | Pubkey Record              | [60](60.md)              |
+| `30383`       | Event Record               | [60](60.md)              |
 | `30402`       | Classified Listing         | [99](99.md)              |
 | `30403`       | Draft Classified Listing   | [99](99.md)              |
 | `30617`       | Repository announcements   | [34](34.md)              |


### PR DESCRIPTION
This is a new take on kind 30382 and 30383 events, originally defined in Event Sets: https://github.com/nostr-protocol/nips/pull/784 (Related: #761 #1321)

But it is a spec for generic records of pubkeys and event IDs, and it does not define `n` tags.

Read here: https://github.com/nostr-protocol/nips/blob/619ff20a871e4316ec59c2b211f20b4f8df26853/60.md

cc @arthurfranca @vitorpamplona 