### PR TITLE
Adds Nostr Naming System (NNS)

### DIFF
--- a/97.md
+++ b/97.md
@@ -1,0 +1,77 @@
+NIP-97
+======
+
+Nostr Name System (NNS)
+-----------------------
+
+`draft` `optional`
+
+Event `30053` defines a DNS record for Nostr. `ip4` and `ip6` tags represent DNS's `A` records. 
+
+```jsonc
+{
+  "created_at": <Unix timestamp in seconds>,
+  "kind": 30053,
+  "tags": [
+    ["d", "<subdomain-like-name or empty for root>"],
+    // relays used by the community (w/optional marker)
+    ["ip4", "230.22.120.232"],
+    ["ip4", "230.22.120.233"], // mirrored servers / client-based load balancing
+    ["ip4", "230.22.120.234"], // mirrored servers / client-based load balancing
+
+    ["ip6", "FE80:0000:0000:0000:0202:B3FF:FE1E:8329"] // same content as ipv4
+  ],
+  ...
+}
+```
+
+Multiple pubkeys can point to the same IP address. 
+
+The server must reply with an IP-only request, such as: `wss://230.22.120.232` or `https://230.22.120.232`. 
+
+# Addressing
+
+[NIP-19](19.md)'s `naddr1` addresses of kind `30053` replace the domain name on any URL or URI. 
+
+Examples 
+- `http://naddr1...ccpzu/image.jpg` makes an http request for `https://<ip4>/image.jpg`
+- `wss://naddr1...ccpzu:443/` makes an websocket request at `wss://<ip4>:443/`
+
+The `naddr1`'s `relay` field SHOULD have the IP-based URI to the relay (e.g.: `wss://<ip4>/`) hosting the NNS record at the time of creating the `naddr1`.
+
+# Resolving
+
+Clients SHOULD intercept the DNS resolution of any `naddr1` domain name and resolve to IP using the latest version of the NNS replaceable event. 
+
+If the NNS event cannot be found locally, Clients SHOULD in parallel:  
+1. Connect to the IP in the `relay` field of the `naddr1` do download a potentially outdated version of the NNS record.
+2. Retrieve the latest version of this replaceable from the (NIP-65)[65.md] WRITE relays of the `naddr1`'s pubkey.
+
+# HTTP URLs (Media Servers)
+
+Clients SHOULD use the NNS address (e.g. `http://naddr1...ccpzu/<rest of the url>`), if available, instead of the regular domain name in all URLs, both in tags and in the content of events. 
+
+# Relay Hints
+
+Clients SHOULD use the NNS record (e.g. `wss://naddr1...ccpzu`), if available, instead of the regular domain name in all relay hints.
+
+# Relay Lists
+
+Clients SHOULD use the NNS record (e.g. `wss://naddr1...ccpzu`), if available, instead of the DNS in all relay lists.
+
+The NNS events to resolve those addresses MUST be broadcasted to the same relays as their kind `10002`
+
+For example: 
+
+```json
+{
+  "kind": 10002,
+  "tags": [
+    ["r", "wss://naddr1...ccpzu"],
+    ["r", "wss://naddr1...2d90k", "write"],
+    ["r", "wss://naddr1...um5wg", "read"]
+  ],
+  "content": "",
+  ...other fields
+}
+```

--- a/97.md
+++ b/97.md
@@ -8,20 +8,19 @@ Nostr Name System (NNS)
 
 Event `30053` defines a DNS record for Nostr. `ip4` and `ip6` tags represent DNS's `A` records. 
 
-```jsonc
+```js
 {
-  "created_at": <Unix timestamp in seconds>,
   "kind": 30053,
   "tags": [
     ["d", "<subdomain-like-name or empty for root>"],
-    // relays used by the community (w/optional marker)
+
     ["ip4", "230.22.120.232"],
     ["ip4", "230.22.120.233"], // mirrored servers / client-based load balancing
     ["ip4", "230.22.120.234"], // mirrored servers / client-based load balancing
 
     ["ip6", "FE80:0000:0000:0000:0202:B3FF:FE1E:8329"] // same content as ipv4
   ],
-  ...
+  // ...
 }
 ```
 
@@ -44,16 +43,39 @@ The `naddr1`'s `relay` field SHOULD have the IP-based URI to the relay (e.g.: `w
 Clients SHOULD intercept the DNS resolution of any `naddr1` domain name and resolve to IP using the latest version of the NNS replaceable event. 
 
 If the NNS event cannot be found locally, Clients SHOULD in parallel:  
-1. Connect to the IP in the `relay` field of the `naddr1` do download a potentially outdated version of the NNS record.
+1. Connect to the IP in the `relay` field of the `naddr1` to download a potentially outdated version of the NNS record.
 2. Retrieve the latest version of this replaceable from the (NIP-65)[65.md] WRITE relays of the `naddr1`'s pubkey.
 
 # HTTP URLs (Media Servers)
 
 Clients SHOULD use the NNS address (e.g. `http://naddr1...ccpzu/<rest of the url>`), if available, instead of the regular domain name in all URLs, both in tags and in the content of events. 
 
+For example, this loads an image without a domain name:
+
+```js
+  "kind": 1,
+  "tags": [],
+  "content": "NNS is amazing: http://naddr1...ccpzu/image.jpg",
+  // ...other fields
+}
+```
+
 # Relay Hints
 
 Clients SHOULD use the NNS record (e.g. `wss://naddr1...ccpzu`), if available, instead of the regular domain name in all relay hints.
+
+For example, this is a reply using an NNS relay hint
+
+```js
+{
+  "kind": 1,
+  "tags": [
+    ["e", "<event id>", "<wss://naddr1...ccpzu>", "root"],
+  ],
+  "content": "",
+  // ...other fields
+}
+```
 
 # Relay Lists
 
@@ -61,9 +83,9 @@ Clients SHOULD use the NNS record (e.g. `wss://naddr1...ccpzu`), if available, i
 
 The NNS events to resolve those addresses MUST be broadcasted to the same relays as their kind `10002`
 
-For example: 
+For example, this is a relay list using NNS addresses
 
-```json
+```js
 {
   "kind": 10002,
   "tags": [
@@ -72,6 +94,6 @@ For example:
     ["r", "wss://naddr1...um5wg", "read"]
   ],
   "content": "",
-  ...other fields
+  // ...other fields
 }
 ```


### PR DESCRIPTION
This offers a potential solution to the widespread use of the easily-capturable DNS-based references inside of Nostr. 

This is a long shot. It's not the only way to solve it, but it is a starting point. 

Read: [here](https://github.com/vitorpamplona/nips/blob/relay-hints-v2/97.md)