### PR TITLE
Add explicit support for address quotes

### DIFF
--- a/18.md
+++ b/18.md
@@ -30,6 +30,11 @@ of the `mark` argument.
 
 `["q", <event-id>, <relay-url>, <pubkey>]`
 
+When quoting an event by address, `q` tags should follow conventions for `a` tags,
+as described in [NIP 01](./01.md).
+
+`["q", <event-address>, <relay-url>]`
+
 Quote reposts MUST include the [NIP-21](21.md) `nevent`, `note`, or `naddr` of the
 event in the content.
 


### PR DESCRIPTION
If a `naddr` is added to a note's content, it should be referred to in the tags. But using an `a` tag will cause the quote to be treated as a reply (as used to happen with events). In some cases, using a `q` tag with the event's id rather than address may work, but it goes against user intention, and it may not always be possible to convert an address to an id if the event is not loaded by the client. Adding an address variant to `q` tags fixes this.

Related conversation: https://github.com/cesardeazevedo/nostr-editor/pull/8