### PR TITLE
nip37: non-harmful editable short notes

### DIFF
--- a/37.md
+++ b/37.md
@@ -1,0 +1,38 @@
+NIP-37
+======
+
+Editable Short Notes
+--------------------
+
+`draft` `optional`
+
+This NIP describes a flow for clients that want to support editable short notes without breaking the experience of clients that don't and keeping `kind:1` a safe place.
+
+The idea is that editable notes are published as `kind:31000` notes that follow all the same rules of `kind:1`, except for the fact that they can be replaceable anytime.
+
+```jsonc
+{
+  "kind": 31000,
+  "created_at": 1730820000,
+  "content": "I like dogs",
+  "tags": [
+    ["d", "c2huy3f"],
+    // other kind1 tags
+  ]
+}
+```
+
+Clients that want to support edits would automatically only publish `kind:31000` notes, then immediately publish `kind:1` notes that quote the `kind:31000` note.
+
+```jsonc
+{
+  "kind": 1,
+  "created_at": 1730820000,
+  "content": "naddr1...",
+  "tags": [
+    ["q", "31000:...:c2huy3f"]
+  ]
+}
+```
+
+Clients that support this NIP would then fetch the `kind:31000` and display it normally in place of the `kind:1`. Other clients would display the editable event embedded inside the `kind:1`.


### PR DESCRIPTION
This is another alternative to https://github.com/nostr-protocol/nips/pull/1090, https://github.com/nostr-protocol/nips/pull/1091 and https://github.com/nostr-protocol/nips/pull/1556

I don't know if this is a good idea ultimately, but I think it is directionally correct because it doesn't harm non-implementing clients and [the openness of kind 1](https://fiatjaf.com/cd8ce2b7.html), while giving more complex clients the ability to do full-blown edits with no extra work than other proposals would.