### PR TITLE
Update 10.md("Commit Changes Description")

### DIFF
--- a/10.md
+++ b/10.md
@@ -26,7 +26,7 @@ A direct reply to the root of a thread should have a single marked "e" tag of ty
 
 >This scheme is preferred because it allows events to mention others without confusing them with `<reply-id>` or `<root-id>`.
 
-`<pubkey>` SHOULD be the pubkey of the author of the `e` tagged event, this is used in the outbox model to search for that event from the authors write relays where relay hints did not resolve the event.
+`<pubkey>` SHOULD be the pubkey of the author of the `e` tagged event, this is used in the outbox model to search for that event from the author's write relays where relay hints did not resolve the event.
 
 ## The "p" tag
 Used in a text event contains a list of pubkeys used to record who is involved in a reply thread.


### PR DESCRIPTION
Changes made: Updated the description for the <pubkey> variable within the context of an event with the 'e' tag. The updated comment explains that the `<pubkey>` SHOULD be the pubkey of the author of the e tagged event, and it is used in the outbox model to search for that event from the author's write relays where relay hints did not resolve the event.