### PR TITLE
Fix filter JSON comments to clarify that timestamp matches are inclusive

### DIFF
--- a/01.md
+++ b/01.md
@@ -125,8 +125,8 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
   "authors": <a list of lowercase pubkeys, the pubkey of an event must be one of these>,
   "kinds": <a list of a kind numbers>,
   "#<single-letter (a-zA-Z)>": <a list of tag values, for #e — a list of event ids, for #p — a list of pubkeys, etc.>,
-  "since": <an integer unix timestamp in seconds, events must be newer than this to pass>,
-  "until": <an integer unix timestamp in seconds, events must be older than this to pass>,
+  "since": <an integer unix timestamp in seconds, created_at timestamps on events must be greater than or equal to this to pass>,
+  "until": <an integer unix timestamp in seconds, created_at timestamps on events must be less than or equal to this to pass>,
   "limit": <maximum number of events relays SHOULD return in the initial query>
 }
 ```


### PR DESCRIPTION
The current wording could either read ambiguously or mislead the reader to think it's an exclusive (not inclusive) time filter.