### PR TITLE
Add `pow` field to filter JSON object

### DIFF
--- a/13.md
+++ b/13.md
@@ -96,6 +96,21 @@ function countLeadingZeroes(hex) {
 }
 ```
 
+Filter
+------
+
+A new `pow` field is introduced for `REQ` messages from clients:
+
+```jsonc
+{
+  // other fields on filter object...
+  "pow": <integer between 0 and 255>
+}
+```
+
+`pow` field is an integer (between 0 and 255) that represent the minimum `difficulty` that an event ID must have.
+Relays SHOULD discard from query result all events with a difficulty lower than `pow`.
+
 Delegated Proof of Work
 -----------------------
 


### PR DESCRIPTION
Add `pow` field to filter JSON object to allow query of events with a certain difficulty.

[Read here](https://github.com/yukibtc/nips/blob/pow-filter/13.md#filter)