### PR TITLE
Update 94 add a d tag to event

### DIFF
--- a/94.md
+++ b/94.md
@@ -31,6 +31,7 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
 {
   "kind": 1063,
   "tags": [
+    ["d",<identifier>],
     ["url",<string with URI of file>],
     ["m", <MIME type>],
     ["x",<Hash SHA-256>],
@@ -55,3 +56,9 @@ This NIP specifies the use of the `1063` event type, having in `content` a descr
 * A relay for indexing shared files. For example, to promote torrents.
 * A pinterest-like client where people can share their portfolio and inspire others.
 * A simple way to distribute configurations and software updates.
+* Use as a movable media for notes.
+  1. Clients upload a file to media service and get a file link and other file infomations.
+  2. Clients send a File Metadata event and this event must contain a ```d``` tag, it means that this event is replacable.
+  3. If a client want to sends notes with this file, it should imports this event with ```nostr:naddr``` style uri.
+  4. When other clients vist a note with kind 1063 naddr style uri, it should find this event and display it like a normal media file.
+  5. If this file's owner want to change the media service, he can upload this file to other media service and resend a File Metadata event with the same ```d``` tag.


### PR DESCRIPTION
Add a d tag to file metadata event and it will make this event replacable.
It means that the file can moving between media services.

You can vist updates easy from here: https://github.com/haorendashu/nips/blob/Replacable-File-Metadata/94.md

## use cases

* Use as a movable media for notes.
  1. Clients upload a file to media service and get a file link and other file infomations.
  2. Clients send a File Metadata event and this event must contain a ```d``` tag, it means that this event is replacable.
  3. If a client want to sends notes with this file, it should imports this event with ```nostr:naddr``` style uri.
  4. When other clients vist a note with kind 1063 naddr style uri, it should find this event and display it like a normal media file.
  5. If this file's owner want to change the media service, he can upload this file to other media service and resend a File Metadata event with the same ```d``` tag.