### PR TITLE
Reconcile NIP-96 and NIP-98 and address implementation challenge

### DIFF
--- a/96.md
+++ b/96.md
@@ -84,7 +84,8 @@ See https://github.com/aljazceru/awesome-nostr#nip-96-file-storage-servers.
 
 ## Auth
 
-When indicated, `clients` must add an [NIP-98](98.md) `Authorization` header (**optionally** with the encoded `payload` tag set to the base64-encoded 256-bit SHA-256 hash of the file - not the hash of the whole request body).
+When indicated, `clients` must add an [NIP-98](98.md) `Authorization` header.
+`clients` SHOULD include either the `payload` tag or the `payload_multipart` tag with the `file` multipart field name included in the digest (`["payload_multipart", "<sha256-of-file>", "file"]`).
 
 ## Upload
 

--- a/98.md
+++ b/98.md
@@ -43,11 +43,26 @@ Servers MUST perform the following checks in order to validate the event:
 3. The `u` tag MUST be exactly the same as the absolute request URL (including query parameters).
 4. The `method` tag MUST be the same HTTP method used for the requested resource.
 
-When the request contains a body (as in POST/PUT/PATCH methods) clients SHOULD include a SHA256 hash of the request body in a `payload` tag as hex (`["payload", "<sha256-hex>"]`), servers MAY check this to validate that the requested payload is authorized.
+When the request contains a body (as in POST/PUT/PATCH methods) clients SHOULD include a SHA256 hash of the request body in a `payload` tag as hex (`["payload", "<sha256-hex>"]`) or a SHA256 hash of the relevant fields in a `payload_multipart` tag.
+Servers MAY check these to validate that the requested payload is authorized.
 
 If one of the checks was to fail the server SHOULD respond with a 401 Unauthorized response code.
 
 Servers MAY perform additional implementation-specific validation checks.
+
+### The `payload_multipart` tag
+
+The `payload_multipart` tag SHOULD only be sent when authorizing a request with a `Content-Type` of `multipart/form-data`.
+A valid `payload_multipart` tag will always consist of 3 or more elements.
+The first element is always the tag name, `payload_multipart`.
+The second element is the sha256 hash, which is computed over the concatenation of every serialized multipart field, in order.
+The third through last elements name the form fields which will be concatenated together to calculate the hash.
+
+`["payload_multipart", "<sha256-hex-of-concatenated-fields>", "<multipart-field-name-0>", ..."<multipart-field-name-N>"]`
+
+The multipart-field-names MUST appear in the same order as they appear in the multipart body.
+Repeated field names MUST have corresponding repeated fields in the multipart body.
+After a multipart field is added to the sha256 digest, no subsequent multipart-field-name may refer to any multipart field up to and including the one which was just processed (field processing always progresses forward in the request body, never backwards).
 
 ## Request Flow
 


### PR DESCRIPTION
Reconcile conflicting language in NIP-96 and NIP-98 identified in #1376 by introducing a new, optional NIP-98 tag `payload_multipart` which allows simple and flexible selective authentication of `multipart/form-data` requests.

# Rationale

NIP-96 specifies that uploaders should include in the `Authorization` header, the `payload` field in a format incompatible with NIP-98 (base64) calculated from a different preimage, the uploaded file. This is opposed to NIP-98 which specifies `payload` hash should be encoded in hex, and should be calculated over the entire request body.

There are *significant* implementation difficulties and drawbacks to using NIP-98 as-is to authenticate NIP-96 uploads (see below).  I suspect this is why the two NIPs are contradictory in the first place.

This change attempts to provide a usefully generic mechanism to NIP-98 that can be used unmodified for NIP-96 uploads.

# Why...?

## Why must the order of fields be consistent between the `payload_multipart` tag and the request body?  

To limit denial of service potential, keeping the order of fields in the `payload_multipart` consistent with the order of the fields in the request body, together with the other rules allows server implementations to process the request body in a single pass. Furthermore, a consistent and unambiguous ordering is necessary, and this (I believe) satisfies that, and also permits efficient implementation.

# Why not...?

## Why not leave it as-is?

  1. Current implementations I'm aware of (Coracle and nostr-tools) don't appear to conform to either NIP.  
     They instead (attempt) to provide a hex encoded sha256 hash of the uploaded file.
  2. Giving the `payload` tag overloaded meaning is undesirable, especially if the encoding (base64 vs sha256) is meant to disambiguate two conflicting meanings of the tag.

The *minimum* change would be to modify NIP-96 to use a different tag such as `nip96_payload`, and probably to use a hex encoding instead of base64 for consistency.

## Why not implement the minimum change you just described?

It's not generic, it remains a special case in NIP-98 handling. Since NIP-96 is so ubiquitous and important, this could be ok, but we can provide a generic mechanism without much effort.

## Why not strike the conflicting language from NIP-96 and implement NIP-98 as-is?

See below, the best case scenario creates significant implementation burden, and will require loading entire files into memory. This *could* be acceptable, maybe, given that NIP-96 uploads tend to be on the order of a few megabytes to tens of megabytes. However, it is preferable to avoid this limitation altogether, in my opinion.

# Open Questions

## Should we allow signing field metadata?

`multipart/form-data` request fields include metadata such as `content-type`, `content-disposition`, and a few others. `content-type` is redundant to the `content_type` form field in NIP-96 but could be significant in other protocols. `content-disposition` includes the desired `filename` of the upload, and its manipulation could be exploited (how? encoding embarassing or incriminating strings in the filename?).

These could be accomodated by a semi-special case, using a dotted notation.

The filename of the field `file` could be represented, for instance, by `"file.content-disposition.filename"`. This adds minimal implementation complexity but increases functionality. I'm inclined (and have chosen to) omit this functionality from this proposal, but I want to propose it as potentially desirable.

## Should we allow signing HTTP headers?  

Like form field metadata, HTTP headers may have significant meaning for a request, and ought to be authenticated in some cases. These could be included with a separate tag such as `http_headers` which works similarly to this proposal.

## Are there any good ideas worth stealing from [HTTP Signatures](https://datatracker.ietf.org/doc/html/rfc9421) which are relevant to NIP-98?

## Did I miss something that would enable implementing NIP-98 as-is on the browser (without the drawback mentioned below) ?

# Implementation difficulty of NIP-98 as-is for NIP-96

The browser is an extremely important target for nostr implementations, so NIPs should be implementable on them without major caveats.

The browser provides two mechanisms for making arbitrary HTTP requests: `XMLHttpRequest` and more recently `fetch()`. When making a `Content-Type: multipart/form-data` request, both of these will serialize a `FormData` object for the caller. This involves generating a `boundary` in an implementation specific manner *which is not available to the caller*. This `boundary` changes the request body, and thus changes the sha256 value provided in the NIP-98 `payload` tag. This makes it *impossible*(?) for an implementor to rely on the browser's serialization of `FormData` objects into `multipart/form-data` payloads and calculate the correct payload hash.

A javascript library *could* with some effort, perform this serialization itself, and use the serialized request body to both calculate the payload hash and to submit the request. The problem with this, is that particularly for NIP-96, the serialized request body may be very large, and take up unacceptable amounts of memory.

The sha256 payload hash may be calculated in constant memory, but the entire serialized request body must be provided to `XMLHttpRequest` or `fetch()` as a string, an `ArrayBuffer` (or similar), or a `Blob` (or similar).

This presents drastically different limitations to users compared to the `FormData` approach. In the `FormData` approach, the browser may be more clever, and stream `File`s from persistent storage rather than loading them into memory in their entirety.
