### PR TITLE
Remove reference to 'username' and update descriptions in metadata

### DIFF
--- a/01.md
+++ b/01.md
@@ -89,7 +89,7 @@ Kinds specify how clients should interpret the meaning of each event and the oth
 
 This NIP defines one basic kind:
 
-- `0`: **user metadata**: the `content` is set to a stringified JSON object `{name: <username>, about: <string>, picture: <url, string>}` describing the user who created the event. [Extra metadata fields](24.md#kind-0) may be set. A relay may delete older events once it gets a new one for the same pubkey.
+- `0`: **user metadata**: the `content` is set to a stringified JSON object `{name: <nickname or full name>, about: <short bio>, picture: <url of the image>}` describing the user who created the event. [Extra metadata fields](24.md#kind-0) may be set. A relay may delete older events once it gets a new one for the same pubkey.
 
 And also a convention for kind ranges that allow for easier experimentation and flexibility of relay implementation:
 


### PR DESCRIPTION
The reference to 'username', designed as identifying and unique elements often needed to login, is not correct since Nostr has not usernames.
In addition, field descriptions such as “string” are not very meaningful, and not consistent with other parts of the document.