### PR TITLE
NIP-5A: Static Websites

### DIFF
--- a/5A.md
+++ b/5A.md
@@ -1,4 +1,4 @@
-NIP-XX
+NIP-5A
 ======
 
 Pubkey Static Websites

--- a/nsite.md
+++ b/nsite.md
@@ -1,8 +1,8 @@
 NIP-XX
 ======
 
-Static Websites (nsite)
------------------------
+Static Websites
+---------------
 
 `draft` `optional`
 
@@ -68,7 +68,7 @@ For example: `/` -> `/index.html` or `/blog/` -> `/blog/index.html`
 Once the host server has found the `34128` event for the pubkey and path it should use the sha256 hash defined in the `x` tag to retrieve the file
 
 If the pubkey has a `10063` [BUD-03 user servers](https://github.com/hzrd149/blossom/blob/master/buds/03.md) event the server MUST attempt to retrieve the file from the listed servers using the path defined in [BUD-01](https://github.com/hzrd149/blossom/blob/master/buds/01.md#get-sha256---get-blob)
-If a pubkey does not have a `10063` event the host server may choose to fallback to a predefined list of Blossom servers
+If a pubkey does not have a `10063` event the host server MUST respond with a status code 404
 
 The host server MUST forward the `Content-Type`, and `Content-Length` header from the Blossom server. If none are defined the host server MAY set `Content-Type` from the file extension in the requested path
 

--- a/nsite.md
+++ b/nsite.md
@@ -46,7 +46,7 @@ example
 Host: npub10phxfsms72rhafrklqdyhempujs9h67nye0p67qe424dyvcx0dkqgvap0e.nsite-host.com
 ```
 
-If the requests `Host` does not have a subdomain server MUST lookup any `CNAME` or `TXT` DNS records for the domain and attempt to resolve the pubkey from them
+If the requests `Host` does not contain an `npub` the server MUST lookup any `CNAME` or `TXT` DNS records for the `Host` and attempt to resolve the pubkey from them
 
 The host server MAY serve anything at its own root domain `nsite-host.com` ( a landing page for example )
 
@@ -70,7 +70,7 @@ Once the host server has found the `34128` event for the pubkey and path it shou
 If the pubkey has a `10063` [BUD-03 user servers](https://github.com/hzrd149/blossom/blob/master/buds/03.md) event the server MUST attempt to retrieve the file from the listed servers using the path defined in [BUD-01](https://github.com/hzrd149/blossom/blob/master/buds/01.md#get-sha256---get-blob)
 If a pubkey does not have a `10063` event the host server MUST respond with a status code 404
 
-The host server MUST forward the `Content-Type`, and `Content-Length` header from the Blossom server. If none are defined the host server MAY set `Content-Type` from the file extension in the requested path
+The host server MUST forward the `Content-Type`, and `Content-Length` headers from the Blossom server. If none are defined the host server MAY set `Content-Type` from the file extension in the requested path
 
 #### Handling Not Found
 

--- a/nsite.md
+++ b/nsite.md
@@ -1,8 +1,8 @@
 NIP-XX
 ======
 
-Static Websites
----------------
+Pubkey Static Websites
+----------------------
 
 `draft` `optional`
 
@@ -17,7 +17,7 @@ The `x` tag MUST be the sha256 hash of the file that will be served under this p
 
 For example:
 
-```json
+```jsonc
 {
   "content": "",
   "created_at": 1727373475,
@@ -26,7 +26,9 @@ For example:
   "pubkey": "266815e0c9210dfa324c6cba3573b14bee49da4209a9456f9484e5106cd408a5",
   "sig": "f4e4a9e785f70e9fcaa855d769438fea10781e84cd889e3fcb823774f83d094cf2c05d5a3ac4aebc1227a4ebc3d56867286c15a6df92d55045658bb428fd5fb5",
   "tags": [
+    // absolute path for the file
     ["d", "/index.html"],
+    // sha256 hash of the file to be served
     ["x", "186ea5fd14e88fd1ac49351759e7ab906fa94892002b60bf7f5a428f28ca1c99"]
   ]
 }
@@ -34,29 +36,25 @@ For example:
 
 ### Host server implementation
 
-A host server is an http server that is responsible for serving the static files for pubkeys
+A host server is a HTTP server that is responsible for serving pubkey static websites
 
 #### Resolving Pubkeys
 
-When a request is made to the host server with a subdomain of a `npub`, the server MUST use it as the pubkey when searching for the static file
+Host servers may choose to resolve a pubkey however they see fit, NIP-05 ids, `npub` subdomains, hardcoded names, DNS records, or a single pubkey for the server
 
-example
+However it is recommended to resolve pubkeys using a NIP-19 encoded pubkey `npub1...` as the subdomain. since this allows the host server to serve all pubkey sites while still keeping the pubkey in the URL
 
-```
-Host: npub10phxfsms72rhafrklqdyhempujs9h67nye0p67qe424dyvcx0dkqgvap0e.nsite-host.com
-```
+If the host server is using `npub` subdomains it MAY serve anything at its own root domain `nsite-host.com` ( a landing page for example )
 
-If the requests `Host` does not contain an `npub` the server MUST lookup any `CNAME` or `TXT` DNS records for the `Host` and attempt to resolve the pubkey from them
-
-The host server MAY serve anything at its own root domain `nsite-host.com` ( a landing page for example )
+Example subdomain `npub10phxfsms72rhafrklqdyhempujs9h67nye0p67qe424dyvcx0dkqgvap0e.npub-sites.com`
 
 #### Resolving Paths
 
 When the host server receives a request and is able to determine the pubkey. it should fetch the users `10002` [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md) relay list and lookup `34128` events with a `d` tag matching the requested path
 
-```json
+```jsonc
 // For /index.html
-{ "kinds": [34128], "authors": [pubkey], "#d": ["/index.html"] }
+{ "kinds": [34128], "authors": [<pubkey>], "#d": ["/index.html"] }
 ```
 
 If the request path does not end with a filename the host server MUST fallback to using the `index.html` filename

--- a/nsite.md
+++ b/nsite.md
@@ -1,0 +1,77 @@
+NIP-XX
+======
+
+Static Websites (nsite)
+-----------------------
+
+`draft` `optional`
+
+This nip describes a method by which static websites can be hosted under public keys using specialized host servers
+
+### Static file definition
+
+A static file event uses the kind `34128` and MUST have a `d` and `x` tag
+
+The `d` tag MUST be an absolute path ending with a filename and extension
+The `x` tag MUST be the sha256 hash of the file that will be served under this path
+
+For example:
+
+```json
+{
+  "content": "",
+  "created_at": 1727373475,
+  "id": "5324d695ed7abf7cdd2a48deb881c93b7f4e43de702989bbfb55a1b97b35a3de",
+  "kind": 34128,
+  "pubkey": "266815e0c9210dfa324c6cba3573b14bee49da4209a9456f9484e5106cd408a5",
+  "sig": "f4e4a9e785f70e9fcaa855d769438fea10781e84cd889e3fcb823774f83d094cf2c05d5a3ac4aebc1227a4ebc3d56867286c15a6df92d55045658bb428fd5fb5",
+  "tags": [
+    ["d", "/index.html"],
+    ["x", "186ea5fd14e88fd1ac49351759e7ab906fa94892002b60bf7f5a428f28ca1c99"]
+  ]
+}
+```
+
+### Host server implementation
+
+A host server is an http server that is responsible for serving the static files for pubkeys
+
+#### Resolving Pubkeys
+
+When a request is made to the host server with a subdomain of a `npub`, the server MUST use it as the pubkey when searching for the static file
+
+example
+
+```
+Host: npub10phxfsms72rhafrklqdyhempujs9h67nye0p67qe424dyvcx0dkqgvap0e.nsite-host.com
+```
+
+If the requests `Host` does not have a subdomain server MUST lookup any `CNAME` or `TXT` DNS records for the domain and attempt to resolve the pubkey from them
+
+The host server MAY serve anything at its own root domain `nsite-host.com` ( a landing page for example )
+
+#### Resolving Paths
+
+When the host server receives a request and is able to determine the pubkey. it should fetch the users `10002` [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md) relay list and lookup `34128` events with a `d` tag matching the requested path
+
+```json
+// For /index.html
+{ "kinds": [34128], "authors": [pubkey], "#d": ["/index.html"] }
+```
+
+If the request path does not end with a filename the host server MUST fallback to using the `index.html` filename
+
+For example: `/` -> `/index.html` or `/blog/` -> `/blog/index.html`
+
+#### Resolving Files
+
+Once the host server has found the `34128` event for the pubkey and path it should use the sha256 hash defined in the `x` tag to retrieve the file
+
+If the pubkey has a `10063` [BUD-03 user servers](https://github.com/hzrd149/blossom/blob/master/buds/03.md) event the server MUST attempt to retrieve the file from the listed servers using the path defined in [BUD-01](https://github.com/hzrd149/blossom/blob/master/buds/01.md#get-sha256---get-blob)
+If a pubkey does not have a `10063` event the host server may choose to fallback to a predefined list of Blossom servers
+
+The host server MUST forward the `Content-Type`, and `Content-Length` header from the Blossom server. If none are defined the host server MAY set `Content-Type` from the file extension in the requested path
+
+#### Handling Not Found
+
+If a host server is unable to find a `34128` event matching the requested path it MUST use `/404.html` as a fallback path

--- a/nsite.md
+++ b/nsite.md
@@ -8,28 +8,69 @@ Pubkey Static Websites
 
 This nip describes a method by which static websites can be hosted under public keys using specialized host servers
 
-### Static file definition
+### Site Manifest Definition
 
-A static file event uses the kind `34128` and MUST have a `d` and `x` tag
+A site manifest event MUST be a replaceable event as defined in [NIP-01](01.md). There are two types of site manifest events:
 
-The `d` tag MUST be an absolute path ending with a filename and extension
-The `x` tag MUST be the sha256 hash of the file that will be served under this path
+- **Root site**: Uses kind `15128` and MUST NOT include a `d` tag. This is a single replaceable event per pubkey.
+- **Identifier-specific sites**: Uses kind `35128` and MUST have a `d` tag containing the site identifier.
 
-For example:
+The event MUST include one or more `path` tags that map absolute paths to sha256 hashes. Each `path` tag MUST have the format `["path", "/absolute/path", "sha256hash"]` where:
+- The first element is the literal string `"path"`
+- The second element is an absolute path ending with a filename and extension
+- The third element is the sha256 hash of the file that will be served under this path
+
+The event MAY include `server` tags that hint at which blossom servers can be used to find the blobs associated with the hashes.
+
+The event MAY include `title` and `description` tags that provide simple site information.
+
+The site icon SHOULD be provided by setting the `/favicon.ico` path in the manifest.
+
+For example, a root site manifest:
 
 ```jsonc
 {
   "content": "",
   "created_at": 1727373475,
   "id": "5324d695ed7abf7cdd2a48deb881c93b7f4e43de702989bbfb55a1b97b35a3de",
-  "kind": 34128,
+  "kind": 15128,
   "pubkey": "266815e0c9210dfa324c6cba3573b14bee49da4209a9456f9484e5106cd408a5",
   "sig": "f4e4a9e785f70e9fcaa855d769438fea10781e84cd889e3fcb823774f83d094cf2c05d5a3ac4aebc1227a4ebc3d56867286c15a6df92d55045658bb428fd5fb5",
   "tags": [
-    // absolute path for the file
-    ["d", "/index.html"],
-    // sha256 hash of the file to be served
-    ["x", "186ea5fd14e88fd1ac49351759e7ab906fa94892002b60bf7f5a428f28ca1c99"]
+    // path mappings: absolute path -> sha256 hash
+    ["path", "/index.html", "186ea5fd14e88fd1ac49351759e7ab906fa94892002b60bf7f5a428f28ca1c99"],
+    ["path", "/about.html", "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456"],
+    ["path", "/favicon.ico", "fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321"],
+    // optional: blossom server hints
+    ["server", "https://blossom.example.com"],
+    // optional: site metadata
+    ["title", "My Nostr Site"],
+    ["description", "A static website hosted on Nostr"]
+  ]
+}
+```
+
+And an identifier-specific site manifest:
+
+```jsonc
+{
+  "content": "",
+  "created_at": 1727373475,
+  "id": "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456",
+  "kind": 35128,
+  "pubkey": "266815e0c9210dfa324c6cba3573b14bee49da4209a9456f9484e5106cd408a5",
+  "sig": "f4e4a9e785f70e9fcaa855d769438fea10781e84cd889e3fcb823774f83d094cf2c05d5a3ac4aebc1227a4ebc3d56867286c15a6df92d55045658bb428fd5fb5",
+  "tags": [
+    // site identifier
+    ["d", "blog"],
+    // path mappings: absolute path -> sha256 hash
+    ["path", "/index.html", "186ea5fd14e88fd1ac49351759e7ab906fa94892002b60bf7f5a428f28ca1c99"],
+    ["path", "/post.html", "a1b2c3d4e5f6789012345678901234567890abcdef1234567890abcdef123456"],
+    // optional: blossom server hints
+    ["server", "https://blossom.example.com"],
+    // optional: site metadata
+    ["title", "My Blog"],
+    ["description", "A blog hosted on Nostr"]
   ]
 }
 ```
@@ -40,22 +81,37 @@ A host server is a HTTP server that is responsible for serving pubkey static web
 
 #### Resolving Pubkeys
 
-Host servers may choose to resolve a pubkey however they see fit, NIP-05 ids, `npub` subdomains, hardcoded names, DNS records, or a single pubkey for the server
+Host servers may choose to resolve a pubkey (and identifier for identifier-specific sites) however they see fit, NIP-05 ids, `npub` subdomains, hardcoded names, DNS records, or a single pubkey for the server
 
-However it is recommended to resolve pubkeys using a NIP-19 encoded pubkey `npub1...` as the subdomain. since this allows the host server to serve all pubkey sites while still keeping the pubkey in the URL
+However it is recommended to use the URL format `[identifier].<npub>.nsite-host.com` where:
+- The root site uses `<npub>.nsite-host.com` (no identifier)
+- Identifier-specific sites use `[identifier].<npub>.nsite-host.com` as subdomains under the npub site
+
+This allows the host server to serve all pubkey sites while still keeping the pubkey in the URL, and enables multiple sites per pubkey through identifiers.
 
 If the host server is using `npub` subdomains it MAY serve anything at its own root domain `nsite-host.com` ( a landing page for example )
 
-Example subdomain `npub10phxfsms72rhafrklqdyhempujs9h67nye0p67qe424dyvcx0dkqgvap0e.npub-sites.com`
+Example subdomains:
+- Root site: `npub10phxfsms72rhafrklqdyhempujs9h67nye0p67qe424dyvcx0dkqgvap0e.nsite-host.com`
+- Identifier-specific site: `blog.npub10phxfsms72rhafrklqdyhempujs9h67nye0p67qe424dyvcx0dkqgvap0e.nsite-host.com`
 
 #### Resolving Paths
 
-When the host server receives a request and is able to determine the pubkey. it should fetch the users `10002` [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md) relay list and lookup `34128` events with a `d` tag matching the requested path
+When the host server receives a request and is able to determine the pubkey and identifier, it should fetch the users `10002` [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md) relay list and lookup the site manifest event for the pubkey and identifier.
+
+The host server MUST determine the identifier from the request. If no identifier is found in the request, it MUST query for the root site manifest.
+
+The host server should query for the site manifest event:
 
 ```jsonc
-// For /index.html
-{ "kinds": [34128], "authors": [<pubkey>], "#d": ["/index.html"] }
+// For root site (kind 15128, no d tag)
+{ "kinds": [15128], "authors": [<pubkey>] }
+
+// For identifier-specific site (kind 35128, with d tag)
+{ "kinds": [35128], "authors": [<pubkey>], "#d": [<identifier>] }
 ```
+
+Once the site manifest event is found, the host server MUST extract the path-to-hash mappings from the `path` tags in the manifest. The host server should look for a `path` tag where the second element matches the requested path.
 
 If the request path does not end with a filename the host server MUST fallback to using the `index.html` filename
 
@@ -63,13 +119,23 @@ For example: `/` -> `/index.html` or `/blog/` -> `/blog/index.html`
 
 #### Resolving Files
 
-Once the host server has found the `34128` event for the pubkey and path it should use the sha256 hash defined in the `x` tag to retrieve the file
+Once the host server has found the site manifest event and located the matching `path` tag for the requested path, it should use the sha256 hash defined in the third element of the `path` tag to retrieve the file.
+
+The host server SHOULD prioritize using `server` tags from the site manifest event as hints for which blossom servers to query. If the manifest includes `server` tags, the host server SHOULD attempt to retrieve the file from those servers first.
 
 If the pubkey has a `10063` [BUD-03 user servers](https://github.com/hzrd149/blossom/blob/master/buds/03.md) event the server MUST attempt to retrieve the file from the listed servers using the path defined in [BUD-01](https://github.com/hzrd149/blossom/blob/master/buds/01.md#get-sha256---get-blob)
-If a pubkey does not have a `10063` event the host server MUST respond with a status code 404
+If a pubkey does not have a `10063` event and no `server` tags are found in the manifest, the host server MUST respond with a status code 404
 
 The host server MUST forward the `Content-Type`, and `Content-Length` headers from the Blossom server. If none are defined the host server MAY set `Content-Type` from the file extension in the requested path
 
 #### Handling Not Found
 
-If a host server is unable to find a `34128` event matching the requested path it MUST use `/404.html` as a fallback path
+If a host server is unable to find a site manifest event or a matching `path` tag for the requested path, it MUST use `/404.html` as a fallback path
+
+### Legacy Support
+
+Kind `34128` is marked as legacy/deprecated. This kind was used for individual static file events where each file was represented by a separate event with a `d` tag for the path and an `x` tag for the sha256 hash.
+
+Host servers MAY still support kind `34128` for backward compatibility with existing sites, but new sites SHOULD use kind `15128` (root site manifest) or kind `35128` (identifier-specific site manifest) instead.
+
+Read the [legacy version](https://github.com/hzrd149/nips/blob/41e77b45a1e8a8d170097e363f7d7254797cc5c5/nsite.md) for more details.

--- a/nsite.md
+++ b/nsite.md
@@ -10,10 +10,10 @@ This nip describes a method by which static websites can be hosted under public 
 
 ### Site Manifest Definition
 
-A site manifest event MUST be a replaceable event as defined in [NIP-01](01.md). There are two types of site manifest events:
+A site manifest event MUST be a replaceable or an addressable event as defined in [NIP-01](01.md). There are two types of site manifest event kinds:
 
-- **Root site**: Uses kind `15128` and MUST NOT include a `d` tag. This is a single replaceable event per pubkey.
-- **Identifier-specific sites**: Uses kind `35128` and MUST have a `d` tag containing the site identifier.
+- **Root site**: Uses kind `15128` and MUST NOT include a `d` tag. This is a single replaceable event per pubkey and serves as the root site for the pubkey.
+- **Named sites**: Uses kind `35128` and MUST have a `d` tag containing the site identifier. These can be smaller websites under a pubkey and can be throught of as sub-domains.
 
 The event MUST include one or more `path` tags that map absolute paths to sha256 hashes. Each `path` tag MUST have the format `["path", "/absolute/path", "sha256hash"]` where:
 - The first element is the literal string `"path"`
@@ -50,7 +50,7 @@ For example, a root site manifest:
 }
 ```
 
-And an identifier-specific site manifest:
+And a named site manifest:
 
 ```jsonc
 {
@@ -81,11 +81,11 @@ A host server is a HTTP server that is responsible for serving pubkey static web
 
 #### Resolving Pubkeys
 
-Host servers may choose to resolve a pubkey (and identifier for identifier-specific sites) however they see fit, NIP-05 ids, `npub` subdomains, hardcoded names, DNS records, or a single pubkey for the server
+Host servers may choose to resolve a pubkey (and identifier for named sites) however they see fit, NIP-05 ids, `npub` subdomains, hardcoded names, DNS records, or a single pubkey for the server
 
 However it is recommended to use the URL format `[identifier].<npub>.nsite-host.com` where:
 - The root site uses `<npub>.nsite-host.com` (no identifier)
-- Identifier-specific sites use `[identifier].<npub>.nsite-host.com` as subdomains under the npub site
+- Named sites use `[identifier].<npub>.nsite-host.com` as subdomains under the npub site
 
 This allows the host server to serve all pubkey sites while still keeping the pubkey in the URL, and enables multiple sites per pubkey through identifiers.
 
@@ -93,7 +93,7 @@ If the host server is using `npub` subdomains it MAY serve anything at its own r
 
 Example subdomains:
 - Root site: `npub10phxfsms72rhafrklqdyhempujs9h67nye0p67qe424dyvcx0dkqgvap0e.nsite-host.com`
-- Identifier-specific site: `blog.npub10phxfsms72rhafrklqdyhempujs9h67nye0p67qe424dyvcx0dkqgvap0e.nsite-host.com`
+- Named site: `blog.npub10phxfsms72rhafrklqdyhempujs9h67nye0p67qe424dyvcx0dkqgvap0e.nsite-host.com`
 
 #### Resolving Paths
 
@@ -107,7 +107,7 @@ The host server should query for the site manifest event:
 // For root site (kind 15128, no d tag)
 { "kinds": [15128], "authors": [<pubkey>] }
 
-// For identifier-specific site (kind 35128, with d tag)
+// For named site (kind 35128, with d tag)
 { "kinds": [35128], "authors": [<pubkey>], "#d": [<identifier>] }
 ```
 
@@ -136,6 +136,6 @@ If a host server is unable to find a site manifest event or a matching `path` ta
 
 Kind `34128` is marked as legacy/deprecated. This kind was used for individual static file events where each file was represented by a separate event with a `d` tag for the path and an `x` tag for the sha256 hash.
 
-Host servers MAY still support kind `34128` for backward compatibility with existing sites, but new sites SHOULD use kind `15128` (root site manifest) or kind `35128` (identifier-specific site manifest) instead.
+Host servers MAY still support kind `34128` for backward compatibility with existing sites, but new sites SHOULD use kind `15128` (root site manifest) or kind `35128` (named site manifest) instead.
 
 Read the [legacy version](https://github.com/hzrd149/nips/blob/41e77b45a1e8a8d170097e363f7d7254797cc5c5/nsite.md) for more details.

--- a/nsite.md
+++ b/nsite.md
@@ -96,9 +96,9 @@ For interoperability, host servers SHOULD use the following canonical URL format
 
 `dTag` is the site identifier (`d` tag value) as plain text. It is appended directly after `pubkeyB36` with no separator.
 
-For canonical named-site URLs, `dTag` MUST match `^[a-z0-9]{1,11}$`.
+For canonical named-site URLs, `dTag` MUST match `^[a-z0-9-]{1,13}$` and MUST NOT end with `-`.
 
-Because DNS labels are limited to 63 characters, `dTag` MUST be 1-11 characters.
+Because DNS labels are limited to 63 characters and `pubkeyB36` uses 50 of them, `dTag` MUST be 1-13 characters.
 
 This single-label format avoids wildcard certificate limitations with multi-level subdomains.
 
@@ -115,9 +115,9 @@ When the host server receives a request and is able to determine the pubkey and 
 For canonical subdomain formats, the host server MUST parse the left-most DNS label as follows:
 
 1. If the label is a valid `npub`, decode it and query for the root site manifest.
-2. Otherwise, if the label matches `^[0-9a-z]{50}[a-z0-9]{1,11}$`, treat it as a named-site label where:
+2. Otherwise, if the label matches `^[0-9a-z]{50}[a-z0-9-]{1,13}$` and does not end with `-`, treat it as a named-site label where:
    - `pubkeyB36` is the first 50 characters
-   - `dTag` is the remaining 1-11 characters
+   - `dTag` is the remaining 1-13 characters
    - decode `pubkeyB36` to a 32-byte pubkey
    - use `dTag` as the identifier (`d` tag value)
 

--- a/nsite.md
+++ b/nsite.md
@@ -90,11 +90,11 @@ A host server is a HTTP server that is responsible for serving pubkey static web
 For interoperability, host servers SHOULD use the following canonical URL formats:
 
 - Root site: `<npub>.nsite-host.com`
-- Named site: `<pubkeyB32><dTag>.nsite-host.com`
+- Named site: `<pubkeyB36><dTag>.nsite-host.com`
 
-`pubkeyB32` is the author's raw 32-byte pubkey encoded with RFC 4648 base32 (lowercase, no padding) and is always exactly 52 characters.
+`pubkeyB36` is the author's raw 32-byte pubkey encoded with base36 (lowercase, digits `0-9` then letters `a-z`, no padding) and is always exactly 50 characters.
 
-`dTag` is the site identifier (`d` tag value) as plain text. It is appended directly after `pubkeyB32` with no separator.
+`dTag` is the site identifier (`d` tag value) as plain text. It is appended directly after `pubkeyB36` with no separator.
 
 For canonical named-site URLs, `dTag` MUST match `^[a-z0-9]{1,11}$`.
 
@@ -106,7 +106,7 @@ If the host server is using subdomain routing it MAY serve anything at its own r
 
 Example subdomains:
 - Root site: `npub10phxfsms72rhafrklqdyhempujs9h67nye0p67qe424dyvcx0dkqgvap0e.nsite-host.com`
-- Named site: `<52-char-pubkeyB32><dTag>.nsite-host.com`
+- Named site: `<50-char-pubkeyB36><dTag>.nsite-host.com`
 
 #### Resolving Paths
 
@@ -115,10 +115,10 @@ When the host server receives a request and is able to determine the pubkey and 
 For canonical subdomain formats, the host server MUST parse the left-most DNS label as follows:
 
 1. If the label is a valid `npub`, decode it and query for the root site manifest.
-2. Otherwise, if the label matches `^[a-z2-7]{52}[a-z0-9]{1,11}$`, treat it as a named-site label where:
-   - `pubkeyB32` is the first 52 characters
+2. Otherwise, if the label matches `^[0-9a-z]{50}[a-z0-9]{1,11}$`, treat it as a named-site label where:
+   - `pubkeyB36` is the first 50 characters
    - `dTag` is the remaining 1-11 characters
-   - decode `pubkeyB32` to a 32-byte pubkey
+   - decode `pubkeyB36` to a 32-byte pubkey
    - use `dTag` as the identifier (`d` tag value)
 
 If parsing fails, the host server MUST treat the site as not found.

--- a/nsite.md
+++ b/nsite.md
@@ -24,6 +24,8 @@ The event MAY include `server` tags that hint at which blossom servers can be us
 
 The event MAY include `title` and `description` tags that provide simple site information.
 
+The event MAY include a `source` tag that links to the site's source code repository or source archive. The `source` tag MUST have the format `["source", "<url>"]`, where `<url>` is an absolute `http` or `https` URL.
+
 The site icon SHOULD be provided by setting the `/favicon.ico` path in the manifest.
 
 For example, a root site manifest:
@@ -45,7 +47,9 @@ For example, a root site manifest:
     ["server", "https://blossom.example.com"],
     // optional: site metadata
     ["title", "My Nostr Site"],
-    ["description", "A static website hosted on Nostr"]
+    ["description", "A static website hosted on Nostr"],
+    // optional: source code location
+    ["source", "https://github.com/example/my-nostr-site"]
   ]
 }
 ```
@@ -70,7 +74,9 @@ And a named site manifest:
     ["server", "https://blossom.example.com"],
     // optional: site metadata
     ["title", "My Blog"],
-    ["description", "A blog hosted on Nostr"]
+    ["description", "A blog hosted on Nostr"],
+    // optional: source code location
+    ["source", "https://github.com/example/my-nostr-blog"]
   ]
 }
 ```
@@ -81,25 +87,41 @@ A host server is a HTTP server that is responsible for serving pubkey static web
 
 #### Resolving Pubkeys
 
-Host servers may choose to resolve a pubkey (and identifier for named sites) however they see fit, NIP-05 ids, `npub` subdomains, hardcoded names, DNS records, or a single pubkey for the server
+For interoperability, host servers SHOULD use the following canonical URL formats:
 
-However it is recommended to use the URL format `[identifier].<npub>.nsite-host.com` where:
-- The root site uses `<npub>.nsite-host.com` (no identifier)
-- Named sites use `[identifier].<npub>.nsite-host.com` as subdomains under the npub site
+- Root site: `<npub>.nsite-host.com`
+- Named site: `<pubkeyB32><dTag>.nsite-host.com`
 
-This allows the host server to serve all pubkey sites while still keeping the pubkey in the URL, and enables multiple sites per pubkey through identifiers.
+`pubkeyB32` is the author's raw 32-byte pubkey encoded with RFC 4648 base32 (lowercase, no padding) and is always exactly 52 characters.
 
-If the host server is using `npub` subdomains it MAY serve anything at its own root domain `nsite-host.com` ( a landing page for example )
+`dTag` is the site identifier (`d` tag value) as plain text. It is appended directly after `pubkeyB32` with no separator.
+
+For canonical named-site URLs, `dTag` MUST match `^[a-z0-9]{1,11}$`.
+
+Because DNS labels are limited to 63 characters, `dTag` MUST be 1-11 characters.
+
+This single-label format avoids wildcard certificate limitations with multi-level subdomains.
+
+If the host server is using subdomain routing it MAY serve anything at its own root domain `nsite-host.com` (a landing page for example).
 
 Example subdomains:
 - Root site: `npub10phxfsms72rhafrklqdyhempujs9h67nye0p67qe424dyvcx0dkqgvap0e.nsite-host.com`
-- Named site: `blog.npub10phxfsms72rhafrklqdyhempujs9h67nye0p67qe424dyvcx0dkqgvap0e.nsite-host.com`
+- Named site: `<52-char-pubkeyB32><dTag>.nsite-host.com`
 
 #### Resolving Paths
 
 When the host server receives a request and is able to determine the pubkey and identifier, it should fetch the users `10002` [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md) relay list and lookup the site manifest event for the pubkey and identifier.
 
-The host server MUST determine the identifier from the request. If no identifier is found in the request, it MUST query for the root site manifest.
+For canonical subdomain formats, the host server MUST parse the left-most DNS label as follows:
+
+1. If the label is a valid `npub`, decode it and query for the root site manifest.
+2. Otherwise, if the label matches `^[a-z2-7]{52}[a-z0-9]{1,11}$`, treat it as a named-site label where:
+   - `pubkeyB32` is the first 52 characters
+   - `dTag` is the remaining 1-11 characters
+   - decode `pubkeyB32` to a 32-byte pubkey
+   - use `dTag` as the identifier (`d` tag value)
+
+If parsing fails, the host server MUST treat the site as not found.
 
 The host server should query for the site manifest event:
 


### PR DESCRIPTION
This nip defines a spec for hosting static websites using site manifest events

- Root site: Use kind `15128` and is a replaceable event per pubkey and serves as the root site for the pubkey.
- Named sites: Use kind `35128` and have a d tag containing the site identifier. These are smaller websites under a pubkey and can be thought of as sub-domains.

Readable version [here](https://github.com/hzrd149/nips/blob/nsite/nsite.md)

Implementations:
 - [nsite-gateway](https://github.com/hzrd149/nsite-gateway)
 - [nsite.run](https://github.com/sandwichfarm/nsite.run)
 - [nsyte](https://nsyte.run/)

Legacy [readable version](https://github.com/hzrd149/nips/blob/41e77b45a1e8a8d170097e363f7d7254797cc5c5/nsite.md)

Legacy Implementations:
 - [nsite](https://github.com/lez/nsite)
 - [nsite-cli](https://github.com/flox1an/nsite-cli)
 - [nous-cli](https://gitlab.com/soapbox-pub/nous-cli)
 - [nostr-deploy-cli](https://github.com/sepehr-safari/nostr-deploy-cli)
 - [nostr-deploy-server](https://github.com/sepehr-safari/nostr-deploy-server)