### PR TITLE
Add functionality to exclude specified relays from deletion requests

### DIFF
--- a/09.md
+++ b/09.md
@@ -6,7 +6,7 @@ Event Deletion Request
 
 `draft` `optional`
 
-A special event with kind `5`, meaning "deletion request" is defined as having a list of one or more `e` or `a` tags, each referencing an event the author is requesting to be deleted. Deletion requests SHOULD include a `k` tag for the kind of each event being requested for deletion.
+A special event with kind `5`, meaning "deletion request" is defined as having a list of one or more `e` or `a` tags, each referencing an event the author is requesting to be deleted. Deletion requests SHOULD include a `k` tag for the kind of each event being requested for deletion. The exclude tag is used to specify relays that are excluded from the deletion request. Relays listed in this tag SHOULD NOT delete the referenced events and SHOULD continue to publish them.
 
 The event's `content` field MAY contain a text note describing the reason for the deletion request.
 
@@ -22,32 +22,33 @@ For example:
     ["a", "<kind>:<pubkey>:<d-identifier>"],
     ["k", "1"],
     ["k", "30023"]
+    ["exclude", "wss://relay1.example.com", "wss://relay2.example.com"]
   ],
   "content": "these posts were published by accident",
   ...other fields
 }
 ```
 
-Relays SHOULD delete or stop publishing any referenced events that have an identical `pubkey` as the deletion request.  Clients SHOULD hide or otherwise indicate a deletion request status for referenced events.
+Relays SHOULD delete or stop publishing any referenced events that have an identical `pubkey` as the deletion request, except for the relays listed in the exclude tag. Relays listed in the exclude tag SHOULD keep the events and continue publishing them. Clients SHOULD hide or otherwise indicate a deletion request status for referenced events, except when accessing them from relays listed in the exclude tag.
 
-Relays SHOULD continue to publish/share the deletion request events indefinitely, as clients may already have the event that's intended to be deleted. Additionally, clients SHOULD broadcast deletion request events to other relays which don't have it.
+Relays SHOULD continue to publish/share the deletion request events indefinitely, as clients may already have the event that's intended to be deleted. Additionally, clients SHOULD broadcast deletion request events to other relays which don't have it, while respecting the exclude tag.
 
 When an `a` tag is used, relays SHOULD delete all versions of the replaceable event up to the `created_at` timestamp of the deletion request event.
 
 ## Client Usage
 
-Clients MAY choose to fully hide any events that are referenced by valid deletion request events.  This includes text notes, direct messages, or other yet-to-be defined event kinds.  Alternatively, they MAY show the event along with an icon or other indication that the author has "disowned" the event.  The `content` field MAY also be used to replace the deleted events' own content, although a user interface should clearly indicate that this is a deletion request reason, not the original content.
+Clients MAY choose to fully hide any events that are referenced by valid deletion request events, except when accessed from relays listed in the exclude tag. This includes text notes, direct messages, or other yet-to-be defined event kinds. Alternatively, they MAY show the event along with an icon or other indication that the author has "disowned" the event. The content field MAY also be used to replace the deleted events' own content, although a user interface should clearly indicate that this is a deletion request reason, not the original content.
 
-A client MUST validate that each event `pubkey` referenced in the `e` tag of the deletion request is identical to the deletion request `pubkey`, before hiding or deleting any event.  Relays can not, in general, perform this validation and should not be treated as authoritative.
+A client MUST validate that each event pubkey referenced in the e tag of the deletion request is identical to the deletion request pubkey, before hiding or deleting any event. This validation should also consider the exclude tag. Relays can not, in general, perform this validation and should not be treated as authoritative.
 
 Clients display the deletion request event itself in any way they choose, e.g., not at all, or with a prominent notice.
 
-Clients MAY choose to inform the user that their request for deletion does not guarantee deletion because it is impossible to delete events from all relays and clients.
+Clients MAY choose to inform the user that their request for deletion does not guarantee deletion because it is impossible to delete events from all relays and clients, especially if the exclude tag is used.
 
 ## Relay Usage
 
-Relays MAY validate that a deletion request event only references events that have the same `pubkey` as the deletion request itself, however this is not required since relays may not have knowledge of all referenced events.
+Relays MAY validate that a deletion request event only references events that have the same pubkey as the deletion request itself, however this is not required since relays may not have knowledge of all referenced events. Relays listed in the exclude tag SHOULD NOT delete the events referenced in the deletion request and SHOULD continue publishing them.
 
 ## Deletion Request of a Deletion Request
 
-Publishing a deletion request event against a deletion request has no effect.  Clients and relays are not obliged to support "unrequest deletion" functionality.
+Publishing a deletion request event against a deletion request has no effect. Clients and relays are not obliged to support "unrequest deletion" functionality. The exclude tag cannot be applied to deletion requests targeting other deletion requests.


### PR DESCRIPTION
This PR proposes an update to NIP-09 by introducing a new exclude tag to the Event Deletion Request specification. The exclude tag allows users to specify relays that should not delete or stop publishing the events referenced in a deletion request.