### PR TITLE
multi_pay_invoice method Response error (grammatical)

### DIFF
--- a/47.md
+++ b/47.md
@@ -175,7 +175,7 @@ Request:
 Response:
 
 For every invoice in the request, a separate response event is sent. To differentiate between the responses, each
-response event contains an `d` tag with the id of the invoice it is responding to, if no id was given, then the
+response event contains a `d` tag with the id of the invoice it is responding to, if no id was given, then the
 payment hash of the invoice should be used.
 
 ```jsonc


### PR DESCRIPTION
The response section that explained how the multi_pay_invoice method worked had a grammatical error of explaining the differentiation between requests.

changed ".....contains an d tag" to "...contains a d tag"