### PR TITLE
Added NIP-100

### DIFF
--- a/100.md
+++ b/100.md
@@ -1,0 +1,42 @@
+NIP-100
+======
+
+Encoded files
+-------------------
+
+This NIP defines `kind:666`: a custom event type used for file storage and transmission. It allows users to store encoded files along with metadata such as file name, extension, and encoding type.
+
+
+**A typical kind 666 event includes:**
+
+id: Unique event ID (SHA256 hash)
+
+pubkey: Event creator's public key
+
+created_at: Timestamp of event creation
+
+kind: 666
+
+tags: Metadata such as name, extension, encoding.
+
+content: Encoded file.
+
+sig: Cryptographic signature for verification.
+
+
+## Example
+```
+{
+    "id": "abc123eventid",
+    "pubkey": "b59f7b6a2d6...",
+    "created_at": 1706000000,
+    "kind": 666,
+    "tags": [
+        ["name", "document"],
+        ["extension", "pdf"],
+        ["encode", "base64"]
+    ],
+    "content": "BTC21MCHILL=",
+    "sig": "3045022100e5b9..."
+}
+```


### PR DESCRIPTION
Added **NIP-100** for kind 666 events. kind 666 is for storing and transmitting encoded files on relays.

For more information: [github.com/untreu2/shut](http://github.com/untreu2/shut)