### PR TITLE
NIP-09: Adding relay implementation potential

### DIFF
--- a/09.md
+++ b/09.md
@@ -48,6 +48,8 @@ Clients MAY choose to inform the user that their request for deletion does not g
 
 Relays MAY validate that a deletion request event only references events that have the same `pubkey` as the deletion request itself, however this is not required since relays may not have knowledge of all referenced events.
 
+Relays MAY consider deletion of reactions (kind 7) and/or replies to specific event intended to be deleted as well. It can be helpful for relays that aimed to be lightweight.
+
 ## Deletion Request of a Deletion Request
 
 Publishing a deletion request event against a deletion request has no effect.  Clients and relays are not obliged to support "unrequest deletion" functionality.


### PR DESCRIPTION
This paragraph can be used in lightweight, personal, or economic relays. It helps them keep their storage cleaner and lighter. reactions are not heavy but in the Nostr we have to wrap them on an event object and they are also easy to send by clients so these to conditions can make the cleaning of them more logical.