### PR TITLE
Time-ordered event ids

### DIFF
--- a/01.md
+++ b/01.md
@@ -42,7 +42,7 @@ To obtain the `event.id`, we `sha256` the serialized event. The serialization is
 ]
 ```
 
-Once the `sha256` is computed, replace the first 4 bytes of the hash byte array by the 4-byte, signed, little-endian representation of the `created_at`. When verifying the event, Clients MUST check if the `id` matches the full hash OR the sorted hash.
+Once the `sha256` is computed, replace the first 4 bytes of the hash byte array by the 4-byte, unsigned, big-endian representation of the `created_at`. When verifying the event, Clients MUST check if the `id` matches the full hash OR the sorted hash.
 
 To prevent implementation differences from creating a different event ID for the same event, the following rules MUST be followed while serializing:
 - UTF-8 should be used for encoding.


### PR DESCRIPTION
There are a lot of performance benefits to having primary keys with temporal locality. For instance, when your database needs to check the uniqueness of IDs, only a small portion of the index needs to be hot (in memory). With the current "random identifiers", the working set eventually becomes all of the data and your database will be page-faulting continuously. Sequential primary keys also make it easier for the database to place new records in order, minimizing the need to rearrange data or update index structures.

This PR makes a simple, but breaking change, to the way we compute event ids. It was inspired by the improvements made by UUIDv7. 

It's a long shot, but I do think we should do this at some point in Nostr's lifetime. 