### PR TITLE
Clearly informs that kind 1 replies can only be used with kind 1 events.

### DIFF
--- a/10.md
+++ b/10.md
@@ -10,8 +10,6 @@ This NIP defines `kind:1` as a simple plaintext note.
 
 ## Abstract
 
-This NIP describes how to use "e" and "p" tags in text events, especially those that are replies to other text events. It helps clients thread the replies into a tree rooted at the original event.
-
 The `.content` property contains some human-readable text. 
 
 `e` and `p` tags can be used to define note threads, replies and mentions. 
@@ -19,6 +17,9 @@ The `.content` property contains some human-readable text.
 Markup languages such as markdown and HTML SHOULD NOT be used. 
 
 ## Marked "e" tags (PREFERRED)
+
+Kind 1 events with `e` tags are replies to other kind 1 events. Kind 1 replies MUST NOT be used to reply to other kinds, use [NIP-22](22.md) instead. 
+
 `["e", <event-id>, <relay-url>, <marker>, <pubkey>]`
 
 Where:


### PR DESCRIPTION
It's obvious now with NIP 22, but I think it is worth declaring to make things 100% clear.