### PR TITLE
Add kind:20070 to NIP-70

### DIFF
--- a/70.md
+++ b/70.md
@@ -16,7 +16,7 @@ Relays that want to accept such events MUST first require that the client perfor
 
 ## The tag
 
-The tag is a simple tag with a single item: `["-"]`. It may be added to any event.
+The tag is a simple tag with a single item: `["-"]`. It may be added to any event. It should be added to replaceable and addressable events, except for the `kind:10002` one.
 
 ## Example flow
 
@@ -43,3 +43,23 @@ It's also possible to create closed access feeds with this when the publisher ha
 Even though it's ultimately impossible to restrict the spread of information on the internet (for example, one of the members of the closed group may want to take an event intended to be restricted and republish it to other relays), most relays would be happy to not facilitate the acts of these so-called "pirates", in respect to the original decision of the author and therefore gladly reject these republish acts if given the means to.
 
 This NIP gives these authors and relays the means to clearly signal when a given event is not intended to be republished by third parties.
+
+## Clearing Protected Events
+
+The `kind:20070` ephemeral event asks the tagged relay to delete all of the author's protected events.
+
+Relays MUST require authentication to fulfill the clearing request. Too old `kind:20070` events MUST be ignored.
+
+The event is useful to prevent replaceable and addressable events from becoming outdated after an user edits their [NIP-65](65.md) write relays.
+
+Example:
+
+```jsonc
+{
+  kind: 20070,
+  tags: [
+    ["relays", "wss://relay1.example", "wss://relay2.example"]
+  ],
+  // ...other fields
+}
+```


### PR DESCRIPTION
When editing NIP-65 write relays, replaceable/addressable events stored on old write relays tend to get stale, cause they won't be updated by clients that follow NIP-65 spec.

Making these events protected and then clearing all protected events from write relays that are no longer on the NIP-65 list prevents outdated events versions from circulating.

This PR recommends clients to add `["-"]` tag to these events (except for NIP-65's `kind:10002`)
and also adds an ephemeral event to act as a command to clear all protected events from a relay
(the old relay no longer on the NIP-65 list).

