### PR TITLE
Add NIP-71 tags to NIP-94 spec

### DIFF
--- a/94.md
+++ b/94.md
@@ -15,7 +15,7 @@ This NIP specifies the use of the `1063` event kind, having in `content` a descr
 * `url` the url to download the file
 * `m` a string indicating the data type of the file. The [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types) format must be used, and they should be lowercase.
 * `x` containing the SHA-256 hexencoded string of the file.
-* `ox` containing the SHA-256 hexencoded string of the original file, before any transformations done by the upload server
+* `ox` (optional) containing the SHA-256 hexencoded string of the original file, before any transformations done by the upload server
 * `size` (optional) size of file in bytes
 * `dim` (optional) size of file in pixels in the form `<width>x<height>`
 * `magnet` (optional) URI to magnet file
@@ -27,6 +27,8 @@ This NIP specifies the use of the `1063` event kind, having in `content` a descr
 * `alt` (optional) description for accessibility
 * `fallback` (optional) zero or more fallback file sources in case `url` fails
 * `service` (optional) service type which is serving the file (eg. [NIP-96](96.md))
+* `duration` (optional) duration of media (video/audio) in seconds
+* `bitrate` (optional) average bitrate of media (video/audio) in seconds
 
 ```jsonc
 {


### PR DESCRIPTION
Adding `duration` and `bitrate` to NIP-94 to cover NIP-71 content