### PR TITLE
NIP-74: addressable chat

### DIFF
--- a/74.md
+++ b/74.md
@@ -1,0 +1,29 @@
+NIP-74
+======
+
+Addressable Chat
+----------------
+
+`draft` `optional`
+
+Every time an addressable event (kinds 30000-39999) contains a `"relays"` tag with any number of relay URLs specified in it (`["relays", "wss://myrelay.com", "wss://addressable.chat"]`) clients have the option of toggling a chat box about the topic of that event.
+
+Chat messages are expected to be read and published from and to the specified relays, which will _somehow_ provide moderation and consistency.
+
+(Clients can also use different relays other than those specified by the addressable event author, but this would be a power/optional/manual feature until other means of signaling this are invented.)
+
+### Chat Message
+
+Chat messages must have `kind:1311`. Clients MUST include the `a` tag of the activity with a `root` marker. Other Kind-1 tags such as `reply` and `mention` can also be used. An `e` tag containing the specific ID of the current addressable event version being replied to SHOULD also be included.
+
+```json
+{
+  "kind": 1311,
+  "tags": [
+    ["a", "<addressable-event-kind>:<addressable-author-pubkey>:<d-identifier>", "<optional relay url>", "root"],
+    ["e", "<addressable-event-id>", "<optional relay url>", "root"]
+  ],
+  "content": "hello fans of this article",
+  ...
+}
+```


### PR DESCRIPTION
This generalizes [NIP-53](../53.md) live chat events to any other addressable events that specifies a `"relays"` tag.

@v0l @pablof7z 