### PR TITLE
[NIP-96] Adding optional file_tags to categorize files and listing public files

### DIFF
--- a/96.md
+++ b/96.md
@@ -282,9 +282,10 @@ The successful response is a 200 OK one with just basic JSON fields:
 
 ## Listing files
 
-`GET $api_url?page=x&count=y&sort=z&search=w`
+`GET $api_url?page=x&count=y&sort=z&order=w&search=term`
 
 AUTH **required** for pubkey file listing.
+
 AUTH **NOT** required for public file listing.
 
 Returns a list of files. If auth event is present, the server should return only files uploaded by the pubkey in the auth event.
@@ -304,7 +305,7 @@ Example Response:
         ["size", "123456"],
         ["alt", "a meme that makes you laugh"],
         ["expiration",  "1715691139"],
-         ["file_tags", "cat, meme, funny, laugh"],
+        ["file_tags", "cat, meme, funny, laugh"],
         // ...other metadata
       ]
       "content": "haha funny meme", // caption
@@ -319,8 +320,13 @@ Example Response:
 
 ### Query args
 
-- `page` page number (`offset=page*count`)
-- `count` number of items per page
+- `page`   **REQUIRED** Page number (`offset=page*count`)
+- `count`  **REQUIRED** Number of items per page
+- `sort`   **OPTIONAL** Can be 'created_at' or 'size'. Default is 'created_at'.
+- `order`  **OPTIONAL** Page order 'ASC' or 'DESC'. Default is 'DESC'.
+- `search` **OPTIONAL** Search term. The server should search in the `alt` and `file_tags` fields.
+
+The server can or not support optional query args.
 
 ## Selecting a Server
 

--- a/96.md
+++ b/96.md
@@ -1,5 +1,7 @@
 # NIP-96
 
+
+
 ## HTTP File Storage Integration
 
 `draft` `optional`
@@ -102,6 +104,7 @@ List of form fields:
 - `media_type`: "avatar" or "banner". Informs the server if the file will be used as an avatar or banner. If absent, the server will interpret it as a normal upload, without special treatment.
 - `content_type`: mime type such as "image/jpeg". This is just a value the server can use to reject early if the mime type isn't supported.
 - `no_transform`: "true" asks server not to transform the file and serve the uploaded file as is, may be rejected.
+- `file_tags`: **RECOMMENDED** a comma-separated list of tags to be used by the server to categorize the file.
 
 Others custom form data fields may be used depending on specific `server` support.
 The `server` isn't required to store any metadata sent by `clients`.
@@ -164,9 +167,11 @@ The upload response is a json object as follows:
       // The server can but does not need to store this value.
       ["x", "543244319525d9d08dd69cb716a18158a249b7b3b3ec4bbde5435543acb34443"],
       // Optional. Recommended for helping clients to easily know file type before downloading it.
-      ["m", "image/png"]
+      ["m", "image/png"],
       // Optional. Recommended for helping clients to reserve an adequate UI space to show the file before downloading it.
-      ["dim", "800x600"]
+      ["dim", "800x600"],
+      // Optional. Accepted file tags from server for categorization
+      ["file_tags", "cat, meme, funny, laugh"],
       // ... other optional NIP-94 tags
     ],
     content: ""
@@ -277,11 +282,12 @@ The successful response is a 200 OK one with just basic JSON fields:
 
 ## Listing files
 
-`GET $api_url?page=x&count=y`
+`GET $api_url?page=x&count=y&sort=z&search=w`
 
-**AUTH required**
+AUTH **required** for pubkey file listing.
+AUTH **NOT** required for public file listing.
 
-Returns a list of files linked to the authenticated users pubkey.
+Returns a list of files. If auth event is present, the server should return only files uploaded by the pubkey in the auth event.
 
 Example Response:
 
@@ -298,6 +304,7 @@ Example Response:
         ["size", "123456"],
         ["alt", "a meme that makes you laugh"],
         ["expiration",  "1715691139"],
+         ["file_tags", "cat, meme, funny, laugh"],
         // ...other metadata
       ]
       "content": "haha funny meme", // caption


### PR DESCRIPTION
#### Objective
The objective of this proposal is to enhance the current file handling capabilities by introducing optional query parameters for categorizing and listing **public files**. This enhancement will provide users with more flexibility and control when interacting with files on the server.

#### Proposed Changes

`GET $api_url?page=x&count=y&sort=z&order=w&search=term`

1. **Adding Optional Query Parameters:**

    - `sort` : Determines the sorting criteria of the listed files. It can take values `'created_at'` or `'size'`. The default value is `'created_at'`.
    - `order` : Specifies the order of the listing, either `'ASC'` for ascending or `'DESC'` for descending. The default value is `'DESC'`.
    - `search` : Allows users to search for files based on a search term. The server should search in the `alt` and `file_tags` fields.

2. **Adding Optional `file_tags` Field When Uploading Files:**

    - The `file_tags` field will be an optional field during file upload, allowing users to specify tags for their files. Example usage: `["file_tags", "cat, meme, funny, laugh"]`.

2. **Authorization Requirements:**

    - AUTH **required** for **pubkey** file listing.
    - AUTH **NOT required** for **public** file listing.

#### Benefits

The introduction of these optional fields and parameters will enable more sophisticated file management and search capabilities. Specifically, it will allow clients to:

- **Categorize Files**: By adding `file_tags` during file upload, users can categorize their files more effectively, making it easier to organize and retrieve them later.
- **Enhanced Search**: The `search` parameter will allow users to search files using specific terms, filtering results based on the `alt` and `file_tags` fields. This will make it easier to find specific files, such as gifs of memes, quickly and efficiently.
- **Flexible Listing**: The `sort` and `order` parameters will provide users with the ability to customize the display order of their files, either by creation date or size, in ascending or descending order.

This is inspired by this note from @jb55, where he shares hisconcerns with the GIPHY service. With this small modification, NIP96 will allow media servers to provide this service, easily and with minimal modifications. 

https://nostrudel.ninja/#/n/nevent1qy88wumn8ghj7mn0wvhxcmmv9uq35amnwvaz7tms09exzmtfvshxv6tpw34xze3wvdhk6tcpzemhxue69uhhyetvv9ujumt0wd68ytnsw43z7qghwaehxw309aex2mrp0yh8qunfd4skctnwv46z7qg3waehxw309ahx7um5wghxcctwvshsz9thwden5te0wfjkccte9ejxzmt4wvhxjme0qyghwumn8ghj7mn0wd68ytnhd9hx2tcqyq4c095djx50q4mtz8xhzhmyhgyn3ezd6jclpg2l5hurnvy9j9wky647wzj

What do you think? @arthurfranca @v0l @vitorpamplona 
