### PR TITLE
NIP-73 - Expand External Content IDs

### DIFF
--- a/73.md
+++ b/73.md
@@ -6,16 +6,28 @@ External Content IDs
 
 `draft` `optional`
 
-There are certain established global content identifiers that would be useful to reference in nostr events so that clients can query all events assosiated with these ids.
+There are certain established global content identifiers such as [Book ISBNs](https://en.wikipedia.org/wiki/ISBN), [Podcast GUIDs](https://podcastnamespace.org/tag/guid), and [Movie ISANs](https://en.wikipedia.org/wiki/International_Standard_Audiovisual_Number) that are useful to reference in nostr events so that clients can query all the events assosiated with these ids.
 
-- Book [ISBNs](https://en.wikipedia.org/wiki/ISBN)
-- Podcast [GUIDs](https://podcastnamespace.org/tag/guid)
-- Movie [ISANs](https://en.wikipedia.org/wiki/International_Standard_Audiovisual_Number)
 
-Since the `i` tag is already used for similar references in kind-0 metadata events it makes sense to use it for these content ids as well.
-
+`i` tags are used for referencing these external content ids, with `k` tags representing the external content id kind so that clients can query all the events for a specific kind. 
 
 ## Supported IDs
+
+| Type | `i` tag | `k` tag |
+|- | - | - |
+| URLs | "`<URL, normalized, no fragment>`" | "`<scheme-host, normalized>`" |
+| Hashtags | "#`<topic, lowercase>`" | "#" |
+| Geohashes| "geo:`<geohash, lowercase>`" | "geo" |
+| Books | "isbn:`<id, without hyphens>`" | "isbn" |
+| Podcast Feeds | "podcast:guid:`<guid>`" | "podcast:guid" |
+| Podcast Episodes | "podcast:item:guid:`<guid>`" | "podcast:item:guid" |
+| Podcast Publishers | "podcast:publisher:guid:`<guid>`" | "podcast:publisher:guid" |
+| Movies | "isan:`<id, without version part>`" | "isan" |
+| Papers | "doi:`<id, lowercase>`" | "doi" |
+
+---
+
+## Examples
 
 ### Books:
 


### PR DESCRIPTION
Following on from the discussion around adding a [Generic Comment NIP](https://github.com/nostr-protocol/nips/pull/1233) - this PR adds the extensions to the `i` tags that are supported in the Generic Comment kind `1111`.

This PR is optional depending on whether the list of supported external content ids should be in it's own NIP or part of the Generic Comment NIP.