### PR TITLE
NIP-22 - Likes and Dislikes (Not replacing NIP-25 anymore)

### DIFF
--- a/22.md
+++ b/22.md
@@ -69,7 +69,9 @@ relays and to to the event being reacted to author's `read` relays.
 ### Counting
 
 Pick one of the `read` relays of the author of the event being reacted to.
-Use that relay with [NIP-45](45.md) to count.
+Use that relay with [NIP-45](45.md) to count. One caveat is it will
+consider multiple `re` tags from the same event as just one occurrence
+when counting.
 
 ### External Entities
 


### PR DESCRIPTION
[Read here](https://github.com/arthurfranca/nips/blob/reaction-2/22.md)

`kind:7/17` events from NIP-25  have [many problems](https://github.com/nostrability/nostrability/issues/88) cause the NIP was conceived when nostr was too young.
