### PR TITLE
Zapraisers

### DIFF
--- a/57.md
+++ b/57.md
@@ -183,6 +183,20 @@ When an event includes one or more `zap` tags, clients wishing to zap it SHOULD 
 
 Clients MAY display the zap split configuration in the note.
 
+### Appendix H: `zapraiser` tag on other events
+
+Any event can include a `zapraiser` tag with the tag's value equal to the total amount of sats the author wishes to fundraise from zaps to its event. 
+
+```jsonc
+{
+    "tags": [
+        [ "zapraiser", "1000" ],  // 1000 sats
+    ]
+}
+```
+
+Clients MAY display fundraising information in any way they see fit.
+
 ## Future Work
 
 Zaps can be extended to be more private by encrypting `zap request` notes to the target user, but for simplicity it has been left out of this initial draft.

--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `tracker`         | torrent tracker URL                  | --                              | [35](35.md)                                        |
 | `web`             | webpage URL                          | --                              | [34](34.md)                                        |
 | `zap`             | pubkey (hex), relay URL              | weight                          | [57](57.md)                                        |
+| `zapraiser`       | value in sats                        | --                              | [57](57.md)                                        |
 
 Please update these lists when proposing new NIPs.
 


### PR DESCRIPTION
Adds a tag to be used in any event as a goal for the amount of zaps to be raised by that event. 

This has been out on Amethyst for 1.5 years now. The field complements [NIP-75](75.md) fundraisers used by fundraising sites.