### PR TITLE
Consistent 'method' naming for NIP 47(NWC) Response

### DIFF
--- a/47.md
+++ b/47.md
@@ -63,7 +63,7 @@ Request:
 Response:
 ```jsonc
 {
-    "result_type": "pay_invoice", //indicates the structure of the result field
+    "method": "pay_invoice", 
     "error": { //object, non-null in case of error
         "code": "UNAUTHORIZED", //string error code, see below
         "message": "human readable error message"
@@ -74,7 +74,6 @@ Response:
 }
 ```
 
-The `result_type` field MUST contain the name of the method that this event is responding to.
 The `error` field MUST contain a `message` field with a human readable error message and a `code` field with the error code if the command was not successful.
 If the command was successful, the `error` field must be null.
 
@@ -144,7 +143,7 @@ Request:
 Response:
 ```jsonc
 {
-    "result_type": "pay_invoice",
+    "method": "pay_invoice",
     "result": {
         "preimage": "0123456789abcdef...", // preimage of the payment
         "fees_paid": 123, // value in msats, optional
@@ -180,7 +179,7 @@ payment hash of the invoice should be used.
 
 ```jsonc
 {
-    "result_type": "multi_pay_invoice",
+    "method": "multi_pay_invoice",
     "result": {
         "preimage": "0123456789abcdef...", // preimage of the payment
         "fees_paid": 123, // value in msats, optional
@@ -214,7 +213,7 @@ Request:
 Response:
 ```jsonc
 {
-    "result_type": "pay_keysend",
+    "method": "pay_keysend",
     "result": {
         "preimage": "0123456789abcdef...", // preimage of the payment
         "fees_paid": 123, // value in msats, optional
@@ -247,12 +246,12 @@ Request:
 Response:
 
 For every keysend in the request, a separate response event is sent. To differentiate between the responses, each
-response event contains an `d` tag with the id of the keysend it is responding to, if no id was given, then the
+response event contains a `d` tag with the id of the keysend it is responding to, if no id was given, then the
 pubkey should be used.
 
 ```jsonc
 {
-    "result_type": "multi_pay_keysend",
+    "method": "multi_pay_keysend",
     "result": {
         "preimage": "0123456789abcdef...", // preimage of the payment
         "fees_paid": 123, // value in msats, optional
@@ -281,7 +280,7 @@ Request:
 Response:
 ```jsonc
 {
-    "result_type": "make_invoice",
+    "method": "make_invoice",
     "result": {
         "type": "incoming", // "incoming" for invoices, "outgoing" for payments
         "invoice": "string", // encoded invoice, optional
@@ -314,7 +313,7 @@ Request:
 Response:
 ```jsonc
 {
-    "result_type": "lookup_invoice",
+    "method": "lookup_invoice",
     "result": {
         "type": "incoming", // "incoming" for invoices, "outgoing" for payments
         "invoice": "string", // encoded invoice, optional
@@ -360,7 +359,7 @@ Request:
 Response:
 ```jsonc
 {
-    "result_type": "list_transactions",
+    "method": "list_transactions",
     "result": {
         "transactions": [
             {
@@ -395,7 +394,7 @@ Request:
 Response:
 ```jsonc
 {
-    "result_type": "get_balance",
+    "method": "get_balance",
     "result": {
         "balance": 10000, // user's balance in msats
     }
@@ -415,7 +414,7 @@ Request:
 Response:
 ```jsonc
 {
-    "result_type": "get_info",
+    "method": "get_info",
     "result": {
             "alias": "string",
             "color": "hex string",


### PR DESCRIPTION
Add consistency to the event structure in (NWC). 

Currently, requests and responses have different keys to identify their method type, which may cause confusion or misunderstandings. 

This change aims to standardize the key names across all request and response events, making it easier for developers to understand and implement the protocol