### PR TITLE
Clarify that Standard lists and Sets are types of lists

### DIFF
--- a/51.md
+++ b/51.md
@@ -14,7 +14,7 @@ When new items are added to an existing list, clients SHOULD append them to the 
 
 ## Types of lists
 
-## Standard lists
+### Standard lists
 
 Standard lists use normal replaceable events, meaning users may only have a single list of each kind. They have special meaning and clients may rely on them to augment a user's profile or browsing experience.
 
@@ -36,7 +36,7 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | Good wiki authors | 10101 | [NIP-54](54.md) user recommended wiki authors               | `"p"` (pubkeys)                                                                   |
 | Good wiki relays  | 10102 | [NIP-54](54.md) relays deemed to only host useful articles  | `"relay"` (relay URLs)                                                            |
 
-## Sets
+### Sets
 
 Sets are lists with well-defined meaning that can enhance the functionality and the UI of clients that rely on them. Unlike standard lists, users are expected to have more than one set of each kind, therefore each of them must be assigned a different `"d"` identifier.
 
@@ -56,7 +56,7 @@ Aside from their main identifier, the `"d"` tag, sets can optionally have a `"ti
 | Emoji sets    | 30030 | categorized emoji groups                                                                     | `"emoji"` (see [NIP-30](30.md))                                                   |
 | Release artifact sets | 30063 | groups of files of a software release  | `"e"` (kind:1063 [file metadata](94.md) events), `"i"` (application identifier, typically reverse domain notation), `"version"`  |
 
-## Deprecated standard lists
+### Deprecated standard lists
 
 Some clients have used these lists in the past, but they should work on transitioning to the [standard formats](#standard-lists) above.
 


### PR DESCRIPTION
I had a little trouble understanding this NIP when I first read it; I think the intent here is that Standard lists and Sets are below the "Types of lists" heading since they're types of lists.