### PR TITLE
nip46: simple public key login using `kind:10046`

### DIFF
--- a/46.md
+++ b/46.md
@@ -191,6 +191,30 @@ _client_ should display (in a popup or new tab) the URL from the `error` field a
 
 ![signing-example-with-auth-challenge](https://i.nostr.build/W3aj.png)
 
+## Pure public key login
+
+A _client_ SHOULD support logins with just an `npub`, an `nprofile` or a NIP-05 address instead of requiring a full `bunker://...` URI. In order to do that, it can follow these steps:
+
+  1. Read _user-pubkey_ from the provided NIP-05, `nprofile` or `npub` code;
+  2. Acquire the list of outbox relays for _user_ (either by fetching the user's `kind:10002` relay list from relay hints or hardcoded relays or by other means);
+  3. Query these relay for a `kind:10046` event from _user_;
+  4. Read NIP-46 bunker connection metadata from that event -- then proceed as if the user had typed that bunker URI.
+
+For this to work _user_ must have somehow published such `kind:10046` event beforehand (which might be a job for the bunker provider or app directly or not).
+
+### `kind:10046` event format:
+
+```jsonc
+{
+    "pubkey": "<user-pubkey>",
+    "kind": 10046,
+    "tags": [
+        ["relays", "<remote-signer-relay-url>", "<any-number-of-other-relay-urls...>"],
+        ["pubkey", "<remote-signer-pubkey>"]
+    ]
+}
+```
+
 ## Appendix
 
 ### Announcing _remote-signer_ metadata


### PR DESCRIPTION
This vastly simplifies the `bunker://` flow while also making it easy on every other front possibly -- and brings back NIP-05 login, but in a simpler, more straightforward way.