### PR TITLE
Remove recommendation to map emoji reactions to like/dislike

### DIFF
--- a/25.md
+++ b/25.md
@@ -7,20 +7,14 @@ Reactions
 
 `draft` `optional`
 
-A reaction is a `kind 7` event that is used to react to other events.
+A reaction is a `kind 7` event that is used to react to other events. A reaction's `content` field
+MUST include a single character indicating the value of the reaction.
 
-The generic reaction, represented by the `content` set to a `+` string, SHOULD
-be interpreted as a "like" or "upvote".
+A reaction with `content` set to `+` or an empty string MUST be interpreted as a "like" or "upvote".
+A reaction with `content` set to `-` MUST be interpreted as a "dislike" or "downvote".
 
-A reaction with `content` set to `-` SHOULD be interpreted as a "dislike" or
-"downvote". It SHOULD NOT be counted as a "like", and MAY be displayed as a
-downvote or dislike on a post. A client MAY also choose to tally likes against
-dislikes in a reddit-like system of upvotes and downvotes, or display them as
-separate tallies.
-
-The `content` MAY be an emoji, or [NIP-30](30.md) custom emoji in this case it MAY be interpreted as a "like" or "dislike",
-or the client MAY display this emoji reaction on the post. If the `content` is an empty string then the client should
-consider it a "+".
+A reaction with `content` set to an emoji or [NIP-30](30.md) custom emoji SHOULD NOT be interpreted
+as a "like" or "dislike". Clients MAY instead display this emoji reaction on the post.
 
 Tags
 ----

--- a/25.md
+++ b/25.md
@@ -7,8 +7,10 @@ Reactions
 
 `draft` `optional`
 
-A reaction is a `kind 7` event that is used to react to other events. A reaction's `content` field
-MUST include a single character indicating the value of the reaction.
+A reaction is a `kind 7` event that is used to indicate user reactions to other events. A
+reaction's `content` field MUST include a single character indicating the value of the reaction.
+Reactions MUST NOT be used to support application-level semantics, they are for user-generated
+content only.
 
 A reaction with `content` set to `+` or an empty string MUST be interpreted as a "like" or "upvote".
 A reaction with `content` set to `-` MUST be interpreted as a "dislike" or "downvote".

--- a/25.md
+++ b/25.md
@@ -8,9 +8,8 @@ Reactions
 `draft` `optional`
 
 A reaction is a `kind 7` event that is used to indicate user reactions to other events. A
-reaction's `content` field MUST include a single character indicating the value of the reaction.
-Reactions MUST NOT be used to support application-level semantics, they are for user-generated
-content only.
+reaction's `content` field MUST include user-generated-content indicating the value of the
+reaction.
 
 A reaction with `content` set to `+` or an empty string MUST be interpreted as a "like" or "upvote".
 A reaction with `content` set to `-` MUST be interpreted as a "dislike" or "downvote".

--- a/25.md
+++ b/25.md
@@ -9,7 +9,7 @@ Reactions
 
 A reaction is a `kind 7` event that is used to indicate user reactions to other events. A
 reaction's `content` field MUST include user-generated-content indicating the value of the
-reaction.
+reaction (conventionally `+`, `-`, or an emoji).
 
 A reaction with `content` set to `+` or an empty string MUST be interpreted as a "like" or "upvote".
 A reaction with `content` set to `-` MUST be interpreted as a "dislike" or "downvote".

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 
 ## Standardized Tags
 
+<<<<<<< HEAD
 | name              | value                                | other parameters                | NIP                                                |
 | ----------------- | ------------------------------------ | ------------------------------- | -------------------------------------------------- |
 | `a`               | coordinates to an event              | relay URL                       | [01](01.md)                                        |
@@ -361,6 +362,58 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `tracker`         | torrent tracker URL                  | --                              | [35](35.md)                                        |
 | `web`             | webpage URL                          | --                              | [34](34.md)                                        |
 | `zap`             | pubkey (hex), relay URL              | weight                          | [57](57.md)                                        |
