### PR TITLE
NIP-60: clarify privkey is optional

### DIFF
--- a/60.md
+++ b/60.md
@@ -23,7 +23,7 @@ This NIP doesn't deal with users' *receiving* money from someone else, it's just
     "kind": 37375,
     "content": nip44_encrypt([
         [ "balance", "100", "sat" ],
-        [ "privkey", "hexkey" ] // explained in NIP-61
+        [ "privkey", "hexkey" ] // explained in NIP-61, appendix 1
     ]),
     "tags": [
         [ "d", "my-wallet" ],
@@ -49,7 +49,7 @@ Tags:
 * `name` - Optional human-readable name for the wallet.
 * `description` - Optional human-readable description of the wallet.
 * `balance` - Optional best-effort balance of the wallet that can serve as a placeholder while an accurate balance is computed from fetching all unspent proofs.
-* `privkey` - Private key used to unlock P2PK ecash. MUST be stored encrypted in the `.content` field. **This is a different private key exclusively used for the wallet, not associated in any way to the user's nostr private key** -- This is only used when receiving funds from others, described in NIP-61.
+* `privkey` - Optional private key used to unlock P2PK ecash. If present, MUST be stored encrypted in the `.content` field. **This is a different private key exclusively used for the wallet, not associated in any way to the user's nostr private key** -- This is only used when receiving funds from others, described in NIP-61, appendix 1.
 
 Any tag, other than the `d` tag, can be [[NIP-44]] encrypted into the `.content` field.
 


### PR DESCRIPTION
I am learning Cashu for the first time, so this may not make sense.  

However, if I understood correctly, to redeem/spend a Cashu with a spending condition, you need a corresponding private key to sign the Proof. In the context of Nostr, this private key can be the user's own Nostr private key or another private key, not related to the user's Nostr private key.  

So, if the client is using the user's own Nostr private key, then the `privkey` tag wouldn't be needed, correct?