### PR TITLE
[NIP93] Curatable Profile Gallery

### DIFF
--- a/93.md
+++ b/93.md
@@ -1,0 +1,32 @@
+NIP-93
+======
+
+Profile Gallery
+-----------------
+
+This NIP defines curatable profile galleries that might be used across clients. The intention is that users might curate a gallery in their profile (or somewhere else) to show some of their visual content of choice, such as art, photographs etc. 
+
+The purpose of this NIP is to define an event Kind for Profile Galleries. A Gallery entry is a Kind 1163 Event consisting of an `e` tag and an `url` tag. The `url` tag must direct to a media file (such as an image or video) that will be shown in the gallery. The `e` tag should direct to a Kind 1 note containing this media file.
+
+
+
+## Example
+
+```json
+{
+  "content": "",
+  "kind": 1163,
+  "tags": [
+    [
+      ["e", <event id of kind 1 note >],
+      ["url", <string with URI of file>],
+    ]
+  ]
+}
+```
+
+## Recommended client behavior
+
+Clients can filter kind 1163 events and show them ordered by created_at. Users might delete 1163 events and readd them later with another timestamp, so clients should consider that events might have been deleted. 
+
+Users do not necessarily need to use their own images or notes for their gallery. Accounts could currate their gallery based of content from others.


### PR DESCRIPTION
This is a small NIP to define Kind 1163 events: Profile gallery entries.

I had withdrawn my earlier pull request #1340 which would have been an addition to NIP51 to add a List for a profile gallery.
After consulting with several people, this new version uses Kind 1163 Events (Gallery entries) instead of a "replaceable list with gallery entries". The reasoning is that lists might have size limits on relays and might easily be wiped by clients and clients can filter for these events instead. 

Feedback is welcome.