### PR TITLE
NIP-85: `d` Tag References in Addressable Events

### DIFF
--- a/85.md
+++ b/85.md
@@ -1,0 +1,33 @@
+NIP-85
+======
+
+`d` Tag References in Addressable Events
+----------------------------------------
+
+`draft` `optional`
+
+Addressable events have a `d` tag whose value is an arbitrary identifier. Usually it's a made-up name such as a blog post slug or a reverse-DNS identifier, but it can also be a reference to another user or event on the network.
+
+When a new addressable kind is defined, it may invoke this NIP by including a third parameter in the `d` tag: a [standardized tag](./README.md#standardized-tags) name such as "e", "p", or "a". In addition, exactly one of those tags MUST be included in the tags list, and its value MUST match the `d` tag value.
+
+For example, an addressable kind that references another event:
+
+```js
+[
+  ["d", eventId, "e"],
+  ["e", eventId, ...rest],
+]
+```
+
+Another addressable kind that references a user:
+
+```js
+[
+  ["d", userId, "p"],
+  ["p", userId, ...rest],
+]
+```
+
+This NIP does not define any kinds on its own. It's meant to be adopted on a per-kind basis. It is only applicable when the event kind will ONLY ever reference a single other standardized tag in its `d` tag.
+
+Clients implementing this NIP MUST validate events of applicable kinds by disposing of them if they do not adhere to the above rules.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-75: Zap Goals](75.md)
 - [NIP-78: Application-specific data](78.md)
 - [NIP-84: Highlights](84.md)
+- [NIP-85: `d` Tag References in Addressable Events](85.md)
 - [NIP-89: Recommended Application Handlers](89.md)
 - [NIP-90: Data Vending Machines](90.md)
 - [NIP-92: Media Attachments](92.md)


### PR DESCRIPTION
This is an alternative solution to https://github.com/nostr-protocol/nips/pull/1510 inspired by the discussion in https://github.com/nostr-protocol/nips/pull/1534