### PR TITLE
Add private relays to kind 10002 in NIP-65

### DIFF
--- a/65.md
+++ b/65.md
@@ -8,7 +8,9 @@ Relay List Metadata
 
 Defines a replaceable event using `kind:10002` to advertise preferred relays for discovering a user's content and receiving fresh content from others.
 
-The event MUST include a list of `r` tags with relay URIs and a `read` or `write` marker. Relays marked as `read` / `write` are called READ / WRITE relays, respectively. If the marker is omitted, the relay is used for both purposes.
+The event MUST include a list of `r` tags with relay URIs and a `read` or `write`. Relays marked as `read` / `write` are called READ / WRITE relays, respectively. If the marker is omitted, the relay is used for both read and write purposes. 
+
+Relays additionally marked as `private` are only meant for local, personal, utilitarian, or community use and aren't meant to be included in the outbox model.
 
 The `.content` is not used.
 
@@ -16,6 +18,9 @@ The `.content` is not used.
 {
   "kind": 10002,
   "tags": [
+    ["r", "ws://localhost:8080", "write", "private"],
+    ["r", "wss://search.nos.today", "read", "private"],
+    ["r", "wss://filter.nostr.wine", "private"],
     ["r", "wss://alicerelay.example.com"],
     ["r", "wss://brando-relay.com"],
     ["r", "wss://expensive-relay.example2.com", "write"],


### PR DESCRIPTION
I'm having increasing difficulty switching from one client, to another, as I have so many different types of relays in use, and only a few are useful for the outbox model. The rest are relays that I use in all/most clients, but that are only meant for some in-app purpose, such as search relays, local relays (ws://localhost:4869, for instance), filters or aggregators, read-restricted project group relays, etc.

I wasn't sure of the best way to fix this, without making it onerous to use multiple clients, but I thought a `private` flag would maybe help.