### PR TITLE
Read status 2

### DIFF
--- a/97.md
+++ b/97.md
@@ -16,9 +16,13 @@ This NIP combines both approaches, tracking categories of things a user might wa
 both timestamp and event id. This results in small event payloads, only a few replaceable events,
 and granular seen status for recent events.
 
-Seen status events SHOULD have one or more `seen` tags associating a timestamp and zero or more event ids
-with a key. The timestamp SHOULD be a time in the recent past, and all known events created after
-that time for the given category should be represented in the id list.
+Seen status events SHOULD have one or more `seen` tags associating a timestamp and zero or more
+event ids with a key. The timestamp SHOULD be a time in the recent past, and all known events
+created after that time for the given category should be represented in the id list.
+
+The status key can be any string, but recommendations are made below. The special key `*` MAY be
+used to indicate a timestamp for all keys not listed explicitly. This can be useful for ignoring
+very old activity.
 
 All tags MUST be encrypted using [NIP 44](./44.md) and placed in the seen status event's `content`
 field to prevent leaking conversation metadata.

--- a/97.md
+++ b/97.md
@@ -1,48 +1,93 @@
 NIP-97
 ======
 
-Read Status
+Seen Status
 -----------
 
 `draft` `optional`
 
-Clients may wish to track whether certain events have been seen by a user, including mentions, replies, likes, messages, community posts, and more.
-Keeping a single timestamp for each category can result in events being missed if they are not fetched successfully on the first attempt. Meanwhile,
-tagging every event seen is wasteful and can result in a lot of events being published and downloaded just to maintain a notification badge.
+Clients may wish to track whether certain events have been seen by a user, including mentions,
+replies, likes, messages, community posts, and more. Keeping a single timestamp for each category
+can result in events being missed if they are not fetched successfully on the first attempt.
+Meanwhile, tagging every event seen is wasteful and can result in a lot of events being published
+and downloaded just to maintain a notification badge.
 
-This NIP combines both approaches, by asking clients to set a kind `30115` read status event's `created_at` timestamp to a time in the recent past,
-then enumerate events created after that time that have been seen by the user. This results in a small event payload, few events, and granular seen
-status for all events since the event's `created_at` time.
+This NIP combines both approaches, tracking categories of things a user might want to "check" by
+both timestamp and event id. This results in small event payloads, only a few replaceable events,
+and granular seen status for recent events.
 
-A `d` tag is required, denoting the read status category. Any name may be used, but for the sake of interoperability the values below SHOULD be
-used when applicable. If multiple categories of events are seen at once, one event should be published for each relevant category.
+Seen status events SHOULD have one or more `seen` tags associating a timestamp and zero or more event ids
+with a key. The timestamp SHOULD be a time in the recent past, and all known events created after
+that time for the given category should be represented in the id list.
+
+All tags MUST be encrypted using [NIP 44](./44.md) and placed in the seen status event's `content`
+field to prevent leaking conversation metadata.
+
+A few event kinds are defined here to separate broad categories and prevent tag lists from filling
+up too quickly.
+
+## Account-level notifications
+
+Kind `10115` tracks account-level notifications, for example reactions, reposts, new followers, etc.
+Kind `10115` SHOULD use the following keys as applicable, but MAY use other keys as needed:
 
 - `reactions` - reactions to the user's notes
 - `reposts` - reposts of the user's notes
 - `zaps` - zaps tagging the user
+- `mentions` - other notes tagging the user that aren't replies
+- `replies` - replies to user notes
 - `follows` - new followers of the current user
 - `unfollows` - lost followers of the current user
 - `mutes` - new mutes of the current user
 - `unmutes` - new mutes of the current user
