### PR TITLE
nip19: remove `nrelay`

### DIFF
--- a/19.md
+++ b/19.md
@@ -34,8 +34,8 @@ These are the possible bech32 prefixes with `TLV`:
 
   - `nprofile`: a nostr profile
   - `nevent`: a nostr event
-  - `nrelay`: a nostr relay
   - `naddr`: a nostr _replaceable event_ coordinate
+  - `nrelay`: a nostr relay (deprecated)
 
 These possible standardized `TLV` types are indicated here:
 
@@ -43,7 +43,6 @@ These possible standardized `TLV` types are indicated here:
   - depends on the bech32 prefix:
     - for `nprofile` it will be the 32 bytes of the profile public key
     - for `nevent` it will be the 32 bytes of the event id
-    - for `nrelay`, this is the relay URL
     - for `naddr`, it is the identifier (the `"d"` tag) of the event being referenced. For non-parameterized replaceable events, use an empty string.
 - `1`: `relay`
   - for `nprofile`, `nevent` and `naddr`, _optionally_, a relay in which the entity (profile or event) is more likely to be found, encoded as ascii


### PR DESCRIPTION
It's better to just use relay hostnames or full URLs, more readable. This encoding just adds unnecessary bloat and confusion and obfuscates things. Is anyone using it? I know @verbiricha's https://nostrrr.com/ has support for it, but now it has transitioned to using hostnames primarily, which is much better.