### PR TITLE
format(all): JSON formatting

### DIFF
--- a/02.md
+++ b/02.md
@@ -14,7 +14,7 @@ The `.content` is not used.
 
 For example:
 
-```json
+```jsonc
 {
   "kind": 3,
   "tags": [
@@ -23,7 +23,7 @@ For example:
     ["p", "612ae..e610f", "ws://carolrelay.com/ws", "carol"]
   ],
   "content": "",
-  ...other fields
+  // other fields...
 }
 ```
 

--- a/05.md
+++ b/05.md
@@ -16,12 +16,12 @@ The result should be a JSON document object with a key `"names"` that should the
 
 If a client sees an event like this:
 
-```json
+```jsonc
 {
   "pubkey": "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9",
   "kind": 0,
   "content": "{\"name\": \"bob\", \"nip05\": \"bob@example.com\"}"
-  ...
+  // other fields...
 }
 ```
 

--- a/09.md
+++ b/09.md
@@ -12,7 +12,7 @@ The event's `content` field MAY contain a text note describing the reason for th
 
 For example:
 
-```
+```jsonc
 {
   "kind": 5,
   "pubkey": <32-bytes hex-encoded public key of the event creator>,
@@ -24,7 +24,7 @@ For example:
     ["k", "30023"]
   ],
   "content": "these posts were published by accident",
-  ...other fields
+  // other fields...
 }
 ```
 

--- a/11.md
+++ b/11.md
@@ -66,7 +66,7 @@ These are limitations imposed by the relay on clients. Your client
 should expect that requests which exceed these *practical* limitations
 are rejected or fail immediately.
 
-```json
+```jsonc
 {
   "limitation": {
     "max_message_length": 16384,
@@ -83,7 +83,7 @@ are rejected or fail immediately.
     "created_at_lower_limit": 31536000,
     "created_at_upper_limit": 3
   },
-  ...
+  // other fields...
 }
 ```
 
@@ -146,14 +146,15 @@ Retention times are given in seconds, with `null` indicating infinity.
 If zero is provided, this means the event will not be stored at
 all, and preferably an error will be provided when those are received.
 
-```json
+```jsonc
 {
   "retention": [
     {"kinds": [0, 1, [5, 7], [40, 49]], "time": 3600},
     {"kinds": [[40000, 49999]], "time": 100},
     {"kinds": [[30000, 39999]], "count": 1000},
     {"time": 3600, "count": 10000}
-  ]
+  ],
+  // other fields...
 }
 ```
 
@@ -186,10 +187,10 @@ Users should be able to avoid relays in countries they don't like,
 and/or select relays in more favorable zones. Exposing this
 flexibility is up to the client software.
 
-```json
+```jsonc
 {
   "relay_countries": [ "CA", "US" ],
-  ...
+  // other fields...
 }
 ```
 
@@ -208,12 +209,12 @@ local community. This would encourage users to follow the global
 feed on that relay, in addition to their usual individual follows.
 To support this goal, relays MAY specify some of the following values.
 
-```json
+```jsonc
 {
   "language_tags": ["en", "en-419"],
   "tags": ["sfw-only", "bitcoin-only", "anime"],
   "posting_policy": "https://example.com/posting-policy.html",
-  ...
+  // other fields...
 }
 ```
 
@@ -260,10 +261,10 @@ Relays that require payments may want to expose their fee schedules.
 
 A URL pointing to an image to be used as an icon for the relay. Recommended to be squared in shape.
 
-```json
+```jsonc
 {
   "icon": "https://nostr.build/i/53866b44135a27d624e99c6165cabd76ac8f72797209700acb189fce75021f47.jpg",
-  ...
+  // other fields...
 }
 ```
 
@@ -271,9 +272,11 @@ A URL pointing to an image to be used as an icon for the relay. Recommended to b
 
 As of 2 May 2023 the following command provided these results:
 
+```bash
+$ curl -H "Accept: application/nostr+json" https://eden.nostr.land | jq
 ```
-~> curl -H "Accept: application/nostr+json" https://eden.nostr.land | jq
 
+```json
 {
   "description": "nostr.land family of relays (us-or-01)",
   "name": "nostr.land",
@@ -312,3 +315,4 @@ As of 2 May 2023 the following command provided these results:
     ]
   },
 }
+```

--- a/15.md
+++ b/15.md
@@ -73,10 +73,10 @@ Fields that are not self-explanatory:
 
 **Event Tags**
 
-```json
+```jsonc
 {
   "tags": [["d", <string, id of stall]],
-  ...
+  // other fields...
 }
 ```
  - the `d` tag is required, its value MUST be the same as the stall `id`.
@@ -124,12 +124,12 @@ Fields that are not self-explanatory:
 
 **Event Tags**
 
-```json
+```jsonc
   "tags": [
     ["d", <string, id of product],
     ["t", <string (optional), product category],
     ["t", <string (optional), product category],
-    ...
+    // other fields...
   ],
   ...
 ```
@@ -158,7 +158,7 @@ The below JSON goes in content of [NIP-04](04.md).
   "type": 0,
   "name": <string (optional), ???>,
   "address": <string (optional), for physical goods an address should be provided>,