-- `mentions` - other notes tagging the user that aren't replies
-- `replies` - replies to user notes
-- The `d` tag of a NIP 72 community for tracking posts to that community
-- The `d` tag of a NIP 89 closed group for tracking posts to that group
-- The id of a NIP 29 group for tracking posts to that group
-- The pubkey of the counterparty in a DM conversation
-- The conversation id of a NIP 17 group chat (all pubkeys in the chat sorted and joined by a comma)
-
-`e` and `a` tags SHOULD be encrypted using [NIP 44](./44.md) and placed in the read status event's `content` field.
 
 ```json
 {
-  "kind": "30115",
+  "kind": "10115",
   "created_at": 1722372950,
   "content": nip44_encrypt_json([
-    ["e", "<event_id>"]
+    ["seen", "mentions", "1722372950", "<event1_id>", "<event2_id>"],
+    ["seen", "replies", "1722372950", "<event1_id>"]
   ]),
-  "tags": [
-    ["d", "mentions"],
-  ],
+}
+```
+
+## Context-level notifications
+
+Kind `10116` tracks context-level notifications, including posts sent to groups or communities.
+Kind `10116` SHOULD use the following key types:
+
+- The `d` tag of a NIP 72 community for tracking posts to that community
+- The `d` tag of a NIP 89 closed group for tracking posts to that group
+- The id of a NIP 29 group for tracking posts to that group
+
+```json
+{
+  "kind": "10116",
+  "created_at": 1722372950,
+  "content": nip44_encrypt_json([
+    ["seen", "34550:7fe92740b0530c0e8f1ec4c7dfbfdbd7e6e5194cc7cb853cb512e4d9862b5406:9174501", "1722372950", "<event1_id>"]
+  ]),
+}
+```
+
+## Conversation-level notifications
+
+Kind `10117` tracks conversation-level notifications, including NIP 04 DMs and NIP 17 group chats.
+Kind `10117` SHOULD sort ascending and concatenate all conversation partner pubkeys with a comma
+to get the conversation id.
+
+Clients MAY choose to delete an entry from the seen status event if the current user was the most
+recent one to post to the conversation, since the existence of that message implies the conversation
+was read.
+
+```json
+{
+  "kind": "10117",
+  "created_at": 1722372950,
+  "content": nip44_encrypt_json([
+    ["seen", "7fe92740b0530c0e8f1ec4c7dfbfdbd7e6e5194cc7cb853cb512e4d9862b5406", "1722372950", "<event1_id>"]
+    ["seen", "7fe92740b0530c0e8f1ec4c7dfbfdbd7e6e5194cc7cb853cb512e4d9862b5406,6fc1d1e7a1b265f531838e2399858c14e4901ac23d927b2de1c36a713646b4de", "1722372950", "<event1_id>"]
+  ]),
 }
 ```

--- a/97.md
+++ b/97.md
@@ -1,0 +1,27 @@
+NIP-97
+======
+
+Read Status
+-----------
+
+`draft` `optional`
+
+Clients may wish to track whether certain events have been seen by a user, including mentions, replies, likes, messages, community posts, and more.
+
+A kind `15` event may be used to mark one or more `e` tags as read.
+
+```json
+{
+  "kind": "15",
+  "tags": [
+    ["expiration", "<one year in the future>"],
+    ["e", "<event1_id>"],
+    ["e", "<event1_id>"]
+  ]
+}
+```
+
+Events MAY be wrapped as described in [NIP 59](./59.md) in order to create private read status events. These can be useful for preserving user privacy, or to selectively reveal read status to other users, for example in a group chat or message thread.
+
+Read status events SHOULD expire after a sufficient amount of time to save storage space, since very old events can be assumed to have been seen. Wrapped events SHOULD put the `expiration` tag on the wrapper event. See [NIP 40](./40.md) for more information expiration.
+

--- a/97.md
+++ b/97.md
@@ -61,8 +61,8 @@ Kind `10115` SHOULD use the following keys as applicable, but MAY use other keys
 Kind `10116` tracks context-level notifications, including posts sent to groups or communities.
 Kind `10116` SHOULD use the following key types:
 
-- The `d` tag of a NIP 72 community for tracking posts to that community
-- The `d` tag of a NIP 89 closed group for tracking posts to that group
+- The address of a NIP 72 community for tracking posts to that community
+- The address of a NIP 89 closed group for tracking posts to that group
 - The id of a NIP 29 group for tracking posts to that group
 
 ```json

--- a/97.md
+++ b/97.md
@@ -74,8 +74,6 @@ Kind `10116` SHOULD use the following key types:
 ## Conversation-level notifications
 
 Kind `10117` tracks conversation-level notifications, including NIP 04 DMs and NIP 17 group chats.
-Kind `10117` SHOULD sort ascending and concatenate all conversation partner pubkeys with a comma
-to get the conversation id.
 
 Clients MAY choose to delete an entry from the seen status event if the current user was the most
 recent one to post to the conversation, since the existence of that message implies the conversation
@@ -87,7 +85,32 @@ was read.
   "created_at": 1722372950,
   "content": nip44_encrypt_json([
     ["seen", "7fe92740b0530c0e8f1ec4c7dfbfdbd7e6e5194cc7cb853cb512e4d9862b5406", "1722372950", "<event1_id>"]
-    ["seen", "7fe92740b0530c0e8f1ec4c7dfbfdbd7e6e5194cc7cb853cb512e4d9862b5406,6fc1d1e7a1b265f531838e2399858c14e4901ac23d927b2de1c36a713646b4de", "1722372950", "<event1_id>"]
+    ["seen", "1f8f6b86ec6f4902eb99058afeb68e0b7ca7aa2a090ea0ae3a2b64653aac9cc2", "1722372951", "<event1_id>"]
   ]),
 }
+```
+
+To get the conversation id:
+
+- Sort user and conversation partner pubkeys in lexicographically ascending order
+- Concatenate and hash with sha256 and convert to hex
+
+```typescript
+// Our partner pubkeys
+const partners = [
+  '7fe92740b0530c0e8f1ec4c7dfbfdbd7e6e5194cc7cb853cb512e4d9862b5406',
+  '6fc1d1e7a1b265f531838e2399858c14e4901ac23d927b2de1c36a713646b4de',
+]
+
+// encode as UTF-8
+const msgBuffer = new TextEncoder().encode(partners.join(''));
+
+// hash the message
+const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
+
+// convert ArrayBuffer to Array
+const hashArray = Array.from(new Uint8Array(hashBuffer));
+
+// convert bytes to hex string
+const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
 ```

