### PR TITLE
Discovery of DVMs and Application Handler relays via NIP-65

### DIFF
--- a/65.md
+++ b/65.md
@@ -41,23 +41,23 @@ When broadcasting an event, Clients SHOULD:
 
 ## Motivation
 
-The old model of using a fixed relay list per user centralizes in large relay operators: 
+The old model of using a fixed relay list per user centralizes in large relay operators:
 
   - Most users submit their posts to the same highly popular relays, aiming to achieve greater visibility among a broader audience
   - Many users are pulling events from a large number of relays in order to get more data at the expense of duplication
   - Events are being copied between relays, oftentimes to many different relays
-  
-This NIP allows Clients to connect directly with the most up-to-date relay set from each individual user, eliminating the need of broadcasting events to popular relays. 
+
+This NIP allows Clients to connect directly with the most up-to-date relay set from each individual user, eliminating the need of broadcasting events to popular relays.
 
 ## Final Considerations
 
-1. Clients SHOULD guide users to keep `kind:10002` lists small (2-4 relays). 
+1. Clients SHOULD guide users to keep `kind:10002` lists small (2-4 relays).
 
-2. Clients SHOULD spread an author's `kind:10002` event to as many relays as viable. 
+2. Clients SHOULD spread an author's `kind:10002` event to as many relays as viable.
 
 3. `kind:10002` events should primarily be used to advertise the user's preferred relays to others. A user's own client may use other heuristics for selecting relays for fetching data.
 
-4. DMs SHOULD only be broadcasted to the author's WRITE relays and to the receiver's READ relays to keep maximum privacy. 
+4. DMs SHOULD only be broadcasted to the author's WRITE relays and to the receiver's READ relays to keep maximum privacy.
 
 5. If a relay signals support for this NIP in their [NIP-11](11.md) document that means they're willing to accept kind 10002 events from a broad range of users, not only their paying customers or whitelisted group.
 

--- a/65.md
+++ b/65.md
@@ -49,6 +49,12 @@ The old model of using a fixed relay list per user centralizes in large relay op
 
 This NIP allows Clients to connect directly with the most up-to-date relay set from each individual user, eliminating the need of broadcasting events to popular relays.
 
+## Usage by DVMs and Application Handlers
+
+In order to support discovery of Application Handlers ([NIP-89](89.md)) and DVMs ([NIP-90](90.md)), such entities can publish kind 10002 events that include `k` tags listing all of the the kinds that they handle/service.
+
+Users can then search for all 10002 events with the `k` tags that they are interested in, and in response they will know which relays to contact these applications/DVMs on.
+
 ## Final Considerations
 
 1. Clients SHOULD guide users to keep `kind:10002` lists small (2-4 relays).


### PR DESCRIPTION
Simple addition to NIP-65 to allow DVMs and application handlers to be discovered without just probing random popular relays and hoping they published a 31990 there.