-  "message": "<string (optional), message for merchant>,
+  "message": <string (optional), message for merchant>,
   "contact": {
     "nostr": <32-bytes hex of a pubkey>,
     "phone": <string (optional), if the customer wants to be contacted by phone>,
@@ -237,7 +237,7 @@ Create a customized user experience using the `naddr` from [NIP-19](19.md#sharea
 
 **Event Content**
 
-```json
+```jsonc
 {
   "name": <string (optional), market name>,
   "about": <string (optional), market description>,
@@ -248,7 +248,7 @@ Create a customized user experience using the `naddr` from [NIP-19](19.md#sharea
     "darkMode": <bool, true/false>
   },
   "merchants": [array of pubkeys (optional)],
-  ...
+  // other fields...
 }
 ```
 
@@ -290,10 +290,11 @@ This event leverages naddr to enable comprehensive customization and sharing of 
 
 ### Event `1021`: Bid
 
-```json
+```jsonc
 {
     "content": <int, amount of sats>,
     "tags": [["e", <event ID of the auction to bid on>]],
+    // other fields...
 }
 ```
 
@@ -335,4 +336,4 @@ Customer support is handled over whatever communication method was specified. If
 
 ## Additional
 
-Standard data models can be found <a href="https://raw.githubusercontent.com/lnbits/nostrmarket/main/models.py">here</a>
+Standard data models can be found [here](https://raw.githubusercontent.com/lnbits/nostrmarket/main/models.py)

--- a/17.md
+++ b/17.md
@@ -12,18 +12,18 @@ This NIP defines an encrypted direct messaging scheme using [NIP-44](44.md) encr
 
 Kind `14` is a chat message. `p` tags identify one or more receivers of the message.
 
-```js
+```jsonc
 {
   "id": "<usual hash>",
   "pubkey": "<sender-pubkey>",
-  "created_at": now(),
+  "created_at": "<current-time>",
   "kind": 14,
   "tags": [
     ["p", "<receiver-1-pubkey>", "<relay-url>"],
     ["p", "<receiver-2-pubkey>", "<relay-url>"],
     ["e", "<kind-14-id>", "<relay-url>", "reply"] // if this is a reply
     ["subject", "<conversation-title>"],
-    ...
+    // rest of tags...
   ],
   "content": "<message-in-plain-text>",
 }
@@ -86,7 +86,7 @@ Clients CAN offer disappearing messages by setting an `expiration` tag in the gi
 
 Kind `10050` indicates the user's preferred relays to receive DMs. The event MUST include a list of `relay` tags with relay URIs.
 
-```js
+```jsonc
 {
   "kind": 10050,
   "tags": [
@@ -94,7 +94,7 @@ Kind `10050` indicates the user's preferred relays to receive DMs. The event MUS
     ["relay", "wss://myrelay.nostr1.com"],
   ],
   "content": "",
-  //...other fields
+  // other fields...
 }
 ```
 

--- a/25.md
+++ b/25.md
@@ -57,14 +57,14 @@ Reactions to a website
 
 If the target of the reaction is a website, the reaction MUST be a `kind 17` event and MUST include an `r` tag with the website's URL.
 
-```json
+```jsonc
 {
   "kind": 17,
   "content": "⭐",
   "tags": [
     ["r", "https://example.com/"]
   ],
-  ...other fields
+  // other fields...
 }
 ```
 
@@ -79,14 +79,14 @@ The client may specify a custom emoji ([NIP-30](30.md)) `:shortcode:` in the
 reaction content. The client should refer to the emoji tag and render the
 content as an emoji if shortcode is specified.
 
-```json
+```jsonc
 {
   "kind": 7,
   "content": ":soapbox:",
   "tags": [
     ["emoji", "soapbox", "https://gleasonator.com/emoji/Gleasonator/soapbox.png"]
   ],
-  ...other fields
+  // other fields...
 }
 ```
 

--- a/28.md
+++ b/28.md
@@ -25,10 +25,10 @@ Create a public chat channel.
 
 In the channel creation `content` field, Client SHOULD include basic channel metadata (`name`, `about`, `picture` and `relays` as specified in kind 41).
 
-```json
+```jsonc
 {
   "content": "{\"name\": \"Demo Channel\", \"about\": \"A test channel.\", \"picture\": \"https://placekitten.com/200/200\", \"relays\": [\"wss://nos.lol\", \"wss://nostr.mom\"]}",
-  ...
+ // other fields...
 }
 ```
 
@@ -52,11 +52,11 @@ Clients MAY add additional metadata fields.
 
 Clients SHOULD use [NIP-10](10.md) marked "e" tags to recommend a relay.
 
-```json
+```jsonc
 {
   "content": "{\"name\": \"Updated Demo Channel\", \"about\": \"Updating a test channel.\", \"picture\": \"https://placekitten.com/201/201\", \"relays\": [\"wss://nos.lol\", \"wss://nostr.mom\"]}",
   "tags": [["e", <channel_create_event_id>, <relay-url>]],
-  ...
+  // other fields...
 }
 ```
 
@@ -71,26 +71,26 @@ Clients SHOULD append [NIP-10](10.md) "p" tags to replies.
 
 Root message:
 
-```json
+```jsonc
 {
   "content": <string>,
   "tags": [["e", <kind_40_event_id>, <relay-url>, "root"]],
-  ...
+  // other fields...
 }
 ```
 
 Reply to another message:
 
-```json
+```jsonc
 {
   "content": <string>,
   "tags": [
       ["e", <kind_40_event_id>, <relay-url>, "root"],
       ["e", <kind_42_event_id>, <relay-url>, "reply"],
       ["p", <pubkey>, <relay-url>],
-      ...
+      // rest of tags...
   ],
-  ...
+  // other fields...
 }
 ```
 
@@ -107,11 +107,11 @@ Clients MAY hide event 42s for other users other than the user who sent the even
 
 (For example, if three users 'hide' an event giving a reason that includes the word 'pornography', a Nostr client that is an iOS app may choose to hide that message for all iOS clients.)
 
-```json
+```jsonc
 {
   "content": "{\"reason\": \"Dick pic\"}",
   "tags": [["e", <kind_42_event_id>]],
-  ...
+  // other fields...
 }
 ```
 
@@ -125,11 +125,11 @@ Clients SHOULD hide event 42s shown to a given user, if there is an event 44 fro
 
 Clients MAY hide event 42s for users other than the user who sent the event 44.
 
-```json
+```jsonc
 {
   "content": "{\"reason\": \"Posting dick pics\"}",
   "tags": [["p", <pubkey>]],
-  ...
+  // other fields...
 }
 ```
 

--- a/29.md
+++ b/29.md
@@ -42,14 +42,14 @@ Relays should prevent late publication (messages published now with a timestamp 
 
 This is the basic unit of a "microblog" root text note sent to a group.
 
-```js
+```jsonc
   "kind": 11,
   "content": "hello my friends lovers of pizza",
   "tags": [
     ["h", "<group-id>"],
-    ["previous", "<event-id-first-chars>", "<event-id-first-chars>", ...]
+    ["previous", "<event-id-first-chars>", "<event-id-first-chars>", /*...*/]
   ]
-  ...
+  // other fields...
 ```
 
 - *threaded text reply* (`kind:12`)
@@ -63,14 +63,14 @@ This is the basic unit of a "microblog" reply note sent to a group. It's the sam
 
 This is the basic unit of a _chat message_ sent to a group.
 
-```js
+```jsonc
   "kind": 9,
   "content": "hello my friends lovers of pizza",
   "tags": [
     ["h", "<group-id>"],
-    ["previous", "<event-id-first-chars>", "<event-id-first-chars>", ...]
+    ["previous", "<event-id-first-chars>", "<event-id-first-chars>", /*...*/]
   ]
-  ...
+  // other fields...
 ```
 
 - *chat message threaded reply* (`kind:10`)
@@ -83,7 +83,7 @@ Similar to `kind:12`, this is the basic unit of a chat message sent to a group. 
 
 Any user can send one of these events to the relay in order to be automatically or manually added to the group. If the group is `open` the relay will automatically issue a `kind:9000` in response adding this user. Otherwise group admins may choose to query for these requests and act upon them.
 
-```js
+```json
 {
   "kind": 9021,
   "content": "optional reason",
@@ -97,7 +97,7 @@ Any user can send one of these events to the relay in order to be automatically 
 
 Any user can send one of these events to the relay in order to be automatically removed from the group. The relay will automatically issue a `kind:9001` in response removing this user.
 
-```js
+```json
 {
   "kind": 9022,
   "content": "optional reason",
@@ -111,13 +111,13 @@ Any user can send one of these events to the relay in order to be automatically 
 
 Clients can send these events to a relay in order to accomplish a moderation action. Relays must check if the pubkey sending the event is capable of performing the given action. The relay may discard the event after taking action or keep it as a moderation log.
 
-```js
+```json
 {
   "kind": 90xx,
   "content": "optional reason",
   "tags": [
     ["h", "<group-id>"],
-    ["previous", ...]
+    ["previous", /*...*/]
   ]
 }
 ```
@@ -142,7 +142,7 @@ This event defines the metadata for the group -- basically how clients should di
 
 If the group is forked and hosted in multiple relays, there will be multiple versions of this event in each different relay and so on.
 
-```js
+```jsonc
 {
   "kind": 39000,
   "content": "",
@@ -154,7 +154,7 @@ If the group is forked and hosted in multiple relays, there will be multiple ver
     ["public"], // or ["private"]
     ["open"] // or ["closed"]
   ]
-  ...
+  // other fields...
 }
 ```
 
@@ -177,7 +177,7 @@ The list of capabilities, as defined by this NIP, for now, is the following:
 - `edit-group-status`
 - `delete-group`
 
-```js
+```json
 {
   "kind": 39001,
   "content": "list of admins for the pizza lovers group",
@@ -186,7 +186,7 @@ The list of capabilities, as defined by this NIP, for now, is the following:
     ["p", "<pubkey1-as-hex>", "ceo", "add-user", "edit-metadata", "delete-event", "remove-user"],
     ["p", "<pubkey2-as-hex>", "secretary", "add-user", "delete-event"]
   ]
-  ...
+  // other fields...
 }
 ```
 

--- a/32.md
+++ b/32.md
@@ -57,7 +57,7 @@ Example events
 
 A suggestion that multiple pubkeys be associated with the `permies` topic.
 
-```json
+```jsonc
 {
   "kind": 1985,
   "tags": [
@@ -66,13 +66,13 @@ A suggestion that multiple pubkeys be associated with the `permies` topic.
     ["p", <pubkey1>, <relay_url>],
     ["p", <pubkey2>, <relay_url>]
   ],
-  ...
+  // other fields...
 }
 ```
 
 A report flagging violence toward a human being as defined by ontology.example.com.
 
-```json
+```jsonc
 {
   "kind": 1985,
   "tags": [
@@ -81,13 +81,13 @@ A report flagging violence toward a human being as defined by ontology.example.c
     ["p", <pubkey1>, <relay_url>],
     ["p", <pubkey2>, <relay_url>]
   ],
-  ...
+  // other fields...
 }
 ```
 
 A moderation suggestion for a chat event.
 
-```json
+```jsonc
 {
   "kind": 1985,
   "tags": [
@@ -95,13 +95,13 @@ A moderation suggestion for a chat event.
     ["l", "approve", "nip28.moderation"],
     ["e", <kind40_event_id>, <relay_url>]
   ],
-  ...
+  // other fields...
 }
 ```
 
 Assignment of a license to an event.
 
-```json
+```jsonc
 {
   "kind": 1985,
   "tags": [
@@ -109,14 +109,14 @@ Assignment of a license to an event.
     ["l", "MIT", "license"],
     ["e", <event_id>, <relay_url>]
   ],
-  ...
+  // other fields...
 }
 ```
 
 Publishers can self-label by adding `l` tags to their own non-1985 events. In this case, the kind 1 event's author
 is labeling their note as being related to Milan, Italy using ISO 3166-2.
 
-```json
+```jsonc
 {
   "kind": 1,
   "tags": [
@@ -124,13 +124,13 @@ is labeling their note as being related to Milan, Italy using ISO 3166-2.
     ["l", "IT-MI", "ISO-3166-2"]
   ],
   "content": "It's beautiful here in Milan!",
-  ...
+  // other fields...
 }
 ```
 
 Author is labeling their note language as English using ISO-639-1.
 
-```json
+```jsonc
 {
   "kind": 1,
   "tags": [
@@ -138,7 +138,7 @@ Author is labeling their note language as English using ISO-639-1.
     ["l", "en", "ISO-639-1"]
   ],
   "content": "English text",
-  ...
+  // other fields...
 }
 ```
 
@@ -169,7 +169,7 @@ be handled in some other way.
 
 
 Appendix: Known Ontologies
--------------------------
+--------------------------
 
 Below is a non-exhaustive list of ontologies currently in widespread use.
 

--- a/34.md
+++ b/34.md
@@ -106,7 +106,7 @@ The first patch in a series MAY be a cover letter in the format produced by `git
 
 Issues are Markdown text that is just human-readable conversational threads related to the repository: bug reports, feature requests, questions or comments of any kind. Like patches, these SHOULD be sent to the relays specified in that repository's announcement event's `"relays"` tag.
 
-```jsonc
+```json
 {
   "kind": 1621,
   "content": "<markdown text>",
@@ -132,8 +132,9 @@ Replies are also Markdown text. The difference is that they MUST be issued as re
     // other "e" and "p" tags should be applied here when necessary, following the threading rules of NIP-10
     ["p", "<patch-author-pubkey-hex>", "", "mention"],
     ["e", "<previous-reply-id-hex>", "", "reply"],
-    // ...
-  ]
+    // rest of tags...
+  ],
+  // other fields...
 }
 ```
 

--- a/35.md
+++ b/35.md
@@ -37,7 +37,7 @@ A second level prefix should be included where the database supports multiple me
 
 In some cases the url mapping isnt direct, mapping the url in general is out of scope for this NIP, the section above is only a guide so that implementers have enough information to succsesfully map the url if they wish.
 
-```jsonc
+```json
 {
   "kind": 2003,
   "content": "<long-description-pre-formatted>",

--- a/38.md
+++ b/38.md
@@ -17,7 +17,7 @@ A special event with `kind:30315` "User Status" is defined as an *optionally exp
 
 For example:
 
-```js
+```json
 {
   "kind": 30315,
   "content": "Sign up for nostrasia!",
@@ -26,7 +26,9 @@ For example:
     ["r", "https://nostr.world"]
   ],
 }
+```
 
+```json
 {
   "kind": 30315,
   "content": "Intergalatic - Beastie Boys",

--- a/39.md
+++ b/39.md
@@ -13,7 +13,8 @@ Nostr protocol users may have other online identities such as usernames, profile
 ## `i` tag on a metadata event
 
 A new optional `i` tag is introduced for `kind 0` metadata event defined in [NIP-01](01.md):
-```json
+
+```jsonc
 {
   "id": <id>,
   "pubkey": <pubkey>,
@@ -23,7 +24,7 @@ A new optional `i` tag is introduced for `kind 0` metadata event defined in [NIP
     ["i", "mastodon:bitcoinhackers.org/@semisol", "109775066355589974"]
     ["i", "telegram:1087295469", "nostrdirectory/770"]
   ],
-  ...
+  // other fields...
 }
 ```
 

--- a/42.md
+++ b/42.md
@@ -22,13 +22,13 @@ A relay may want to require clients to authenticate to access restricted resourc
 
 This NIP defines a new message, `AUTH`, which relays CAN send when they support authentication and clients can send to relays when they want to authenticate. When sent by relays the message has the following form:
 
-```json
+```
 ["AUTH", <challenge-string>]
 ```
 
 And, when sent by clients, the following form:
 
-```json
+```
 ["AUTH", <signed-event-json>]
 ```
 
@@ -38,14 +38,14 @@ And, when sent by clients, the following form:
 
 The signed event is an ephemeral event not meant to be published or queried, it must be of `kind: 22242` and it should have at least two tags, one for the relay URL and one for the challenge string as received from the relay. Relays MUST exclude `kind: 22242` events from being broadcasted to any client. `created_at` should be the current time. Example:
 
-```json
+```jsonc
 {
   "kind": 22242,
   "tags": [
     ["relay", "wss://relay.example.com/"],
     ["challenge", "challengestringhere"]
   ],
-  ...
+  // other fields...
 }
 ```
 

--- a/46.md
+++ b/46.md
@@ -94,7 +94,7 @@ nostrconnect://<local-keypair-pubkey>?relay=<wss://relay-to-connect-on>&metadata
 
 ## Request Events `kind: 24133`
 
-```json
+```jsonc
 {
     "id": <id>,
     "kind": 24133,

--- a/47.md
+++ b/47.md
@@ -173,7 +173,7 @@ Request:
         "amount": 123, // invoice amount in msats, required
         "pubkey": "03...", // payee pubkey, required
         "preimage": "0123456789abcdef...", // preimage of the payment, optional
-        "tlv_records: [ // tlv records, optional
+        "tlv_records": [ // tlv records, optional
             {
                 "type": 5482373484, // tlv type
                 "value": "0123456789abcdef" // hex encoded tlv value
@@ -208,7 +208,7 @@ Request:
     "method": "multi_pay_keysend",
     "params": {
         "keysends": [
-          {"id": "4c5b24a351", pubkey": "03...", "amount": 123},
+          {"id": "4c5b24a351", "pubkey": "03...", "amount": 123},
           {"id": "3da52c32a1", "pubkey": "02...", "amount": 567, "preimage": "abc123..", "tlv_records": [{"type": 696969, "value": "77616c5f6872444873305242454d353736"}]},
         ],
     }
@@ -358,8 +358,7 @@ Request:
 ```jsonc
 {
     "method": "get_balance",
-    "params": {
-    }
+    "params": {}
 }
 ```
 
@@ -379,8 +378,7 @@ Request:
 ```jsonc
 {
     "method": "get_info",
-    "params": {
-    }
+    "params": {}
 }
 ```
 

--- a/50.md
+++ b/50.md
@@ -15,9 +15,9 @@ extensible framework for performing such queries.
 ## `search` filter field 
 
 A new `search` field is introduced for `REQ` messages from clients:
-```json
+```jsonc
 {
-  ...
+  // other fields on filter object...
   "search": <string>
 }
 ```

--- a/51.md
+++ b/51.md
@@ -111,7 +111,7 @@ Some clients have used these lists in the past, but they should work on transiti
 
 ### A _release artifact set_ of an Example App
 
-```json
+```jsonc
 {
   "id": "567b41fc9060c758c4216fe5f8d3df7c57daad7ae757fa4606f0c39d4dd220ef",
   "pubkey": "d6dc95542e18b8b7aec2f14610f55c335abebec76f3db9e58c254661d0593a0c",

--- a/53.md
+++ b/53.md
@@ -16,7 +16,7 @@ A special event with `kind:30311` "Live Event" is defined as an _addressable eve
 
 For example:
 
-```json
+```jsonc
 {
   "kind": 30311,
   "tags": [
@@ -35,10 +35,10 @@ For example:
     ["p", "91cf9..4e5ca", "wss://provider1.com/", "Host", "<proof>"],
     ["p", "14aeb..8dad4", "wss://provider2.com/nostr", "Speaker"],
     ["p", "612ae..e610f", "ws://provider3.com/ws", "Participant"],
-    ["relays", "wss://one.com", "wss://two.com", ...]
+    ["relays", "wss://one.com", "wss://two.com", /*...*/]
   ],
   "content": "",
-  ...
+  // other fields...
 }
 ```
 
@@ -64,14 +64,14 @@ This feature is important to avoid malicious event owners adding large account h
 
 Event `kind:1311` is live chat's channel message. Clients MUST include the `a` tag of the activity with a `root` marker. Other Kind-1 tags such as `reply` and `mention` can also be used.
 
-```json
+```jsonc
 {
   "kind": 1311,
   "tags": [
     ["a", "30311:<Community event author pubkey>:<d-identifier of the community>", "<Optional relay url>", "root"],
   ],
   "content": "Zaps to live streams is beautiful.",
-  ...
+  // other fields...
 }
 ```
 

--- a/54.md
+++ b/54.md
@@ -11,7 +11,7 @@ This NIP defines `kind:30818` (an _addressable event_) for long-form text conten
 Articles are identified by lowercase, normalized ascii `d` tags.
 
 ### Articles
-```jsonc
+```json
 {
   "content": "A wiki is a hypertext publication collaboratively edited and managed by its own audience.",
   "tags": [
@@ -96,13 +96,13 @@ Asciidoc has a strict spec, multiple implementations in many languages, and supp
 # Appendix 1: Merge requests
 Users can request other users to get their entries merged into someone else's entry by creating a `kind:818` event.
 
-```jsonc
+```json
 {
   "content": "I added information about how to make hot ice-creams",
   "kind": 818,
   "tags": [
     [ "a", "30818:<destination-pubkey>:hot-ice-creams", "<relay-url>" ],
-    [ "e", "<version-against-which-the-modification-was-made>", "<relay-url>' ],
+    [ "e", "<version-against-which-the-modification-was-made>", "<relay-url>" ],
     [ "p", "<destination-pubkey>" ],
     [ "e", "<version-to-be-merged>", "<relay-url>", "source" ]
   ]
@@ -114,4 +114,4 @@ Users can request other users to get their entries merged into someone else's en
 `e` tag: optional version of the article in which this modifications is based
 `e` tag with `source` marker: the ID of the event that should be merged. This event id MUST be of a `kind:30818` as defined in this NIP.
 
-The destination-pubkey (the pubkey being requested to merge something into their article can create [[NIP-25]] reactions that tag the `kind:818` event with `+` or `-`
+The destination-pubkey is the pubkey being requested to merge something into their article can create [[NIP-25]] reactions that tag the `kind:818` event with `+` or `-`

--- a/56.md
+++ b/56.md
@@ -41,7 +41,7 @@ further qualification and querying.
 Example events
 --------------
 
-```json
+```jsonc
 {
   "kind": 1984,
   "tags": [
@@ -50,9 +50,11 @@ Example events
     ["l", "NS-nud", "social.nos.ontology"]
   ],
   "content": "",
-  ...
+  // other fields...
 }
+```
 
+```jsonc
 {
   "kind": 1984,
   "tags": [
@@ -60,16 +62,18 @@ Example events
     ["p", <pubkey>]
   ],
   "content": "He's insulting the king!",
-  ...
+  // other fields...
 }
+```
 
+```jsonc
 {
   "kind": 1984,
   "tags": [
     ["p", <impersonator pubkey>, "impersonation"]
   ],
   "content": "Profile is impersonating nostr:<victim bech32 pubkey>",
-  ...
+  // other fields...
 }
 ```
 

--- a/57.md
+++ b/57.md
@@ -171,7 +171,7 @@ A client can retrieve `zap receipt`s on events and pubkeys using a NIP-01 filter
 
 When an event includes one or more `zap` tags, clients wishing to zap it SHOULD calculate the lnurl pay request based on the tags value instead of the event author's profile field. The tag's second argument is the `hex` string of the receiver's pub key and the third argument is the relay to download the receiver's metadata (Kind-0). An optional fourth parameter specifies the weight (a generalization of a percentage) assigned to the respective receiver. Clients should parse all weights, calculate a sum, and then a percentage to each receiver. If weights are not present, CLIENTS should equally divide the zap amount to all receivers. If weights are only partially present, receivers without a weight should not be zapped (`weight = 0`).
 
-```js
+```jsonc
 {
     "tags": [
         [ "zap", "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2", "wss://nostr.oxtr.dev", "1" ],  // 25%

--- a/58.md
+++ b/58.md
@@ -74,7 +74,7 @@ Clients SHOULD attempt to render the most appropriate badge thumbnail according 
 
 ### Example of a Badge Definition event
 
-```json
+```jsonc
 {
   "pubkey": "alice",
   "kind": 30009,
@@ -85,13 +85,13 @@ Clients SHOULD attempt to render the most appropriate badge thumbnail according 
     ["image", "https://nostr.academy/awards/bravery.png", "1024x1024"],
     ["thumb", "https://nostr.academy/awards/bravery_256x256.png", "256x256"]
   ],
-  ...
+  // other fields...
 }
 ```
 
 ### Example of Badge Award event
 
-```json
+```jsonc
 {
   "id": "<badge award event id>",
   "kind": 8,
@@ -101,14 +101,14 @@ Clients SHOULD attempt to render the most appropriate badge thumbnail according 
     ["p", "bob", "wss://relay"],
     ["p", "charlie", "wss://relay"]
   ],
-  ...
+  // other fields...
 }
 ```
 
 ### Example of a Profile Badges event
 
 Honorable Bob The Brave:
-```json
+```jsonc
 {
   "kind": 30008,
   "pubkey": "bob",
@@ -119,6 +119,6 @@ Honorable Bob The Brave:
     ["a", "30009:alice:honor"],
     ["e", "<honor badge award event id>", "wss://nostr.academy"]
   ],
-  ...
+  // other fields...
 }
 ```

--- a/59.md
+++ b/59.md
@@ -41,7 +41,7 @@ A `seal` is a `kind:13` event that wraps a `rumor` with the sender's regular key
 to a receiver's pubkey but there is no `p` tag pointing to the receiver. There is no way to know who the rumor is for
 without the receiver's or the sender's private key. The only public information in this event is who is signing it.
 
-```js
+```json
 {
   "id": "<id>",
   "pubkey": "<real author's pubkey>",
@@ -60,7 +60,7 @@ Tags MUST must always be empty in a `kind:13`. The inner event MUST always be un
 A `gift wrap` event is a `kind:1059` event that wraps any other event. `tags` SHOULD include any information
 needed to route the event to its intended recipient, including the recipient's `p` tag or [NIP-13](13.md) proof of work.
 
-```js
+```json
 {
   "id": "<id>",
   "pubkey": "<random, one-time-use pubkey>",

--- a/64.md
+++ b/64.md
@@ -16,23 +16,23 @@ The `.content` of these notes is a string representing a [PGN-database][pgn_form
 
 ### Notes
 
-```json
+```jsonc
 {
   "kind": 64,
   "content": "1. e4 *",
-  ...
+  // other fields...
 }
 ```
 
-```json
+```jsonc
 {
   "kind": 64,
   "tags": [
     ["alt", "Fischer vs. Spassky in Belgrade on 1992-11-04 (F/S Return Match, Round 29)"],
-    ...
+    // rest of tags...
   ],
-  "content": "[Event \"F/S Return Match\"]\n[Site \"Belgrade, Serbia JUG\"]\n[Date \"1992.11.04\"]\n[Round \"29\"]\n[White \"Fischer, Robert J.\"]\n[Black \"Spassky, Boris V.\"]\n[Result \"1/2-1/2\"]\n\n1. e4 e5 2. Nf3 Nc6 3. Bb5 {This opening is called the Ruy Lopez.} 3... a6\n4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8 10. d4 Nbd7\n11. c4 c6 12. cxb5 axb5 13. Nc3 Bb7 14. Bg5 b4 15. Nb1 h6 16. Bh4 c5 17. dxe5\nNxe4 18. Bxe7 Qxe7 19. exd6 Qf6 20. Nbd2 Nxd6 21. Nc4 Nxc4 22. Bxc4 Nb6\n23. Ne5 Rae8 24. Bxf7+ Rxf7 25. Nxf7 Rxe1+ 26. Qxe1 Kxf7 27. Qe3 Qg5 28. Qxg5\nhxg5 29. b3 Ke6 30. a3 Kd6 31. axb4 cxb4 32. Ra5 Nd5 33. f3 Bc8 34. Kf2 Bf5\n35. Ra7 g6 36. Ra6+ Kc5 37. Ke1 Nf4 38. g3 Nxh3 39. Kd2 Kb5 40. Rd6 Kc5 41. Ra6\nNf2 42. g4 Bd3 43. Re6 1/2-1/2"
-  ...
+  "content": "[Event \"F/S Return Match\"]\n[Site \"Belgrade, Serbia JUG\"]\n[Date \"1992.11.04\"]\n[Round \"29\"]\n[White \"Fischer, Robert J.\"]\n[Black \"Spassky, Boris V.\"]\n[Result \"1/2-1/2\"]\n\n1. e4 e5 2. Nf3 Nc6 3. Bb5 {This opening is called the Ruy Lopez.} 3... a6\n4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8 10. d4 Nbd7\n11. c4 c6 12. cxb5 axb5 13. Nc3 Bb7 14. Bg5 b4 15. Nb1 h6 16. Bh4 c5 17. dxe5\nNxe4 18. Bxe7 Qxe7 19. exd6 Qf6 20. Nbd2 Nxd6 21. Nc4 Nxc4 22. Bxc4 Nb6\n23. Ne5 Rae8 24. Bxf7+ Rxf7 25. Nxf7 Rxe1+ 26. Qxe1 Kxf7 27. Qe3 Qg5 28. Qxg5\nhxg5 29. b3 Ke6 30. a3 Kd6 31. axb4 cxb4 32. Ra5 Nd5 33. f3 Bc8 34. Kf2 Bf5\n35. Ra7 g6 36. Ra6+ Kc5 37. Ke1 Nf4 38. g3 Nxh3 39. Kd2 Kb5 40. Rd6 Kc5 41. Ra6\nNf2 42. g4 Bd3 43. Re6 1/2-1/2",
+  // other fields...
 }
 ```
 

--- a/65.md
+++ b/65.md
@@ -12,7 +12,7 @@ The event MUST include a list of `r` tags with relay URIs and a `read` or `write
 
 The `.content` is not used.
 
-```json
+```jsonc
 {
   "kind": 10002,
   "tags": [
@@ -22,7 +22,7 @@ The `.content` is not used.
     ["r", "wss://nostr-relay.example.com", "read"]
   ],
   "content": "",
-  ...other fields
+  // other fields...
 }
 ```
 

--- a/71.md
+++ b/71.md
@@ -42,7 +42,7 @@ The list of tags are as follows:
 * `p` (optional, repeated) 32-bytes hex pubkey of a participant in the video, optional recommended relay URL
 * `r` (optional, repeated) references / links to web pages
 
-```json
+```jsonc
 {
   "id": <32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>,
   "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>,

--- a/72.md
+++ b/72.md
@@ -35,7 +35,7 @@ The goal of this NIP is to enable public communities. It defines the replaceable
     ["relay", "<relay where to send and receive approvals>", "approvals"],
     ["relay", "<relay where to post requests to and fetch approvals from>"]
   ],
-  ...
+  // other fields...
 }
 ```
 
@@ -50,7 +50,7 @@ Any Nostr event can be posted to a community. Clients MUST add one or more commu
     ["a", "34550:<community event author pubkey>:<community-d-identifier>", "<optional-relay-url>"],
   ],
   "content": "hello world",
-  // ...
+  // other fields...
 }
 ```
 
@@ -75,7 +75,7 @@ Moderators MAY request deletion of their approval of a post at any time using [N
     ["k", "<post-request-kind>"]
   ],
   "content": "<the full approved event, JSON-encoded>",
-  // ...
+  // other fields...
 }
 ```
 

--- a/75.md
+++ b/75.md
@@ -21,15 +21,16 @@ The following tags are defined as REQUIRED.
 
 Example event:
 
-```json
+```jsonc
 {
   "kind": 9041,
   "tags": [
-    ["relays", "wss://alicerelay.example.com", "wss://bobrelay.example.com", ...],
+    ["relays", "wss://alicerelay.example.com", "wss://bobrelay.example.com", /*...*/],
     ["amount", "210000"],
   ],
   "content": "Nostrasia travel expenses",
-  ...
+  // other fields...
+}
 ```
 
 The following tags are OPTIONAL.
@@ -38,18 +39,18 @@ The following tags are OPTIONAL.
 - `image` - an image for the goal
 - `summary` - a brief description
 
-```json
+```jsonc
 {
   "kind": 9041,
   "tags": [
-    ["relays", "wss://alicerelay.example.com", "wss://bobrelay.example.com", ...],
+    ["relays", "wss://alicerelay.example.com", "wss://bobrelay.example.com", /*...*/],
     ["amount", "210000"],
     ["closed_at", "<unix timestamp in seconds>"],
     ["image", "<image URL>"],
     ["summary", "<description of the goal>"],
   ],
   "content": "Nostrasia travel expenses",
-  ...
+  // other fields...
 }
 ```
 
@@ -59,15 +60,14 @@ The goal MAY include multiple beneficiary pubkeys by specifying [`zap` tags](57.
 
 Addressable events can link to a goal by using a `goal` tag specifying the event id and an optional relay hint.
 
-```json
+```jsonc
 {
-  ...
   "kind": 3xxxx,
   "tags": [
-    ...
     ["goal", "<event id>", "<Relay URL (optional)>"],
+    // rest of tags...
   ],
-  ...
+  // other fields...
 }
 ```
 

--- a/84.md
+++ b/84.md
@@ -26,14 +26,14 @@ useful when highlighting non-nostr content for which the client might be able to
 (e.g. prompting the user or reading a `<meta name="nostr:nprofile1..." />` tag on the document). A role MAY be included as the
 last value of the tag.
 
-```json
+```jsonc
 {
   "tags": [
     ["p", "<pubkey-hex>", "<relay-url>", "author"],
     ["p", "<pubkey-hex>", "<relay-url>", "author"],
     ["p", "<pubkey-hex>", "<relay-url>", "editor"]
   ],
-  ...
+  // other fields...
 }
 ```
 

--- a/89.md
+++ b/89.md
@@ -27,7 +27,7 @@ There are three actors to this workflow:
 ## Events
 
 ### Recommendation event
-```json
+```jsonc
 {
   "kind": 31989,
   "pubkey": <recommender-user-pubkey>,
@@ -35,7 +35,8 @@ There are three actors to this workflow:
     ["d", <supported-event-kind>],
     ["a", "31990:app1-pubkey:<d-identifier>", "wss://relay1", "ios"],
     ["a", "31990:app2-pubkey:<d-identifier>", "wss://relay2", "web"]
-  ]
+  ],
+  // other fields...
 }
 ```
 
@@ -47,7 +48,7 @@ The second value of the tag SHOULD be a relay hint.
 The third value of the tag SHOULD be the platform where this recommendation might apply.
 
 ## Handler information
-```json
+```jsonc
 {
   "kind": 31990,
   "pubkey": "<application-pubkey>",
@@ -59,7 +60,8 @@ The third value of the tag SHOULD be the platform where this recommendation migh
     ["web", "https://..../p/<bech32>", "nprofile"],
     ["web", "https://..../e/<bech32>"],
     ["ios", ".../<bech32>"]
-  ]
+  ],
+  // other fields...
 }
 ```
 
@@ -77,13 +79,13 @@ A tag without a second value in the array SHOULD be considered a generic handler
 # Client tag
 When publishing events, clients MAY include a `client` tag. Identifying the client that published the note. This tag is a tuple of `name`, `address` identifying a handler event and, a relay `hint` for finding the handler event. This has privacy implications for users, so clients SHOULD allow users to opt-out of using this tag.
 
-```json
+```jsonc
 {
   "kind": 1,
   "tags": [
     ["client", "My Client", "31990:app1-pubkey:<d-identifier>", "wss://relay1"]
   ]
-  ...
+  // other fields...
 }
 ```
 
@@ -99,14 +101,14 @@ The client MIGHT query for the user's and the user's follows handler.
 ### User A recommends a `kind:31337`-handler
 User A might be a user of Zapstr, a `kind:31337`-centric client (tracks). Using Zapstr, user A publishes an event recommending Zapstr as a `kind:31337`-handler.
 
-```json
+```jsonc
 {
   "kind": 31989,
   "tags": [
     ["d", "31337"],
     ["a", "31990:1743058db7078661b94aaf4286429d97ee5257d14a86d6bfa54cb0482b876fb0:abcd", <relay-url>, "web"]
   ],
-  ...
+  // other fields...
 }
 ```
 
@@ -115,7 +117,7 @@ User B might see in their timeline an event referring to a `kind:31337` event (e
 
 User B's client, not knowing how to handle a `kind:31337` might display the event using its `alt` tag (as described in NIP-31). When the user clicks on the event, the application queries for a handler for this `kind`:
 
-```json
+```
 ["REQ", <id>, { "kinds": [31989], "#d": ["31337"], "authors": [<user>, <users-contact-list>] }]
 ```
 
@@ -126,6 +128,6 @@ User B's client sees the application's `kind:31990` which includes the informati
 ### Alternative query bypassing `kind:31989`
 Alternatively, users might choose to query directly for `kind:31990` for an event kind. Clients SHOULD be careful doing this and use spam-prevention mechanisms or querying high-quality restricted relays to avoid directing users to malicious handlers.
 
-```json
+```
 ["REQ", <id>, { "kinds": [31990], "#k": [<desired-event-kind>], "authors": [...] }]
 ```

--- a/90.md
+++ b/90.md
@@ -36,7 +36,7 @@ There are two actors in the workflow described in this NIP:
 ## Job request (`kind:5000-5999`)
 A request to process data, published by a customer. This event signals that a customer is interested in receiving the result of some kind of compute.
 
-```json
+```jsonc
 {
     "kind": 5xxx, // kind in 5000-5999 range
     "content": "",
@@ -46,7 +46,8 @@ A request to process data, published by a customer. This event signals that a cu
         [ "relays", "wss://..." ],
         [ "bid", "<msat-amount>" ],
         [ "t", "bitcoin" ]
-    ]
+    ],
+    // other fields...
 }
 ```
 
@@ -81,19 +82,18 @@ If the user wants to keep the input parameters a secret, they can encrypt the `i
   ["param", "top-p", "0.7"],
   ["param", "frequency_penalty", "1"]
 ]
-
 ```
 
 This param data will be encrypted and added to the `content` field and `p` tag should be present
 
-```json
+```jsonc
 {
   "content": "BE2Y4xvS6HIY7TozIgbEl3sAHkdZoXyLRRkZv4fLPh3R7LtviLKAJM5qpkC7D6VtMbgIt4iNcMpLtpo...",
   "tags": [
     ["p", "04f74530a6ede6b24731b976b8e78fb449ea61f40ff10e3d869a3030c4edc91f"],
     ["encrypted"]
   ],
-  ...
+  // other fields...
 }
 ```
 
@@ -102,7 +102,7 @@ This param data will be encrypted and added to the `content` field and `p` tag s
 
 Service providers publish job results, providing the output of the job result. They should tag the original job request event id as well as the customer's pubkey.
 
-```json
+```jsonc
 {
   "pubkey": "<service-provider pubkey>",
   "content": "<payload>",
@@ -114,7 +114,7 @@ Service providers publish job results, providing the output of the job result. T
     ["p", "<customer's-pubkey>"],
     ["amount", "requested-payment-amount", "<optional-bolt11>"]
   ],
-  ...
+  // other fields...
 }
 ```
 
@@ -127,7 +127,7 @@ Service providers publish job results, providing the output of the job result. T
 If the request has encrypted params, then output should be encrypted and placed in  `content` field. If the output is encrypted, then avoid including `i` tag with input-data as clear text.
 Add a tag encrypted to mark the output content as `encrypted`
 
-```json
+```jsonc
 {
   "pubkey": "<service-provider pubkey>",
   "content": "<encrypted payload>",
@@ -139,7 +139,7 @@ Add a tag encrypted to mark the output content as `encrypted`
     ["amount", "requested-payment-amount", "<optional-bolt11>"],
     ["encrypted"]
   ],
-  ...
+  // other fields...
 }
 ```
 
@@ -147,7 +147,7 @@ Add a tag encrypted to mark the output content as `encrypted`
 
 Service providers can give feedback about a job back to the customer.
 
-```json
+```jsonc
 {
   "kind": 7000,
   "content": "<empty-or-payload>",
@@ -157,7 +157,7 @@ Service providers can give feedback about a job back to the customer.
     ["e", "<job-request-id>", "<relay-hint>"],
     ["p", "<customer's-pubkey>"],
   ],
-  ...
+  // other fields...
 }
 ```
 
@@ -211,7 +211,7 @@ This gives a higher level of flexibility to service providers (which sophisticat
 # Appendix 2: Service provider discoverability
 Service Providers MAY use NIP-89 announcements to advertise their support for job kinds:
 
-```js
+```jsonc
 {
   "kind": 31990,
   "pubkey": "<pubkey>",
@@ -223,7 +223,7 @@ Service Providers MAY use NIP-89 announcements to advertise their support for jo
     ["k", "5005"], // e.g. translation
     ["t", "bitcoin"] // e.g. optionally advertises it specializes in bitcoin audio transcription that won't confuse "Drivechains" with "Ridechains"
   ],
-  ...
+  // other fields...
 }
 ```
 

