### PR TITLE
Update language around kind 11 and kind 12 removing microblog and rep…

### DIFF
--- a/29.md
+++ b/29.md
@@ -40,7 +40,7 @@ Relays should prevent late publication (messages published now with a timestamp 
 
 - *text root note* (`kind:11`)
 
-This is the basic unit of a "microblog" root text note sent to a group.
+This is the basic unit of a "forum" root text note sent to a group. These should likely be seperated from `kind:9` & `kind:10` events as mixing the two could be quite confusing. 
 
 ```js
   "kind": 11,
@@ -54,7 +54,7 @@ This is the basic unit of a "microblog" root text note sent to a group.
 
 - *threaded text reply* (`kind:12`)
 
-This is the basic unit of a "microblog" reply note sent to a group. It's the same as `kind:11`, except for the fact that it must be used whenever it's in reply to some other note (either in reply to a `kind:11` or a `kind:12`). `kind:12` events SHOULD use NIP-10 markers, leaving an empty relay url:
+This is the basic unit of a "forum" reply note sent to a group. It's the same as `kind:11`, except for the fact that it must be used whenever it's in reply to some other note (either in reply to a `kind:11` or a `kind:12`). `kind:12` events SHOULD use NIP-10 markers, leaving an empty relay url:
 
 * `["e", "<kind-11-root-id>", "", "root"]`
 * `["e", "<kind-12-event-id>", "", "reply"]`


### PR DESCRIPTION
After discussing with @fiatjaf it was thought that replacing the term microblog with forum was more indicative of what is meant for kind 11 and kind 12.

Ps. I named my branch wrong, but shouldn't be an issue. This update is around kind 11 and kind 12.

@pablof7z 