### PR TITLE
NIP-102: Subkey Attestation

### DIFF
--- a/102.md
+++ b/102.md
@@ -1,0 +1,96 @@
+NIP-102
+=======
+
+Hierarchical Deterministic Key Management
+-----------------------------------------
+
+`draft` `optional`
+
+This NIP defines a way to separate identity from authentication using hierarchical deterministic (HD) keys. This allows people to use one key pair to issue independent key pairs for different apps. If a key is compromised, the root key pair can publish an event revoking that key as of a specific time.
+
+HD keys (BIP-32, BIP-39, BIP-44) provide a means of creating new key pairs from a parent in such a way that the new pubkey can be verified to be a child of the parent's pubkey. A message signed by this new key can be rapidly and locally verified as an authentic subkey of the claimed parent.
+
+NIP-06 declares the default nostr derivation path to be `m/44'/1237'/<account>'/0/0`.
+
+```
+recovery phrase -> seed -> xpriv
+   -> m/44'/1237'/0'     -> Account0
+   -> m/44'/1237'/0'/0/0 -> Account0 Subkey0
+   -> m/44'/1237'/0'/1/0 -> Account0 Subkey1
+   -> m/44'/1237'/0'/2/0 -> Account0 Subkey2
+```
+
+## Management Event
+
+The parent key can publish a `Kind 10102` event for subkey management. This event lists subkeys that have been revoked, as well as those that are currently active, and a preference for how valid subkeys that are not listed should be treated. This is only a preference, as it may not always be immediately available to clients and relays.
+
+Content:
+```json
+{
+  "keys": {
+    "<hex-subkey0-pubkey>": { "active_at": "<epoch-timestamp>" },
+    "<hex-subkey1-pubkey>": { "active_at": "<epoch-timestamp>", "revoked_at": "<epoch-timestamp>" },
+    "<hex-subkey2-pubkey>": { "active_at": "<epoch-timestamp>" }
+  },
+  "default_policy": "allow"
+}
+```
+
+## Signing
+
+When signing events using a subkey, the account pubkey and subkey derivation path will be included as a well known attribute. Relays and clients should validate the subkey->parent relationship, and immediately discard messages with invalid claims.
+
+```json
+{
+  "pubkey": "<hex-subkey1-pubkey>",
+  "kind": 1,
+  "tags": [
+    ["account", "<hex-account0-pubkey>", "<subkey1-derivation-path>"],
+  ],
+}
+```
+
+For clients that don't implement NIP-102, we can have the account key publish a `Kind 10102` key management event using the subkey at the time of creation:
+
+Content:
+```json
+{
+  "account": "<hex-account0-pubkey>",
+  "derivation_path": "<subkey1-derivation-path>"
+}
+```
+
+## Behavior
+
+All searches for the account pubkey should return those signed by any account subkey. If an event is replaceable, it is up to the client or relay as to whether both messages are maintained, or if only the latest across all subkeys is maintained. In any situation where data will be lost, a reasonable effort should be made to locate the most recent revocation list before proceeding.
+
+## Migration
+
+Most current keys do not use BIP-39 derivation and will need to perform a manual key rotation to a new pubkey using a method not defined here.
+
+## Reference Code
+
+```python
+from bip_utils import Bip39SeedGenerator, Bip32Slip10Secp256k1
+
+account0_derivation_path = "m/44'/1237'/0'"
+subkey0_derivation_path = "0/0"
+
+mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+master_xpriv = "xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRRuL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu"
+account0_xpub = "xpub6D6V5EX8HTe95getx2tTH2QApmrA1nPJFEnneAK813RjcDdSc3WaAF7BRNpTF7o7zXjVm3DD3VMX66jhQ7wLaZ9sS6NzyfiwfzqDZbxvpDN"
+subkey0_xpub = "xpub6Gf5o5yEF14TykSmvZBzS9wFSgnqvPsxit1v4CaaNf6S6S5mm169FRN3QkCsVsDm8NNaN8eGbQg9vR43BD9UqQTrfWFmRKoWep2gxQpFh3Q"
+
+seed = Bip32Slip10Secp256k1.FromSeed(Bip39SeedGenerator(mnemonic).Generate())
+account0 = seed.DerivePath(account0_derivation_path)
+subkey0 = account0.DerivePath(subkey0_derivation_path)
+
+def is_subkey(pubkey, subkey, derivation_path):
+    parent = Bip32Slip10Secp256k1.FromExtendedKey(pubkey)
+    if parent.DerivePath(derivation_path).PublicKey().ToExtended() == subkey:
+        return True
+    else:
+        return False
+
+print(f'subkey0_xpub is child of account0_xpub: {is_subkey(account0_xpub, subkey0_xpub, subkey0_derivation_path)}')
+```

