### PR TITLE
Grammar updates to 47.md

### DIFF
--- a/47.md
+++ b/47.md
@@ -107,7 +107,7 @@ The content of notifications is encrypted with [NIP04](https://github.com/nostr-
 ## Nostr Wallet Connect URI
 **client** discovers **wallet service** by scanning a QR code, handling a deeplink or pasting in a URI.
 
-The **wallet service** generates this connection URI with protocol `nostr+walletconnect://` and base path it's hex-encoded `pubkey` with the following query string parameters:
+The **wallet service** generates this connection URI with protocol `nostr+walletconnect://` and base path its hex-encoded `pubkey` with the following query string parameters:
 
 - `relay` Required. URL of the relay where the **wallet service** is connected and will be listening for events. May be more than one.
 - `secret` Required. 32-byte randomly generated hex encoded string. The **client** MUST use this to sign events and encrypt payloads when communicating with the **wallet service**.
@@ -175,7 +175,7 @@ Request:
 Response:
 
 For every invoice in the request, a separate response event is sent. To differentiate between the responses, each
-response event contains a `d` tag with the id of the invoice it is responding to, if no id was given, then the
+response event contains a `d` tag with the id of the invoice it is responding to; if no id was given, then the
 payment hash of the invoice should be used.
 
 ```jsonc
@@ -247,7 +247,7 @@ Request:
 Response:
 
 For every keysend in the request, a separate response event is sent. To differentiate between the responses, each
-response event contains an `d` tag with the id of the keysend it is responding to, if no id was given, then the
+response event contains a `d` tag with the id of the keysend it is responding to; if no id was given, then the
 pubkey should be used.
 
 ```jsonc


### PR DESCRIPTION
Minor grammatical edits for clarity.
- "It's" to "its" to show the possessive case intended instead of the contraction
- Correct article from "an" to "a" for the following d letter (consonant sound)
- Minor edit to fix comma splices with a semicolon ( ; ) to clarify two independent thoughts. Somewhat optional, but it clarifies the two long sentences. Period can instead be used instead as a new sentence.