### PR TITLE
Trusted Assertions

### DIFF
--- a/85.md
+++ b/85.md
@@ -1,0 +1,54 @@
+NIP-85
+======
+
+Trusted Assertions
+------------------
+
+`draft` `optional`
+
+Certain calculations in Nostr require access to the entire dataset of events and are impossible to do directly by Clients. This NIP allows the creation of services that can perform such calculations and output signed events for each result in a continuous basis. Each calculation types receives a separate event kind. Users can setup which service providers they trust to perform these calculations and Clients can load and display the results accordingly.
+
+Assertions are always addressable events with the `d` tag pointing to the subject of the assertion. 
+
+| name                 | kind  | `d` tag value | result tags                           | 
+| -------------------- | ----- | ------------- | ------------------------------------- |
+| Follower Count       | 30382 | target pubkey | `"followers"` (integer)               | 
+| WebOfTrust Score     | 30382 | target pubkey | `"wot"` (integer, normalized 0-100)   | 
+| Zap Amount Received  | 30382 | target pubkey | `"zap_amt_recd"` (integer, millisats) | 
+| Zap Amount Sent      | 30382 | target pubkey | `"zap_amt_sent"` (integer, millisats) | 
+| Zap Number Received  | 30382 | target pubkey | `"zap_num_recd"` (integer, millisats) | 
+| Zap Number Sent      | 30382 | target pubkey | `"zap_num_sent"` (integer, millisats) | 
+
+Example: 
+
+```jsonc
+{
+  "kind": 30382,
+  "tags": [
+    ["d", "e88a691e98d9987c964521dff60025f60700378a4879180dcbbb4a5027850411"],
+    ["wot", "89"],
+    ["zap_amt_sent", "1000000"],
+  ],
+  "content": "",
+  //...
+}
+```
+
+## Declaring Trusted Service Providers
+
+Kind `10040` lists the user's authorized providers for each service. The service tag is followed by the `pubkey` of the service and the relay where the results are published.
+
+```jsonc
+{
+  "kind": 10040,
+  "tags": [
+    ["wot", "818a39b5f164235f86254b12ca586efccc1f95e98b45cb1c91c71dc5d9486dda", "wss://relay.nostr.band"],
+    ["wot", "3d842afecd5e293f28b6627933704a3fb8ce153aa91d790ab11f6a752d44a42d", "wss://nostr.wine"],
+    ["zap_amt_sent", "818a39b5f164235f86254b12ca586efccc1f95e98b45cb1c91c71dc5d9486dda", "wss://relay.nostr.band"],
+  ],
+  "content": "",
+  //...
+}
+```
+
+Clients should download this list, load and display assertions when appropriate. 

--- a/85.md
+++ b/85.md
@@ -10,14 +10,14 @@ Certain calculations in Nostr require access to the entire dataset of events and
 
 Assertions are always addressable events with the `d` tag pointing to the subject of the assertion. 
 
-| name                 | kind  | `d` tag value | result tags                           | 
-| -------------------- | ----- | ------------- | ------------------------------------- |
-| Follower Count       | 30382 | target pubkey | `"followers"` (integer)               | 
-| WebOfTrust Score     | 30382 | target pubkey | `"wot"` (integer, normalized 0-100)   | 
-| Zap Amount Received  | 30382 | target pubkey | `"zap_amt_recd"` (integer, millisats) | 
-| Zap Amount Sent      | 30382 | target pubkey | `"zap_amt_sent"` (integer, millisats) | 
-| Zap Number Received  | 30382 | target pubkey | `"zap_num_recd"` (integer, millisats) | 
-| Zap Number Sent      | 30382 | target pubkey | `"zap_num_sent"` (integer, millisats) | 
+| name                 | kind  | `d` tag value | result tags                             | 
+| -------------------- | ----- | ------------- | --------------------------------------- |
+| Follower Count       | 30382 | target pubkey | `"followers"` (integer)                 | 
+| WebOfTrust Score     | 30382 | target pubkey | `"wot"` (integer, normalized 0-100)     | 
+| Zap Amount Received  | 30382 | target pubkey | `"zap_amt_recd"` (integer, millisats)   | 
+| Zap Amount Sent      | 30382 | target pubkey | `"zap_amt_sent"` (integer, millisats)   | 
+| Zap Number Received  | 30382 | target pubkey | `"zap_num_recd"` (integer, evt counter) | 
+| Zap Number Sent      | 30382 | target pubkey | `"zap_num_sent"` (integer, evt counter) | 
 
 Example: 
 
@@ -33,6 +33,8 @@ Example:
   //...
 }
 ```
+
+Service providers SHOULD update their results constantly and MAY limit access to their results by using paid relays.
 
 ## Declaring Trusted Service Providers
 


### PR DESCRIPTION
Certain calculations in Nostr require access to the entire dataset of events and are impossible to do directly by Clients. This PR offers a simple way for users to declare trust in service providers for those calculations. 

Yes, it's similar to DVMs, but without the need to request/response each item. The service just runs constantly and updates events as quickly as it can.  

Read [here](https://github.com/vitorpamplona/nips/blob/user-summaries/85.md)