--- a/102.md
+++ b/102.md
@@ -27,12 +27,9 @@ The parent key can publish a `Kind 10102` event for subkey management. This even
 Content:
 ```json
 {
-  "keys": {
-    "<hex-subkey0-pubkey>": { "active_at": "<epoch-timestamp>" },
-    "<hex-subkey1-pubkey>": { "active_at": "<epoch-timestamp>", "revoked_at": "<epoch-timestamp>" },
-    "<hex-subkey2-pubkey>": { "active_at": "<epoch-timestamp>" }
-  },
-  "default_policy": "allow"
+  "inbox_keys": ["<hex-subkey0-pubkey>", "hex-subkey2-pubkey"],
+  "revoked_keys": ["<hex-subkey1-pubkey>"],
+  "other_keys": ["<non-derived-subkey>"]
 }
 ```
 
@@ -45,8 +42,8 @@ When signing events using a subkey, the account pubkey and subkey derivation pat
   "pubkey": "<hex-subkey1-pubkey>",
   "kind": 1,
   "tags": [
-    ["account", "<hex-account0-pubkey>", "<subkey1-derivation-path>"],
-  ],
+    ["I", "<hex-account0-pubkey>", "<subkey1-derivation-path>"],
+  ]
 }
 ```
 
@@ -55,8 +52,26 @@ For clients that don't implement NIP-102, we can have the account key publish a 
 Content:
 ```json
 {
-  "account": "<hex-account0-pubkey>",
+  "account_key": "<hex-account0-pubkey>",
   "derivation_path": "<subkey1-derivation-path>"
+}
+```
+
+## Migration
+
+Most current keys do not use BIP-39 derivation and will need to publish a `Kind 10102` event pointing to a new pubkey:
+
+```json
+{
+  "other_keys": ["<non-derived-subkey>"]
+}
+```
+
+The new key must publish the opposite `Kind 10102` event claiming the parent:
+
+```json
+{
+  "account_key": ["<parent-pubkey>"]
 }
 ```
 
@@ -64,9 +79,7 @@ Content:
 
 All searches for the account pubkey should return those signed by any account subkey. If an event is replaceable, it is up to the client or relay as to whether both messages are maintained, or if only the latest across all subkeys is maintained. In any situation where data will be lost, a reasonable effort should be made to locate the most recent revocation list before proceeding.
 
-## Migration
-
-Most current keys do not use BIP-39 derivation and will need to perform a manual key rotation to a new pubkey using a method not defined here.
+Do not attempt to resolve `other_keys`, as this could grow exponentially. Always work up from the subkey, as each key can only have a single `account_key`. Limit any search to a reasonable constant maximum depth, maybe 8. If the maximum depth is reached, use the original key instead of the most recently found.
 
 ## Reference Code
 

--- a/102.md
+++ b/102.md
@@ -1,109 +1,107 @@
 NIP-102
 =======
 
-Hierarchical Deterministic Key Management
------------------------------------------
+Subkey Attestation and Management
+------------------------------
 
 `draft` `optional`
 
-This NIP defines a way to separate identity from authentication using hierarchical deterministic (HD) keys. This allows people to use one key pair to issue independent key pairs for different apps. If a key is compromised, the root key pair can publish an event revoking that key as of a specific time.
+This NIP defines a way to separate identity from authentication using subkey attestations. This allows the use of one keypair to issue independent keypairs for different apps. If any subkey key is compromised, the root keypair can publish an event revoking the key.
 
-HD keys (BIP-32, BIP-39, BIP-44) provide a means of creating new key pairs from a parent in such a way that the new pubkey can be verified to be a child of the parent's pubkey. A message signed by this new key can be rapidly and locally verified as an authentic subkey of the claimed parent.
+## Attestation
 
-NIP-06 declares the default nostr derivation path to be `m/44'/1237'/<account>'/0/0`.
+A subkey attestation is created by signing the message:
 
 ```
-recovery phrase -> seed -> xpriv
-   -> m/44'/1237'/0'     -> Account0
-   -> m/44'/1237'/0'/0/0 -> Account0 Subkey0
-   -> m/44'/1237'/0'/1/0 -> Account0 Subkey1
-   -> m/44'/1237'/0'/2/0 -> Account0 Subkey2
+nip102:<hex-subkey1-pubkey>
 ```
 
-## Management Event
+This signature is then added to events to demonstrate authorization to post on behalf of the original key.
 
