### PR TITLE
Add support for address quotes

### DIFF
--- a/10.md
+++ b/10.md
@@ -47,7 +47,7 @@ Where:
  * `<marker>` is optional and if present is one of `"reply"`, `"root"`, or `"mention"`.
  * `<pubkey>` is optional, SHOULD be the pubkey of the author of the referenced event
 
-Those marked with `"reply"` denote the id of the reply event being responded to.  Those marked with `"root"` denote the root id of the reply thread being responded to. For top level replies (those replying directly to the root event), only the `"root"` marker should be used. Those marked with `"mention"` denote a quoted or reposted event id.
+Those marked with `"reply"` denote the id of the reply event being responded to.  Those marked with `"root"` denote the root id of the reply thread being responded to. For top level replies (those replying directly to the root event), only the `"root"` marker should be used. Those marked with `"mention"` denote a non-root/parent event id in the reply chain, *not* a quote.
 
 A direct reply to the root of a thread should have a single marked "e" tag of type "root".
 

--- a/18.md
+++ b/18.md
@@ -30,6 +30,11 @@ of the `mark` argument.
 
 `["q", <event-id>, <relay-url>, <pubkey>]`
 
+When quoting an event by address, `q` tags should follow conventions for `a` tags,
+as described in [NIP 01](./01.md).
+
+`["q", <event-address>, <relay-url>]`
+
 Quote reposts MUST include the [NIP-21](21.md) `nevent`, `note`, or `naddr` of the
 event in the content.
 


### PR DESCRIPTION
Previous conversations:

https://github.com/nostr-protocol/nips/pull/1525
https://github.com/nostr-protocol/nips/pull/1558

It's a pretty extreme edge case, but currently address quotes are broken, because the standard way to do them is to use an `a` tag with a `mention` mark. This is ambiguous, since it collides with great-grandchild replies whose grandparent is a replaceable event referred to with an `a` tag. Maybe we can live with this, but since things are already broken, I think it's a nice opportunity to make address quotes work the same way as event id quotes.

Re-opening this since it had some support, even if @mikedilger's point about it being a breaking change is valid. Currently address quotes (and address replies) are undefined in the nips repo, from what I can see. FWIW, Flotilla currently uses `q` for address quotes.