### PR TITLE
Users should be able to choose which servers are for reading, and which are for writing.

### DIFF
--- a/96.md
+++ b/96.md
@@ -320,8 +320,9 @@ Example Response:
 
 Note: HTTP File Storage Server developers may skip this section. This is meant for client developers.
 
-A File Server Preference event is a kind 10096 replaceable event meant to select one or more servers the user wants
-to upload files to. Servers are listed as `server` tags:
+A File Server Preference event is a kind 10096 replaceable event meant to select one or more servers the user wants to upload files to / read files from.
+
+Servers are listed as `server` tags, with corresponding server URIs and an optional `read` or `write` marker. If the marker is omitted, the server is used for both purposes.
 
 ```jsonc
 {
@@ -329,7 +330,8 @@ to upload files to. Servers are listed as `server` tags:
   "content": "",
   "tags": [
     ["server", "https://file.server.one"],
-    ["server", "https://file.server.two"]
+    ["server", "https://file.server.two"],
+    ["server", "https://file.server.three","read"]
   ],
   // other fields...
 }


### PR DESCRIPTION
Adjusted kind 10096 in [NIP-96](https://github.com/nostr-protocol/nips/blob/master/96.md#selecting-a-server) to be more closely aligned with [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md)

Use case - in our application ([sigit.io](https://sigit.io)) we allow users to store their data on their own blossom server(s).

The problem is that they may have some servers which are readonly (eg if their subscription expired), or perhaps they have upload limits and would like to stop writing to a particular server (but still read from it).  Or would just like more control over their storage defaults in general.

