### PR TITLE
Add Kind 15 for Encrypted File message

### DIFF
--- a/17.md
+++ b/17.md
@@ -54,7 +54,7 @@ Kind `14`s MUST never be signed. If it is signed, the message might leak to rela
     ["decryptiion-nonce", "<decryption-nonce>"],
     // rest of tags...
   ],
-  "content": "<file-url-or-base64-content-in-plain-text>"
+  "content": "<file-url>"
 }
 ```
 
@@ -64,7 +64,7 @@ Kind 15 is used for sending encrypted file event messages:
 - `encryption-algorithm`: Indicates the encryption algorithm used for encrypting the file. Supported algorithms may include `aes-gcm`, `chacha20-poly1305`,`aes-cbc` etc.
 - `decryption-key`: The decryption key that will be used by the recipient to decrypt the file.
 - `decryption-nonce`: The decryption nonce that will be used by the recipient to decrypt the file.
-- `content`: Contains either the URL of the file (`<file-url>`) or the encrypted data in base64 format (`<base64-content-in-plain-text>`).
+- `content`: The URL of the file (`<file-url>`).
 
 ## Chat Rooms
 

--- a/17.md
+++ b/17.md
@@ -50,7 +50,8 @@ Kind `14`s MUST never be signed. If it is signed, the message might leak to rela
     ["subject", "<conversation-title>"],
     ["file-type", "<file-mime-type>"],
     ["encryption-algorithm", "<encryption-algorithm>"],
-    ["decryption-key", "<decryption-key>"]
+    ["decryption-key", "<decryption-key>"],
+    ["decryptiion-nonce", "<decryption-nonce>"],
     // rest of tags...
   ],
   "content": "<file-url-or-base64-content-in-plain-text>"
@@ -62,6 +63,7 @@ Kind 15 is used for sending encrypted file event messages:
 - `file-type`: Specifies the MIME type of the attached file (e.g., `image/jpeg`, `audio/mpeg`, etc.).
 - `encryption-algorithm`: Indicates the encryption algorithm used for encrypting the file. Supported algorithms may include `aes-gcm`, `chacha20-poly1305`,`aes-cbc` etc.
 - `decryption-key`: The decryption key that will be used by the recipient to decrypt the file.
+- `decryption-nonce`: The decryption nonce that will be used by the recipient to decrypt the file.
 - `content`: Contains either the URL of the file (`<file-url>`) or the encrypted data in base64 format (`<base64-content-in-plain-text>`).
 
 ## Chat Rooms

--- a/17.md
+++ b/17.md
@@ -35,6 +35,35 @@ Tags that mention, quote and assemble threading structures MUST follow [NIP-10](
 
 Kind `14`s MUST never be signed. If it is signed, the message might leak to relays and become **fully public**.
 
+## File Message Kind
+
+```jsonc
+{
+  "id": "<usual hash>",
+  "pubkey": "<sender-pubkey>",
+  "created_at": "<current-time>",
+  "kind": 15,
+  "tags": [
+    ["p", "<receiver-1-pubkey>", "<relay-url>"],
+    ["p", "<receiver-2-pubkey>", "<relay-url>"],
+    ["e", "<kind-14-id>", "<relay-url>", "reply"], // if this is a reply
+    ["subject", "<conversation-title>"],
+    ["file-type", "<file-mime-type>"],
+    ["encryption-algorithm", "<encryption-algorithm>"],
+    ["decryption-key", "<decryption-key>"]
+    // rest of tags...
+  ],
+  "content": "<file-url-or-base64-content-in-plain-text>"
+}
+```
+
+Kind 15 is used for sending encrypted file event messages:
+
+- `file-type`: Specifies the MIME type of the attached file (e.g., `image/jpeg`, `audio/mpeg`, etc.).
+- `encryption-algorithm`: Indicates the encryption algorithm used for encrypting the file. Supported algorithms may include `aes-gcm`, `chacha20-poly1305`,`aes-cbc` etc.
+- `decryption-key`: The decryption key that will be used by the recipient to decrypt the file.
+- `content`: Contains either the URL of the file (`<file-url>`) or the encrypted data in base64 format (`<base64-content-in-plain-text>`).
+
 ## Chat Rooms
 
 The set of `pubkey` + `p` tags defines a chat room. If a new `p` tag is added or a current one is removed, a new room is created with clean message history.

--- a/17.md
+++ b/17.md
@@ -52,6 +52,7 @@ Kind `14`s MUST never be signed. If it is signed, the message might leak to rela
     ["encryption-algorithm", "<encryption-algorithm>"],
     ["decryption-key", "<decryption-key>"],
     ["decryptiion-nonce", "<decryption-nonce>"],
+    ["x", "<the SHA-256 hexencoded string of the file>"],
     // rest of tags...
   ],
   "content": "<file-url>"
@@ -65,6 +66,14 @@ Kind 15 is used for sending encrypted file event messages:
 - `decryption-key`: The decryption key that will be used by the recipient to decrypt the file.
 - `decryption-nonce`: The decryption nonce that will be used by the recipient to decrypt the file.
 - `content`: The URL of the file (`<file-url>`).
+- `x` containing the SHA-256 hexencoded string of the file.
+- `size` (optional) size of file in bytes
+- `dim` (optional) size of file in pixels in the form `<width>x<height>`
+- `blurhash`(optional) the [blurhash](https://github.com/woltapp/blurhash) to show while the file is being loaded by the client
+- `thumb` (optional) url of thumbnail with same aspect ratio
+- `fallback` (optional) zero or more fallback file sources in case `url` fails
+
+Just like kind 14, kind `15`s MUST never be signed.
 
 ## Chat Rooms
 
@@ -76,7 +85,7 @@ An optional `subject` tag defines the current name/topic of the conversation. An
 
 ## Encrypting
 
-Following [NIP-59](59.md), the **unsigned** `kind:14` chat message must be sealed (`kind:13`) and then gift-wrapped (`kind:1059`) to each receiver and the sender individually.
+Following [NIP-59](59.md), the **unsigned** `kind:14` & `kind:15` chat message must be sealed (`kind:13`) and then gift-wrapped (`kind:1059`) to each receiver and the sender individually.
 
 ```js
 {


### PR DESCRIPTION
## File Message Kind

```jsonc
{
  "id": "<usual hash>",
  "pubkey": "<sender-pubkey>",
  "created_at": "<current-time>",
  "kind": 15,
  "tags": [
    ["p", "<receiver-1-pubkey>", "<relay-url>"],
    ["p", "<receiver-2-pubkey>", "<relay-url>"],
    ["e", "<kind-14-id>", "<relay-url>", "reply"], // if this is a reply
    ["subject", "<conversation-title>"],
    ["file-type", "<file-mime-type>"],
    ["encryption-algorithm", "<encryption-algorithm>"],
    ["decryption-key", "<decryption-key>"],
    ["decryption-nonce", "<decryption-nonce>"]
    // rest of tags...
  ],
  "content": "<file-url>"
}
```

Kind 15 is used for sending encrypted file event messages:

- `file-type`: Specifies the MIME type of the attached file (e.g., `image/jpeg`, `audio/mpeg`, etc.).
- `encryption-algorithm`: Indicates the encryption algorithm used for encrypting the file. Supported algorithms may include `aes-gcm`, `chacha20-poly1305`,`aes-cbc` etc.
- `decryption-key`: The decryption key that will be used by the recipient to decrypt the file.
- `decryption-nonce`: The decryption nonce that will be used by the recipient to decrypt the file.
- `content`: The URL of the file (`<file-url>`).