### PR TITLE
Quoted highlights

### DIFF
--- a/84.md
+++ b/84.md
@@ -40,3 +40,10 @@ last value of the tag.
 ### Context
 Clients MAY include a `context` tag, useful when the highlight is a subset of a paragraph and displaying the
 surrounding content might be beneficial to give context to the highlight.
+
+## Quote Highlights
+A `comment` tag may be added to create a quote highlight. This should be rendered like a quote repost with the highlight as the quoted note.
+
+This is to prevent the creation and multiple notes (highlight + kind 1) for a single highlight action, which looks bad in micro-blogging clients where these notes may appear in succession.
+
+p-tag mentions should have a `mention` attribute to distinguish it from authors and editors.


### PR DESCRIPTION
This is in preparation for Damus' highlight implementation. We have a new quote highlight variation. This is to prevent the creation and multiple notes (highlight + kind 1) for a single highlight action that wishes to add a comment along side a highlight, which looks bad in micro-blogging clients where these notes may appear in succession.

This is backwards compatible with existing highlights, except for the situation where clients might not properly handle the mention attribute.

Since @pablof7z has already mentioned he does not like this approach, we will create a [DIP] if/when this is not accepted.

[DIP]: https://github.com/damus-io/dips