### PR TITLE
NIP-17: Add tag for file attachments

### DIFF
--- a/17.md
+++ b/17.md
@@ -23,6 +23,7 @@ Kind `14` is a chat message. `p` tags identify one or more receivers of the mess
     ["p", "<receiver-2-pubkey>", "<relay-url>"],
     ["e", "<kind-14-id>", "<relay-url>", "reply"] // if this is a reply
     ["subject", "<conversation-title>"],
+    ["attachment", "<attachment-url>", "<file-name>"], // URL to an attachment, small files could be data: URIs
     ...
   ],
   "content": "<message-in-plain-text>",

--- a/17.md
+++ b/17.md
@@ -23,7 +23,7 @@ Kind `14` is a chat message. `p` tags identify one or more receivers of the mess
     ["p", "<receiver-2-pubkey>", "<relay-url>"],
     ["e", "<kind-14-id>", "<relay-url>", "reply"] // if this is a reply
     ["subject", "<conversation-title>"],
-    ["attachment", "<attachment-url>", "<file-name>"], // URL to an attachment, small files could be data: URIs
+    ["attachment", "<attachment-url>", "[file-name]"], // URL to an attachment with optional file name, small files could be data: URIs
     ...
   ],
   "content": "<message-in-plain-text>",

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `r`               | relay url                            | marker                          | [65](65.md)                           |
 | `t`               | hashtag                              | --                              |                                       |
 | `alt`             | summary                              | --                              | [31](31.md)                           |
+| `attachment`      | attachment URL, file name            | --                              | [17](17.md)                           |
 | `amount`          | millisatoshis, stringified           | --                              | [57](57.md)                           |
 | `bolt11`          | `bolt11` invoice                     | --                              | [57](57.md)                           |
 | `challenge`       | challenge string                     | --                              | [42](42.md)                           |

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `r`               | relay url                            | marker                          | [65](65.md)                           |
 | `t`               | hashtag                              | --                              |                                       |
 | `alt`             | summary                              | --                              | [31](31.md)                           |
-| `attachment`      | attachment URL, file name            | --                              | [17](17.md)                           |
+| `attachment`      | attachment URL                       | file name                       | [17](17.md)                           |
 | `amount`          | millisatoshis, stringified           | --                              | [57](57.md)                           |
 | `bolt11`          | `bolt11` invoice                     | --                              | [57](57.md)                           |
 | `challenge`       | challenge string                     | --                              | [42](42.md)                           |


### PR DESCRIPTION
I'm working on something that uses Nostr as a WebRTC signaling server. I tried to create a solution that is as general as possible, so it can apply to more than just my use case.

My project could use this tag, where a "call invite" could be a NIP-17 Private DM with an `attachment` tag with an SDP offer as a `data:application/sdp;base64,` URL, and a "call answer" could be the corresponding SDP answer.

This could also be used for normal DM file sending without having to put the files in the content itself. It seems like a pretty extendable approach. For example, if a service wanted to add Discord-like embeds to messages: they could send it as something like `data:application/discord-embed+json;base64,`.

I can imagine this tag could be relevant to event kinds other than just NIP-17's kind `14`, let me know if you think this is missing something!