### PR TITLE
NIP-88: make poll response a parameterized replaceable event

### DIFF
--- a/88.md
+++ b/88.md
@@ -50,7 +50,7 @@ Example Event
 
 ### Responses
 
-The response event is a `kind:1018` event. It contains an e tag with the poll event it is referencing, followed by one or more response tags.
+The response event is a `kind:30068` event. It contains a d tag with the poll event it is referencing, followed by one or more response tags.
 
 - **response** : The tag contains "response" as it's first positional argument followed by the option Id selected.
 
@@ -61,11 +61,11 @@ Example Response Event
   "content": "",
   "created_at": 1720097117,
   "id": "60a005e32e9596c3f544a841a9bc4e46d3020ca3650d6a739c95c1568e33f6d8",
-  "kind": 1018,
+  "kind": 30068,
   "pubkey": "1bc70a0148b3f316da33fe7e89f23e3e71ac4ff998027ec712b905cd24f6a411",
   "sig": "30071a633c65db8f3a075c7a8de757fbd8ce65e3607f4ba287fe6d7fbf839a380f94ff4e826fbba593f6faaa13683b7ea9114ade140720ecf4927010ebf3e44f",
   "tags": [
-    ["e", "1fc80cf813f1af33d5a435862b7ef7fb96b47e68a48f1abcadf8081f5a545550"],
+    ["d", "1fc80cf813f1af33d5a435862b7ef7fb96b47e68a48f1abcadf8081f5a545550"],
     ["response", "gga6cdnqj"],
     ["response", "m3agjsdq1"]
   ]
@@ -74,7 +74,7 @@ Example Response Event
 
 ### Poll Types
 
-Poll Types can be configured in the settings object of the poll, the setting dictates how multiple response tags are handled in the `kind:1018` event.
+Poll Types can be configured in the settings object of the poll, the setting dictates how multiple response tags are handled in the `kind:30068` event.
 
 - **PollType: singlechoice**: The first response tag is to be considered the actual response.
 - **PollType: multiplechoice**: The first response tag pointing to each id is considered the actual response, without considering the order of the response tags.
@@ -82,7 +82,7 @@ Poll Types can be configured in the settings object of the poll, the setting dic
 
 ### Counting Results
 
-Results can be queried by fetching `kind:1018` events from the relays specified in the poll.
+Results can be queried by fetching `kind:30068` events from the relays specified in the poll.
 The results displayed should only be 1 vote event per pubkey.
 In case of multiple events for a pubkey, the event with the largest timestamp should be considered.
 


### PR DESCRIPTION
Follow up to https://github.com/nostr-protocol/nips/pull/1346

Change kind 1018 to 30068.

We already have existing code, relays, systems etc that apply the right semantics for replacing an event, so we should use that, otherwise people will have to do a lot of extra work to add special support for polls.