### PR TITLE
NIP-39: clarify that i tag should be in tags

### DIFF
--- a/39.md
+++ b/39.md
@@ -12,9 +12,11 @@ Nostr protocol users may have other online identities such as usernames, profile
 
 ## `i` tag on a metadata event
 
-A new optional `i` tag is introduced for `kind 0` metadata event contents in addition to name, about, picture fields as included in [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md):
+A new optional `i` tag is introduced for `kind 0` metadata event defined in [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md):
 ```json
 {
+  "id": <id>,
+  "pubkey": <pubkey>,
   "tags": [
     ["i", "github:semisol", "9721ce4ee4fceb91c9711ca2a6c9a5ab"],
     ["i", "twitter:semisol_public", "1619358434134196225"],


### PR DESCRIPTION
## Why

The text `in addition to the name, about, and picture fields` confuses implementers about where the `i` tag should be placed. This can be interpreted as a `"tags"` field should be in a JSON in `"content"` of `kind:0`.

```
A new optional `i` tag is introduced for `kind 0` metadata event contents in addition to name, about, picture fields as included in [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md):
```

However, `i` tag should be in `tags` directly under the root of event actually.

This PR clarify that `i` tags should be in `"tags"` field directly under the root.

## Background

I checked the background of this NIP, I found that `i` tag should be in `"tags"` directly under the root.

In the very initial version of this NIP, identities was in `"content"` JSON.

https://github.com/pseudozach/nips/blob/6fdda92a6644eae9545dc50629dd92b9990bb94d/39.md

fiatjaf review this and said, 
> I've said this on Telegram, but let me say again that I think these fit better in tags.
> https://github.com/nostr-protocol/nips/pull/201#issuecomment-1407261890

And then, the change was made:

https://github.com/nostr-protocol/nips/pull/201/commits/24d6233f2c346fde00eef65fa8ef1708b5209bea#diff-5368758730d828a473eee52f7dac1b50f72a3c2f5f5d7aa64a28767a489b9d18R15

However, the text `in addition to name, about, picture fields` was left and is still there today.

## Implementation status

Using `i` tag in `tags` directly under the root:

- Amethyst
    - https://github.com/vitorpamplona/amethyst/blob/97d0cf56a73189faec704c30bedeb49506dd9c79/quartz/src/main/java/com/vitorpamplona/quartz/events/MetadataEvent.kt#L166
- Nosta.me
    - https://github.com/GBKS/nosta-me/blob/93a9b0cc1795e8d18e3313ca104264baf398b4ab/components/profile/info.vue#L125

Apps which doesn't support NIP-39:
Iris, Snort, Damus, Nostrudel, Coracle, Primal, gossip