### PR TITLE
style: fix header styles in same format

### DIFF
--- a/09.md
+++ b/09.md
@@ -2,7 +2,7 @@ NIP-09
 ======
 
 Event Deletion Request
---------------
+----------------------
 
 `draft` `optional`
 

--- a/10.md
+++ b/10.md
@@ -2,8 +2,8 @@ NIP-10
 ======
 
 
-On "e" and "p" tags in Text Events (kind 1).
---------------------------------------------
+On "e" and "p" tags in Text Events (kind 1)
+-------------------------------------------
 
 `draft` `optional`
 

--- a/11.md
+++ b/11.md
@@ -2,7 +2,7 @@ NIP-11
 ======
 
 Relay Information Document
----------------------------
+--------------------------
 
 `draft` `optional`
 
@@ -172,7 +172,7 @@ There is no need to specify retention times for _ephemeral events_ since they ar
 ### Content Limitations
 
 Some relays may be governed by the arbitrary laws of a nation state. This
-may limit what content can be stored in cleartext on those relays. All
+may limit what content can be stored in clear-text on those relays. All
 clients are encouraged to use encryption to work around this limitation.
 
 It is not possible to describe the limitations of each country's laws
@@ -183,7 +183,7 @@ countries' laws might end up being enforced on them, and then
 indirectly on their users' content.
 
 Users should be able to avoid relays in countries they don't like,
-and/or select relays in more favourable zones. Exposing this
+and/or select relays in more favorable zones. Exposing this
 flexibility is up to the client software.
 
 ```json

--- a/26.md
+++ b/26.md
@@ -2,7 +2,7 @@ NIP-26
 =======
 
 Delegated Event Signing
------
+-----------------------
 
 `draft` `optional`
 

--- a/32.md
+++ b/32.md
@@ -2,7 +2,7 @@ NIP-32
 ======
 
 Labeling
----------
+--------
 
 `draft` `optional`
 

--- a/35.md
+++ b/35.md
@@ -2,7 +2,7 @@ NIP-35
 ======
 
 Torrents
------------
+--------
 
 `draft` `optional`
 

--- a/38.md
+++ b/38.md
@@ -3,7 +3,7 @@ NIP-38
 ======
 
 User Statuses
---------------
+-------------
 
 `draft` `optional`
 

--- a/44.md
+++ b/44.md
@@ -1,5 +1,5 @@
 NIP-44
-=====
+======
 
 Encrypted Payloads (Versioned)
 ------------------------------

--- a/45.md
+++ b/45.md
@@ -2,7 +2,7 @@ NIP-45
 ======
 
 Event Counts
---------------
+------------
 
 `draft` `optional`
 

--- a/46.md
+++ b/46.md
@@ -1,4 +1,8 @@
-# NIP-46 - Nostr Remote Signing
+NIP-46
+======
+
+Nostr Remote Signing
+--------------------
 
 ## Rationale
 

--- a/55.md
+++ b/55.md
@@ -1,6 +1,8 @@
-# NIP-55
+NIP-55
+======
 
-## Android Signer Application
+Android Signer Application
+--------------------------
 
 `draft` `optional`
 

--- a/64.md
+++ b/64.md
@@ -2,7 +2,7 @@ NIP-64
 ======
 
 Chess (Portable Game Notation)
------
+------------------------------
 
 `draft` `optional`
 

--- a/71.md
+++ b/71.md
@@ -2,7 +2,7 @@ NIP-71
 ======
 
 Video Events
----------------
+------------
 
 `draft` `optional`
 

--- a/73.md
+++ b/73.md
@@ -2,7 +2,7 @@ NIP-73
 ======
 
 External Content IDs
--------------------------
+--------------------
 
 `draft` `optional`
 

--- a/96.md
+++ b/96.md
@@ -1,6 +1,8 @@
-# NIP-96
+NIP-96
+======
 
-## HTTP File Storage Integration
+HTTP File Storage Integration
+-----------------------------
 
 `draft` `optional`
 


### PR DESCRIPTION
Some NIP headers were different from others. I just changed their style to the same format. That's not bad to take care of their format in reviews when someone changes them.