### PR TITLE
[NIP90 ] - replace NIP04 encryption with NIP44 encryption for encrypted jobs

### DIFF
--- a/90.md
+++ b/90.md
@@ -69,7 +69,7 @@ All tags are optional.
 
 ## Encrypted Params
 
-If the user wants to keep the input parameters a secret, they can encrypt the `i` and `param` tags with the service provider's 'p' tag and add it to the content field. Add a tag `encrypted` as tags. Encryption for private tags will use [NIP-04 - Encrypted Direct Message encryption](https://github.com/nostr-protocol/nips/blob/master/04.md), using the user's private and service provider's public key for the shared secret
+If the user wants to keep the input parameters a secret, they can encrypt the `i` and `param` tags with the service provider's 'p' tag and add it to the content field. Add a tag `encrypted` as tags. Encryption for private tags will use [NIP-44 - Encrypted Payloads](https://github.com/nostr-protocol/nips/blob/master/44.md), using the user's private and service provider's public key for the shared secret
 
 ```json
 [


### PR DESCRIPTION
As there are considerations to fully replace nip04 with nip44 encryption and major libraries used for DVMs like rust-nostr and ndk already support nip44 en/decryption this PR suggests replacing nip04 encryption for "encrypted jobs" with nip44 encryption. This only concerns jobs that are encrypted aka use the "encrypted" tag. 