### PR TITLE
Create fifth parameter in zap tag

### DIFF
--- a/57.md
+++ b/57.md
@@ -169,12 +169,12 @@ A client can retrieve `zap receipt`s on events and pubkeys using a NIP-01 filter
 
 ### Appendix G: `zap` tag on other events
 
-When an event includes one or more `zap` tags, clients wishing to zap it SHOULD calculate the lnurl pay request based on the tags value instead of the event author's profile field. The tag's second argument is the `hex` string of the receiver's pub key and the third argument is the relay to download the receiver's metadata (Kind-0). An optional fourth parameter specifies the weight (a generalization of a percentage) assigned to the respective receiver. Clients should parse all weights, calculate a sum, and then a percentage to each receiver. If weights are not present, CLIENTS should equally divide the zap amount to all receivers. If weights are only partially present, receivers without a weight should not be zapped (`weight = 0`).
+When an event includes one or more `zap` tags, clients wishing to zap it SHOULD calculate the lnurl pay request based on the tags value instead of the event author's profile field. The tag's second argument is the `hex` string of the receiver's pub key and the third argument is the relay to download the receiver's metadata (Kind-0). An optional fourth parameter specifies the weight (a generalization of a percentage) assigned to the respective receiver. Clients should parse all weights, calculate a sum, and then a percentage to each receiver. If weights are not present, CLIENTS should equally divide the zap amount to all receivers. If weights are only partially present, receivers without a weight should not be zapped (`weight = 0`). An optional fifth parameter specifies some information about the pubkey.
 
 ```js
 {
     "tags": [
-        [ "zap", "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2", "wss://nostr.oxtr.dev", "1" ],  // 25%
+        [ "zap", "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2", "wss://nostr.oxtr.dev", "1", "Creator of Twitter"],  // 25%
         [ "zap", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52", "wss://nostr.wine/",    "1" ],  // 25%
         [ "zap", "460c25e682fda7832b52d1f22d3d22b3176d972f60dcdc3212ed8c92ef85065c", "wss://nos.lol/",       "2" ]   // 50%
     ]

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `thumb`           | badge thumbnail                      | dimensions in pixels            | [58](58.md)                           |
 | `title`           | article title                        | --                              | [23](23.md)                           |
 | `web`             | webpage URL                          | --                              | [34](34.md)                           |
-| `zap`             | pubkey (hex), relay URL              | weight                          | [57](57.md)                           |
+| `zap`             | pubkey (hex), relay URL              | weight, message                 | [57](57.md)                           |
 
 Please update these lists when proposing new NIPs.
 


### PR DESCRIPTION
A normal zap happens when the lightning address is got from the kind 0 of the recipient being zapped. 
A zap split takes into account the lightning addresses of the kind 0s of the pubkeys specified in the zap tags instead of the recipient's pubkey.

If I am zapping someone directly, I am sure of what I'm doing.
If I am zapping someone directly and 5% of the total amount goes to a random pubkey, I may get skeptical and may refuse paying it.

Therefore, one way to prevent such cases is to explain to the user who are the extra pubkeys.
I don't think using the `about` field from the kind 0 is a good idea because it's more intended for general cases, the message in the zap tag is more straightforward, example: "Designer of Snort", "Creator of Amethyst", "Relay X", etc...

I don't think this is a breaking change because it adds a parameter to the end of the array. This feature seem to be done separately by some clients, but if done separately then no interoperability is achieved. 

