### PR TITLE
Adds Reaction-based Polling

### DIFF
--- a/25.md
+++ b/25.md
@@ -71,3 +71,22 @@ content as an emoji if shortcode is specified.
 ```
 
 The content can be set only one `:shortcode:`. And emoji tag should be one.
+
+Polling
+-------
+
+Authors can request a reaction poll any event kind by using the tag `poll`. Supporting clients SHOULD present pool options as reaction options, tally and render results as part of the display of the event.
+
+For example:
+
+```js
+{
+  "kind": 1,
+  "content": "Do you folks like pizza?",
+  "tags": [
+    ["poll", "👍", "👎"]
+  ],
+  ...other fields
+}
+```
+

--- a/25.md
+++ b/25.md
@@ -90,3 +90,4 @@ For example:
 }
 ```
 
+Clients MAY offer to tally results by Web of Trust scores.


### PR DESCRIPTION
Adds a simple way to use reactions for polling. 

This is not for serious pools but for fun/social media ones: 
- It doesn't have a closing date because people can distort the tally by creating reaction events in the past anyway. 
- It doesn't have a central tallying place that can control and distort the results. It's whatever authors want to believe. 
- It doesn't pretend to address spam because there is no way to block spam on Nostr.

Example of use: https://njump.me/nevent1qqsdrt3lekgna5navscqd726pr7vnz8jhru6mwcmkeg7jpawafteyzczyr9utmmtq89arlazew26j48sfsu94ymvr2rwrwuuehev7r6wh6kvkqg894q

For reference: 
- Zap Polls are implemented on Amethyst and Snort https://github.com/nostr-protocol/nips/pull/320
- Member-only Form Polls are implemented on FormStr https://github.com/nostr-protocol/nips/pull/1190
- Multi-choice Polls were proposed on: https://github.com/nostr-protocol/nips/pull/148
- Multi-choice Replaceable Polls were proposed on: https://github.com/nostr-protocol/nips/pull/111/
