### PR TITLE
Enhancing NIP-05 Efficiency with TTL Caching

### DIFF
--- a/05.md
+++ b/05.md
@@ -30,7 +30,10 @@ It will make a GET request to `https://example.com/.well-known/nostr.json?name=b
 ```json
 {
   "names": {
-    "bob": "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9"
+    "bob": {
+      "pubkey": "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9",
+      "ttl": 3600  // in seconds
+    }
   }
 }
 ```
@@ -40,15 +43,25 @@ or with the **recommended** `"relays"` attribute:
 ```json
 {
   "names": {
-    "bob": "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9"
+    "bob": {
+      "pubkey": "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9",
+      "ttl": 3600  // in seconds
+    }
   },
   "relays": {
-    "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9": [ "wss://relay.example.com", "wss://relay2.example.com" ]
+    "b0635d6a9851d3aed0cd6c495b282167acf761729078d975fc341b22650b07b9": {
+      "urls": [ "wss://relay.example.com", "wss://relay2.example.com" ],
+      "ttl": 7200  // in seconds
+    }
   }
 }
 ```
 
-If the pubkey matches the one given in `"names"` (as in the example above) that means the association is right and the `"nip05"` identifier is valid and can be displayed.
+If the `pubkey` matches the one given in `"names"` (as in the example above) that means the association is right and the `"nip05"` identifier is valid and can be displayed.
+
+The `ttl` (Time-To-Live in seconds) attribute may include in the `names` and `relays` sections, allows clients to manage caching and the validity of the resolved information more effectively.
+When `ttl` is provided for a record, clients RECOMMENDED to cache the record (e.g., public keys for names and URLs for relays) for the duration specified in the ttl.
+If a record has a `ttl` of `0`, it SHOULD NOT be cached, and clients SHOULD always fetch a fresh response for that record and If the `ttl` is absent, it can be assumed to be `0`.
 
 The recommended `"relays"` attribute may contain an object with public keys as properties and arrays of relay URLs as values. When present, that can be used to help clients learn in which relays the specific user may be found. Web servers which serve `/.well-known/nostr.json` files dynamically based on the query string SHOULD also serve the relays data for any name they serve in the same reply when that is available.
 

--- a/05.md
+++ b/05.md
@@ -27,7 +27,7 @@ If a client sees an event like this:
 
 It will make a GET request to `https://example.com/.well-known/nostr.json?name=bob` and get back a response that will look like
 
-```json
+```jsonc
 {
   "names": {
     "bob": {
@@ -40,7 +40,7 @@ It will make a GET request to `https://example.com/.well-known/nostr.json?name=b
 
 or with the **recommended** `"relays"` attribute:
 
-```json
+```jsonc
 {
   "names": {
     "bob": {


### PR DESCRIPTION
The NIP-05 response can include a `TTL` (Time-To-Live in seconds) attribute for each record in the names and relays sections. This feature enables clients to manage caching and the validity of the resolved information more effectively. It also allows NIP-05 providers to cache records, which leads to greater efficiency, faster response times, and reduced network traffic.