### PR TITLE
Typed schemes.

### DIFF
--- a/21.md
+++ b/21.md
@@ -18,3 +18,14 @@ The identifiers that come after are expected to be the same as those defined in 
 - `nostr:nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p`
 - `nostr:note1fntxtkcy9pjwucqwa9mddn7v03wwwsu9j330jj350nvhpky2tuaspk6nqc`
 - `nostr:nevent1qqstna2yrezu5wghjvswqqculvvwxsrcvu7uc0f78gan4xqhvz49d9spr3mhxue69uhkummnw3ez6un9d3shjtn4de6x2argwghx6egpr4mhxue69uhkummnw3ez6ur4vgh8wetvd3hhyer9wghxuet5nxnepm`
+
+# Typed Schemes
+
+Nostr apps SHOULD register for the specific event types they support, enabling operating systems to suggest only applications that can handle those event types and allowing the OS to have a different default application for each type.
+
+The typed scheme is `nostr<event type number>:` followed by a `note`, `nevent` or an `naddr` [NIP-19](19.md) identifier.
+
+## Examples
+
+- `nostr1:note1fntxtkcy9pjwucqwa9mddn7v03wwwsu9j330jj350nvhpky2tuaspk6nqc`
+- `nostr1:nevent1qqstna2yrezu5wghjvswqqculvvwxsrcvu7uc0f78gan4xqhvz49d9spr3mhxue69uhkummnw3ez6un9d3shjtn4de6x2argwghx6egpr4mhxue69uhkummnw3ez6ur4vgh8wetvd3hhyer9wghxuet5nxnepm`


### PR DESCRIPTION
I am trying to figure out a way to allow micro clients to register only the event types they support on Android/iOS. 

Then if we use these URIs when opening external events, a more appropriate client list can be recommended by the OS. 

Today, all the dozens of clients pop up and the OS can only have one of them as the default for the `nostr:` URI. 

The more we go into the direction of mini and micro clients, the more we will need something like this. 
