### PR TITLE
Push Notification - Event Watch API

### DIFF
--- a/97.md
+++ b/97.md
@@ -6,7 +6,9 @@ Push Notification Server API
 
 `draft` `optional`
 
-This NIP defines a common API to register push notification tokens into an event watcher server. The goal is to allow users to choose their push notification servers by simply adding an http address to their account. 
+This NIP defines a common API to register push notification tokens into one or more event watch servers, which constantly query several relays to notify users on new events. 
+
+The goal is to allow users to choose their event watch servers by simply adding an http address to their account. 
 
 ## Registration Call
 
@@ -58,9 +60,9 @@ Servers send new events via the user's preferred system. The event is [NIP-59 Gi
 
 Clients SHOULD try to decrypt the GiftWrap with all logged-in accounts. 
 
-## Event Watcher Server list
+## Event Watch Server list
 
-An Event Watcher Server list is a kind 10097 replaceable event meant to select one or more servers the user wants
+An Event Watch Server list is a kind 10097 replaceable event meant to select one or more servers the user wants
 to register for push notifications. Servers are listed as `server` tags:
 
 ```json

--- a/97.md
+++ b/97.md
@@ -1,0 +1,75 @@
+NIP-96
+======
+
+Push Notification Server API
+----------------------------
+
+`draft` `optional`
+
+This NIP defines a common API to register push notification tokens into an event watcher server. The goal is to allow users to choose their push notification servers by simply adding an http address to their account. 
+
+## Registration Call
+
+After receiving a `token` from the push system (Google Services, Unified Push, Apple Push Notification), clients should upload a list of signed NIP-98 events, one for each account in the device, in a `POST` to `/register` with the following body:
+
+```jsonc
+{
+  "events": [ 
+    {
+      "id": "..",
+      "pubkey": "...",
+      "created_at": ...,
+      "kind": 22242,
+      "tags":[
+        [ "relay","<inbox relay 1>" ],
+        [ "relay","<inbox relay 2>" ],
+        [ "challenge", "<system>:<token>" ]
+      ],
+      "content":"",
+      "sig":"..."
+    }
+  ]
+}
+```
+
+where `system` is `google`, `apple` or `unifiedpush`.
+
+Servers will use the `system` information to select where to send new events from the relays marked as such.
+
+The server returns with an array of 
+
+```jsonc
+  [
+    {
+        "pubkey": "<pubkey>",
+        "result": "<added|replaced|error>",
+        "error": "<message>",
+    }
+  ]
+```
+
+Servers SHOULD accept multiple tokens per pubkey, but may limit the number of them.
+
+Servers SHOULD delete tokens after failure to deliver.
+
+## Sending Events
+
+Servers send new events via the user's preferred system. The event is [NIP-59 GiftWrapped](59.md) to the receiver, but no `p`-tag is added to the wrap event. In that way, the chosen system cannot know which key is receiving this event.
+
+Clients SHOULD try to decrypt the GiftWrap with all logged-in accounts. 
+
+## Event Watcher Server list
+
+An Event Watcher Server list is a kind 10097 replaceable event meant to select one or more servers the user wants
+to register for push notifications. Servers are listed as `server` tags:
+
+```json
+{
+  "kind": 10097,
+  "content": "",
+  "tags": [
+    ["server", "https://push.amethyst.social"],
+    ["server", "https://server2.com"],
+  ]
+}
+```

--- a/97.md
+++ b/97.md
@@ -1,8 +1,8 @@
 NIP-97
 ======
 
-Push Notification Server API
-----------------------------
+Push Notification Event Watcher API
+-----------------------------------
 
 `draft` `optional`
 
@@ -60,10 +60,9 @@ Servers send new events via the user's preferred system. The event is [NIP-59 Gi
 
 Clients SHOULD try to decrypt the GiftWrap with all logged-in accounts. 
 
-## Event Watch Server list
+## Event Watcher list
 
-An Event Watch Server list is a kind 10097 replaceable event meant to select one or more servers the user wants
-to register for push notifications. Servers are listed as `server` tags:
+An Event Watcher list is a kind 10097 replaceable event meant to select one or more servers the user wants to register for push notifications. Servers are listed as `server` tags:
 
 ```json
 {

--- a/97.md
+++ b/97.md
@@ -1,4 +1,4 @@
-NIP-96
+NIP-97
 ======
 
 Push Notification Server API
@@ -12,7 +12,7 @@ The goal is to allow users to choose their event watch servers by simply adding 
 
 ## Registration Call
 
-After receiving a `token` from the push system (Google Services, Unified Push, Apple Push Notification), clients should upload a list of signed NIP-98 events, one for each account in the device, in a `POST` to `/register` with the following body:
+After receiving a `token` from the push system (Google Services, Unified Push, Apple Push Notification), clients should upload a list of signed [NIP-98](98.md) events, one for each account in the device, in a `POST` to `/register` with the following body:
 
 ```jsonc
 {

--- a/97.md
+++ b/97.md
@@ -56,9 +56,11 @@ Servers SHOULD delete tokens after failure to deliver.
 
 ## Sending Events
 
-Servers send new events via the user's preferred system. The event is [NIP-59 GiftWrapped](59.md) to the receiver, but no `p`-tag is added to the wrap event. In that way, the chosen system cannot know which key is receiving this event.
+Servers send new events as stringified JSONs in the user's preferred system. 
 
-Clients SHOULD try to decrypt the GiftWrap with all logged-in accounts. 
+The event MUST be [NIP-59 GiftWrapped](59.md) to the receiver. But since it already goes to the destination via the token, no `p`-tag is added to the wrap event. In this way, the chosen system cannot know which key is receiving a notification.
+
+Clients SHOULD decrypt the GiftWrap with all logged-in accounts to find the user this event is for.
 
 ## Event Watcher list
 


### PR DESCRIPTION
This is basically a NIP-96 spec for Push Notification event-watching servers. Users can pick which server will watch their events and send push notifications via their preferred systems. Event-watching servers can be the relays themselves or separate operators. 

Features: 
- Simple POST interface.
- Support for multiple Nostr accounts in a single registration event
- Encryption via wraps to hide the destination's pubkey from the user's push system.
- Support for multiple servers, multiple relays, and multiple tokes

Read [here](https://github.com/vitorpamplona/nips/blob/push/97.md)