### PR TITLE
change NIP-01 to only allow a single filter per `REQ`

### DIFF
--- a/01.md
+++ b/01.md
@@ -112,7 +112,7 @@ Relays expose a websocket endpoint to which clients can connect. Clients SHOULD 
 Clients can send 3 types of messages, which must be JSON arrays, according to the following patterns:
 
   * `["EVENT", <event JSON as defined above>]`, used to publish events.
-  * `["REQ", <subscription_id>, <filters1>, <filters2>, ...]`, used to request events and subscribe to new updates.
+  * `["REQ", <subscription_id>, <filter>]`, used to request events and subscribe to new updates.
   * `["CLOSE", <subscription_id>]`, used to stop previous subscriptions.
 
 `<subscription_id>` is an arbitrary, non-empty string of max length 64 chars. It represents a subscription per connection. Relays MUST manage `<subscription_id>`s independently for each WebSocket connection. `<subscription_id>`s are not guaranteed to be globally unique.
@@ -140,8 +140,6 @@ The `ids`, `authors`, `#e` and `#p` filter lists MUST contain exact 64-character
 The `since` and `until` properties can be used to specify the time range of events returned in the subscription. If a filter includes the `since` property, events with `created_at` greater than or equal to `since` are considered to match the filter. The `until` property is similar except that `created_at` must be less than or equal to `until`. In short, an event matches a filter if `since <= created_at <= until` holds.
 
 All conditions of a filter that are specified must match for an event for it to pass the filter, i.e., multiple conditions are interpreted as `&&` conditions.
-
-A `REQ` message may contain multiple filters. In this case, events that match any of the filters are to be returned, i.e., multiple filters are to be interpreted as `||` conditions.
 
 The `limit` property of a filter is only valid for the initial query and MUST be ignored afterwards. When `limit: n` is present it is assumed that the events returned in the initial query will be the last `n` events ordered by the `created_at`. Newer events should appear first, and in the case of ties the event with the lowest id (first in lexical order) should be first. It is safe to return less events than `limit` specifies, but it is expected that relays do not return (much) more events than requested so clients don't get unnecessarily overwhelmed by data.
 


### PR DESCRIPTION
In practice the existence of the possibility of multiple filters in a single `REQ` has no benefit and only serves to hurt performance and increase complexity of codebases.

Anything that can be done with a single `REQ` and multiple filters can much more easily be done with multiple `REQ`s each with a single filter.

I know this is a breaking change, but not a very drastic one. We can easily transition to this by having clients stop being built with this "feature" in mind, and relays can follow later. If a client sends a `REQ` with more than one filter to a relay that only supports one that's also ok, the client will just get less results than it expected.