-The parent key can publish a `Kind 10102` event for subkey management. This event lists subkeys that have been revoked, as well as those that are currently active, and a preference for how valid subkeys that are not listed should be treated. This is only a preference, as it may not always be immediately available to clients and relays.
+The parent key can publish a `Kind 10102` event for subkey management. This event lists attestations that have been revoked, as well as those that should be used to encrypt messages so that they can be read using preferred clients. These declarations are only a preference, as they may not be available in a timely manner.
 
 Content:
 ```json
 {
-  "inbox_keys": ["<hex-subkey0-pubkey>", "hex-subkey2-pubkey"],
-  "revoked_keys": ["<hex-subkey1-pubkey>"],
-  "other_keys": ["<non-derived-subkey>"]
+  "inbox_keys": ["<hex-subkey1-pubkey>", "<hex-subkey2-pubkey>"],
+  "revoked_subkeys": ["<hex-subkey3-pubkey>"]
 }
 ```
 
-## Signing
+## Event Signing
 
-When signing events using a subkey, the account pubkey and subkey derivation path will be included as a well known attribute. Relays and clients should validate the subkey->parent relationship, and immediately discard messages with invalid claims.
+When signing events using a subkey, the account pubkey will be included as a well-known attribute. The event will also include an attestation of the subkey's authorization signed by the main key. Relays and clients should validate this attestation, and discard messages that make invalid claims.
 
 ```json
 {
   "pubkey": "<hex-subkey1-pubkey>",
   "kind": 1,
   "tags": [
-    ["I", "<hex-account0-pubkey>", "<subkey1-derivation-path>"],
+    ["I", "<hex-account0-pubkey>"],
+    ["Ia", "<subkey1-attestation>"]
   ]
 }
 ```
 
-For clients that don't implement NIP-102, we can have the account key publish a `Kind 10102` key management event using the subkey at the time of creation:
+## Event Validation
 
-Content:
-```json
-{
-  "account_key": "<hex-account0-pubkey>",
-  "derivation_path": "<subkey1-derivation-path>"
-}
-```
+An implementing client's subscriptions will be slightly different. For each subscription using `authors`, a second subscription will be registered specifying `#I` instead of `authors`. This will collect all events published by subkeys of the authors, each of which will be checked for a valid attestation in `Ia`. This can be done at the same time the event signature is validated. As the client finds new values of `I`, it will request `Kind 10102` events with an author of `I` in order to check for revocations. When a `Kind 10102` event with `revoked_attestations` is received, use this index to find events that are no longer valid.
 
-## Migration
+After validation, the client will treat an event as if it were signed by the pubkey specified in `I`. This includes honoring NIP-9 deletion requests for events authored by `account0` as well as those having an `I` of `account0` (eg, a subkey acting on behalf of `account0`).
 
-Most current keys do not use BIP-39 derivation and will need to publish a `Kind 10102` event pointing to a new pubkey:
+If `subkey1` publishes an event without an `I` attribute, it should be treated as having an author of `subkey1` and NOT `account0`. `subkey1` may have its own profile, etc, separate from `account0` that is used in these circumstances.
 
-```json
-{
-  "other_keys": ["<non-derived-subkey>"]
-}
-```
+## Destructive Events
 
-The new key must publish the opposite `Kind 10102` event claiming the parent:
+`NIP-09` deletion requests should be honored for events authored by `account0` or having an `I` of `account0`.
+
+## Adoption
+
+### Stage 1:
+
+Client support is required for basic functionality, so we start when the first client implements this spec.
+
+The client will be able to sign messages for the keypair `account0`. A new keypair `subkey1` is generated, and an attestation that `subkey1` is authorized to post on behalf of `account0` is signed by `account0`. For brevity we will say this is a key rotation, and the client now switches to signing messages using `subkey1` with `subkey1-attestation`. The client publishes the message:
 
 ```json
 {
-  "account_key": ["<parent-pubkey>"]
+  "kind": 1,
+  "content": "GM",
+  "I": "<hex-account0-pubkey>",
+  "Ia": "<subkey1-attestation1>"
 }
 ```
 
-## Behavior
+All instances of the client will create secondary subscriptions with `#I` instead of `authors`. Valid events will be merged with those authored by the key in `I`, though destructive events (deletions / replacements) will be deferred until a `Kind 10102` has been retrieved for the pubkey `I`.
 
-All searches for the account pubkey should return those signed by any account subkey. If an event is replaceable, it is up to the client or relay as to whether both messages are maintained, or if only the latest across all subkeys is maintained. In any situation where data will be lost, a reasonable effort should be made to locate the most recent revocation list before proceeding.
+Clients that do not support this NIP will continue to treat `subkey1` and `account0` as different accounts.
 
