### PR TITLE
[NIP-55] - Change return field from signature to result

### DIFF
--- a/55.md
+++ b/55.md
@@ -53,8 +53,8 @@ val launcher = rememberLauncherForActivityResult(
                 Toast.LENGTH_SHORT
             ).show()
         } else {
-            val signature = activityResult.data?.getStringExtra("signature")
-            // Do something with signature ...
+            val result = activityResult.data?.getStringExtra("result")
+            // Do something with result ...
         }
     }
 )
@@ -101,10 +101,10 @@ launcher.launch(intent)
     context.startActivity(intent)
     ```
   - result:
-    - If the user approved intent it will return the **pubkey** in the signature field
+    - If the user approved intent it will return the **pubkey** in the result field
 
       ```kotlin
-      val pubkey = intent.data?.getStringExtra("signature")
+      val pubkey = intent.data?.getStringExtra("result")
       // The package name of the signer application
       val packageName = intent.data?.getStringExtra("package")
       ```
@@ -124,10 +124,10 @@ launcher.launch(intent)
     context.startActivity(intent)
     ```
   - result:
-    - If the user approved intent it will return the **signature**, **id** and **event** fields
+    - If the user approved intent it will return the **result**, **id** and **event** fields
 
       ```kotlin
-      val signature = intent.data?.getStringExtra("signature")
+      val signature = intent.data?.getStringExtra("result")
       // The id you sent
       val id = intent.data?.getStringExtra("id")
       val signedEventJson = intent.data?.getStringExtra("event")
@@ -150,10 +150,10 @@ launcher.launch(intent)
     context.startActivity(intent)
     ```
   - result:
-    - If the user approved intent it will return the **signature** and **id** fields
+    - If the user approved intent it will return the **result** and **id** fields
 
       ```kotlin
-      val encryptedText = intent.data?.getStringExtra("signature")
+      val encryptedText = intent.data?.getStringExtra("result")
       // the id you sent
       val id = intent.data?.getStringExtra("id")
       ```
@@ -200,10 +200,10 @@ launcher.launch(intent)
     context.startActivity(intent)
     ```
   - result:
-    - If the user approved intent it will return the **signature** and **id** fields
+    - If the user approved intent it will return the **result** and **id** fields
 
       ```kotlin
-      val plainText = intent.data?.getStringExtra("signature")
+      val plainText = intent.data?.getStringExtra("result")
       // the id you sent
       val id = intent.data?.getStringExtra("id")
       ```
@@ -225,10 +225,10 @@ launcher.launch(intent)
     context.startActivity(intent)
     ```
   - result:
-    - If the user approved intent it will return the **signature** and **id** fields
+    - If the user approved intent it will return the **result** and **id** fields
 
       ```kotlin
-      val plainText = intent.data?.getStringExtra("signature")
+      val plainText = intent.data?.getStringExtra("result")
       // the id you sent
       val id = intent.data?.getStringExtra("id")
       ```
@@ -248,10 +248,10 @@ launcher.launch(intent)
     context.startActivity(intent)
     ```
   - result:
-    - If the user approved intent it will return the **signature** and **id** fields
+    - If the user approved intent it will return the **result** and **id** fields
 
       ```kotlin
-      val relayJsonText = intent.data?.getStringExtra("signature")
+      val relayJsonText = intent.data?.getStringExtra("result")
       // the id you sent
       val id = intent.data?.getStringExtra("id")
       ```
@@ -270,10 +270,10 @@ launcher.launch(intent)
     context.startActivity(intent)
     ```
   - result:
-    - If the user approved intent it will return the **signature** and **id** fields
+    - If the user approved intent it will return the **result** and **id** fields
 
       ```kotlin
-      val eventJson = intent.data?.getStringExtra("signature")
+      val eventJson = intent.data?.getStringExtra("result")
       // the id you sent
       val id = intent.data?.getStringExtra("id")
       ```
@@ -284,9 +284,9 @@ To get the result back from Signer Application you should use contentResolver.qu
 
 If the user did not check the "remember my choice" option, the pubkey is not in Signer Application or the signer type is not recognized the `contentResolver` will return null
 
