### PR TITLE
NIP-15 - Replaced NIP-04 (deprecated) with NIP-17: Private Direct Messages

### DIFF
--- a/15.md
+++ b/15.md
@@ -139,7 +139,7 @@ Fields that are not self-explanatory:
 
 ## Checkout events
 
-All checkout events are sent as JSON strings using [NIP-04](04.md).
+All checkout events are sent as JSON strings using [NIP-17](17.md).
 
 The `merchant` and the `customer` can exchange JSON messages that represent different actions. Each `JSON` message `MUST` have a `type` field indicating the what the JSON represents. Possible types:
 
@@ -150,7 +150,7 @@ The `merchant` and the `customer` can exchange JSON messages that represent diff
 | 2            | Merchant | Order Status Update |
 
 ### Step 1: `customer` order (event)
-The below JSON goes in content of [NIP-04](04.md).
+The below JSON goes in content of [NIP-17](17.md).
 
 ```json
 {
@@ -182,7 +182,7 @@ _Open_: is `contact.nostr` required?
 
 Sent back from the merchant for payment. Any payment option is valid that the merchant can check.
 
-The below JSON goes in `content` of [NIP-04](04.md).
+The below JSON goes in `content` of [NIP-17](17.md).
 
 `payment_options`/`type` include:
 
@@ -217,7 +217,7 @@ The below JSON goes in `content` of [NIP-04](04.md).
 
 Once payment has been received and processed.
 
-The below JSON goes in `content` of [NIP-04](04.md).
+The below JSON goes in `content` of [NIP-17](17.md).
 
 ```json
 {
@@ -331,7 +331,7 @@ Another thing that can happen is - if bids happen very close to the end date of 
 
 ## Customer support events
 
-Customer support is handled over whatever communication method was specified. If communicating via nostr, [NIP-04](04.md) is used.
+Customer support is handled over whatever communication method was specified. If communicating via nostr, [NIP-17](17.md) is used.
 
 ## Additional
 


### PR DESCRIPTION
### Replaced NIP-04 (deprecated) with NIP-17: Private Direct Messages

Cheers,
Any opposition to an outright update of this protocol to replace the use of NIP-04 (deprecated) with NIP-17: Private Direct Messages?