### PR TITLE
NIP-65: rename "Relay List Metadata" to "Outbox model"

### DIFF
--- a/65.md
+++ b/65.md
@@ -1,8 +1,8 @@
 NIP-65
 ======
 
-Relay List Metadata
--------------------
+Outbox model
+------------
 
 `draft` `optional`
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-58: Badges](58.md)
 - [NIP-59: Gift Wrap](59.md)
 - [NIP-64: Chess (PGN)](64.md)
-- [NIP-65: Relay List Metadata](65.md)
+- [NIP-65: Outbox model](65.md)
 - [NIP-70: Protected Events](70.md)
 - [NIP-71: Video Events](71.md)
 - [NIP-72: Moderated Communities](72.md)


### PR DESCRIPTION
The "Outbox model" is familiar to many nostriches. And for beginners who don't know this NIP, there is no significant difference between the names "Outbox model" and the "Relay List Metadata".