### PR TITLE
remove nip45 code block type

### DIFF
--- a/45.md
+++ b/45.md
@@ -16,14 +16,14 @@ Some queries a client may want to execute against connected relays are prohibiti
 
 This NIP defines the verb `COUNT`, which accepts a subscription id and filters as specified in [NIP 01](01.md) for the verb `REQ`. Multiple filters are OR'd together and aggregated into a single count result.
 
-```json
+```
 ["COUNT", <subscription_id>, <filters JSON>...]
 ```
 
 Counts are returned using a `COUNT` response in the form `{"count": <integer>}`. Relays may use probabilistic counts to reduce compute requirements.
 In case a relay uses probabilistic counts, it MAY indicate it in the response with `approximate` key i.e. `{"count": <integer>, "approximate": <true|false>}`.
 
-```json
+```
 ["COUNT", <subscription_id>, {"count": <integer>}]
 ```
 
@@ -33,14 +33,14 @@ Whenever the relay decides to refuse to fulfill the `COUNT` request, it MUST ret
 
 ### Followers count
 
-```json
+```
 ["COUNT", <subscription_id>, {"kinds": [3], "#p": [<pubkey>]}]
 ["COUNT", <subscription_id>, {"count": 238}]
 ```
 
 ### Count posts and reactions
 
-```json
+```
 ["COUNT", <subscription_id>, {"kinds": [1, 7], "authors": [<pubkey>]}]
 ["COUNT", <subscription_id>, {"count": 5}]
 ```


### PR DESCRIPTION
remove nip45 code block type and then code will not highlight error.

before changed:
![before](https://github.com/user-attachments/assets/cb979593-c718-4c03-a6e3-a200ce243056)

after changed:
![after](https://github.com/user-attachments/assets/72d700fa-7d21-42d7-855e-5f5c8ae8bb32)