### PR TITLE
Mention Protected Events in NIP-01

### DIFF
--- a/01.md
+++ b/01.md
@@ -73,13 +73,14 @@ Each tag is an array of one or more strings, with some conventions around them. 
 
 The first element of the tag array is referred to as the tag _name_ or _key_ and the second as the tag _value_. So we can safely say that the event above has an `e` tag set to `"5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36"`, an `alt` tag set to `"reply"` and so on. All elements after the second do not have a conventional name.
 
-This NIP defines 3 standard tags that can be used across all event kinds with the same meaning. They are as follows:
+This NIP defines 4 standard tags that can be used across all event kinds with the same meaning. They are as follows:
 
 - The `e` tag, used to refer to an event: `["e", <32-bytes lowercase hex of the id of another event>, <recommended relay URL, optional>]`
 - The `p` tag, used to refer to another user: `["p", <32-bytes lowercase hex of a pubkey>, <recommended relay URL, optional>]`
 - The `a` tag, used to refer to a (maybe parameterized) replaceable event
     - for a parameterized replaceable event: `["a", <kind integer>:<32-bytes lowercase hex of a pubkey>:<d tag value>, <recommended relay URL, optional>]`
     - for a non-parameterized replaceable event: `["a", <kind integer>:<32-bytes lowercase hex of a pubkey>:, <recommended relay URL, optional>]`
+- The `"-"` tag, used to signal that given event is [protected](70.md). By default relays should reject such event unless the client is [authenticated](42.md) and has the same pubkey as the event being published.
 
 As a convention, all single-letter (only english alphabet letters: a-z, A-Z) key tags are expected to be indexed by relays, such that it is possible, for example, to query or subscribe to events that reference the event `"5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36"` by using the `{"#e": ["5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36"]}` filter.
 


### PR DESCRIPTION
The default behavior of rejecting protected events when client isn't authenticated should be at least mentioned in NIP-01 with links to NIP-42 and NIP-70.