### PR TITLE
Instagram feeds

### DIFF
--- a/68.md
+++ b/68.md
@@ -6,9 +6,9 @@ Picture-first feeds
 
 `draft` `optional`
 
-This NIP defines event kind `20` for picture-first clients. Images must be self-contained. They are hosted externally and referenced using `imeta` tags
+This NIP defines event kind `20` for picture-first clients. Images must be self-contained. They are hosted externally and referenced using `imeta` tags.
 
-Unlike a `kind 1` event with a pircture attached, Picture events are meant to contain all additional metadata concerning the subject media and to be surfaced in picture-specific clients rather than general micro-blogging clients. The thought is for events of this kind to be referenced in a Instagram/Flickr/Snapshat/9gag like nostr client where the picture itself is at the center of the experience.
+The idea is for this type of event to cater to Nostr clients resembling platforms like Instagram, Flickr, Snapchat, or 9GAG, where the picture itself takes center stage in the user experience.
 
 ## Picture Events
 
@@ -60,6 +60,8 @@ They may contain multiple images to be displayed as a single post.
 
     // Specify the media type for filters to allow clients to filter by supported kinds
     ["m", "image/jpeg"],
+
+    // Hashes of each image to make them queryable
     ["x", "<sha256>"]
 
     // Hashtags

--- a/68.md
+++ b/68.md
@@ -64,6 +64,10 @@ They may contain multiple images to be displayed as a single post.
     // Hashtags
     ["t", "<tag>"],
     ["t", "<tag>"],
+
+    // When text is written in the image, add the tag to represent the language
+    ["L", "ISO-639-1"],
+    ["l", "en", "ISO-639-1"]
   ]
 }
 ```

--- a/68.md
+++ b/68.md
@@ -58,6 +58,9 @@ They may contain multiple images to be displayed as a single post.
     ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>"],
     ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>"],
 
+    // Specify the media type for filters to allow clients to filter by supported kinds
+    ["m", "image/jpeg"]
+
     // Hashtags
     ["t", "<tag>"],
     ["t", "<tag>"],
@@ -66,5 +69,13 @@ They may contain multiple images to be displayed as a single post.
 ```
 
 The `imeta` tag `annotate-user` places a user link in the specific position in the image.
+
+Only the following media types are accepted: 
+- `image/apng`: Animated Portable Network Graphics (APNG)
+- `image/avif`: AV1 Image File Format (AVIF)
+- `image/gif`: Graphics Interchange Format (GIF)
+- `image/jpeg`: Joint Photographic Expert Group image (JPEG)
+- `image/png`: Portable Network Graphics (PNG)
+- `image/webp`: Web Picture format (WEBP)
 
 Picture events might be used with [NIP-71](71.md)'s kind `34236` to display short vertical videos in the same feed.

--- a/68.md
+++ b/68.md
@@ -65,6 +65,10 @@ They may contain multiple images to be displayed as a single post.
     ["t", "<tag>"],
     ["t", "<tag>"],
 
+    // location
+    ["location", "<location>"], // city name, state, country
+    ["g", "<geohash>"],
+
     // When text is written in the image, add the tag to represent the language
     ["L", "ISO-639-1"],
     ["l", "en", "ISO-639-1"]

--- a/68.md
+++ b/68.md
@@ -1,0 +1,70 @@
+NIP-68
+======
+
+Picture-first feeds
+-------------------
+
+`draft` `optional`
+
+This NIP defines event kind `20` for picture-first clients. Images must be self-contained. They are hosted externally and referenced using `imeta` tags
+
+Unlike a `kind 1` event with a pircture attached, Picture events are meant to contain all additional metadata concerning the subject media and to be surfaced in picture-specific clients rather than general micro-blogging clients. The thought is for events of this kind to be referenced in a Instagram/Flickr/Snapshat/9gag like nostr client where the picture itself is at the center of the experience.
+
+## Picture Events
+
+Picture events contain a `title` tag and description in the `.content`. 
+
+They may contain multiple images to be displayed as a single post.
+
+```jsonc
+{
+  "id": <32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>,
+  "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>,
+  "created_at": <Unix timestamp in seconds>,
+  "kind": 20,
+  "content": "<description of post>",
+  "tags": [
+    ["title", "<short title of post>"],
+
+    // Picture Data
+    [
+      "imeta",
+      "url https://nostr.build/i/my-image.jpg",
+      "m image/jpeg",
+      "blurhash eVF$^OI:${M{o#*0-nNFxakD-?xVM}WEWB%iNKxvR-oetmo#R-aen$",
+      "dim 3024x4032",
+      "alt A scenic photo overlooking the coast of Costa Rica",
+      "x <sha256 hash as specified in NIP 94>",
+      "fallback https://nostrcheck.me/alt1.jpg",
+      "fallback https://void.cat/alt1.jpg"
+    ],
+    [
+      "imeta",
+      "url https://nostr.build/i/my-image2.jpg",
+      "m image/jpeg",
+      "blurhash eVF$^OI:${M{o#*0-nNFxakD-?xVM}WEWB%iNKxvR-oetmo#R-aen$",
+      "dim 3024x4032",
+      "alt Another scenic photo overlooking the coast of Costa Rica",
+      "x <sha256 hash as specified in NIP 94>",
+      "fallback https://nostrcheck.me/alt2.jpg",
+      "fallback https://void.cat/alt2.jpg",
+
+      "annotate-user <32-bytes hex of a pubkey>:<posX>:<posY>" // Tag users in specific locations in the picture
+    ],
+
+    ["content-warning", "<reason>"], // if NSFW
+
+    // Tagged users
+    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>"],
+    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>"],
+
+    // Hashtags
+    ["t", "<tag>"],
+    ["t", "<tag>"],
+  ]
+}
+```
+
+The `imeta` tag `annotate-user` places a user link in the specific position in the image.
+
+Picture events might be used with [NIP-71](71.md)'s kind `34236` to display short vertical videos in the same feed.

--- a/68.md
+++ b/68.md
@@ -59,7 +59,8 @@ They may contain multiple images to be displayed as a single post.
     ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>"],
 
     // Specify the media type for filters to allow clients to filter by supported kinds
-    ["m", "image/jpeg"]
+    ["m", "image/jpeg"],
+    ["x", "<sha256>"]
 
     // Hashtags
     ["t", "<tag>"],


### PR DESCRIPTION
Adds a simple kind for picture-first clients building Instagram-like feeds, where the picture should be attenuated and the descriptions are less important and might not even be displayed in the main UI.

No, I don't think Kind 1s must be reused for these clients. 

And no, NIP-94 became too generic for this.

Read [here](https://github.com/vitorpamplona/nips/blob/instagram/68.md)