### PR TITLE
fix some info of nip55 to be same as other nips

### DIFF
--- a/55.md
+++ b/55.md
@@ -99,10 +99,10 @@ launcher.launch(intent)
     context.startActivity(intent)
     ```
   - result:
-    - If the user approved intent it will return the **npub** in the signature field
+    - If the user approved intent it will return the **pubkey** in the signature field
 
       ```kotlin
-      val npub = intent.data?.getStringExtra("signature")
+      val pubkey = intent.data?.getStringExtra("signature")
       // The package name of the signer application
       val packageName = intent.data?.getStringExtra("package")
       ```
@@ -116,8 +116,8 @@ launcher.launch(intent)
     intent.putExtra("type", "sign_event")
     // To handle results when not waiting between intents
     intent.putExtra("id", event.id)
-    // Send the current logged in user npub
-    intent.putExtra("current_user", npub)
+    // Send the current logged in user pubkey
+    intent.putExtra("current_user", pubkey)
 
     context.startActivity(intent)
     ```
@@ -140,10 +140,10 @@ launcher.launch(intent)
     intent.putExtra("type", "nip04_encrypt")
     // to control the result in your application in case you are not waiting the result before sending another intent
     intent.putExtra("id", "some_id")
-    // Send the current logged in user npub
-    intent.putExtra("current_user", account.keyPair.pubKey.toNpub())
-    // Send the hex pubKey that will be used for encrypting the data
-    intent.putExtra("pubKey", pubKey)
+    // Send the current logged in user pubkey
+    intent.putExtra("current_user", account.keyPair.pubkey)
+    // Send the hex pubkey that will be used for encrypting the data
+    intent.putExtra("pubkey", pubkey)
 
     context.startActivity(intent)
     ```
@@ -165,10 +165,10 @@ launcher.launch(intent)
     intent.putExtra("type", "nip44_encrypt")
     // to control the result in your application in case you are not waiting the result before sending another intent
     intent.putExtra("id", "some_id")
-    // Send the current logged in user npub
-    intent.putExtra("current_user", account.keyPair.pubKey.toNpub())
-    // Send the hex pubKey that will be used for encrypting the data
-    intent.putExtra("pubKey", pubKey)
+    // Send the current logged in user pubkey
+    intent.putExtra("current_user", account.keyPair.pubkey)
+    // Send the hex pubkey that will be used for encrypting the data
+    intent.putExtra("pubkey", pubkey)
 
     context.startActivity(intent)
     ```
@@ -190,10 +190,10 @@ launcher.launch(intent)
     intent.putExtra("type", "nip04_decrypt")
     // to control the result in your application in case you are not waiting the result before sending another intent
     intent.putExtra("id", "some_id")
-    // Send the current logged in user npub
-    intent.putExtra("current_user", account.keyPair.pubKey.toNpub())
-    // Send the hex pubKey that will be used for decrypting the data
-    intent.putExtra("pubKey", pubKey)
+    // Send the current logged in user pubkey
+    intent.putExtra("current_user", account.keyPair.pubkey)
+    // Send the hex pubkey that will be used for decrypting the data
+    intent.putExtra("pubkey", pubkey)
 
     context.startActivity(intent)
     ```
@@ -215,10 +215,10 @@ launcher.launch(intent)
     intent.putExtra("type", "nip04_decrypt")
     // to control the result in your application in case you are not waiting the result before sending another intent
     intent.putExtra("id", "some_id")
-    // Send the current logged in user npub
-    intent.putExtra("current_user", account.keyPair.pubKey.toNpub())
-    // Send the hex pubKey that will be used for decrypting the data
-    intent.putExtra("pubKey", pubKey)
+    // Send the current logged in user pubkey
+    intent.putExtra("current_user", account.keyPair.pubkey)
+    // Send the hex pubkey that will be used for decrypting the data
+    intent.putExtra("pubkey", pubkey)
 
     context.startActivity(intent)
     ```
