### PR TITLE
Set correct a-tag with the provided d-tag value in the example code (NIP-23)

### DIFF
--- a/23.md
+++ b/23.md
@@ -54,7 +54,7 @@ References to other Nostr notes, articles or profiles must be made according to 
     ["published_at", "1296962229"],
     ["t", "placeholder"],
     ["e", "b3e392b11f5d4f28321cedd09303a748acfd0487aea5a7450b3481c60b6e4f87", "wss://relay.example.com"],
-    ["a", "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:ipsum", "wss://relay.nostr.org"]
+    ["a", "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:lorem-ipsum", "wss://relay.nostr.org"]
   ],
   "pubkey": "...",
   "id": "..."


### PR DESCRIPTION
In the example code the d-tag value is `lorum-ipsum` so I adjusted the a-tag value with this value instead of `lorum`.