### PR TITLE
NIP-800: Define BDD Payload Execution Protocol (because 800 and BDD are a match made in alphanumeric heaven)

### DIFF
--- a/800.md
+++ b/800.md
@@ -1,0 +1,121 @@
+NIP-800
+=======
+
+BDD Payload Execution Protocol
+------------------------------
+
+`draft` `optional`
+
+This NIP defines `kind:800` and `kind:801`: a standardized protocol for relays to handle and execute Behavior-Driven Development (BDD) payloads. The protocol enables developers to send structured BDD test cases as Nostr events and provides a framework for relays to execute, validate, and return the results.
+
+---
+
+#### **Motivation**
+The need for BDD payloads arises from the desire to integrate automated testing into the Nostr ecosystem. This enables developers to leverage relays for distributed and immutable BDD test case execution, reducing reliance on centralized CI/CD systems and providing auditable on-chain results.
+
+---
+
+#### **Specification**
+
+##### 1. **Event Structure**
+A BDD payload is a specialized Nostr event (`kind` value: `800`). The payload must conform to the following structure:
+
+```json
+{
+  "id": "<event_id>",
+  "pubkey": "<developer_pubkey>",
+  "created_at": <timestamp>,
+  "kind": 800,
+  "tags": [
+    ["test-suite", "<suite_name>"],
+    ["test-scenario", "<scenario_name>"],
+    ["test-description", "<description>"],
+    ["expected-result", "<expected_result>"]
+  ],
+  "content": {
+    "given": "<given_clause>",
+    "when": "<when_clause>",
+    "then": "<then_clause>"
+  },
+  "sig": "<signature>"
+}
+```
+
+---
+
+##### 2. **Tags**
+
+- **`test-suite`**: The name of the test suite.
+- **`test-scenario`**: A specific scenario name within the test suite.
+- **`test-description`**: A detailed description of the test case.
+- **`expected-result`**: The expected outcome for validation.
+
+---
+
+##### 3. **BDD Payload Content**
+The `content` field must contain the BDD clauses:
+- **`given`**: The initial context or state.
+- **`when`**: The action or trigger.
+- **`then`**: The expected outcome or result.
+
+---
+
+##### 4. **Relay Execution**
+Relays supporting NIP-800 must:
+1. Validate the event structure and signature.
+2. Parse the `content` to extract the BDD clauses.
+3. Execute the BDD test using a sandboxed runtime environment.
+4. Return the results as a new Nostr event (`kind: 801`).
+
+---
+
+##### 5. **Result Event Structure**
+The results of a BDD test are published as a new event (`kind: 801`) by the relay:
+
+```json
+{
+  "id": "<result_event_id>",
+  "pubkey": "<relay_pubkey>",
+  "created_at": <timestamp>,
+  "kind": 801,
+  "tags": [
+    ["test-suite", "<suite_name>"],
+    ["test-scenario", "<scenario_name>"],
+    ["status", "<pass|fail>"],
+    ["error", "<error_message_if_any>"]
+  ],
+  "content": {
+    "execution-log": "<log_of_steps>",
+    "result": "<result_output>"
+  },
+  "sig": "<signature>"
+}
+```
+
+---
+
+##### 6. **Status Tag**
+- **`status`**: Indicates whether the test passed or failed.
+- **`error`**: Contains an error message if the test failed.
+
+---
+
+#### **Use Cases**
+- Decentralized CI/CD for Nostr apps and protocols.
+- Immutable record of test executions.
+- Enabling collaborative debugging via shared test scenarios.
+
+---
+
+#### **Security Considerations**
+- Relays must execute tests in a sandboxed environment to prevent malicious code execution.
+- Event sizes must be limited to prevent denial-of-service attacks.
+- Results must be cryptographically signed by the relay for authenticity.
+
+---
+
+#### **Future Extensions**
+- Support for additional test formats (e.g., unit tests).
+- Integration with popular test frameworks.
+- Mechanisms for incentivizing relays to execute tests (e.g., Lightning payments).
+


### PR DESCRIPTION
While breaking convention by jumping to NIP-800, the alphanumeric and visual similarity between "800" and "BDD" is too perfect to ignore. This synchronicity aligns with the purpose of the protocol, making it instantly memorable and symbolically representative of the structured nature of BDD itself. Some conventions are worth bending for elegance.