### PR TITLE
replaceability using other tags

### DIFF
--- a/85.md
+++ b/85.md
@@ -1,0 +1,15 @@
+NIP-85
+======
+
+Specific Tag Replaceableability
+-------------------------------
+
+`draft` `optional`
+
+This NIP establishes semantics similar to addressable events in the range `30000-39999`, but using different tags as the deduplication mechanism.
+
+Events in the range `40000-43999` are deemed to be replaceable by another event that contains the same `author`, the same `kind` and a duplicated `e` tag.
+
+Events in the range `44000-47999` are deemed to be replaceable by another event that contains the same `author`, the same `kind` and a duplicated `p` tag.
+
+Events in the range `48000-49999` are deemed to be replaceable by another event that contains the same `author`, the same `kind` and a duplicated `a` tag.


### PR DESCRIPTION
This might be a solution to the https://github.com/nostr-protocol/nips/pull/1501 conundrum (we can just grandfather in that specific kind like we did with normal replaceables and kinds `0` and `3`).

And also address https://github.com/nostr-protocol/nips/pull/1506 and other similar issues that will certainly arrive in the future.

Just a preliminary idea.