### PR TITLE
Relay chat

### DIFF
--- a/xx.md
+++ b/xx.md
@@ -1,0 +1,56 @@
+NIP-XX
+======
+
+Relay Chat
+----------
+
+`draft` `optional`
+
+This NIP defines a standard for relay-local chat messages.
+
+# Chat Message
+
+A relay chat message is a kind `209` event. A `~` tag MUST be included, indicating the name of the chat room and the relay url. Chat room IDs SHOULD be human-readable, and no longer than 30 characters.
+
+```json
+{
+  "content": "GM",
+  "tags": [
+    ["~", "Good Morning", "wss://relay.example.com/"],
+  ]
+}
+```
+
+Replies to kind `209` MUST use [NIP-73](https://github.com/nostr-protocol/nips/pull/1233) `kind 1111` comments. Clients MAY support arbitrarily nested replies, but SHOULD encourage flat reply hierarchies.
+
+# Membership
+
+Users MAY track and optionally advertise their own group memberships using a [NIP 51](51.md) kind `10209` event. Tags MAY be either public or encrypted with [NIP 44](44.md), depending on user/client preference.
+
+Room membership SHOULD be indicated using both an `r` tag for each relay the user is a member of, and a `~` tag for each room the user is a member of. `~` tags MUST include a relay url as the second argument.
+
+```json
+{
+  "kind": "10209",
+  "tags": [
+    ["r", "wss://relay.other.com/"],
+    ["~", "Good Morning", "wss://relay.other.com/"]
+  ],
+}
+```
+
+# Migrations
+
+If a conversation needs to be moved from one relay to another, the new host relay may explicitly map this relation using a `kind 30209` event indicating valid relay urls for a given room. Multiple previous urls may be supported for a single room.
+
+```json
+{
+  "kind": "30209",
+  "tags": [
+    ["~", "Good Morning", "wss://relay.other1.com/"],
+    ["~", "Good Morning", "wss://relay.other2.com/"]
+  ],
+}
+```
+
+Chat messages MUST NOT be considered valid unless they have an `~` tag matching the current relay, or a relay specified in a `kind 30209` migration event.

--- a/xx.md
+++ b/xx.md
@@ -28,9 +28,11 @@ A relay chat message is a kind `209` event. A `~` tag MUST be included, indicati
 }
 ```
 
-Replies to kind `209` MUST use [NIP-73](https://github.com/nostr-protocol/nips/pull/1233) `kind 1111` comments. Clients MAY support arbitrarily nested replies, but SHOULD encourage flat reply hierarchies.
+Replies to kind `209` MUST use [NIP-73](https://github.com/nostr-protocol/nips/pull/1233) `kind 1111` comments. Clients MAY support arbitrarily nested replies, but SHOULD encourage flat reply hierarchies. These replies MUST also include a `~` tag.
 
-Other note kinds MAY be posted to rooms, but care should be taken that any non-`kind 209` events will make sense out of context either of the room or the host relay.
+Kind `209` events MUST NOT be considered valid unless they have a `~` tag matching the current relay, or a relay specified in a `kind 30209` migration event.
+
+Other note kinds MAY also be posted to rooms using the `~` tag.
 
 # Membership
 
@@ -61,5 +63,3 @@ If a conversation needs to be moved from one relay to another, the new host rela
   ],
 }
 ```
-
-Chat messages MUST NOT be considered valid unless they have a `~` tag matching the current relay, or a relay specified in a `kind 30209` migration event.

--- a/xx.md
+++ b/xx.md
@@ -50,6 +50,9 @@ Room membership SHOULD be indicated using both an `r` tag for each relay the use
 }
 ```
 
+Room membership events SHOULD be sent both to the user's [NIP-65](./65.md) WRITE relays, and to
+each relay listed in the membership event (in order to allow clients to build room lists).
+
 # Migrations
 
 If a conversation needs to be moved from one relay to another, the new host relay may explicitly map this relation using a `kind 30209` event indicating valid relay urls for a given room. Multiple previous urls may be supported for a single room. This event MUST be signed by the `pubkey` indicated by the relay's NIP 11 document.

--- a/xx.md
+++ b/xx.md
@@ -72,8 +72,11 @@ Room membership SHOULD be indicated using both an `r` tag for each relay the use
 }
 ```
 
-Room membership events SHOULD be sent both to the user's [NIP-65](./65.md) WRITE relays, and to
-each relay listed in the membership event (in order to allow clients to build room lists).
+Room membership events SHOULD be sent to:
+
+- The user's [NIP-65](./65.md) WRITE relays
+- Each relay listed in the membership event
+- Each relay being removed from the member list
 
 # Federation
 