@@ -227,6 +227,29 @@ launcher.launch(intent)
 
       ```kotlin
       val plainText = intent.data?.getStringExtra("signature")
+      // the id you sent
+      val id = intent.data?.getStringExtra("id")
+      ```
+
+- **get_relays**
+  - params:
+
+    ```kotlin
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("nostrsigner:"))
+    intent.`package` = "com.example.signer"
+    intent.putExtra("type", "get_relays")
+    // to control the result in your application in case you are not waiting the result before sending another intent
+    intent.putExtra("id", "some_id")
+    // Send the current logged in user pubkey
+    intent.putExtra("current_user", account.keyPair.pubkey)
+
+    context.startActivity(intent)
+    ```
+  - result:
+    - If the user approved intent it will return the **signature** and **id** fields
+
+      ```kotlin
+      val relayJsonText = intent.data?.getStringExtra("signature")
       // the id you sent
       val id = intent.data?.getStringExtra("id")
       ```
@@ -240,8 +263,8 @@ launcher.launch(intent)
     intent.putExtra("type", "decrypt_zap_event")
     // to control the result in your application in case you are not waiting the result before sending another intent
     intent.putExtra("id", "some_id")
-    // Send the current logged in user npub
-    intent.putExtra("current_user", account.keyPair.pubKey.toNpub())
+    // Send the current logged in user pubkey
+    intent.putExtra("current_user", account.keyPair.pubkey)
     context.startActivity(intent)
     ```
   - result:
@@ -257,7 +280,7 @@ launcher.launch(intent)
 
 To get the result back from Signer Application you should use contentResolver.query in Kotlin. If you are using another framework check the documentation of your framework or a third party library to get the result.
 
-If the user did not check the "remember my choice" option, the npub is not in Signer Application or the signer type is not recognized the `contentResolver` will return null
+If the user did not check the "remember my choice" option, the pubkey is not in Signer Application or the signer type is not recognized the `contentResolver` will return null
 
 For the SIGN_EVENT type Signer Application returns two columns "signature" and "event". The column event is the signed event json
 
@@ -280,7 +303,7 @@ If the user chose to always reject the event, signer application will return the
     )
     ```
   - result:
-    - Will return the **npub** in the signature column
+    - Will return the **pubkey** in the signature column
 
       ```kotlin
         if (result == null) return
@@ -288,7 +311,7 @@ If the user chose to always reject the event, signer application will return the
         if (result.moveToFirst()) {
             val index = it.getColumnIndex("signature")
             if (index < 0) return
-            val npub = it.getString(index)
+            val pubkey = it.getString(index)
         }
       ```
 
