### PR TITLE
[NIP-96] Adding Payment Requirements and payment_request Field

### DIFF
--- a/96.md
+++ b/96.md
@@ -319,9 +319,11 @@ Example Response:
 
 ## Payment required
 
-`servers` may require payment for file storage. In that case, the server SHOULD serve the normal response with a **402 Payment Required** status code and a the `payment_request` field filled with a LN invoice.
+Some servers may require payment for file storage. In that case, the server SHOULD serve the normal response with a **402 Payment Required** status code and a the `payment_request` field filled. The `payment_request` field MUST be a standard bolt11 invoice.
 
-Until the payment is done, the server SHOULD display a QR code in the url tag of the NIP-94 event response. When the payment is done, the server MUST swap the QR code for the uploaded file.
+Until the payment is done, the server SHOULD display a QR code (or another usefull information) in the url tag of the NIP-94 event response. When the payment is done, the server MUST swap the QR code for the uploaded file.
+
+Clients SHOULD check the `payment_request` field and display the QR code to the user if the field is present.
 
 ## Selecting a Server
 

--- a/96.md
+++ b/96.md
@@ -121,7 +121,7 @@ The `server` MUST link the user's `pubkey` string as the owner of the file so to
 - `413 Payload Too Large`: File size exceeds limit
 - `400 Bad Request`: Form data is invalid or not supported.
 - `403 Forbidden`: User is not allowed to upload or the uploaded file hash didnt match the hash included in the `Authorization` header `payload` tag.
-- `402 Payment Required`: Payment is required by the server, **this flow is undefined**.
+- `402 Payment Required`: Payment is required by the server, see [Payment required](#payment-required) section.
 
 The upload response is a json object as follows:
 
@@ -133,6 +133,8 @@ The upload response is a json object as follows:
   message: "Upload successful.",
   // Optional. See "Delayed Processing" section
   processing_url: "...",
+  // Optional. Required if payment is required
+  payment_request: "lnbc1...", 
   // This uses the NIP-94 event format but DO NOT need
   // to fill some fields like "id", "pubkey", "created_at" and "sig"
   //
@@ -314,6 +316,12 @@ Example Response:
 
 - `page` page number (`offset=page*count`)
 - `count` number of items per page
+
+## Payment required
+
+`servers` may require payment for file storage. In that case, the server SHOULD serve the normal response with a **402 Payment Required** status code and a the `payment_request` field filled with a LN invoice.
+
+Until the payment is done, the server SHOULD display a QR code in the url tag of the NIP-94 event response. When the payment is done, the server MUST swap the QR code for the uploaded file.
 
 ## Selecting a Server
 


### PR DESCRIPTION
#### Objective
The objective of this proposal is to introduce a payment requirement mechanism for file storage on the server, ensuring a smooth adaptation process for clients while maintaining backward compatibility.

#### Proposed Changes

1. **Using actual spec header:**

    - `402 Payment Required`: Payment is required by the server, see [Payment required](#payment-required) section.

2. **Adding a New Field to the Server's JSON Response:**

    - `payment_request`: A string representing a BOLT11 invoice, e.g., `"lnbc1..."`.

#### Payment Required

Some servers may require payment for file storage. In that case, the server SHOULD serve the normal response with a **402 Payment Required** status code and the `payment_request` field filled. The `payment_request` field MUST be a standard BOLT11 invoice.

Until the payment is completed, the server SHOULD display a QR code (or another useful information) in the URL tag of the NIP-94 event response. When the payment is done, the server MUST swap the QR code for the uploaded file.

Clients SHOULD check the `payment_request` field and display the QR code to the user if the field is present.

#### Example

Here is an example of a QR code generated by nostrcheck-server for the `payment_request`:

![QR Code Example](https://example.com/qr-code.png)

#### Compatibility

This proposal maintains backward compatibility. If a client does not adopt this change but a server requires payment for its services, the resulting URL will display the QR code until someone pays the invoice. This ensures a smooth adaptation process for clients, as the system will function correctly without breaking existing functionality.
