### PR TITLE
Update nip34 git stuff

### DIFF
--- a/34.md
+++ b/34.md
@@ -22,9 +22,11 @@ Git repositories are hosted in Git-enabled servers, but their existence can be a
     ["description", "brief human-readable project description>"],
     ["web", "<url for browsing>", ...], // a webpage url, if the git server being used provides such a thing
     ["clone", "<url for git-cloning>", ...], // a url to be given to `git clone` so anyone can clone it
-    ["relays", "<relay-url>", ...] // relays that this repository will monitor for patches and issues
-    ["r", "<earliest-unique-commit-id>", "euc"]
-    ["maintainers", "<other-recognized-maintainer>", ...]
+    ["relays", "<relay-url>", ...], // relays that this repository will monitor for patches and issues
+    ["r", "<earliest-unique-commit-id>", "euc"],
+    ["maintainers", "<other-recognized-maintainer>", ...],
+    ["t", "some-topic"], // topics for improved discoverability
+    ["t", "another-topic"]
   ]
 }
 ```

--- a/34.md
+++ b/34.md
@@ -141,10 +141,13 @@ Root Patches and Issues have a status that defaults to 'Open' and can be set by 
   "content": "<markdown text>",
   "tags": [
     ["e", "<issue-or-original-root-patch-id-hex>", "relay-url", "issue-or-patch-author-pubkey"],
-    ["e", "<accepted-revision-root-id-hex>", "relay-url", "issue-or-patch-author-pubkey"], // For when revisions applied
+    ["e", "<accepted-revision-root-id-hex>", "relay-url", "revision-author-pubkey"], // For when revisions applied
     ["p", "<repository-owner>"],
     ["p", "<root-event-author>"],
     ["p", "<revision-author>"],
+
+    ["k", "1621"] // For issues
+    ["k", "1617"] // For patches
 
     // Optional for improved subscription filter efficiency
     ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>", "<relay-url>"],

--- a/34.md
+++ b/34.md
@@ -124,24 +124,9 @@ Issues may have a `subject` tag, which clients can utilize to display a header. 
 
 ## Replies
 
-Replies are also Markdown text. The difference is that they MUST be issued as replies to either a `kind:1621` _issue_ or a `kind:1617` _patch_ event. The threading of replies and patches should follow NIP-10 rules.
+Replies to `kind:1621` _issue_ and `kind:1617` _patch_, or any other event is described in [NIP-22 Comments](https://github.com/nostr-protocol/nips/blob/master/22.md).
 
-```jsonc
-{
-  "kind": 1622,
-  "content": "<markdown text>",
-  "tags": [
-    ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>", "<relay-url>"],
-    ["e", "<issue-or-patch-id-hex>", "", "root"],
-
-    // other "e" and "p" tags should be applied here when necessary, following the threading rules of NIP-10
-    ["p", "<patch-author-pubkey-hex>", "", "mention"],
-    ["e", "<previous-reply-id-hex>", "", "reply"],
-    // rest of tags...
-  ],
-  // other fields...
-}
-```
+_**Deprecation:** `kind:1622` replies for issue and patch events is deprecated in favor of [NIP-22 Comments](https://github.com/nostr-protocol/nips/blob/master/22.md)._
 
 ## Status
 

--- a/34.md
+++ b/34.md
@@ -130,41 +130,43 @@ _**Deprecation:** `kind:1622` replies for issue and patch events is deprecated i
 
 ## Status
 
-Root Patches and Issues have a Status that defaults to 'Open' and can be set by issuing Status events.
+Root Patches and Issues have a status that defaults to 'Open' and can be set by issuing status events.
 
 ```jsonc
 {
   "kind": 1630, // Open
-  "kind": 1631, // Applied / Merged for Patches; Resolved for Issues
+  "kind": 1631, // Applied / Merged for patches; Resolved for issues
   "kind": 1632, // Closed
   "kind": 1633, // Draft
   "content": "<markdown text>",
   "tags": [
-    ["e", "<issue-or-original-root-patch-id-hex>", "", "root"],
-    ["e", "<accepted-revision-root-id-hex>", "", "reply"], // for when revisions applied
+    ["e", "<issue-or-original-root-patch-id-hex>", "relay-url", "issue-or-patch-author-pubkey"],
+    ["e", "<accepted-revision-root-id-hex>", "relay-url", "issue-or-patch-author-pubkey"], // For when revisions applied
     ["p", "<repository-owner>"],
     ["p", "<root-event-author>"],
     ["p", "<revision-author>"],
 
-    // optional for improved subscription filter efficiency
+    // Optional for improved subscription filter efficiency
     ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>", "<relay-url>"],
     ["r", "<earliest-unique-commit-id-of-repo>"]
 
-    // optional for `1631` status
-    ["e", "<applied-or-merged-patch-event-id>", "", "mention"], // for each
-    // when merged
+    // Optional for `1631` status
+    ["e", "<applied-or-merged-patch-event-id>", "relay-url", "patch-author-pubkey"], // For each
+
+    // When merged
     ["merge-commit", "<merge-commit-id>"]
     ["r", "<merge-commit-id>"]
-    // when applied
+
+    // When applied / resolved
     ["applied-as-commits", "<commit-id-in-master-branch>", ...]
-    ["r", "<applied-commit-id>"] // for each
+    ["r", "<applied-commit-id>"] // For each
   ]
 }
 ```
 
-The Status event with the largest created_at date is valid.
+The Status event with the largest `created_at` date is valid.
 
-The Status of a patch-revision defaults to either that of the root-patch, or `1632` (Closed) if the root-patch's Status is `1631` and the patch-revision isn't tagged in the `1631` event.
+The Status of a patch-revision defaults to either that of the root-patch, or `1632` (Closed) if the root-patch's status is `1631` and the patch-revision isn't tagged in the `1631` event.
 
 
 ## Possible things to be added later

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `1311`        | Live Chat Message               | [53](53.md)                            |
 | `1617`        | Patches                         | [34](34.md)                            |
 | `1621`        | Issues                          | [34](34.md)                            |
-| `1622`        | Replies                         | [34](34.md)                            |
+| `1622`        | Replies                         | [34](34.md) (deprecated)               |
 | `1630`-`1633` | Status                          | [34](34.md)                            |
 | `1971`        | Problem Tracker                 | [nostrocket][nostrocket]               |
 | `1984`        | Reporting                       | [56](56.md)                            |


### PR DESCRIPTION
- Deprecate issue/patch replies in favor of [NIP-22](https://github.com/nostr-protocol/nips/blob/master/22.md)
- Replace nip10 tags with more useful pubkey hint
- Add `k` tag to differentiate between patch and issue status
- Add repository topics