--- a/94.md
+++ b/94.md
@@ -27,7 +27,7 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
 * `alt` (optional) description for accessibility
 * `fallback` (optional) zero or more fallback file sources in case `url` fails
 
-```json
+```jsonc
 {
   "kind": 1063,
   "tags": [
@@ -46,7 +46,7 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
     ["alt", <description>]
   ],
   "content": "<caption>",
-  ...
+  // other fields...
 }
 ```
 

--- a/96.md
+++ b/96.md
@@ -143,7 +143,7 @@ The upload response is a json object as follows:
   // and, optionally, all file metadata the server wants to make available
   //
   // nip94_event field is absent if unsuccessful upload
-  "nip94_event2":{
+  "nip94_event2": {
     // Required tags: "url" and "ox"
     "tags": [
       // Can be same from /.well-known/nostr/nip96.json's "download_url" field
@@ -166,7 +166,7 @@ The upload response is a json object as follows:
       // The server can but does not need to store this value.
       ["x", "543244319525d9d08dd69cb716a18158a249b7b3b3ec4bbde5435543acb34443"],
       // Optional. Recommended for helping clients to easily know file type before downloading it.
-      ["m", "image/png"]
+      ["m", "image/png"],
       // Optional. Recommended for helping clients to reserve an adequate UI space to show the file before downloading it.
       ["dim", "800x600"]
       // ... other optional NIP-94 tags

--- a/96.md
+++ b/96.md
@@ -19,7 +19,7 @@ will not have to learn anything about nostr relays.
 
 File storage servers wishing to be accessible by nostr users should opt-in by making available an https route at `/.well-known/nostr/nip96.json` with `api_url`:
 
-```js
+```jsonc
 {
   // Required
   // File upload and deletion are served from this url
@@ -59,7 +59,7 @@ File storage servers wishing to be accessible by nostr users should opt-in by ma
       "file_expiration": [14, 90],
       "media_transformations": {
         "image": [
-          'resizing'
+          "resizing"
         ]
       }
     }
@@ -127,14 +127,14 @@ The `server` MUST link the user's `pubkey` string as the owner of the file so to
 
 The upload response is a json object as follows:
 
-```js
+```jsonc
 {
   // "success" if successful or "error" if not
-  status: "success",
+  "status": "success",
   // Free text success, failure or info message
-  message: "Upload successful.",
+  "message": "Upload successful.",
   // Optional. See "Delayed Processing" section
-  processing_url: "...",
+  "processing_url": "...",
   // This uses the NIP-94 event format but DO NOT need
   // to fill some fields like "id", "pubkey", "created_at" and "sig"
   //
@@ -143,9 +143,9 @@ The upload response is a json object as follows:
   // and, optionally, all file metadata the server wants to make available
   //
   // nip94_event field is absent if unsuccessful upload
-  nip94_event: {
+  "nip94_event2":{
     // Required tags: "url" and "ox"
-    tags: [
+    "tags": [
       // Can be same from /.well-known/nostr/nip96.json's "download_url" field
       // (or "api_url" field if "download_url" is absent or empty) with appended
       // original file hash.
@@ -171,7 +171,7 @@ The upload response is a json object as follows:
       ["dim", "800x600"]
       // ... other optional NIP-94 tags
     ],
-    content: ""
+    "content": ""
   },
   // ... other custom fields (please consider adding them to this NIP or to NIP-94 tags)
 }
@@ -202,12 +202,12 @@ the file processing is done.
 
 If the processing isn't done, the server should reply at the `processing_url` url with **200 OK** and the following JSON:
 
-```
+```jsonc
 {
   // It should be "processing". If "error" it would mean the processing failed.
-  status: "processing",
-  message: "Processing. Please check again later for updated status.",
-  percentage: 15 // Processing percentage. An integer between 0 and 100.
+  "status": "processing",
+  "message": "Processing. Please check again later for updated status.",
+  "percentage": 15 // Processing percentage. An integer between 0 and 100.
 }
 ```
 
