### PR TITLE
Add shouldAutoLogin flag to NIP-07

### DIFF
--- a/07.md
+++ b/07.md
@@ -24,6 +24,12 @@ async window.nostr.nip44.encrypt(pubkey, plaintext): string // returns ciphertex
 async window.nostr.nip44.decrypt(pubkey, ciphertext): string // takes ciphertext as specified in nip-44
 ```
 
+### Automatic Login
+
+An optional `window.nostr.shouldAutoLogin` boolean may be added.
+
+When set to `true`, clients with login functionality should automatically login using the pubkey returned from `await window.nostr.getPublicKey()` call, i.e, without the need to manually click a "Login with Extension" or similar button.
+
 ### Recommendation to Extension Authors
 To make sure that the `window.nostr` is available to nostr clients on page load, the authors who create Chromium and Firefox extensions should load their scripts by specifying `"run_at": "document_end"` in the extension's manifest.
 


### PR DESCRIPTION
Reason: user should be able to configure the NIP-07 extension to skip the step of manually having to click a "Login with Extension" button.