### PR TITLE
Update 11.md with banner, and icon fields

### DIFF
--- a/11.md
+++ b/11.md
@@ -39,7 +39,7 @@ Detailed plain-text information about the relay may be contained in the `descrip
 
 ### Banner
 
-If nostr relay management is not to be relegated to PhD or protocol developers only, an effort should be made by relay owners to communicate with non-dev non-technical nostr end users. A banner is a visual representation of the relay. It should aim to visually communicate the brand of the relay, complementing the text `Description`. [Here is an example banner](https://image.nostr.build/232ddf6846e8aea5a61abcd70f9222ab521f711aa545b7ab02e430248fa3a249.png) mockup as visualized in Damus iOS relay view of the Damus relay.
+To make nostr relay management more user friendly, an effort should be made by relay owners to communicate with non-dev non-technical nostr end users. A banner is a visual representation of the relay. It should aim to visually communicate the brand of the relay, complementing the text `Description`. [Here is an example banner](https://image.nostr.build/232ddf6846e8aea5a61abcd70f9222ab521f711aa545b7ab02e430248fa3a249.png) mockup as visualized in Damus iOS relay view of the Damus relay.
 
 ### Icon
 

--- a/11.md
+++ b/11.md
@@ -15,7 +15,7 @@ When a relay receives an HTTP(s) request with an `Accept` header of `application
   "name": <string identifying relay>,
   "description": <string with detailed information>,
   "banner": <a link to an image (e.g. in .jpg, or .png format)>,
