### PR TITLE
Update 92.md

### DIFF
--- a/92.md
+++ b/92.md
@@ -6,10 +6,10 @@ Media Attachments
 
 Media attachments (images, videos, and other files) may be added to events by including a URL in the event content, along with a matching `imeta` tag.
 
-`imeta` ("inline metadata") tags add information about media URLs in the event's content. Each `imeta` tag SHOULD match a URL in the event content. Clients may replace imeta URLs with rich previews.
+`imeta` ("inline metadata") tags MAY add information about media URLs in the event's content. Each `imeta` tag SHOULD match a URL in the event content. Clients MAY replace imeta URLs with rich previews.
 
 The `imeta` tag is variadic, and each entry is a space-delimited key/value pair.
-Each `imeta` tag MUST have a `url`, and at least one other field. `imeta` may include
+Each `imeta` tag MUST have a `url`, and at least one other field. `imeta` MAY include
 any field specified by [NIP 94](./94.md). There SHOULD be only one `imeta` tag per URL.
 
 ## Example


### PR DESCRIPTION
Reword `imeta` usage for NIP-71 and NIP-68 usages where content does not contain the url