### PR TITLE
Fix #1377: NIP-46: It's not obvious to the end-user that optional secrets are not temporary

### DIFF
--- a/46.md
+++ b/46.md
@@ -28,7 +28,7 @@ The remote signer would provide a connection token in the form:
 bunker://<remote-user-pubkey>?relay=<wss://relay-to-connect-on>&relay=<wss://another-relay-to-connect-on>&secret=<optional-secret-value>
 ```
 
-This token is pasted into the client by the user and the client then uses the details to connect to the remote signer via the specified relay(s). Optional secret can be used for single successfully established connection only, remote signer SHOULD ignore new attempts to establish connection with old secret key.
+This token is pasted into the client by the user and the client then uses the details to connect to the remote signer via the specified relay(s). Optional secret can be used for single successfully established connection only, remote signer SHOULD ignore new attempts to establish connection with old optional secret.
 
 ### Direct connection initiated by the client
 

--- a/46.md
+++ b/46.md
@@ -28,7 +28,7 @@ The remote signer would provide a connection token in the form:
 bunker://<remote-user-pubkey>?relay=<wss://relay-to-connect-on>&relay=<wss://another-relay-to-connect-on>&secret=<optional-secret-value>
 ```
 
-This token is pasted into the client by the user and the client then uses the details to connect to the remote signer via the specified relay(s).
+This token is pasted into the client by the user and the client then uses the details to connect to the remote signer via the specified relay(s). Optional secret can be used for single successfully established connection only, remote signer SHOULD ignore new attempts to establish connection with old secret key.
 
 ### Direct connection initiated by the client
 


### PR DESCRIPTION
Not sure whether I phrased it unambiguously enough and correctly in terms of this NIP, feel free to make any changes.