### PR TITLE
nip-01: clarify response to close message.

### DIFF
--- a/01.md
+++ b/01.md
@@ -149,15 +149,16 @@ The `limit` property of a filter is only valid for the initial query and MUST be
 
 Relays can send 5 types of messages, which must also be JSON arrays, according to the following patterns:
 
-  * `["EVENT", <subscription_id>, <event JSON as defined above>]`, used to send events requested by clients.
-  * `["OK", <event_id>, <true|false>, <message>]`, used to indicate acceptance or denial of an `EVENT` message.
-  * `["EOSE", <subscription_id>]`, used to indicate the _end of stored events_ and the beginning of events newly received in real-time.
-  * `["CLOSED", <subscription_id>, <message>]`, used to indicate that a subscription was ended on the server side.
-  * `["NOTICE", <message>]`, used to send human-readable error messages or other things to clients.
+* `["EVENT", <subscription_id>, <event JSON as defined above>]`, used to send events requested by clients.
+* `["OK", <event_id>, <true|false>, <message>]`, used to indicate acceptance or denial of an `EVENT` message.
+* `["EOSE", <subscription_id>]`, used to indicate the _end of stored events_ and the beginning of events newly received in real-time.
+* `["CLOSED", <subscription_id>, <message>]`, used to indicate that a subscription was ended on the server side.
+* `["NOTICE", <message>]`, used to send human-readable error messages or other things to clients.
 
 This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 
 - `EVENT` messages MUST be sent only with a subscription ID related to a subscription previously initiated by the client (using the `REQ` message above).
+
 - `OK` messages MUST be sent in response to `EVENT` messages received from clients, they must have the 3rd parameter set to `true` when an event has been accepted by the relay, `false` otherwise. The 4th parameter MUST always be present, but MAY be an empty string when the 3rd is `true`, otherwise it MUST be a string formed by a machine-readable single-word prefix followed by a `:` and then a human-readable message. Some examples:
   * `["OK", "b1a649ebe8...", true, ""]`
   * `["OK", "b1a649ebe8...", true, "pow: difficulty 25>=24"]`
@@ -168,8 +169,11 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
   * `["OK", "b1a649ebe8...", false, "invalid: event creation date is too far off from the current time"]`
   * `["OK", "b1a649ebe8...", false, "pow: difficulty 26 is less than 30"]`
   * `["OK", "b1a649ebe8...", false, "error: could not connect to the database"]`
-- `CLOSED` messages MUST be sent in response to a `REQ` when the relay refuses to fulfill it. It can also be sent when a relay decides to kill a subscription on its side before a client has disconnected or sent a `CLOSE`. This message uses the same pattern of `OK` messages with the machine-readable prefix and human-readable message. Some examples:
+
+- `CLOSED` messages MUST be sent in response to a `REQ` when the relay refuses to fulfill it, or in response to `CLOSE` to acknowledge the end of a subscription based on client request. It can also be sent when a relay decides to kill a subscription on its side before a client has disconnected or sent a `CLOSE`. This message uses the same pattern of `OK` messages with the machine-readable prefix and human-readable message. Some examples:
   * `["CLOSED", "sub1", "unsupported: filter contains unknown elements"]`
   * `["CLOSED", "sub1", "error: could not connect to the database"]`
   * `["CLOSED", "sub1", "error: shutting down idle subscription"]`
-- The standardized machine-readable prefixes for `OK` and `CLOSED` are: `duplicate`, `pow`, `blocked`, `rate-limited`, `invalid`, and `error` for when none of that fits.
+  * `["CLOSED", "sub1", "ok: sub1 closed successfully"]`
+
+- The standardized machine-readable prefixes for `OK` and `CLOSED` are: `duplicate`, `ok`, `pow`, `blocked`, `rate-limited`, `invalid`, and `error` for when none of that fits.


### PR DESCRIPTION
we have to clarify how a relay can acknowledge a close request from a client. here is a [draft pr on immortal](https://github.com/dezh-tech/immortal/pull/23/files#diff-65376c52e7093ac631724e7edc57361fc3d6be28d42df033d842d43172d34deeR168) which implements that. more implementation may do that which im not aware of.