+=======
+| name              | value                                | other parameters                | NIP                                   |
+| ----------------- | ------------------------------------ | ------------------------------- | ------------------------------------- |
+| `e`               | event id (hex)                       | relay URL, marker, pubkey (hex) | [01](01.md), [10](10.md)              |
+| `p`               | pubkey (hex)                         | relay URL, petname              | [01](01.md), [02](02.md)              |
+| `a`               | coordinates to an event              | relay URL                       | [01](01.md)                           |
+| `d`               | identifier                           | --                              | [01](01.md)                           |
+| `-`               | --                                   | --                              | [70](70.md)                           |
+| `g`               | geohash                              | --                              | [52](52.md)                           |
+| `h`               | group id                             | --                              | [29](29.md)                           |
+| `i`               | external identity                    | proof, url hint                 | [39](39.md), [73](73.md)              |
+| `k`               | kind number (string)                 | --                              | [18](18.md), [25](25.md), [72](72.md) |
+| `l`               | label, label namespace               | --                              | [32](32.md)                           |
+| `L`               | label namespace                      | --                              | [32](32.md)                           |
+| `m`               | MIME type                            | --                              | [94](94.md)                           |
+| `q`               | event id (hex)                       | relay URL, pubkey (hex)         | [18](18.md)                           |
+| `r`               | a reference (URL, etc)               | --                              | [24](24.md), [25](25.md)              |
+| `r`               | relay url                            | marker                          | [65](65.md)                           |
+| `t`               | hashtag                              | --                              | [24](24.md), [34](34.md)              |
+| `alt`             | summary                              | --                              | [31](31.md)                           |
+| `amount`          | millisatoshis, stringified           | --                              | [57](57.md)                           |
+| `bolt11`          | `bolt11` invoice                     | --                              | [57](57.md)                           |
+| `challenge`       | challenge string                     | --                              | [42](42.md)                           |
+| `client`          | name, address                        | relay URL                       | [89](89.md)                           |
+| `clone`           | git clone URL                        | --                              | [34](34.md)                           |
+| `content-warning` | reason                               | --                              | [36](36.md)                           |
+| `delegation`      | pubkey, conditions, delegation token | --                              | [26](26.md)                           |
+| `description`     | description                          | --                              | [34](34.md), [57](57.md), [58](58.md) |
+| `emoji`           | shortcode, image URL                 | --                              | [30](30.md)                           |
+| `encrypted`       | --                                   | --                              | [90](90.md)                           |
+| `expiration`      | unix timestamp (string)              | --                              | [40](40.md)                           |
+| `goal`            | event id (hex)                       | relay URL                       | [75](75.md)                           |
+| `image`           | image URL                            | dimensions in pixels            | [23](23.md), [52](52.md), [58](58.md) |
+| `imeta`           | inline metadata                      | --                              | [92](92.md)                           |
+| `lnurl`           | `bech32` encoded `lnurl`             | --                              | [57](57.md)                           |
+| `location`        | location string                      | --                              | [52](52.md), [99](99.md)              |
+| `name`            | name                                 | --                              | [34](34.md), [58](58.md), [72](72.md) |
+| `nonce`           | random                               | difficulty                      | [13](13.md)                           |
+| `preimage`        | hash of `bolt11` invoice             | --                              | [57](57.md)                           |
+| `price`           | price                                | currency, frequency             | [99](99.md)                           |
+| `proxy`           | external ID                          | protocol                        | [48](48.md)                           |
+| `published_at`    | unix timestamp (string)              | --                              | [23](23.md)                           |
+| `relay`           | relay url                            | --                              | [42](42.md), [17](17.md)              |
+| `relays`          | relay list                           | --                              | [57](57.md)                           |
+| `server`          | file storage server url              | --                              | [96](96.md)                           |
+| `subject`         | subject                              | --                              | [14](14.md), [17](17.md), [34](34.md) |
+| `summary`         | summary                              | --                              | [23](23.md), [52](52.md)              |
+| `thumb`           | badge thumbnail                      | dimensions in pixels            | [58](58.md)                           |
+| `title`           | article title                        | --                              | [23](23.md)                           |
+| `web`             | webpage URL                          | --                              | [34](34.md)                           |
+| `zap`             | pubkey (hex), relay URL              | weight                          | [57](57.md)                           |
+>>>>>>> 11effc4 (Add category tag to reactions)
 
 Please update these lists when proposing new NIPs.
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,6 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 
 ## Standardized Tags
 
-<<<<<<< HEAD
 | name              | value                                | other parameters                | NIP                                                |
 | ----------------- | ------------------------------------ | ------------------------------- | -------------------------------------------------- |
 | `a`               | coordinates to an event              | relay URL                       | [01](01.md)                                        |
@@ -362,58 +361,6 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `tracker`         | torrent tracker URL                  | --                              | [35](35.md)                                        |
 | `web`             | webpage URL                          | --                              | [34](34.md)                                        |
 | `zap`             | pubkey (hex), relay URL              | weight                          | [57](57.md)                                        |
