### PR TITLE
NIP-60: Provide an option to use ncryptsec

### DIFF
--- a/60.md
+++ b/60.md
@@ -23,7 +23,8 @@ This NIP doesn't deal with users' *receiving* money from someone else, it's just
     "kind": 37375,
     "content": nip44_encrypt([
         [ "balance", "100", "sat" ],
-        [ "privkey", "hexkey" ] // explained in NIP-61
+        [ "privkey", "hexkey" ], // explained in NIP-61
+        [ "ncryptsec", "NIP-49 encrypted private key" ]
     ]),
     "tags": [
         [ "d", "my-wallet" ],
@@ -50,6 +51,7 @@ Tags:
 * `description` - Optional human-readable description of the wallet.
 * `balance` - Optional best-effort balance of the wallet that can serve as a placeholder while an accurate balance is computed from fetching all unspent proofs.
 * `privkey` - Private key used to unlock P2PK ecash. MUST be stored encrypted in the `.content` field. **This is a different private key exclusively used for the wallet, not associated in any way to the user's nostr private key** -- This is only used when receiving funds from others, described in NIP-61.
+* `ncryptsec` - Provide an option to use either the above `privkey` or `ncryptsec`. This approach can help prevent the user's wallet `privkey` from being exposed in case the main nsec is leaked.
 
 Any tag, other than the `d` tag, can be [[NIP-44]] encrypted into the `.content` field.
 


### PR DESCRIPTION
```jsonc
{
    "kind": 37375,
    "content": nip44_encrypt([
        [ "balance", "100", "sat" ],
        [ "privkey", "hexkey" ], // explained in NIP-61
        [ "ncryptsec", "NIP-49 encrypted private key" ]
    ]),
    "tags": [
        [ "d", "my-wallet" ],
        [ "mint", "https://mint1" ],
        [ "mint", "https://mint2" ],
        [ "mint", "https://mint3" ],
        [ "name", "my shitposting wallet" ],
        [ "unit", "sat" ],
        [ "description", "a wallet for my day-to-day shitposting" ],
        [ "relay", "wss://relay1" ],
        [ "relay", "wss://relay2" ],
    ]
}
```

Provide an option to use either the `privkey` or `ncryptsec`. This approach can help prevent the user's wallet `privkey` from being exposed in case the main `nsec` is leaked.