-For the SIGN_EVENT type Signer Application returns two columns "signature" and "event". The column event is the signed event json
+For the SIGN_EVENT type Signer Application returns two columns "result" and "event". The column event is the signed event json
 
-For the other types Signer Application returns the column "signature"
+For the other types Signer Application returns the column "result"
 
 If the user chose to always reject the event, signer application will return the column "rejected" and you should not open signer application
 
@@ -305,13 +305,13 @@ If the user chose to always reject the event, signer application will return the
     )
     ```
   - result:
-    - Will return the **pubkey** in the signature column
+    - Will return the **pubkey** in the result column
 
       ```kotlin
         if (result == null) return
 
         if (result.moveToFirst()) {
-            val index = it.getColumnIndex("signature")
+            val index = it.getColumnIndex("result")
             if (index < 0) return
             val pubkey = it.getString(index)
         }
@@ -330,13 +330,13 @@ If the user chose to always reject the event, signer application will return the
     )
     ```
   - result:
-    - Will return the **signature** and the **event** columns
+    - Will return the **result** and the **event** columns
 
       ```kotlin
         if (result == null) return
 
         if (result.moveToFirst()) {
-            val index = it.getColumnIndex("signature")
+            val index = it.getColumnIndex("result")
             val indexJson = it.getColumnIndex("event")
             val signature = it.getString(index)
             val eventJson = it.getString(indexJson)
@@ -356,13 +356,13 @@ If the user chose to always reject the event, signer application will return the
     )
     ```
   - result:
-    - Will return the **signature** column
+    - Will return the **result** column
 
       ```kotlin
         if (result == null) return
 
         if (result.moveToFirst()) {
-            val index = it.getColumnIndex("signature")
+            val index = it.getColumnIndex("result")
             val encryptedText = it.getString(index)
         }
       ```
@@ -380,13 +380,13 @@ If the user chose to always reject the event, signer application will return the
     )
     ```
   - result:
-    - Will return the **signature** column
+    - Will return the **result** column
 
       ```kotlin
         if (result == null) return
 
         if (result.moveToFirst()) {
-            val index = it.getColumnIndex("signature")
+            val index = it.getColumnIndex("result")
             val encryptedText = it.getString(index)
         }
       ```
@@ -404,13 +404,13 @@ If the user chose to always reject the event, signer application will return the
     )
     ```
   - result:
-    - Will return the **signature** column
+    - Will return the **result** column
 
       ```kotlin
         if (result == null) return
 
         if (result.moveToFirst()) {
-            val index = it.getColumnIndex("signature")
+            val index = it.getColumnIndex("result")
             val encryptedText = it.getString(index)
         }
       ```
@@ -428,13 +428,13 @@ If the user chose to always reject the event, signer application will return the
     )
     ```
   - result:
-    - Will return the **signature** column
+    - Will return the **result** column
 
       ```kotlin
         if (result == null) return
 
         if (result.moveToFirst()) {
-            val index = it.getColumnIndex("signature")
+            val index = it.getColumnIndex("result")
             val encryptedText = it.getString(index)
         }
       ```
@@ -452,13 +452,13 @@ If the user chose to always reject the event, signer application will return the
     )
     ```
   - result:
-    - Will return the **signature** column
+    - Will return the **result** column
 
       ```kotlin
         if (result == null) return
 
         if (result.moveToFirst()) {
-            val index = it.getColumnIndex("signature")
+            val index = it.getColumnIndex("result")
             val relayJsonText = it.getString(index)
         }
       ```
@@ -476,13 +476,13 @@ If the user chose to always reject the event, signer application will return the
     )
     ```
   - result:
-    - Will return the **signature** column
+    - Will return the **result** column
 
       ```kotlin
         if (result == null) return
 
         if (result.moveToFirst()) {
-            val index = it.getColumnIndex("signature")
+            val index = it.getColumnIndex("result")
             val eventJson = it.getString(index)
         }
       ```


### PR DESCRIPTION
This changes the return field from signature to result
Returning signature can confuse people since it only returns the signature if it's a sign_event