### PR TITLE
NIP-37 - Transport method announcement

### DIFF
--- a/137.md
+++ b/137.md
@@ -1,4 +1,4 @@
-NIP-37
+NIP-137
 ======
 
 Transport methods announcement
@@ -28,8 +28,8 @@ A replacable event of kind `11111`, containing one or more of the following tag(
     ["clearnet", "some.domain.com", "wss"],
     ["tor", "somehash.onion", "ws"],
     ["i2p", "somehash.b32.i2p/", "ws"],
-    ["ipv4", "157.240.212.35", "http"],
-    ["ipv6", "2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF", "http"]
+    ["clearnet", "157.240.212.35", "http"],
+    ["clearnet", "2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF", "http"]
   ]
 }
 ```


### PR DESCRIPTION

## Motivation
Nostr decouples applications completely from the transportation layer, meaning services no longer have to be designed around a single transportation method, but can be accessible through a plethora of ways. This NIP is meant to act as a lookup system that tells a client which transportation methods can be used to access its services.

## Rationale

### Similar proposals
There have been NIP proposals that touch the connection between pubkeys and addresses, examples of this are:
- [NIP-97 - Nostr Naming System](https://github.com/nostr-protocol/nips/blob/91fc18746824b3bf980ad1fa223927764dc51c74/97.md)
- [NIP-66 - Relay Discovery and Liveness Monitoring](https://github.com/nostr-protocol/nips/pull/230)

#### NIP-97
I believe NIP-97 is very close to solving the issue of this mapping. However, it attempts to also include human-readable naming into the solution. I believe that human-readable naming of pubkeys/services is inherently different from mapping a pubkey to an address where a user can access that pubkey's services, which may or may not map to a legacy domain name.

I argue that Nostr introduces a new paradigm of addressing services, and that that creates an opportunity to make services accessible through different networks and protocols simultaneously.

Human-readable names are and will always be ambiguous and opinionated. Addressing is not nearly as ambiguous. A location is either controlled by a pubkey, or it is not. A pubkey can quite easily prove that it controls an address.
Therefore connecting a name to pubkey to a pubkey should be solved in a separate NIP.

#### NIP-66
NIP-66 covers discoverability from the client side and can be a very important tool to discern which services are worth connecting to. I think it can act as the feedback mechanism to the proposed event of this NIP. It can be used to build metrics for the various networks a pubkey announces it to be accessible. Things like `rtt` (round trip time) can also be different for each network and should be measured seperately.


