### PR TITLE
Define l-tag on Text Events

### DIFF
--- a/10.md
+++ b/10.md
@@ -2,8 +2,8 @@ NIP-10
 ======
 
 
-On "e" and "p" tags in Text Events (kind 1).
---------------------------------------------
+On "e", "p" and "l" tags in Text Events (kind 1).
+-------------------------------------------------
 
 `draft` `optional`
 
@@ -62,3 +62,13 @@ When replying to a text event E the reply event's "p" tags should contain all of
 
 Example:  Given a text event authored by `a1` with "p" tags [`p1`, `p2`, `p3`] then the "p" tags of the reply should be [`a1`, `p1`, `p2`, `p3`]
 in no particular order.
+
+## The "l" tag
+
+Text events MUST indicate the level in their respective thread. The root event
+MUST use ["l", "0"], replies to an l-0 event MUST use ["l", "1"] etc.
+
+As this tag was not defined from day one, clients should not assume 100%
+adoption and use it when querying for root events `…,kinds:[1],"#l":["0"]` or
+immediate replies `…,kinds:[1],"e":[<event-id>],"#l":["3"]` only once broad
+adoption was achieved.


### PR DESCRIPTION
Clients currently have no way of querying only root Text Events, which is all they need for a timeline for example. To improve this, the l-tag allows querying root-events or even improve loading of replies on very busy threads by only loading the next level at a time.