### PR TITLE
Fix NIP-96

### DIFF
--- a/96.md
+++ b/96.md
@@ -84,7 +84,9 @@ See https://github.com/aljazceru/awesome-nostr#nip-96-file-storage-servers.
 
 ## Auth
 
-When indicated, `clients` must add an [NIP-98](98.md) `Authorization` header (**optionally** with the encoded `payload` tag set to the base64-encoded 256-bit SHA-256 hash of the file - not the hash of the whole request body).
+When indicated, `clients` must add an [NIP-98](98.md) `Authorization` header.
+The NIP-98 event can **optionally** include the encoded `payload` tag set to the hex-encoded 256-bit SHA-256 hash of the file - not the hash of the whole request body.
+The event may include multiple `u` tags to make it possible to reuse the same header for different servers.
 
 ## Upload
 
@@ -94,7 +96,7 @@ When indicated, `clients` must add an [NIP-98](98.md) `Authorization` header (**
 
 List of form fields:
 
-- `file`: **REQUIRED** the file to upload
+- `file`: **REQUIRED** the file to upload. It should be the last form field;
 - `caption`: **RECOMMENDED** loose description;
 - `expiration`: UNIX timestamp in seconds. Empty string if file should be stored forever. The server isn't required to honor this.
 - `size`: File byte size. This is just a value the server can use to reject early if the file size exceeds the server limits.


### PR DESCRIPTION
- Fixed typo: changed `base64-encoded` to `hex-encoded`
- Fixed regression: Re-added text saying the file field should be the last sent form field (because of how multipart works)

Also, added the following so that NIP-96 has 100% feature-parity with Blossom:
`The ("NIP-98") event may include multiple "u" tags to make it possible to reuse the same header for different servers.` <- Can you support this, @fishcakeday @v0l @quentintaranpino @nostrband? Just need to consider that the `u` tag with your server url may not be the first one.

I think this addition (to be able to sign a single NIP-98 event to upload a file to multiple servers) is the only thing blossom has that NIP-96 lacks. RIP Blossom.