-=======
-| name              | value                                | other parameters                | NIP                                   |
-| ----------------- | ------------------------------------ | ------------------------------- | ------------------------------------- |
-| `e`               | event id (hex)                       | relay URL, marker, pubkey (hex) | [01](01.md), [10](10.md)              |
-| `p`               | pubkey (hex)                         | relay URL, petname              | [01](01.md), [02](02.md)              |
-| `a`               | coordinates to an event              | relay URL                       | [01](01.md)                           |
-| `d`               | identifier                           | --                              | [01](01.md)                           |
-| `-`               | --                                   | --                              | [70](70.md)                           |
-| `g`               | geohash                              | --                              | [52](52.md)                           |
-| `h`               | group id                             | --                              | [29](29.md)                           |
-| `i`               | external identity                    | proof, url hint                 | [39](39.md), [73](73.md)              |
-| `k`               | kind number (string)                 | --                              | [18](18.md), [25](25.md), [72](72.md) |
-| `l`               | label, label namespace               | --                              | [32](32.md)                           |
-| `L`               | label namespace                      | --                              | [32](32.md)                           |
-| `m`               | MIME type                            | --                              | [94](94.md)                           |
-| `q`               | event id (hex)                       | relay URL, pubkey (hex)         | [18](18.md)                           |
-| `r`               | a reference (URL, etc)               | --                              | [24](24.md), [25](25.md)              |
-| `r`               | relay url                            | marker                          | [65](65.md)                           |
-| `t`               | hashtag                              | --                              | [24](24.md), [34](34.md)              |
-| `alt`             | summary                              | --                              | [31](31.md)                           |
-| `amount`          | millisatoshis, stringified           | --                              | [57](57.md)                           |
-| `bolt11`          | `bolt11` invoice                     | --                              | [57](57.md)                           |
-| `challenge`       | challenge string                     | --                              | [42](42.md)                           |
-| `client`          | name, address                        | relay URL                       | [89](89.md)                           |
-| `clone`           | git clone URL                        | --                              | [34](34.md)                           |
-| `content-warning` | reason                               | --                              | [36](36.md)                           |
-| `delegation`      | pubkey, conditions, delegation token | --                              | [26](26.md)                           |
-| `description`     | description                          | --                              | [34](34.md), [57](57.md), [58](58.md) |
-| `emoji`           | shortcode, image URL                 | --                              | [30](30.md)                           |
-| `encrypted`       | --                                   | --                              | [90](90.md)                           |
-| `expiration`      | unix timestamp (string)              | --                              | [40](40.md)                           |
-| `goal`            | event id (hex)                       | relay URL                       | [75](75.md)                           |
-| `image`           | image URL                            | dimensions in pixels            | [23](23.md), [52](52.md), [58](58.md) |
-| `imeta`           | inline metadata                      | --                              | [92](92.md)                           |
-| `lnurl`           | `bech32` encoded `lnurl`             | --                              | [57](57.md)                           |
-| `location`        | location string                      | --                              | [52](52.md), [99](99.md)              |
-| `name`            | name                                 | --                              | [34](34.md), [58](58.md), [72](72.md) |
-| `nonce`           | random                               | difficulty                      | [13](13.md)                           |
-| `preimage`        | hash of `bolt11` invoice             | --                              | [57](57.md)                           |
-| `price`           | price                                | currency, frequency             | [99](99.md)                           |
-| `proxy`           | external ID                          | protocol                        | [48](48.md)                           |
-| `published_at`    | unix timestamp (string)              | --                              | [23](23.md)                           |
-| `relay`           | relay url                            | --                              | [42](42.md), [17](17.md)              |
-| `relays`          | relay list                           | --                              | [57](57.md)                           |
-| `server`          | file storage server url              | --                              | [96](96.md)                           |
-| `subject`         | subject                              | --                              | [14](14.md), [17](17.md), [34](34.md) |
-| `summary`         | summary                              | --                              | [23](23.md), [52](52.md)              |
-| `thumb`           | badge thumbnail                      | dimensions in pixels            | [58](58.md)                           |
-| `title`           | article title                        | --                              | [23](23.md)                           |
-| `web`             | webpage URL                          | --                              | [34](34.md)                           |
-| `zap`             | pubkey (hex), relay URL              | weight                          | [57](57.md)                           |
->>>>>>> 11effc4 (Add category tag to reactions)
 
 Please update these lists when proposing new NIPs.
 


### PR DESCRIPTION
See the discussion [here](https://github.com/nostrability/nostrability/issues/88)

Emojis are a high-fidelity medium of expression subject to a significant amount of interpretation, while +/- reactions are a low-fidelity medium of expression subject to much less interpretation. The two are semantically incompatible ways of reacting to content, and should not be conflated.

Previously, the NIP included a recommendation to interpret emojis as likes/dislikes, but this put a burden on receiving clients to map every possible emoji to a binary sentiment. This is not only a huge mapping, it's also impossible because the same emoji reaction can be used in different contexts to mean different things.

Additionally, some clients created emoji reactions on their users' behalf to indicate certain application states, such as a failed zap or a content warning. These concepts should instead be represented as first-class things within the protocol.

This PR also adds a recommendation to add a `c` tag so that reaction content can be indexed. This will allow clients that only support like/dislike or a subset of emojis to fetch only relevant events.