### PR TITLE
[NIP-01] Update regular events kind range

### DIFF
--- a/01.md
+++ b/01.md
@@ -92,7 +92,7 @@ Kinds specify how clients should interpret the meaning of each event and the oth
 
 And also a convention for kind ranges that allow for easier experimentation and flexibility of relay implementation:
 
-- for kind `n` such that `1000 <= n < 10000 || 4 <= n < 45 || n == 1 || n == 2`, events are **regular**, which means they're all expected to be stored by relays.
+- for kind `n` such that `4 <= n < 10000 || n == 1 || n == 2`, events are **regular**, which means they're all expected to be stored by relays.
 - for kind `n` such that `10000 <= n < 20000 || n == 0 || n == 3`, events are **replaceable**, which means that, for each combination of `pubkey` and `kind`, only the latest event MUST be stored by relays, older versions MAY be discarded.
 - for kind `n` such that `20000 <= n < 30000`, events are **ephemeral**, which means they are not expected to be stored by relays.
 - for kind `n` such that `30000 <= n < 40000`, events are **parameterized replaceable**, which means that, for each combination of `pubkey`, `kind` and the `d` tag's first value, only the latest event MUST be stored by relays, older versions MAY be discarded.


### PR DESCRIPTION
Current spec for regular events doesn't match kind 818. Let's simplify it and make all kinds < 10000 except 0 & 3 regular events?