### PR TITLE
Clarify nostrconnect metadata

### DIFF
--- a/46.md
+++ b/46.md
@@ -45,15 +45,25 @@ _remote-signer_ provides connection token in the form:
 bunker://<remote-signer-pubkey>?relay=<wss://relay-to-connect-on>&relay=<wss://another-relay-to-connect-on>&secret=<optional-secret-value>
 ```
 
-_user_ passes this token to _client_, which then sends `connect` request to _remote-signer_ via the specified relays. Optional secret can be used for single successfully established connection only, _remote-signer_ SHOULD ignore new attempts to establish connection with old secret. 
+_user_ passes this token to _client_, which then sends `connect` request to _remote-signer_ via the specified relays. Optional secret can be used for single successfully established connection only, _remote-signer_ SHOULD ignore new attempts to establish connection with old secret.
 
 ### Direct connection initiated by the _client_
 
-_client_ provides a connection token in the form: 
+_client_ provides a connection token using `nostrconnect://` as the protocol, and `client-pubkey` as the origin. Additional information should be passed as query parameters:
+
+- `relay` (required) - one or more relay urls on which the _client_ is listening for responses from the _remote-signer_.
+- `secret` (required) - a short random string that the _remote-signer_ should return as the `result` field of its response.
+- `perms` (optional) - a comma-separated list of permissions the _client_ is requesting be approved by the _remote-signer_
+- `name` (optional) - the name of the _client_ application
+- `url` (optional) - the canonical url of the _client_ application
+- `image` (optional) - a small image representing the _client_ application
+
+Here's an example:
 
 ```
-nostrconnect://<client-pubkey>?relay=<wss://relay-to-connect-on>&metadata=<json metadata: {"name":"...", "url": "...", "description": "...", "perms": "..."}>&secret=<required-secret-value>
+nostrconnect://83f3b2ae6aa368e8275397b9c26cf550101d63ebaab900d19dd4a4429f5ad8f5?relay=wss%3A%2F%2Frelay1.example.com&perms=nip44_encrypt%2Cnip44_decrypt%2Csign_event%3A13%2Csign_event%3A14%2Csign_event%3A1059&name=My+Client&secret=0s8j2djs&relay=wss%3A%2F%2Frelay2.example2.com
 ```
+
 _user_ passes this token to _remote-signer_, which then sends `connect` *response* event to the `client-pubkey` via the specified relays. Client discovers `remote-signer-pubkey` from connect response author. `secret` value MUST be provided to avoid connection spoofing, _client_ MUST validate the `secret` returned by `connect` response.
 
 ## Request Events `kind: 24133`


### PR DESCRIPTION
Fixes https://github.com/nostr-protocol/nips/issues/1596

Technically backwards incompatible, so should be added to breaking.md after merge. But in practice this was underspecified and doesn't currently work.