@@ -298,7 +321,7 @@ If the user chose to always reject the event, signer application will return the
     ```kotlin
     val result = context.contentResolver.query(
         Uri.parse("content://com.example.signer.SIGN_EVENT"),
-        listOf("$eventJson", "", "${logged_in_user_npub}"),
+        listOf("$eventJson", "", "${logged_in_user_pubkey}"),
         null,
         null,
         null
@@ -324,7 +347,7 @@ If the user chose to always reject the event, signer application will return the
     ```kotlin
     val result = context.contentResolver.query(
         Uri.parse("content://com.example.signer.NIP04_ENCRYPT"),
-        listOf("$plainText", "${hex_pub_key}", "${logged_in_user_npub}"),
+        listOf("$plainText", "${hex_pub_key}", "${logged_in_user_pubkey}"),
         null,
         null,
         null
@@ -348,7 +371,7 @@ If the user chose to always reject the event, signer application will return the
     ```kotlin
     val result = context.contentResolver.query(
         Uri.parse("content://com.example.signer.NIP44_ENCRYPT"),
-        listOf("$plainText", "${hex_pub_key}", "${logged_in_user_npub}"),
+        listOf("$plainText", "${hex_pub_key}", "${logged_in_user_pubkey}"),
         null,
         null,
         null
@@ -372,7 +395,7 @@ If the user chose to always reject the event, signer application will return the
     ```kotlin
     val result = context.contentResolver.query(
         Uri.parse("content://com.example.signer.NIP04_DECRYPT"),
-        listOf("$encryptedText", "${hex_pub_key}", "${logged_in_user_npub}"),
+        listOf("$encryptedText", "${hex_pub_key}", "${logged_in_user_pubkey}"),
         null,
         null,
         null
@@ -396,7 +419,7 @@ If the user chose to always reject the event, signer application will return the
     ```kotlin
     val result = context.contentResolver.query(
         Uri.parse("content://com.example.signer.NIP44_DECRYPT"),
-        listOf("$encryptedText", "${hex_pub_key}", "${logged_in_user_npub}"),
+        listOf("$encryptedText", "${hex_pub_key}", "${logged_in_user_pubkey}"),
         null,
         null,
         null
@@ -414,13 +437,37 @@ If the user chose to always reject the event, signer application will return the
         }
       ```
 
+- **get_relays**
+  - params:
+
+    ```kotlin
+    val result = context.contentResolver.query(
+        Uri.parse("content://com.example.signer.GET_RELAYS"),
+        listOf("${logged_in_user_pubkey}"),
+        null,
+        null,
+        null
+    )
+    ```
+  - result:
+    - Will return the **signature** column
+
+      ```kotlin
+        if (result == null) return
+
+        if (result.moveToFirst()) {
+            val index = it.getColumnIndex("signature")
+            val relayJsonText = it.getString(index)
+        }
+      ```
+
 - **decrypt_zap_event**
   - params:
 
     ```kotlin
     val result = context.contentResolver.query(
         Uri.parse("content://com.example.signer.DECRYPT_ZAP_EVENT"),
-        listOf("$eventJson", "", "${logged_in_user_npub}"),
+        listOf("$eventJson", "", "${logged_in_user_pubkey}"),
         null,
         null,
         null
@@ -470,28 +517,35 @@ Android intents and browser urls have limitations, so if you are using the `retu
   - params:
 
     ```js
-    window.href = `nostrsigner:${plainText}?pubKey=${hex_pub_key}&compressionType=none&returnType=signature&type=nip04_encrypt&callbackUrl=https://example.com/?event=`;
+    window.href = `nostrsigner:${plainText}?pubkey=${hex_pub_key}&compressionType=none&returnType=signature&type=nip04_encrypt&callbackUrl=https://example.com/?event=`;
     ```
 
 - **nip44_encrypt**
   - params:
 
     ```js
-    window.href = `nostrsigner:${plainText}?pubKey=${hex_pub_key}&compressionType=none&returnType=signature&type=nip44_encrypt&callbackUrl=https://example.com/?event=`;
+    window.href = `nostrsigner:${plainText}?pubkey=${hex_pub_key}&compressionType=none&returnType=signature&type=nip44_encrypt&callbackUrl=https://example.com/?event=`;
     ```
 
 - **nip04_decrypt**
   - params:
 
     ```js
-    window.href = `nostrsigner:${encryptedText}?pubKey=${hex_pub_key}&compressionType=none&returnType=signature&type=nip04_decrypt&callbackUrl=https://example.com/?event=`;
+    window.href = `nostrsigner:${encryptedText}?pubkey=${hex_pub_key}&compressionType=none&returnType=signature&type=nip04_decrypt&callbackUrl=https://example.com/?event=`;
     ```
 
 - **nip44_decrypt**
   - params:
 
     ```js
-    window.href = `nostrsigner:${encryptedText}?pubKey=${hex_pub_key}&compressionType=none&returnType=signature&type=nip44_decrypt&callbackUrl=https://example.com/?event=`;
+    window.href = `nostrsigner:${encryptedText}?pubkey=${hex_pub_key}&compressionType=none&returnType=signature&type=nip44_decrypt&callbackUrl=https://example.com/?event=`;
+    ```
+
+- **get_relays**
+  - params:
+
+    ```js
+    window.href = `nostrsigner:?compressionType=none&returnType=signature&type=get_relays&callbackUrl=https://example.com/?event=`;
     ```
 
 - **decrypt_zap_event**


### PR DESCRIPTION
# fix some info of nip55 to be same as other nips

1. Change some fields ```pubKey``` to ```pubkey```, just other nips does.
2. When transmitting information, other nips use pubkey, but here npub is used, and npub is changed to pubkey.
3. Add a function ```get_relays``` just like other nostr signer [NIP-07](https://github.com/nostr-protocol/nips/blob/master/07.md) and [NIP-46](https://github.com/nostr-protocol/nips/blob/master/46.md)

You can see the detail from this [link](https://github.com/haorendashu/nips/blob/nip55-fix/55.md) .