### PR TITLE
Update NIP-51 for software applications

### DIFF
--- a/51.md
+++ b/51.md
@@ -54,7 +54,8 @@ Aside from their main identifier, the `"d"` tag, sets can optionally have a `"ti
 | Kind mute sets | 30007 | mute pubkeys by kinds<br>`"d"` tag MUST be the kind string                                  | `"p"` (pubkeys)                                                                   |
 | Interest sets | 30015 | interest topics represented by a bunch of "hashtags"                                         | `"t"` (hashtags)                                                                  |
 | Emoji sets    | 30030 | categorized emoji groups                                                                     | `"emoji"` (see [NIP-30](30.md))                                                   |
-| Release artifact sets | 30063 | groups of files of a software release  | `"e"` (kind:1063 [file metadata](94.md) events), `"i"` (application identifier, typically reverse domain notation), `"version"`  |
+| Release artifact sets | 30063 | group of artifacts of a software release  | `"e"` (kind:1063 [file metadata](94.md) events), `"a"` (software application event) |
+| App curation sets | 30267 | references to multiple software applications  | `"a"` (software application event) |
 
 ### Deprecated standard lists
 
@@ -117,19 +118,36 @@ Some clients have used these lists in the past, but they should work on transiti
   "pubkey": "d6dc95542e18b8b7aec2f14610f55c335abebec76f3db9e58c254661d0593a0c",
   "created_at": 1695327657,
   "kind": 30063,
+  "content": "Release notes in markdown",
   "tags": [
-    ["d", "ak8dy3v7"],
-    ["i", "com.example.app"],
-    ["version", "0.0.1"],
-    ["title", "Example App"],
-    ["image", "http://cdn.site/p/com.example.app/icon.png"],
+    ["d", "com.example.app@0.0.1"],
     ["e", "d78ba0d5dce22bfff9db0a9e996c9ef27e2c91051de0c4e1da340e0326b4941e"], // Windows exe
     ["e", "f27e2c91051de0c4e1da0d5dce22bfff9db0a9340e0326b4941ed78bae996c9e"], // MacOS dmg
     ["e", "9d24ddfab95ba3ff7c03fbd07ad011fff245abea431fb4d3787c2d04aad02332"], // Linux AppImage
-    ["e", "340e0326b340e0326b4941ed78ba340e0326b4941ed78ba340e0326b49ed78ba"] // PWA
+    ["e", "340e0326b340e0326b4941ed78ba340e0326b4941ed78ba340e0326b49ed78ba"], // PWA
+    ["a", "32267:d6dc95542e18b8b7aec2f14610f55c335abebec76f3db9e58c254661d0593a0c:com.example.app"] // Reference to parent software application
   ],
   "content": "Example App is a decentralized marketplace for apps",
   "sig": "a9a4e2192eede77e6c9d24ddfab95ba3ff7c03fbd07ad011fff245abea431fb4d3787c2d04aad001cb039cb8de91d83ce30e9a94f82ac3c5a2372aa1294a96bd"
+}
+```
+
+### An _app curation set_
+
+```jsonc
+{
+    "id": "d8037fa866eb5acd2159960b3ada7284172f7d687b5289cc72a96ca2b431b611",
+    "pubkey": "78ce6faa72264387284e647ba6938995735ec8c7d5c5a65737e55130f026307d",
+    "sig": "c1ce0a04521c020ae7485307cd86285530c1f778766a3fd594d662a73e7c28f307d7cd9a9ab642ae749fce62abbabb3a32facfe8d19a21fba551b60fae863d95",
+    "kind": 30267,
+    "created_at": 1729302793,
+    "content": "My nostr app selection",
+    "tags": [
+        ["d", "nostr"],
+        ["a", "32267:7579076d9aff0a4cfdefa7e2045f2486c7e5d8bc63bfc6b45397233e1bbfcb19:com.example.app1"],
+        ["a", "32267:045f2486c7e5d8bc63bfc6b45397233e1bbfcb197579076d9aff0a4cfdefa7e2:net.example.app2"],
+        ["a", "32267:264387284e647ba6938995735ec8c7d5c5a6f026307d78ce6faa725737e55130:pl.code.app3"]
+    ]
 }
 ```
 


### PR DESCRIPTION
 - Introduce app curation sets, used to group applications (for curation, recommendation, organization, backup)
 - Minor fixes to release artifact sets, reflecting current usage

Both kinds 30063 and 30267 have been heavily used for months in Zapstore