### PR TITLE
Clarify quote reposts

### DIFF
--- a/18.md
+++ b/18.md
@@ -30,7 +30,7 @@ of the `mark` argument.
 
 `["q", <event-id>, <relay-url>, <pubkey>]`
 
-Quote reposts MUST include the [NIP-19](19.md) `nevent`, `note`, or `naddr` of the
+Quote reposts MUST include the [NIP-21](21.md) `nevent`, `note`, or `naddr` of the
 event in the content.
 
 ## Generic Reposts

--- a/18.md
+++ b/18.md
@@ -18,13 +18,6 @@ to indicate where it can be fetched.
 The repost SHOULD include a `p` tag with the `pubkey` of the event being
 reposted.
 
-## Quote Reposts
-
-Quote reposts are `kind 1` events with an embedded `q` tag of the note being
-quote reposted. The `q` tag ensures quote reposts are not pulled and included
-as replies in threads. It also allows you to easily pull and count all of the
-quotes for a post.
-
 ## Generic Reposts
 
 Since `kind 6` reposts are reserved for `kind 1` contents, we use `kind 16`
@@ -33,3 +26,20 @@ as a "generic repost", that can include any kind of event inside other than
 
 `kind 16` reposts SHOULD contain a `k` tag with the stringified kind number
 of the reposted event as its value.
+
+## Quote Reposts
+
+Quote reposts are `kind 1` events with an embedded `q` tag of the note being
+quote reposted. The `q` tag ensures quote reposts are not pulled and included
+as replies in threads. It also allows you to easily pull and count all of the
+quotes for a post.
+
+`q` tags should follow the same conventions as NIP 10 `e` tags, with the exception
+of the `mark` argument. The first argument MAY be either an event id or an address.
+
+`["q", <event-id-or-address>, <relay-url>, <pubkey>]`
+
+Quote reposts MUST include the bech32-encoded `nevent`, `note`, or `naddr` of the
+event in the content. The embedded entity should match the type of the tag (in
+other words, if embedding a `naddr`, the `q` tag should contain an address, not
+an event id).

--- a/18.md
+++ b/18.md
@@ -39,7 +39,7 @@ of the `mark` argument. The first argument MAY be either an event id or an addre
 
 `["q", <event-id-or-address>, <relay-url>, <pubkey>]`
 
-Quote reposts MUST include the bech32-encoded `nevent`, `note`, or `naddr` of the
+Quote reposts MUST include the [NIP-19](19.md) `nevent`, `note`, or `naddr` of the
 event in the content. The embedded entity should match the type of the tag (in
 other words, if embedding a `naddr`, the `q` tag should contain an address, not
 an event id).

--- a/18.md
+++ b/18.md
@@ -35,14 +35,9 @@ as replies in threads. It also allows you to easily pull and count all of the
 quotes for a post.
 
 `q` tags should follow the same conventions as NIP 10 `e` tags, with the exception
-of the `mark` argument. The first argument MAY be either an event id or an address.
+of the `mark` argument.
 
-`["q", <event-id-or-address>, <relay-url>, <pubkey>]`
+`["q", <event-id>, <relay-url>, <pubkey>]`
 
 Quote reposts MUST include the [NIP-19](19.md) `nevent`, `note`, or `naddr` of the
-event in the content. The embedded entity should match the type of the tag (in
-other words, if embedding a `naddr`, the `q` tag should contain an address, not
-an event id).
-
-Quote reposts also SHOULD include a `k` tag matching the stringified `kind` of
-the quoted note.
+event in the content.

--- a/18.md
+++ b/18.md
@@ -18,15 +18,6 @@ to indicate where it can be fetched.
 The repost SHOULD include a `p` tag with the `pubkey` of the event being
 reposted.
 
-## Generic Reposts
-
-Since `kind 6` reposts are reserved for `kind 1` contents, we use `kind 16`
-as a "generic repost", that can include any kind of event inside other than
-`kind 1`.
-
-`kind 16` reposts SHOULD contain a `k` tag with the stringified kind number
-of the reposted event as its value.
-
 ## Quote Reposts
 
 Quote reposts are `kind 1` events with an embedded `q` tag of the note being
@@ -41,3 +32,12 @@ of the `mark` argument.
 
 Quote reposts MUST include the [NIP-19](19.md) `nevent`, `note`, or `naddr` of the
 event in the content.
+
+## Generic Reposts
+
+Since `kind 6` reposts are reserved for `kind 1` contents, we use `kind 16`
+as a "generic repost", that can include any kind of event inside other than
+`kind 1`.
+
+`kind 16` reposts SHOULD contain a `k` tag with the stringified kind number
+of the reposted event as its value.

--- a/18.md
+++ b/18.md
@@ -43,3 +43,6 @@ Quote reposts MUST include the bech32-encoded `nevent`, `note`, or `naddr` of th
 event in the content. The embedded entity should match the type of the tag (in
 other words, if embedding a `naddr`, the `q` tag should contain an address, not
 an event id).
+
+Quote reposts also SHOULD include a `k` tag matching the stringified `kind` of
+the quoted note.


### PR DESCRIPTION
This change is fairly opinionated in terms of dictating best practices. I'm also not sure if address support is desired/implemented anywhere, so I'm happy to take that out if appropriate.

The diff is kind of hard to read because I moved the quote reposts section to the bottom of the NIP for better readability.