-Do not attempt to resolve `other_keys`, as this could grow exponentially. Always work up from the subkey, as each key can only have a single `account_key`. Limit any search to a reasonable constant maximum depth, maybe 8. If the maximum depth is reached, use the original key instead of the most recently found.
+### Stage 2:
+
+Relays should ensure that `I` is indexed, and may drop events with invalid `Ia` attestations or have been revoked with the expectation that these will be discarded by clients anyway. Replacement events should ignore `I` and maintained per signing key until there is sufficient client support. In the interim conforming clients will merge these locally.
 
 ## Reference Code
 
 ```python
-from bip_utils import Bip39SeedGenerator, Bip32Slip10Secp256k1
+import secp256k1
 
-account0_derivation_path = "m/44'/1237'/0'"
-subkey0_derivation_path = "0/0"
+def create_attestation(account_privkey, subkey_pubkey):
+    privkey = secp256k1.PrivateKey(bytes.fromhex(account_privkey))
+    signature = privkey.ecdsa_sign(bytes.fromhex(subkey_pubkey))
+    return privkey.ecdsa_serialize(signature).hex()
 
-mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-master_xpriv = "xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRRuL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu"
-account0_xpub = "xpub6D6V5EX8HTe95getx2tTH2QApmrA1nPJFEnneAK813RjcDdSc3WaAF7BRNpTF7o7zXjVm3DD3VMX66jhQ7wLaZ9sS6NzyfiwfzqDZbxvpDN"
-subkey0_xpub = "xpub6Gf5o5yEF14TykSmvZBzS9wFSgnqvPsxit1v4CaaNf6S6S5mm169FRN3QkCsVsDm8NNaN8eGbQg9vR43BD9UqQTrfWFmRKoWep2gxQpFh3Q"
+def verify_attestation(account_pubkey, subkey_pubkey, attestation):
+    pubkey = secp256k1.PublicKey(bytes.fromhex(account_pubkey), raw=True)
+    signature = pubkey.ecdsa_deserialize(bytes.fromhex(attestation))
+    return pubkey.ecdsa_verify(bytes.fromhex(subkey_pubkey), signature)
 
-seed = Bip32Slip10Secp256k1.FromSeed(Bip39SeedGenerator(mnemonic).Generate())
-account0 = seed.DerivePath(account0_derivation_path)
-subkey0 = account0.DerivePath(subkey0_derivation_path)
+# Example usage
+account_privkey = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+account_pubkey = secp256k1.PrivateKey(bytes.fromhex(account_privkey)).pubkey.serialize().hex()
+subkey_pubkey = "fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321"
 
-def is_subkey(pubkey, subkey, derivation_path):
-    parent = Bip32Slip10Secp256k1.FromExtendedKey(pubkey)
-    if parent.DerivePath(derivation_path).PublicKey().ToExtended() == subkey:
-        return True
-    else:
-        return False
+attestation = create_attestation(account_privkey, subkey_pubkey)
+# attestation is "30440220198c94e388c3a5d7eed7f66ea83dd60a0156ba612c1d5067286ace5c641cbb600220739ca9cd3f3780f28c3a98df954736e323d3f23905bfea4482365055b2fb9fe5"
 
-print(f'subkey0_xpub is child of account0_xpub: {is_subkey(account0_xpub, subkey0_xpub, subkey0_derivation_path)}')
+print(f"Attestation is valid: {verify_attestation(account_pubkey, subkey_pubkey, attestation)}")
 ```

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `10030`       | User emoji list                 | [51](51.md)                            |
 | `10050`       | Relay list to receive DMs       | [51](51.md), [17](17.md)               |
 | `10096`       | File storage server list        | [96](96.md)                            |
+| `10102`       | Key management                  | [102](102.md)                            |
 | `13194`       | Wallet Info                     | [47](47.md)                            |
 | `21000`       | Lightning Pub RPC               | [Lightning.Pub][lnpub]                 |
 | `22242`       | Client Authentication           | [42](42.md)                            |

--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `g`               | geohash                              | --                              | [52](52.md)                           |
 | `h`               | group id                             | --                              | [29](29.md)                           |
 | `i`               | external identity                    | proof, url hint                 | [39](39.md), [73](73.md)              |
+| `I`               | parent of subkey                     | pubkey (hex)                    | [102](102.md)                         |
 | `k`               | kind number (string)                 | --                              | [18](18.md), [25](25.md), [72](72.md) |
 | `l`               | label, label namespace               | --                              | [32](32.md)                           |
 | `L`               | label namespace                      | --                              | [32](32.md)                           |


### PR DESCRIPTION
This NIP defines a way to separate identity from authentication by using separate keys for each while still allowing immediate local validation of identity. If a subkey is compromised, the identity key can publish an event disavowing it, similar to a NIP-09 recovation.