--- a/97.md
+++ b/97.md
@@ -7,21 +7,42 @@ Read Status
 `draft` `optional`
 
 Clients may wish to track whether certain events have been seen by a user, including mentions, replies, likes, messages, community posts, and more.
+Keeping a single timestamp for each category can result in events being missed if they are not fetched successfully on the first attempt. Meanwhile,
+tagging every event seen is wasteful and can result in a lot of events being published and downloaded just to maintain a notification badge.
 
-A kind `15` event may be used to mark one or more `e` tags as read.
+This NIP combines both approaches, by asking clients to set a kind `30115` read status event's `created_at` timestamp to a time in the recent past,
+then enumerate events created after that time that have been seen by the user. This results in a small event payload, few events, and granular seen
+status for all events since the event's `created_at` time.
+
+A `d` tag is required, denoting the read status category. Any name may be used, but for the sake of interoperability the values below SHOULD be
+used when applicable. If multiple categories of events are seen at once, one event should be published for each relevant category.
+
+- `reactions` - reactions to the user's notes
+- `reposts` - reposts of the user's notes
+- `zaps` - zaps tagging the user
+- `follows` - new followers of the current user
+- `unfollows` - lost followers of the current user
+- `mutes` - new mutes of the current user
+- `unmutes` - new mutes of the current user
+- `mentions` - other notes tagging the user that aren't replies
+- `replies` - replies to user notes
+- The `d` tag of a NIP 72 community for tracking posts to that community
+- The `d` tag of a NIP 89 closed group for tracking posts to that group
+- The id of a NIP 29 group for tracking posts to that group
+- The pubkey of the counterparty in a DM conversation
+- The conversation id of a NIP 17 group chat (all pubkeys in the chat sorted and joined by a comma)
+
+`e` and `a` tags SHOULD be encrypted using [NIP 44](./44.md) and placed in the read status event's `content` field.
 
 ```json
 {
-  "kind": "15",
+  "kind": "30115",
+  "created_at": 1722372950,
+  "content": nip44_encrypt_json([
+    ["e", "<event_id>"]
+  ]),
   "tags": [
-    ["expiration", "<one year in the future>"],
-    ["e", "<event1_id>"],
-    ["e", "<event1_id>"]
-  ]
+    ["d", "mentions"],
+  ],
 }
 ```
-
-Events MAY be wrapped as described in [NIP 59](./59.md) in order to create private read status events. These can be useful for preserving user privacy, or to selectively reveal read status to other users, for example in a group chat or message thread.
-
-Read status events SHOULD expire after a sufficient amount of time to save storage space, since very old events can be assumed to have been seen. Wrapped events SHOULD put the `expiration` tag on the wrapper event. See [NIP 40](./40.md) for more information expiration.
-

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-92: Media Attachments](92.md)
 - [NIP-94: File Metadata](94.md)
 - [NIP-96: HTTP File Storage Integration](96.md)
+- [NIP-97: Read Status](97.md)
 - [NIP-98: HTTP Auth](98.md)
 - [NIP-99: Classified Listings](99.md)
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-92: Media Attachments](92.md)
 - [NIP-94: File Metadata](94.md)
 - [NIP-96: HTTP File Storage Integration](96.md)
-- [NIP-97: Read Status](97.md)
+- [NIP-97: Seen Status](97.md)
 - [NIP-98: HTTP Auth](98.md)
 - [NIP-99: Classified Listings](99.md)
 
@@ -161,6 +161,9 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `10050`       | Relay list to receive DMs       | [51](51.md), [17](17.md)               |
 | `10063`       | User server list                | [Blossom][blossom]                     |
 | `10096`       | File storage server list        | [96](96.md)                            |
+| `10115`       | Account level seen statuses     | [97](97.md)                            |
+| `10116`       | Context level seen statuses     | [97](97.md)                            |
+| `10117`       | Conversation level seen statuses| [97](97.md)                            |
 | `13194`       | Wallet Info                     | [47](47.md)                            |
 | `21000`       | Lightning Pub RPC               | [Lightning.Pub][lnpub]                 |
 | `22242`       | Client Authentication           | [42](42.md)                            |


### PR DESCRIPTION
Another attempt to solve interoperable read statuses. This one combines the timestamp-based approach with the event-id based approach in #933. It uses e tags, not a tags to allow clients to differentiate versions of replaceable events. It uses replaceable events of a few different kinds to reduce storage requirements. It allows for only private read receipts in order to avoid leaking conversation metadata.