### PR TITLE
Add multi_invoice_lookup to NWC / NIP47

### DIFF
--- a/47.md
+++ b/47.md
@@ -305,6 +305,69 @@ Response:
 Errors:
 - `NOT_FOUND`: The invoice could not be found by the given parameters.
 
+### `multi_lookup_invoice`
+
+Description: Requests information for multiple invoices simultaneously.
+
+Request:
+```jsonc
+{
+    "method": "multi_lookup_invoice",
+    "params": {
+        "invoices": [
+            {"invoice": "lnbc1...", "payment_hash": "abc123..."}, // Optional payment hash
+            {"invoice": "lnbc20n1..."}
+        ]
+    }
+}
+```
+
+Response:
+
+A single response is sent with data for each invoice in the requested invoices list
+
+```jsonc
+{
+    "result_type": "multi_lookup_invoice",
+    "results": [
+        {
+            "type": "incoming", // "incoming" for invoices, "outgoing" for payments
+            "invoice": "string", // encoded invoice, optional
+            "description": "string", // invoice's description, optional
+            "description_hash": "string", // invoice's description hash, optional
+            "preimage": "string", // payment's preimage, optional if unpaid
+            "payment_hash": "string", // Payment hash for the payment
+            "amount": 123, // value in msats
+            "fees_paid": 123, // value in msats
+            "created_at": unixtimestamp, // invoice/payment creation time
+            "expires_at": unixtimestamp, // invoice expiration time, optional if not applicable
+            "settled_at": unixtimestamp, // invoice/payment settlement time, optional if unpaid
+            "metadata": {} // generic metadata that can be used to add things like zap/boostagram details for a payer name/comment/etc.
+        },
+        {
+            "type": "outgoing",
+            "invoice": "lnbc20n1...",
+            "description": "Second invoice description",
+            "description_hash": "string",
+            "preimage": "string",
+            "payment_hash": "def456...",
+            "amount": 200,
+            "fees_paid": 20,
+            "created_at": 1592604483,
+            "expires_at": 1592608083,
+            "settled_at": 1592607583,
+            "metadata": {}
+        }
+    ]
+}
+```
+
+Errors:
+
+- NOT_FOUND: One or more of the requested invoices could not be found by the given parameters.
+- INVALID_REQUEST: The request format is incorrect or missing required fields.
+- 
+
 ### `list_transactions`
 
 Lists invoices and payments. If `type` is not specified, both invoices and payments are returned.


### PR DESCRIPTION
Performing individual lookups for multiple invoices can be very network heavy and potentially a DOS vector. Adding a `multi_invoice_lookup` method to NIP47 will reduce network usage and reduce the potential for a wallet service / relay DOS attack.