@@ -270,10 +270,10 @@ in the same file hash).
 
 The successful response is a 200 OK one with just basic JSON fields:
 
-```
+```json
 {
-  status: "success",
-  message: "File deleted."
+  "status": "success",
+  "message": "File deleted."
 }
 ```
 
@@ -287,7 +287,7 @@ Returns a list of files linked to the authenticated users pubkey.
 
 Example Response:
 
-```js
+```jsonc
 {
   "count": 1, // server page size, eg. max(1, min(server_max_page_size, arg_count))
   "total": 1, // total number of files
@@ -295,17 +295,16 @@ Example Response:
   "files": [
     {
       "tags": [
-        ["ox": "719171db19525d9d08dd69cb716a18158a249b7b3b3ec4bbdec5698dca104b7b"],
-        ["x": "5d2899290e0e69bcd809949ee516a4a1597205390878f780c098707a7f18e3df"],
+        ["ox", "719171db19525d9d08dd69cb716a18158a249b7b3b3ec4bbdec5698dca104b7b"],
+        ["x", "5d2899290e0e69bcd809949ee516a4a1597205390878f780c098707a7f18e3df"],
         ["size", "123456"],
         ["alt", "a meme that makes you laugh"],
         ["expiration",  "1715691139"],
         // ...other metadata
-      ]
+      ],
       "content": "haha funny meme", // caption
       "created_at": 1715691130 // upload timestamp
-    },
-    ...
+    }
   ]
 }
 ```
@@ -324,14 +323,14 @@ Note: HTTP File Storage Server developers may skip this section. This is meant f
 A File Server Preference event is a kind 10096 replaceable event meant to select one or more servers the user wants
 to upload files to. Servers are listed as `server` tags:
 
-```js
-{
-  // ...
+```json
+{.
   "kind": 10096,
   "content": "",
   "tags": [
     ["server", "https://file.server.one"],
     ["server", "https://file.server.two"]
-  ]
+  ],
+  // other fields...
 }
 ```

--- a/99.md
+++ b/99.md
@@ -54,7 +54,7 @@ Other standard tags that might be useful.
 
 ## Example Event
 
-```json
+```jsonc
 {
   "kind": 30402,
   "created_at": 1675642635,


### PR DESCRIPTION
The JSON format is used commonly in different NIPs and the correction of JSONs and the correct Markdown format is important when someone reads them or uses them for implementation, testing, and more.

In this PR I've just fixed some broken JSON formats and used `jsonc` for JSON examples with comments to make all of them integrated with NIP-01!