### PR TITLE
NIP-50: Adding regex extension

### DIFF
--- a/50.md
+++ b/50.md
@@ -48,8 +48,9 @@ Relays SHOULD exclude spam from search results by default if they support some f
 ## Extensions
 
 Relay MAY support these extensions:
-- `include:spam` - turn off spam filtering, if it was enabled by default
-- `domain:<domain>` - include only events from users whose valid nip05 domain matches the domain
-- `language:<two letter ISO 639-1 language code>` - include only events of a specified language
-- `sentiment:<negative/neutral/positive>` - include only events of a specific sentiment
-- `nsfw:<true/false>` - include or exclude nsfw events (default: true)
+- `include:spam` - turn off spam filtering, if it was enabled by default.
+- `domain:<domain>` - include only events from users whose valid nip05 domain matches the domain.
+- `language:<two letter ISO 639-1 language code>` - include only events of a specified language.
+- `sentiment:<negative/neutral/positive>` - include only events of a specific sentiment.
+- `nsfw:<true/false>` - include or exclude nsfw events. (default: true)
+- `regex:<regular-expression>` - A regex pattern to be searched.

--- a/50.md
+++ b/50.md
@@ -53,4 +53,4 @@ Relay MAY support these extensions:
 - `language:<two letter ISO 639-1 language code>` - include only events of a specified language.
 - `sentiment:<negative/neutral/positive>` - include only events of a specific sentiment.
 - `nsfw:<true/false>` - include or exclude nsfw events. (default: true)
-- `regex:<regular-expression>` - A regex pattern to be searched.
+- `regex:<regular-expression>` - A regex pattern to be searched which must be compatible with the PCRE flavor.


### PR DESCRIPTION
Regular expressions are commonly used for querying and searching, so it's a good reason to have it as an extension so clients can make specific and complex search queries.