### PR TITLE
Fix Ambiguous Wording for REQs in NIP-01

### DIFF
--- a/01.md
+++ b/01.md
@@ -115,7 +115,7 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
   * `["REQ", <subscription_id>, <filters1>, <filters2>, ...]`, used to request events and subscribe to new updates.
   * `["CLOSE", <subscription_id>]`, used to stop previous subscriptions.
 
-`<subscription_id>` is an arbitrary, non-empty string of max length 64 chars. It represents a subscription per connection. Relays MUST manage `<subscription_id>`s independently for each WebSocket connection. `<subscription_id>`s are not guaranteed to be globally unique.
+`<subscription_id>` is an arbitrary, non-empty string. It represents a subscription per connection. Relays MUST manage `<subscription_id>`s independently for each WebSocket connection. `<subscription_id>`s are not guaranteed to be globally unique.
 
 `<filtersX>` is a JSON object that determines what events will be sent in that subscription, it can have the following attributes:
 
@@ -169,7 +169,6 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
   * `["OK", "b1a649ebe8...", false, "pow: difficulty 26 is less than 30"]`
   * `["OK", "b1a649ebe8...", false, "error: could not connect to the database"]`
 - `CLOSED` messages MUST be sent in response to a `REQ` when the relay refuses to fulfill it. It can also be sent when a relay decides to kill a subscription on its side before a client has disconnected or sent a `CLOSE`. This message uses the same pattern of `OK` messages with the machine-readable prefix and human-readable message. Some examples:
-  * `["CLOSED", "sub1", "duplicate: sub1 already opened"]`
   * `["CLOSED", "sub1", "unsupported: filter contains unknown elements"]`
   * `["CLOSED", "sub1", "error: could not connect to the database"]`
   * `["CLOSED", "sub1", "error: shutting down idle subscription"]`


### PR DESCRIPTION
In NIP-01, one part of the NIP says
> (...) a new `REQ` is sent using the same `<subscription_id>`, in which case relay MUST overwrite the previous subscription.

And in another part of the NIP, it gives an example of a relay sending a `CLOSED` message to a client upon receiving a REQ with an already existing `subscription_id`.

After investigating 33 relay implementations linked here: https://github.com/aljazceru/awesome-nostr?tab=readme-ov-file#implementations, I have found 20 implementations which clearly overwrite the previous subscription, 6 that clearly do not and 7 where it is unclear or the relay is a WIP or this wasn't applicable to the particular project .

Here is a table summarizing the findings:

