### PR TITLE
Yet Another Editable Kind:1 Proposal

### DIFF
--- a/37.md
+++ b/37.md
@@ -44,18 +44,29 @@ As it will be seen on next sections, complexity is shifted to clients that choos
 
 ### Replying
 
-A reply is made of two events. The first one is a regular `kind:1` note using [NIP-10](10.md) `e` tags to please
-unsupporting clients.
+A reply is made of two events. The first one is a regular `kind:1` note (no `dd` tag - not editable)
+using [NIP-10](10.md) `e` tags to please unsupporting clients.
 
-The second is a [NIP-22](https://github.com/arthurfranca/nips/blob/comment/22.md) comment using `U/u` tags
+The second one is a [NIP-22](https://github.com/arthurfranca/nips/blob/comment/22.md) `kind:1111` event
+using `U/u` tags instead of `E/e`
 and it must have the same `.created_at` as the former one for deduplication,
 because supporting clients will need to fetch both
 reply kinds to see the whole conversation.
+The NIP-22 event should only be generated when replying to editable `kind:1` notes (those with a `dd` tag).
 
-The NIP-22 comment should also reference the twin reply of kind 1 with an `o` tag set to its id, which
-would be used to reply (to the reply) with a `kind:1` (using NIP-10) to please unsupporting clients.
+The NIP-22 reply should also reference the twin reply of kind 1 with an `o` tag set to its id, which
+could be used later to reply again (to the NIP-22 reply) with a regular `kind:1` (using NIP-10) to please unsupporting clients
+in addition to the NIP-22's `kind:1111` event. That is, when replying to a NIP-22 with `K` tag set to `"1"`,
+two events are also used.
 
-**Hey, we should make NIP-22 comments editable too! They would also be referenced by `u` tag for replies of replies**
+#### TBD
+
+We should think of making NIP-22 comments editable too.
+
+They likewise would be referenced by `u` tag for replies of replies instead of by `e` tag.
+
+Probably a good idea to make the `dd` tag for them be `"@u"` (instead of just `"@"`).
+It would prevent an edit from making the reply migrate to another thread if maliciously changing the `u` tag value.
 
 ### Editing
 


### PR DESCRIPTION
[Read here](https://github.com/arthurfranca/nips/blob/kindone/37.md)

I think this way won't break regular kind:1 clients. It is similar to using `d` tag but won't make chronological feeds see the edited note at the top at every edit.