--- a/xx.md
+++ b/xx.md
@@ -8,12 +8,19 @@ Relay Chat
 
 This NIP defines a standard for relay-local chat messages.
 
+# Rooms
+
+A `room` is identified by an arbitrary, human-readable string no longer than 30 characters and referred to using a `~` tag indicating the room id and a relay url.
+
+Rooms on different relays with the same name SHOULD NOT be considered the same room.
+
 # Chat Message
 
-A relay chat message is a kind `209` event. A `~` tag MUST be included, indicating the name of the chat room and the relay url. Chat room IDs SHOULD be human-readable, and no longer than 30 characters.
+A relay chat message is a kind `209` event. A `~` tag MUST be included, indicating the name of the chat room and the relay url.
 
 ```json
 {
+  "kind": 209,
   "content": "GM",
   "tags": [
     ["~", "Good Morning", "wss://relay.example.com/"],
@@ -22,6 +29,8 @@ A relay chat message is a kind `209` event. A `~` tag MUST be included, indicati
 ```
 
 Replies to kind `209` MUST use [NIP-73](https://github.com/nostr-protocol/nips/pull/1233) `kind 1111` comments. Clients MAY support arbitrarily nested replies, but SHOULD encourage flat reply hierarchies.
+
+Other note kinds MAY be posted to rooms, but care should be taken that any non-`kind 209` events will make sense out of context either of the room or the host relay.
 
 # Membership
 
@@ -41,7 +50,7 @@ Room membership SHOULD be indicated using both an `r` tag for each relay the use
 
 # Migrations
 
-If a conversation needs to be moved from one relay to another, the new host relay may explicitly map this relation using a `kind 30209` event indicating valid relay urls for a given room. Multiple previous urls may be supported for a single room.
+If a conversation needs to be moved from one relay to another, the new host relay may explicitly map this relation using a `kind 30209` event indicating valid relay urls for a given room. Multiple previous urls may be supported for a single room. This event MUST be signed by the `pubkey` indicated by the relay's NIP 11 document.
 
 ```json
 {
@@ -53,4 +62,4 @@ If a conversation needs to be moved from one relay to another, the new host rela
 }
 ```
 
-Chat messages MUST NOT be considered valid unless they have an `~` tag matching the current relay, or a relay specified in a `kind 30209` migration event.
+Chat messages MUST NOT be considered valid unless they have a `~` tag matching the current relay, or a relay specified in a `kind 30209` migration event.


### PR DESCRIPTION
This is an alternative to NIP 29. Here's why I'm going this direction:

- NIP 29 is over-prescriptive in several ways. The most obvious example is that it has a rigid model for moderation, whereas moderation is highly community-specific and dynamic. It think it's better to let people send 1984 reports to relays and let relays/clients deal with them as desired. No moderation is specified in this nip.
- NIP 29 encourages group admins to run their groups on a third-party relay. This results in centralization, since if a single relay goes down, many groups go with it. Making groups equivalent to relays compares favorably with Discord's "servers", and encourages users to run their own relays.
- Moving group-like features to relays means we don't need separate specs for each. For example, join requests for relays already exist: https://github.com/nostr-protocol/nips/pull/1079. There's no need for NIP 29's version. Same thing with access control, querying for user permissions (LIMITS), user roles, etc. These are all useful concepts for many kinds of relays.
- Group metadata is also redundant, since relays already have a nip 11 information document and a pubkey with which they can publish additional information.
- Admins and moderators can be handled implicitly, out of band, or by querying feature support using [`LIMITS`](https://github.com/nostr-protocol/nips/pull/1434). This allows the base spec to be small, and add things like moderator lists as an optional extension.
- Member lists are managed by the members themselves. This way they can choose whether to publish their membership in a group. This allows for web-of-trust based community recommendations.

Additional notes:

- `kind 209` chat messages are similar to `kind 9`, and `kind 309` threads are similar to NIP 29's `kind `11` threads. We could probably merge the two, but I wasn't certain enough about the details to potentially overload them. Plus, the kinds in this PR are more prescriptive, in that they encourage flat reply hierarchies, and MUST be sent to a room. Ultimately those use cases should probably live in a different NIPs anyhow.

To see this PR in action, visit https://flotilla.social. To try it out, join the relay.nostrtalk.org space (relay).