| Relay Name             | Link                                                                                                                                           | Overwrites Duplicate SubId? |
| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
| strfry                 | https://github.com/hoytech/strfry/blob/master/src/QueryScheduler.h#L25                                                                         | Yes                         |
| gnost                  | https://github.com/barkyq/gnost-relay/blob/main/main.go#L661                                                                                   | Yes                         |
| nostr-rs-relay         | https://git.sr.ht/~gheartsfield/nostr-rs-relay/tree/master/item/src/conn.rs#L118                                                               | Yes                         |
| nostream               | https://github.com/cameri/nostream/blob/main/src/handlers/subscribe-message-handler.ts#L92                                                     | No                          |
| nnostr                 | https://github.com/Kukks/NNostr/blob/master/Relay/StateManager.cs#L56                                                                          | Yes                         |
| astro                  | https://github.com/Nostrology/astro/blob/main/lib/astro/event_router.ex#L20                                                                    | Yes                         |
| bostr                  |                                                                                                                                                | N/A                         |
| bostr2                 |                                                                                                                                                | N/A                         |
| bucket                 | https://github.com/coracle-social/bucket/blob/master/src/index.js#L61                                                                          | Yes                         |
| cagliostr              | https://github.com/mattn/cagliostr/blob/main/main.cxx#L143                                                                                     | Yes                         |
| cfrelay                | https://github.com/haorendashu/cfrelay/blob/master/src/index.js#L234                                                                           | N/A*                        |
| denostr                | https://github.com/denostr-lab/denostr/blob/main/src/handlers/subscribe-message-handler.ts#L122                                                | No                          |
| ditto                  | https://github.com/soapbox-pub/ditto/blob/main/src/controllers/nostr/relay.ts#L97                                                              | Yes                         |
| ephemerelay            | https://gitlab.com/soapbox-pub/ephemerelay/-/blob/develop/server.ts?ref_type=heads#L52                                                         | Yes                         |
| knostr                 | https://github.com/lpicanco/knostr/blob/master/src/main/kotlin/com/neutrine/knostr/domain/SubscriptionService.kt#L25                           | Yes                         |
| me.untethr.nostr-relay | https://github.com/atdixon/me.untethr.nostr-relay/blob/main/src/me/untethr/nostr/subscribe.clj#L145                                            | Unclear                     |
| minds                  | https://gitlab.com/minds/infrastructure/nostr-relay/-/blob/master/src/handler/index.ts?ref_type=heads#L32                                      | Yes                         |
| monstr                 | https://github.com/monty888/monstr/blob/master/src/monstr/relay/relay.py#L443                                                                  | No**                        |
| multiplextr            | https://github.com/coracle-social/multiplextr/blob/master/src/index.js#L121                                                                    | Yes***                      |
| nex                    | https://github.com/lebrunel/nex/blob/main/lib/nex/handlers/subscription_hander.ex#L27                                                          | No**                        |
| nostr_relay            | https://code.pobblelabs.org/nostr_relay/file?name=nostr_relay/storage/base.py&ci=tip                                                           | Yes***                      |
| nostr-filter-relay     | strfry                                                                                                                                         | Yes                         |
| nostring               | https://github.com/xbol0/nostring/blob/main/app.ts#L347                                                                                        | Yes                         |
| superconductor         | https://github.com/avlo/superconductor/blob/master/src/main/java/com/prosilion/superconductor/service/request/CachedSubscriberService.java#L43 | Yes****                     |
| NostrPostr             | https://github.com/Giszmo/NostrPostr/blob/master/NostrRelay/src/main/java/nostr/relay/Relay.kt#L238                                            | Yes                         |
| nostpy                 |                                                                                                                                                | Unclear                     |
| nostrpy                | https://github.com/monty888/nostrpy/blob/master/nostr/relay/relay.py#L304                                                                      | No**                        |
| pyrelay                | https://github.com/johnny423/pyrelay/blob/master/pyrelay/relay/relay_service.py#L54                                                            | Yes                         |
| relayer (basic)        | https://github.com/fiatjaf/relayer/blob/master/listener.go#L59                                                                                 | Yes                         |
| rnostr                 | https://github.com/rnostr/rnostr/blob/44dffc9799af7eee9b4661fd85e95ebb54d99196/relay/src/subscriber.rs#L166                                    | Yes                         |
| servus                 | https://github.com/servuscms/servus/blob/f625392fc6542cb253b3355958cfce21865595b2/src/main.rs#L220                                             | WIP                         |
| s0str                  |                                                                                                                                                | WIP                         |
| nostra                 | https://github.com/lontivero/Nostra/blob/master/Nostra.Relay/MessageProcessing.fs#L55                                                          | No**                        |
| nostr_client_relay     |                                                                                                                                                | WIP                         |
| nosflare               |                                                                                                                                                | WIP                         |

\* = Relay doesn't even store subscriptions
\** = Relay sends a NOTICE instead of a CLOSED
\*** = Relay closes/unsubscribes first before re-adding the subscription
\**** = Dude fuck java

In doing this exercise, I have also found a couple of strange things:
- some implementations don't send a `CLOSED` for duplicate `subscription_id` but instead send a `NOTICE`
- from what I could tell, only [rnostr](https://github.com/rnostr/rnostr) is enforcing the rule that `subscription_id` be maximum 64 characters in length. Though someone should go through my list to double check (I would but my eyes are crossed from looking at all these implementations). I know for sure a minority of implementations are enforcing this, so in this MR, I propose to also remove the restriction. 

**NOTE:** It's worth mentioning I have no idea what the distribution of relay implementations is out in the wild and whether or not this discrepancy is more or less widespread than what I'm seeing based solely on the different relay implementations.