### PR TITLE
NIP-01: sort events by id after created_at

### DIFF
--- a/01.md
+++ b/01.md
@@ -143,7 +143,7 @@ All conditions of a filter that are specified must match for an event for it to 
 
 A `REQ` message may contain multiple filters. In this case, events that match any of the filters are to be returned, i.e., multiple filters are to be interpreted as `||` conditions.
 
-The `limit` property of a filter is only valid for the initial query and MUST be ignored afterwards. When `limit: n` is present it is assumed that the events returned in the initial query will be the last `n` events ordered by the `created_at`. It is safe to return less events than `limit` specifies, but it is expected that relays do not return (much) more events than requested so clients don't get unnecessarily overwhelmed by data.
+The `limit` property of a filter is only valid for the initial query and MUST be ignored afterwards. When `limit: n` is present it is assumed that the events returned in the initial query will be the last `n` events ordered by the `created_at`. Newer events should appear first, and in the case of ties the event with the lowest id (first in lexical order) should be first. It is safe to return less events than `limit` specifies, but it is expected that relays do not return (much) more events than requested so clients don't get unnecessarily overwhelmed by data.
 
 ### From relay to client: sending events and notices
 


### PR DESCRIPTION
See discussion in https://github.com/nbd-wtf/nostr-tools/pull/398

It's a small detail, but can matter a lot for syncing relays, pagination, and ultimately UX.

The order is: `created_by DESC, id ASC`