### PR TITLE
Add hints to nip 25

### DIFF
--- a/25.md
+++ b/25.md
@@ -33,12 +33,17 @@ If the event being reacted to is an addressable event, an `a` SHOULD be included
 
 The reaction SHOULD include a `k` tag with the stringified kind number of the reacted event as its value.
 
+The `e` and `a` tags SHOULD include relay and pubkey hints. The `p` tags SHOULD include relay hints.
+
+The reaction event MAY include a `k` tag with the stringified kind number of the reacted event as its value.
+
 **Example code**
 
 ```swift
-func make_like_event(pubkey: String, privkey: String, liked: NostrEvent) -> NostrEvent {
-    tags.append(["e", liked.id, liked.source_relays.first ?? ""])
-    tags.append(["p", liked.pubkey])
+func make_like_event(pubkey: String, privkey: String, liked: NostrEvent, hint: String) -> NostrEvent {
+    var tags: [[String]] = []
+    tags.append(["e", liked.id, hint, liked.pubkey])
+    tags.append(["p", liked.pubkey, hint])
     tags.append(["k", String(liked.kind)])
     let ev = NostrEvent(content: "+", pubkey: pubkey, kind: 7, tags: tags)
     ev.calculate_id()


### PR DESCRIPTION
Currently most reaction tags have only one argument, but there are many out there that follow NIP 10, including a relay hint and marker. But I think the marker is basically meaningless in this context.