### PR TITLE
Add feature detection for unmanaged groups

### DIFF
--- a/29.md
+++ b/29.md
@@ -52,11 +52,9 @@ Users with any roles that have any privilege can be considered _admins_ in a bro
 
 ## Unmanaged groups
 
-Unmanaged groups are impromptu groups that can be used in any public relay unaware of NIP-29 specifics. They piggyback on relays' natural white/blacklists (or lack of) but aside from that are not actively managed and won't have any admins, group state or metadata events.
+If a group doesn't have a kind `39000` metadata event, it is considered `unmanaged`. Events posted to `unmanaged` group MUST NOT be handled by relays in any special way.
 
-In `unmanaged` groups, everybody is considered to be a member.
-
-Unmanaged groups can transition to managed groups, in that case the relay master key just has to publish moderation events setting the state of all groups and start enforcing the rules they choose to.
+Relays that do not allow `unmanaged` groups MUST set `nip29.unmanaged` to `false` in their NIP 11 document. In this mode, events sent to non-existent groups MUST be rejected by the relay.
 
 ## Event definitions
 
@@ -143,8 +141,6 @@ These events contain the group id in a `d` tag instead of the `h` tag. They MUST
 This event defines the metadata for the group -- basically how clients should display it. It must be generated and signed by the relay in which is found. Relays shouldn't accept these events if they're signed by anyone else.
 
 If the group is forked and hosted in multiple relays, there will be multiple versions of this event in each different relay and so on.
-
-When this event is not found, clients may still connect to the group, but treat it as having a different status, `unmanaged`,
 
 ```jsonc
 {

--- a/29.md
+++ b/29.md
@@ -54,7 +54,7 @@ Users with any roles that have any privilege can be considered _admins_ in a bro
 
 If a group doesn't have a kind `39000` metadata event, it is considered `unmanaged`. Events posted to `unmanaged` group MUST NOT be handled by relays in any special way.
 
-Relays that do not allow `unmanaged` groups MUST set `nip29.unmanaged` to `false` in their NIP 11 document. In this mode, events sent to non-existent groups MUST be rejected by the relay.
+Relays that do not allow `unmanaged` groups MUST NOT include `29` in their NIP 11 document's `supported_nips` field. In this mode, events sent to non-existent groups MUST be rejected by the relay.
 
 ## Event definitions
 


### PR DESCRIPTION
Feature detection for unmanaged groups has to exist on two levels:

- On the group level, so that clients can toggle the richer NIP 29 behavior on or off. Feature detection based on NIP 11's `supported_nips` field isn't sufficient, since a relay implementation might support NIP 29, but the actual relay may not.
- On the relay level, since clients need to be able to know whether users can post events to groups that don't yet exist, or whether they have to send a `create-group` event instead.

The default (obviously) has to be that unmanaged groups are allowed, so unmanaged group support is opt-out.