### PR TITLE
NIP 74 - NWS

### DIFF
--- a/443.md
+++ b/443.md
@@ -1,0 +1,74 @@
+NIP-443
+======
+
+Nostr Web Services (NWS)
+======
+
+`draft` `optional`
+
+This NIP defines a standard for facilitating TCP requests over NOSTR relays to a specified destination. The implementation is currently available at [https://github.com/asmogo/nws](https://github.com/asmogo/nws).
+
+### Motivation
+
+While Nostr has been primarily focused on message-based communications, there is a growing need to extend its capabilities to support other types of network communication, such as TCP.
+
+The motivation behind NWS is to leverage the existing Nostr infrastructure to facilitate TCP connections in a decentralized and privacy-preserving manner. By using Nostr relays as intermediaries, clients can establish connections to remote servers without needing direct access to their IP addresses, thereby reducing exposure to potential security risks and censorship.
+
+### Terminology
+* `client` - The entity initiating a TCP request over NOSTR.
+* `exit-node` - The entity receiving a TCP request over NOSTR and forwarding it to the intended destination.
+
+## Kinds
+* `28333: KindEphemeralEvent` - Used to specify TCP messages.
+* `38333: KindAnnouncementEvent` - Used to publicly announce the exit node to clients.
+* `38334: KindCertificateEvent` - Used to publish the SSL certificate for the exit node.
+
+### Message Format
+Every message must have the following format:
+```json
+{
+    "key": "3b1f09a8-2b10-4daa-880c-2a392e781f09",
+    "type": "CONNECT",
+    "data": "GET /hello HTTP/1.1",
+    "destination": "google.com",
+    "entryPublicAddress": "<client public IP>"
+}
+```
+The `key` field is used to identify the message and is required. All TCP messages from one stream must have the same key.
+
+The `data` field contains the data to be transmitted to the destination.
+
+The `destination` field specifies the destination of the TCP connection (if the exit node wants to establish a connection to a remote server).
+
+The `entryPublicAddress` field specifies the public IP address of the client (when the client wants to use the `CONNECTR` message type).
+
+The `type` field specifies the type of message and is required. There are three defined message types within this protocol:
+1. `CONNECT`:
+    - Used to establish an initial TCP connection.
+    - The exit node receives this message to initiate a TCP connection with the upstream target (the destination).
+2. `CONNECTR`:
+    - Similar to `CONNECT`, but includes a secondary connection from the exit node back to the client.
+    - The exit node creates a connection to the client using the `entryPublicAddress` provided in the message, allowing bidirectional communication.
+3. `DATA`:
+    - Used for transmitting data to the upstream destination after a connection has been established.
+    - The `entryPublicAddress` parameter should only be provided when using `CONNECTR` message types.
+
+Messages must be sent using events with `kind:28333`. The content must be encrypted using NIP-04 or NIP-44.
+
+### Domain
+
+The `.nostr` domain of an exit node is a [base32](https://datatracker.ietf.org/doc/html/rfc4648) encoded public key with the `.nostr` TLD suffix.
+Subdomains are also [base32](https://datatracker.ietf.org/doc/html/rfc4648) encoded and are used to specify relay servers.
+The client can use this domain to resolve the relays and the recipient of the messages.
+
+#### Example:
+Sending a request to the following domain:
+`etpjkbpf60n30bhg5oo3kdpn6srg.7rqkr7rul8t6vbtekq0b3k274i696g47eo1765t9add20llitt9g.nostr`
+
+will create direct message events for public key `3ef54d9f7eaa3a6fafaea680b1d047248c93408776027317a9535a2056b2ef53` on relay `ws://0.0.0.0:7777`.
+
+### Basic Control Flow
+Unlike traditional TCP/IP communications that resolve a domain name to an IP address and establish a direct connection, NIP-443 leverages NOSTR relays as intermediate proxies for TCP communications.
+
+The client must send an encrypted direct message to the desired NOSTR public key, following the format outlined in the [Message Format] section.  
+Upon receiving the message, the exit node will process the request according to the specified message type, facilitating communication between the client and the destination.

--- a/74.md
+++ b/74.md
@@ -33,6 +33,7 @@ Every message must have the following format:
     "destination": "google.com",
 }
 ```
+
 The `key` field is used to identify the message and is required. All TCP messages from one stream must have the same key.
 
 The `data` field contains the data to be transmitted to the destination.
@@ -40,10 +41,11 @@ The `data` field contains the data to be transmitted to the destination.
 The `destination` field specifies the destination of the TCP connection (if the exit node wants to establish a connection to a remote server).
 
 The `type` field specifies the type of message and is required. There are three defined message types within this protocol:
+
 1. `CONNECT`:
     - Used to establish the initial TCP connection.
     - The exit node receives this message to initiate a TCP connection with the upstream target (the destination).
-3. `DATA`:
+2. `DATA`:
     - Used for transmitting data to the upstream destination after a connection has been established.
 
 Messages must be sent using events with `kind:28333`. The content must be encrypted using NIP-44.

--- a/74.md
+++ b/74.md
@@ -31,7 +31,6 @@ Every message must have the following format:
     "type": "CONNECT",
     "data": "GET /hello HTTP/1.1",
     "destination": "google.com",
-    "entryPublicAddress": "<client public IP>"
 }
 ```
 The `key` field is used to identify the message and is required. All TCP messages from one stream must have the same key.
@@ -40,18 +39,12 @@ The `data` field contains the data to be transmitted to the destination.
 
 The `destination` field specifies the destination of the TCP connection (if the exit node wants to establish a connection to a remote server).
 
-The `entryPublicAddress` field specifies the public IP address of the client (when the client wants to use the `CONNECTR` message type).
-
 The `type` field specifies the type of message and is required. There are three defined message types within this protocol:
 1. `CONNECT`:
-    - Used to establish an initial TCP connection.
+    - Used to establish the initial TCP connection.
     - The exit node receives this message to initiate a TCP connection with the upstream target (the destination).
-2. `CONNECTR`:
-    - Similar to `CONNECT`, but includes a secondary connection from the exit node back to the client.
-    - The exit node creates a connection to the client using the `entryPublicAddress` provided in the message, allowing bidirectional communication.
 3. `DATA`:
     - Used for transmitting data to the upstream destination after a connection has been established.
-    - The `entryPublicAddress` parameter should only be provided when using `CONNECTR` message types.
 
 Messages must be sent using events with `kind:28333`. The content must be encrypted using NIP-44.
 

--- a/74.md
+++ b/74.md
@@ -6,7 +6,7 @@ Nostr Web Services (NWS)
 
 `draft` `optional`
 
-This NIP defines a standard for facilitating TCP requests over NOSTR relays to a specified destination. The implementation is currently available at [https://github.com/asmogo/nws](https://github.com/asmogo/nws).
+This NIP defines a standard for facilitating TCP requests over NOSTR relays to a specified destination. One basic implementation is currently available at [https://github.com/asmogo/nws](https://github.com/asmogo/nws).
 
 ### Motivation
 
@@ -53,13 +53,16 @@ The `type` field specifies the type of message and is required. There are three 
     - Used for transmitting data to the upstream destination after a connection has been established.
     - The `entryPublicAddress` parameter should only be provided when using `CONNECTR` message types.
 
-Messages must be sent using events with `kind:28333`. The content must be encrypted using NIP-04 or NIP-44.
+Messages must be sent using events with `kind:28333`. The content must be encrypted using NIP-44.
 
-### Domain
+### Domain Name System
 
-The `.nostr` domain of an exit node is a [base32](https://datatracker.ietf.org/doc/html/rfc4648) encoded public key with the `.nostr` TLD suffix.
+The `.nostr` domain of an exit node is a [base32](https://datatracker.ietf.org/doc/html/rfc4648) encoded public key with the `.nostr` TLD suffix.  
 Subdomains are also [base32](https://datatracker.ietf.org/doc/html/rfc4648) encoded and are used to specify relay servers.
-The client can use this domain to resolve the relays and the recipient of the messages.
+Base32 encodings are required to use the "Extended Hex Alpabeth" defined in RFC 4648 and should no contain any padding. 
+
+This domain name system essential, as exit nodes can inform clients of how they can be reached while creating a `kind:38333` event.
+Clients can use this domain to resolve the relays and the recipient of the messages they want dispatch.
 
 #### Example:
 Sending a request to the following domain:

--- a/74.md
+++ b/74.md
@@ -19,7 +19,7 @@ The motivation behind NWS is to leverage the existing Nostr infrastructure to fa
 * `exit-node` - The entity receiving a TCP request over NOSTR and forwarding it to the intended destination.
 
 ## Kinds
-* `28333: KindEphemeralEvent` - Used to specify TCP messages.
+* `28333: KindEphemeralEvent` - Used to specify TCP messages. Exit nodes must subscribe to this message kind. 
 * `38333: KindAnnouncementEvent` - Used to publicly announce the exit node to clients.
 * `38334: KindCertificateEvent` - Used to publish the SSL certificate for the exit node.
 

--- a/74.md
+++ b/74.md
@@ -1,7 +1,7 @@
 NIP-74
 ======
 
-Nostr Web Services (NWS)
+Transmission Control Protocol (TCP)
 ======
 
 `draft` `optional`
@@ -68,5 +68,5 @@ will create direct message events for public key `3ef54d9f7eaa3a6fafaea680b1d047
 ### Basic Control Flow
 Unlike traditional TCP/IP communications that resolve a domain name to an IP address and establish a direct connection, NIP-74 leverages NOSTR relays as intermediate proxies for TCP communications.
 
-The client must send an encrypted direct message to the desired NOSTR public key, following the format outlined in the [Message Format] section.  
-Upon receiving the message, the exit node will process the request according to the specified message type, facilitating communication between the client and the destination.
+The client must publish an encrypted event to the desired NOSTR public key, following the format outlined in the [Message Format] section.  
+Upon receiving the event, the exit node will process the request according to the specified message type, facilitating communication between the client and the destination.

--- a/74.md
+++ b/74.md
@@ -1,4 +1,4 @@
-NIP-443
+NIP-74
 ======
 
 Nostr Web Services (NWS)
@@ -68,7 +68,7 @@ Sending a request to the following domain:
 will create direct message events for public key `3ef54d9f7eaa3a6fafaea680b1d047248c93408776027317a9535a2056b2ef53` on relay `ws://0.0.0.0:7777`.
 
 ### Basic Control Flow
-Unlike traditional TCP/IP communications that resolve a domain name to an IP address and establish a direct connection, NIP-443 leverages NOSTR relays as intermediate proxies for TCP communications.
+Unlike traditional TCP/IP communications that resolve a domain name to an IP address and establish a direct connection, NIP-74 leverages NOSTR relays as intermediate proxies for TCP communications.
 
 The client must send an encrypted direct message to the desired NOSTR public key, following the format outlined in the [Message Format] section.  
 Upon receiving the message, the exit node will process the request according to the specified message type, facilitating communication between the client and the destination.


### PR DESCRIPTION
This NIP defines a specification on how to send TCP messages trough NOSTR. 

TCP messages can be received by `exit-nodes`. This also introduces a Domain Name System to announce exit nodes to NOSTR clients. 
Exit nodes will further forward the TCP connection to a desired destination (static service or chosen by the client).
NIP-74 enables people to use HTTP, SSL, SSH and many more protocols built on top of TCP trough NOSTR.

The example implementation uses a SOCKS5 proxy as a client. This client publishes signed nostr events for the exit node using the nostr relays from the resolved domain. 