### PR TITLE
NIP-60: more consistent state transition

### DIFF
--- a/60.md
+++ b/60.md
@@ -57,7 +57,7 @@ Any tag, other than the `d` tag, can be [[NIP-44]] encrypted into the `.content`
 Due to addressable event being hard to delete, if a user wants to delete a wallet, they should empty the event and keep just the `d` identifier and add a `deleted` tag.
 
 ## Token Event
-Token events are used to record the unspent proofs that come from the mint.
+Token events are used to record unspent proofs.
 
 There can be multiple `kind:7375` events for the same mint, and multiple proofs inside each `kind:7375` event.
 
@@ -73,7 +73,9 @@ There can be multiple `kind:7375` events for the same mint, and multiple proofs 
                 "secret": "z+zyxAVLRqN9lEjxuNPSyRJzEstbl69Jc1vtimvtkPg=",
                 "C": "0241d98a8197ef238a192d47edf191a9de78b657308937b4f7dd0aa53beae72c46"
             }
-        ]
+        ],
+        // tokens that were destroyed in the creation of this token
+        "del": [ "token-id-1" ]
     }),
     "tags": [
         [ "a", "37375:<pubkey>:my-wallet" ]
@@ -81,8 +83,11 @@ There can be multiple `kind:7375` events for the same mint, and multiple proofs 
 }
 ```
 
-`.content` is a [[NIP-44]] encrypted payload storing the mint and the unencoded proofs.
-* `a` an optional tag linking the token to a specific wallet.
+ * `a` an optional tag linking the token to a specific wallet.
+ * `.content` is a [[NIP-44]] encrypted payload:
+   * `mint`: The mint the proofs belong to.
+   * `proofs`: unecoded proofs
+   * `del`: token-ids that were destroyed by the creation of this token. This assists with state transitions.
 
 ### Spending proofs
 When one or more proofs of a token are spent, the token event should be [[NIP-09]]-deleted and, if some proofs are unspent from the same token event, a new token event should be created rolling over the unspent proofs and adding any change outputs to the new token event.
@@ -96,7 +101,7 @@ Clients SHOULD publish `kind:7376` events to create a transaction history when t
     "content": nip44_encrypt([
         [ "direction", "in" ], // in = received, out = sent
         [ "amount", "1", "sat" ],
-        [ "e", "<event-id-of-spent-token>", "<relay-hint>", "created" ],
+        [ "e", "<event-id-of-created-token>", "<relay-hint>", "created" ],
     ]),
     "tags": [
         [ "a", "37375:<pubkey>:my-wallet" ],
@@ -160,7 +165,8 @@ Her client:
             { "id": "1", "amount": 1 },
             { "id": "2", "amount": 2 },
             { "id": "4", "amount": 8 },
-        ]
+        ],
+        "del": [ "event-id-1" ]
     }),
     "tags": [
         [ "a", "37375:<pubkey>:my-wallet" ]
@@ -168,6 +174,7 @@ Her client:
 }
 ```
 * MUST delete event `event-id-1`
+* SHOULD add the `event-id-1` to the `del` array of deleted token-ids.
 * SHOULD create a `kind:7376` event to record the spend
 ```jsonconc
 {


### PR DESCRIPTION
NIP-60 wallets use `kind:5` delete request events to mark tokens as deleted, particularly important when some proofs in a token are spent and the remaining proofs are moved to a new token event.

The same wallet running synchronously in two devices need this event to properly update their state.

This PR adds a `del` property to new tokens to make state transitions more explicit and not dependent on clients getting the `kind:5` event from relays (some relays seem to not want to send those 🤷‍♂️)