### PR TITLE
LIMITS command 

### DIFF
--- a/20.md
+++ b/20.md
@@ -1,9 +1,40 @@
 NIP-20
 ======
 
-Command Results
----------------
+Connection Limitations
+----------------------
 
-`final` `mandatory`
+`draft` `optional`
 
-Moved to [NIP-01](01.md).
+Upon connection, and at any point during the connection, the Relay can send a `LIMITS` payload to the Client reflecting the current state of the user's rights in the relay. 
+
+```json
+["LIMITS", { <limit_properties> }]
+``` 
+
+Where `limit_properties` includes properties that are specifically designed to change the way Clients communicate. Options are: 
+
+- `can_write: <true|false>`, If false, Clients MUST NOT publish events to the relay. 
+- `can_read: <true|false>`, If true, Clients MUST NOT send `REQ` commands to the relay.
+
+- `accepted_event_kinds: [<unsigned int>, <unsigned int>, ...]`, Clients MUST filter publishing events by these types.
+- `blocked_event_kinds: [<unsigned int>, <unsigned int>, ...]`, Clients MUST remove these types from publishing actions.
+
+- `min_pow_difficulty: <int>`: Clients MUST filter publishing events if they don't have at least this PoW bit difficulty.
+
+- `max_message_length: <int>`, Clients MUST filter publishing events and crop/chunk `REQ` filters by this length.
+- `max_subscriptions: <int>`, Clients MUST reduce the number of subscriptions to this amount.
+- `max_filters: <int>`, Clients MUST crop/chunk `REQ` filters by this amount.
+- `max_limit: <int>`, Clients MUST clump each filter's `limit` value to this number and use `since` and `until` to get additional results.
+- `max_event_tags: <int>`, Clients MUST filter publishing events by this `.tags` length.
+- `max_content_length: <int>`, Clients MUST filter publishing events by this `.content` length.
+
+- `created_at_lower_limit: <unix timestamp>`, Clients MUST filter publishing events whose `.created_at` is smaller than this number
+- `created_at_upper_limit: <unix timestamp>`, Clients MUST filter publishing events whose `.created_at` is bigger than this number
+
+- `filter_rate_limit: <int, milliseconds>`: Clients MUST debounce filter changes after by this amount in milliseconds.
+- `publishing_rate_limit: <int, milliseconds>`: Clients MUST debounce publishing events by this amount in milliseconds.
+
+- `required_tags: [ [ <key>, <value, optional> ], [ <key>, <value, optional> ] ]`, Clients MUST filter publishing events that don't include all listed tag names and values.
+
+This payload SHOULD be cached in the Client's Relay connection object and updated as many times as the relay requests. Clients should use the information here to apply filters when sending events and `REQs` to the relay.


### PR DESCRIPTION
Adds a LIMITS command to help relays define "NIP-11-like" limits for each connection. It is designed to be reactive and actionable by clients. These LIMITS can change at any time and MUST reflect the rights the connected user has into the relay. 

The properties were designed to be easy for Clients to implement and filter which and when `REQ`s and events they can be sent to the relay.

Use cases: 
- Unauthed connection has different limits than authed. 
- Limits can be clarified based on location/IP, pubkey reputation, etc.
- Rate limits can get more limiting over time if abused
- Clear requirements for which kinds are acceptable and rejected based on the connection information.
- Relays that only accept posts in a given language or location can make that clear to clients.