### PR TITLE
NIP 51: Adds Kind 10011 Profile Gallery

### DIFF
--- a/51.md
+++ b/51.md
@@ -29,7 +29,8 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | Public chats      | 10005 | [NIP-28](28.md) chat channels the user is in                | `"e"` (kind:40 channel definitions)                                               |
 | Blocked relays    | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                            |
 | Search relays     | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                            |
-| Simple groups     | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group ids + mandatory relay URL)                       |
+| Simple groups     | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group ids + mandatory relay URL)     
+| Profile Gallery   | 10011 | Profile Media Gallery                                       | `"g"` (gallery entry), (kind:1 notes), (url to media file)|
 | Interests         | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a"` (kind:30015 interest set)                              |
 | Emojis            | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                  |
 | Good wiki authors | 10101 | [NIP-54](54.md) user recommended wiki authors               | `"p"` (pubkeys)                                                                   |

--- a/51.md
+++ b/51.md
@@ -30,7 +30,7 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | Blocked relays    | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                            |
 | Search relays     | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                            |
 | Simple groups     | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group ids + mandatory relay URL)     
-| Profile Gallery   | 10011 | Profile Media Gallery                                       | `"g"` + (kind:1 notes) + (url to media file)
+| Profile Gallery   | 10011 | Profile Media Gallery                                       | `"r"` + (kind:1 notes) + (url to media file)
 | Interests         | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a"` (kind:30015 interest set)                              |
 | Emojis            | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                  |
 | Good wiki authors | 10101 | [NIP-54](54.md) user recommended wiki authors               | `"p"` (pubkeys)                                                                   |

--- a/51.md
+++ b/51.md
@@ -30,7 +30,7 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | Blocked relays    | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                            |
 | Search relays     | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                            |
 | Simple groups     | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group ids + mandatory relay URL)                       |
-| Profile Gallery   | 10011 | Profile Media Gallery                                       | `"G"` + (kind:1 notes) + (url to media file)                                |
+| Profile Gallery   | 10011 | Profile Media Gallery                                       | `"url"` + (url to media file) + (kind:1 note) + (relay hint)                      |
 | Interests         | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a"` (kind:30015 interest set)                              |
 | Emojis            | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                  |
 | Good wiki authors | 10101 | [NIP-54](54.md) user recommended wiki authors               | `"p"` (pubkeys)                                                                   |
@@ -53,7 +53,7 @@ Aside from their main identifier, the `"d"` tag, sets can optionally have a `"ti
 | Curation sets | 30005 | groups of videos picked by users as interesting and/or belonging to the same category        | `"a"` (kind:34235 videos)                                                         |
 | Interest sets | 30015 | interest topics represented by a bunch of "hashtags"                                         | `"t"` (hashtags)                                                                  |
 | Emoji sets    | 30030 | categorized emoji groups                                                                     | `"emoji"` (see [NIP-30](30.md))                                                   |
-| Release artifact sets | 30063 | groups of files of a software release  | `"e"` (kind:1063 [file metadata](94.md) events), `"i"` (application identifier, typically reverse domain notation), `"version"`  |
+| Release artifact sets | 30063 | groups of files of a software release  | `"e"` (kind:1063 [file metadata](94.md) events), `"i"` (application identifier, typically reverse domain notation), `"version"` |
 
 ## Deprecated standard lists
 

--- a/51.md
+++ b/51.md
@@ -30,7 +30,7 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | Blocked relays    | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                            |
 | Search relays     | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                            |
 | Simple groups     | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group ids + mandatory relay URL)     
-| Profile Gallery   | 10011 | Profile Media Gallery                                       | `"g"` (gallery entry), (kind:1 notes), (url to media file)|
+| Profile Gallery   | 10011 | Profile Media Gallery                                       | `"g"` + (kind:1 notes) + (url to media file)
 | Interests         | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a"` (kind:30015 interest set)                              |
 | Emojis            | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                  |
 | Good wiki authors | 10101 | [NIP-54](54.md) user recommended wiki authors               | `"p"` (pubkeys)                                                                   |

--- a/51.md
+++ b/51.md
@@ -21,7 +21,7 @@ Standard lists use non-parameterized replaceable events, meaning users may only 
 For example, _mute list_ can contain the public keys of spammers and bad actors users don't want to see in their feeds or receive annoying notifications from.
 
 | name              | kind  | description                                                 | expected tag items                                                                |
-| ---               | ---   | ---                                                         | ---                                                                               |
+|-------------------|-------|-------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | Mute list         | 10000 | things the user doesn't want to see in their feeds          | `"p"` (pubkeys), `"t"` (hashtags), `"word"` (lowercase string), `"e"` (threads)   |
 | Pinned notes      | 10001 | events the user intends to showcase in their profile page   | `"e"` (kind:1 notes)                                                              |
 | Bookmarks         | 10003 | uncategorized, "global" list of things a user wants to save | `"e"` (kind:1 notes), `"a"` (kind:30023 articles), `"t"` (hashtags), `"r"` (URLs) |
@@ -29,8 +29,8 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | Public chats      | 10005 | [NIP-28](28.md) chat channels the user is in                | `"e"` (kind:40 channel definitions)                                               |
 | Blocked relays    | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                            |
 | Search relays     | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                            |
-| Simple groups     | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group ids + mandatory relay URL)     
-| Profile Gallery   | 10011 | Profile Media Gallery                                       | `"gallery"` + (kind:1 notes) + (url to media file)
+| Simple groups     | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group ids + mandatory relay URL)                       |
+| Profile Gallery   | 10011 | Profile Media Gallery                                       | `"gallery"` + (kind:1 notes) + (url to media file)                                |
 | Interests         | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a"` (kind:30015 interest set)                              |
 | Emojis            | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                  |
 | Good wiki authors | 10101 | [NIP-54](54.md) user recommended wiki authors               | `"p"` (pubkeys)                                                                   |

--- a/51.md
+++ b/51.md
@@ -30,7 +30,7 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | Blocked relays    | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                            |
 | Search relays     | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                            |
 | Simple groups     | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group ids + mandatory relay URL)     
-| Profile Gallery   | 10011 | Profile Media Gallery                                       | `"r"` + (kind:1 notes) + (url to media file)
+| Profile Gallery   | 10011 | Profile Media Gallery                                       | `"gallery"` + (kind:1 notes) + (url to media file)
 | Interests         | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a"` (kind:30015 interest set)                              |
 | Emojis            | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                  |
 | Good wiki authors | 10101 | [NIP-54](54.md) user recommended wiki authors               | `"p"` (pubkeys)                                                                   |

--- a/51.md
+++ b/51.md
@@ -30,7 +30,7 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | Blocked relays    | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                            |
 | Search relays     | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                            |
 | Simple groups     | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group ids + mandatory relay URL)                       |
-| Profile Gallery   | 10011 | Profile Media Gallery                                       | `"gallery"` + (kind:1 notes) + (url to media file)                                |
+| Profile Gallery   | 10011 | Profile Media Gallery                                       | `"G"` + (kind:1 notes) + (url to media file)                                |
 | Interests         | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a"` (kind:30015 interest set)                              |
 | Emojis            | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                  |
 | Good wiki authors | 10101 | [NIP-54](54.md) user recommended wiki authors               | `"p"` (pubkeys)                                                                   |


### PR DESCRIPTION
A Profile Gallery is predefined List containing "G" tags. ["G", eventid, urltomediafile]. 
A User might add media (images, videos etc) and the eventid where the media appears to the list. Clients can render these for example as galleries in the User's profile and reference to the original Note. 
Capital G as g is taken for geotags