### PR TITLE
add restricted to standardized machine-readable prefixes

### DIFF
--- a/01.md
+++ b/01.md
@@ -168,9 +168,10 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
   * `["OK", "b1a649ebe8...", false, "rate-limited: slow down there chief"]`
   * `["OK", "b1a649ebe8...", false, "invalid: event creation date is too far off from the current time"]`
   * `["OK", "b1a649ebe8...", false, "pow: difficulty 26 is less than 30"]`
+  * `["OK", "b1a649ebe8...", false, "restricted: not allowed to write."]`
   * `["OK", "b1a649ebe8...", false, "error: could not connect to the database"]`
 - `CLOSED` messages MUST be sent in response to a `REQ` when the relay refuses to fulfill it. It can also be sent when a relay decides to kill a subscription on its side before a client has disconnected or sent a `CLOSE`. This message uses the same pattern of `OK` messages with the machine-readable prefix and human-readable message. Some examples:
   * `["CLOSED", "sub1", "unsupported: filter contains unknown elements"]`
   * `["CLOSED", "sub1", "error: could not connect to the database"]`
   * `["CLOSED", "sub1", "error: shutting down idle subscription"]`
-- The standardized machine-readable prefixes for `OK` and `CLOSED` are: `duplicate`, `pow`, `blocked`, `rate-limited`, `invalid`, and `error` for when none of that fits.
+- The standardized machine-readable prefixes for `OK` and `CLOSED` are: `duplicate`, `pow`, `blocked`, `rate-limited`, `invalid`, `restricted`, and `error` for when none of that fits.


### PR DESCRIPTION
The `restricted` prefix is useful in situations where an individual is not whitelisted to write on a relay or has been banned from it. 

For example, [Immortal (websocket/event_handler.go#L125)](https://github.com/dezh-tech/immortal/blob/f0829316f3ea8af478e34cd04ed6c550bdd93559/delivery/websocket/event_handler.go#L125) uses a restricted prefix to send a message when someone who is not whitelisted tries to write on the relay, provided that the whitelist feature is enabled in the configurations.

Additionally, if this event is sent on nostr.wine:
```
["EVENT", {"kind":1,"id":"ba5a810abf66864fcde9ea1d2ecb33c83bd62833923e428540a0d7bccf93be74","pubkey":"79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798","created_at":1736858900,"tags":[],"content":"hello from the nostr army knife","sig":"c36b46d141d2d37f39a02c7437415a9913b6f13d4a4078afc3037504023d69705dd75ed12483192dafed4ed861282dace2997d096b8b346dd8b0a7d7a50fa024"}
]
```

 the response will be:
 ```
["OK","ba5a810abf66864fcde9ea1d2ecb33c83bd62833923e428540a0d7bccf93be74",false,"restricted: not an active paid member"]
```

 