### PR TITLE
NIP-34: clarify issue title

### DIFF
--- a/34.md
+++ b/34.md
@@ -117,6 +117,8 @@ Issues are Markdown text that is just human-readable conversational threads rela
 }
 ```
 
+An issue title is any `content` proceeding the first `\n`.
+
 ## Replies
 
 Replies are also Markdown text. The difference is that they MUST be issued as replies to either a `kind:1621` _issue_ or a `kind:1617` _patch_ event. The threading of replies and patches should follow NIP-10 rules.


### PR DESCRIPTION
added as dluvian implemented the title as a `subject` tag in voyage which caused the issue title not to display in may clients such as: amethyst, Nostter, nostrudel, coracle and gitworkshop.

nostr:nevent1qvzqqqqx25pzpgqgmmc409hm4xsdd74sf68a2uyf9pwel4g9mfdg8l5244t6x4jdqy88wumn8ghj7mn0wvhxcmmv9uqzqqta74rkqgzt4akdw3acrparwnq46u2dusg4fzuu2d7ppyhgcmu6kz2ahd