### PR TITLE
Add NIP-4A Event Onion Routing

### DIFF
--- a/4A.md
+++ b/4A.md
@@ -1,0 +1,41 @@
+NIP-4A
+======
+
+Event Onion Routing
+-------------------
+
+`draft` `optional`
+
+This NIP defines a way for a client to indirectly publish events to a relay by onion routing the event through peers willing to route it. This helps preserve the privacy of a client's network metadata.
+
+```
+<Alice> --> [Relay-1] --> <Router> --> [Relay-2] --> <Bob>
+```
+
+Alice wants to send an event to *Bob*, but not reveal her IP address to *Relay-2*. Another client, *Router*, has offered to provide an onion routing service. This allows Alice to encrypt her message to *Router* and send it through *Relay-1*. *Router* decrypts the message and publishes it to *Relay-2* for *Bob*.
+
+This is not perfect network privacy. There is a chance that the relays are operated by the same party or two colluding parties. Alice may choose to introduce different routers on the path to increase the difficulty of detection, at the cost of performance.
+
+## Routing an Event
+
+Kind `20444` is an onion route request event. The event MUST include a `p` tag specifying the router to route the event. The `content` is encrypted for the router using [NIP-44](44.md) encryption. The `content` MUST contain an `event` to publish as well as at least one `relay` to target.
+
+```
+{
+    "kind": 20444,
+    "content": nip44_encrypt("[
+        [ "event", "<event-as-json-string>" ],  // required event to publish
+        [ "relay", "wss://example1.com" ]       // required relay to target
+        [ "ecash", "<token-uri>" ],             // optional ecash incentive with ecash proof and mint info
+    ]")
+    "tags": [
+        [ "p", "<pubkey-of-router>" ]
+    ]
+} 
+```
+
+Multiple `event`s and `relays` MAY be provided. Every given `event` SHOULD be published to every gieven `relay`.
+
+OPTIONAL `ecash` may be provided as incentive for the router.
+
+The routing event could use a [NIP-59](59.md) gift wrap to hide that it is a routing request, but the effectiveness would vary depending on if a router's pubkey is well known as an onion router.


### PR DESCRIPTION
I believe onion routing is a key missing piece to client privacy and would be extremely valuable in high value, low bandwidth use cases like bitcoin transaction collaboration. A lot of work has been done recently with things like NIP-17 to hide application metadata in events, but I do not believe a nostr native way to protect network metadata has been addressed. Event onion routing is not a new concept and has been proposed a few times over the years:

* https://github.com/nostr-protocol/nips/pull/430 for NIP-705 Republish Events by Peers and the original issue https://github.com/nostr-protocol/nips/issues/411.
* https://github.com/nostr-protocol/nips/pull/499 for NIP-103 Onion Routed Direct Messages.
* Comments in https://github.com/nostr-protocol/nips/pull/686#issuecomment-1930106812 for NIP-17 Direct Messages.
* A long form note proposal for [NIP-37](https://wikifreedia.xyz/a/naddr1qqgk7mnfdahz6un0w46xjmn894hxjuqpz3mhxue69uhhyetvv9ujuerpd46hxtnfdupzp75cf0tahv5z7plpdeaws7ex52nmnwgtwfr2g3m37r844evqrr6jqvzqqqrcvg972gy5) Event Publication Onion-routing (although it looks like NIP-37 has been taken, so NIP-37-ish?).

I am restarting onion routing discussion here with a bare bones proposal which attempts to grab the best parts from the ones above, plus use the most modern practices (e.g. NIP-44). 

Some open questions initially left off, but could be added:

* @pablof7z's NIP-37 proposal defined a normal kind `2444` and ephemeral kind `20444`, I left off the normal one for simplicity but see the value.
* I believe how a routing service service announces itself as available should be defined here, but is that as simple as pointing to NIP-89?
* I like the simplicity of [cashu's V4 serialization](https://github.com/cashubtc/nuts/blob/main/00.md#serialization-of-tokens) and is what I had in mind for the `ecash` tag. Is how it is defined right now too open ended?

