### PR TITLE
nip18: do not set content of repost event

### DIFF
--- a/18.md
+++ b/18.md
@@ -9,7 +9,7 @@ Reposts
 A repost is a `kind 6` event that is used to signal to followers
 that a `kind 1` text note is worth reading.
 
-The `content` of a repost event is _the stringified JSON of the reposted note_. It MAY also be empty, but that is not recommended.
+For security reasons, The `content` of a repost event MUST not be set _the stringified JSON of the reposted note_. It SHOULD also be empty.
 
 The repost event MUST include an `e` tag with the `id` of the note that is
 being reposted. That tag MUST include a relay URL as its third entry


### PR DESCRIPTION
For security reasons, I think that the JSON string of the reposted note should NOT be set in the kind 6 content.
For example, suppose someone accidentally posted confidential or private content to a Nostr relay. It could be a link to an image showing someone's nudity. And if someone has already reposted the event even though they receive a request to cancel it from the person in the picture, we will not be able to erase it. I think that all of nostr client should not store a copy of the event.