### PR TITLE
NIP-53 Live Events - Optional Pinned Chat Messages

### DIFF
--- a/53.md
+++ b/53.md
@@ -35,7 +35,8 @@ For example:
     ["p", "91cf9..4e5ca", "wss://provider1.com/", "Host", "<proof>"],
     ["p", "14aeb..8dad4", "wss://provider2.com/nostr", "Speaker"],
     ["p", "612ae..e610f", "ws://provider3.com/ws", "Participant"],
-    ["relays", "wss://one.com", "wss://two.com", /*...*/]
+    ["relays", "wss://one.com", "wss://two.com", /*...*/],
+    ["pinned", "<event id of pinned live chat message>"],
   ],
   "content": "",
   // other fields...
@@ -74,6 +75,8 @@ Event `kind:1311` is live chat's channel message. Clients MUST include the `a` t
   // other fields...
 }
 ```
+
+Hosts may choose to pin one or more live chat messages by updating the `pinned` tags in the live event kind `30311`.
 
 ## Use Cases
 


### PR DESCRIPTION
Adds the ability to optionally pin one or more live chat messages by adding the kind `1311` event id to a `pinned` tag.

cc @v0l 