### PR TITLE
NIP-XX - Multiple Public Key Types and Signature Algorithms for Event Signing

### DIFF
--- a/XXX.md
+++ b/XXX.md
@@ -53,7 +53,7 @@ We want to eliminate this problem, and it is quite simple...
 
 ### Signature Prefixes
 
-This NIP introduces a prefix mechanism for the `.sig` field of Nostr events, that by default (without any prefix) falls back to `Schnorr/secp256k1`, but when present defines the signature algorithm and public key derivation curve.
+This NIP introduces a prefix mechanism for the `.sig` field of Nostr events, that by default (without any prefix) falls back to `schnorr/secp256k1`, but when present defines the signature algorithm and public key derivation curve.
 
 #### Signature Algorithms
 
@@ -106,4 +106,8 @@ To use another Signature Algorithm and another ECC Curve, an event would look li
 
 ### Clients and Relays
 
-Clients and Relays are free to choose what combinations of Signatures Algorithms and ECC Curves they support, the only mandatory one is `Schnorr/secp256k1`, which is the default for Nostr, but highly encouraged to support more, at least `ecdsa` and `eddsa` with their default curves. This way Nostr network will be increasingly more compatible and possible to interoperate with other networks.
+Clients and Relays are free to choose what combinations of Signatures Algorithms and ECC Curves they support, the only mandatory one is `schnorr/secp256k1`, which is the default for Nostr, but highly encouraged to support more, at least `ecdsa` and `eddsa` with their default curves. This way Nostr network will be increasingly more compatible and possible to interoperate with other networks.
+
+### Integration into NIP-01
+
+We propose that this NIP, when discussed and approved, should be integrated into NIP-01, as it represents a global improvement for event signing. We decided to keep it separated in a different file to be more concise for discussion for now.


### PR DESCRIPTION
As mentioned in [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md):

> Each user has a keypair. Signatures, public key, and encodings are done according to the [Schnorr signatures standard for the curve `secp256k1`](https://bips.xyz/340).

This is a limitation for Nostr adoption, as many Blockchains and other Cryptographic Networks have already identities in place using different ECC Public Key curves, and may use different Signature Algorithms. Even Bitcoin pre Taproot uses `ECDSA/secp256k1` and not `Schnorr/secp256k1`.

In this case it is just the signatures that differ, and the public key derivation is based out of the same `secp256k1` curve, so the public keys remain valid, but for other networks that use `EdDSA` signatures, for instance, not even the public keys would be valid, as the curve used is `Curve25519` instead.

This means that Nostr identities would have to be different than the ones used in the other networks, making it impossible to consider a direct match between one network identity and the other, for instance, for having a smart contract as a Nostr identity (public key).

We want to eliminate this problem, and it is quite simple...