### PR TITLE
kind-scoped follow

### DIFF
--- a/FA.md
+++ b/FA.md
@@ -1,0 +1,45 @@
+NIP-FA
+======
+
+Kind-scoped follows
+-------------------
+
+`draft` `optional`
+
+This NIP defines kind `967`, a kind-scoped follow event.
+
+```jsonc
+{
+  "kind": 967,
+  "tags": [
+    ["p", "<followed-pubkey>", 'relay-url'],
+    ["k", "<some-kind>"],
+    ["k", "<some-other-kind>"]
+  ]
+}
+```
+
+Multiple `p` tags and multiple `k` tags are allowed.
+
+The `k` tag(s) define the scope of the follows.
+
+### Unfollow action
+
+Unfollowing is done by deleting the follow event, copying over the `k` tags from the follow event.
+
+```jsonc
+{
+  "kind": 5,
+  "tags": [
+    ["e", "<follow-event-id>"],
+    ["k", "<some-kind>"],
+    ["k", "<some-other-kind>"]
+  ]
+}
+```
+
+### Constructing specialized follow lists
+
+A client can fetch the events of the kinds they are interested in, and perhaps adjacent kinds if they choose to. For example, a client specialized in videos might also want to extend its computed follow list to include events related to live streams.
+
+Clients can use the last `kind:967` and `kind:5` tagged with a `k` they care about and use the last `created_at` they have seen to REQ for updates.


### PR DESCRIPTION
This proposal does NOT (necessarily) replace `kind:3`, it's a way to do a very simple follow of one or more kinds that might be of interest.

A user might be interested in following someone's classified updates but don't care about the rest of their content.
Following in a classified app might create one of these follows.

This way we also start moving away from huge follow lists that can get wiped at a moment's notice and instead clients are responsible for computing the follow list and updating its local state.

This also allows apps to show "followed" notifications without a central source.

### Example
Apps like Amethyst and Coracle, that support a vast range of kinds can REQ for updates merging the filters

If a user has in kind:3 `p`s `"pubkey1", "pubkey2"` and in a `kind:967` with `["k", "30023"]` has `"pubkey2", "pubkey3"`

it might REQ with:

```
{ "kinds": [<everything-the-app-supports>], "authors": ["pubkey1", "pubkey2"] },
{ "kinds": [30023], "authors": ["pubkey3"] }
```

[Read here](https://github.com/nostr-protocol/nips/blob/1187d2ba5d3c914b62e2d1360a5d6532dfb18b53/FA.md)

@vitorpamplona @staab @fiatjaf 