-  "icon": <a link to an icon in .ico format>,
+  "icon": <a link to an icon (e.g.in .ico format, or .png format etc>,
   "pubkey": <administrative contact pubkey>,
   "contact": <administrative alternate contact>,
   "supported_nips": <a list of NIP numbers supported by the relay>,
@@ -43,7 +43,7 @@ To make nostr relay management more user friendly, an effort should be made by r
 
 ### Icon
 
-Icon is a compact visual representation of the relay for use in UI with limited real estate such as a nostr user's relay list view. Example relay icon link `https://damus.io/favicon.ico`.
+Icon is a compact visual representation of the relay for use in UI with limited real estate such as a nostr user's relay list view. Example relay icon links `https://damus.io/favicon.ico`, `https://example.com/icon.png`.
 
 ### Pubkey
 

--- a/11.md
+++ b/11.md
@@ -15,6 +15,7 @@ When a relay receives an HTTP(s) request with an `Accept` header of `application
   "name": <string identifying relay>,
   "description": <string with detailed information>,
   "banner": <a link to an image (e.g. in .jpg, or .png format)>,
+  "icon": <a link to an icon in .ico format>,
   "pubkey": <administrative contact pubkey>,
   "contact": <administrative alternate contact>,
   "supported_nips": <a list of NIP numbers supported by the relay>,
@@ -39,6 +40,10 @@ Detailed plain-text information about the relay may be contained in the `descrip
 ### Banner
 
 If nostr relay management is not to be relegated to PhD or protocol developers only, an effort should be made by relay owners to communicate with non-dev non-technical nostr end users. A banner is a visual representation of the relay. It should aim to visually communicate the brand of the relay, complementing the text `Description`. [Here is an example banner](https://image.nostr.build/232ddf6846e8aea5a61abcd70f9222ab521f711aa545b7ab02e430248fa3a249.png) mockup as visualized in Damus iOS relay view of the Damus relay.
+
+### Icon
+
+Icon is a compact visual representation of the relay for use in UI with limited real estate such as a nostr user's relay list view. Example relay icon link `https://damus.io/favicon.ico`.
 
 ### Pubkey
 

--- a/11.md
+++ b/11.md
@@ -14,6 +14,7 @@ When a relay receives an HTTP(s) request with an `Accept` header of `application
 {
   "name": <string identifying relay>,
   "description": <string with detailed information>,
+  "banner": <a link to an image (e.g. in .jpg, or .png format)>,
   "pubkey": <administrative contact pubkey>,
   "contact": <administrative alternate contact>,
   "supported_nips": <a list of NIP numbers supported by the relay>,
@@ -34,6 +35,10 @@ A relay may select a `name` for use in client software.  This is a string, and S
 ### Description
 
 Detailed plain-text information about the relay may be contained in the `description` string.  It is recommended that this contain no markup, formatting or line breaks for word wrapping, and simply use double newline characters to separate paragraphs.  There are no limitations on length.
+
+### Banner
+
+If nostr relay management is not to be relegated to PhD or protocol developers only, an effort should be made by relay owners to communicate with non-dev non-technical nostr end users. A banner is a visual representation of the relay. It should aim to visually communicate the brand of the relay, complementing the text `Description`. [Here is an example banner](https://image.nostr.build/232ddf6846e8aea5a61abcd70f9222ab521f711aa545b7ab02e430248fa3a249.png) mockup as visualized in Damus iOS relay view of the Damus relay.
 
 ### Pubkey
 

--- a/11.md
+++ b/11.md
@@ -15,7 +15,7 @@ When a relay receives an HTTP(s) request with an `Accept` header of `application
   "name": <string identifying relay>,
   "description": <string with detailed information>,
   "banner": <a link to an image (e.g. in .jpg, or .png format)>,
-  "icon": <a link to an icon (e.g.in .ico format, or .png format etc>,
+  "icon": <a link to an icon (e.g. in .ico, or .png format etc>,
   "pubkey": <administrative contact pubkey>,
   "contact": <administrative alternate contact>,
   "supported_nips": <a list of NIP numbers supported by the relay>,

--- a/11.md
+++ b/11.md
@@ -15,7 +15,7 @@ When a relay receives an HTTP(s) request with an `Accept` header of `application
   "name": <string identifying relay>,
   "description": <string with detailed information>,
   "banner": <a link to an image (e.g. in .jpg, or .png format)>,
-  "icon": <a link to an icon (e.g. in .ico, or .png format etc>,
+  "icon": <a link to an icon (e.g. in .jpg, or .png format>,
   "pubkey": <administrative contact pubkey>,
   "contact": <administrative alternate contact>,
   "supported_nips": <a list of NIP numbers supported by the relay>,
@@ -43,7 +43,7 @@ To make nostr relay management more user friendly, an effort should be made by r
 
 ### Icon
 
-Icon is a compact visual representation of the relay for use in UI with limited real estate such as a nostr user's relay list view. Example relay icon links `https://damus.io/favicon.ico`, `https://example.com/icon.png`.
+Icon is a compact visual representation of the relay for use in UI with limited real estate such as a nostr user's relay list view. Example relay icon links  `https://example.com/icon.png`.
 
 ### Pubkey
 

--- a/11.md
+++ b/11.md
@@ -43,7 +43,14 @@ To make nostr relay management more user friendly, an effort should be made by r
 
 ### Icon
 
-Icon is a compact visual representation of the relay for use in UI with limited real estate such as a nostr user's relay list view. Example relay icon links  `https://example.com/icon.png`.
+Icon is a compact visual representation of the relay for use in UI with limited real estate such as a nostr user's relay list view. Below is an example URL pointing to an image to be used as an icon for the relay. Recommended to be squared in shape.
+
+```jsonc
+{
+  "icon": "https://nostr.build/i/53866b44135a27d624e99c6165cabd76ac8f72797209700acb189fce75021f47.jpg",
+  // other fields...
+}
+```
 
 ### Pubkey
 
@@ -264,17 +271,6 @@ Relays that require payments may want to expose their fee schedules.
     "publication": [{ "kinds": [4], "amount": 100, "unit": "msats" }],
   },
   ...
-}
-```
-
-### Icon
-
-A URL pointing to an image to be used as an icon for the relay. Recommended to be squared in shape.
-
-```jsonc
-{
-  "icon": "https://nostr.build/i/53866b44135a27d624e99c6165cabd76ac8f72797209700acb189fce75021f47.jpg",
-  // other fields...
 }
 ```
 


### PR DESCRIPTION
Added banner relay metadata field. 

If nostr relay management is not to be relegated to PhD or protocol developers only, an effort should be made by relay owners to communicate with non-dev non-technical nostr end users. A banner is a visual representation of the relay. It should aim to visually communicate the brand of the relay.