### PR TITLE
Re-write NIP 89 to accommodate relays/dvms

### DIFF
--- a/89.md
+++ b/89.md
@@ -6,56 +6,40 @@ Recommended Application Handlers
 
 `draft` `optional`
 
-This NIP describes `kind:31989` and `kind:31990`: a way to discover applications that can handle unknown event-kinds.
+This NIP describes a way to discover different types of applications that can handle unknown event-kinds.
 
 ## Rationale
 
 Nostr's discoverability and transparent event interaction is one of its most interesting/novel mechanics.
 This NIP provides a simple way for clients to discover applications that handle events of a specific kind to ensure smooth cross-client and cross-kind interactions.
 
-### Parties involved
+## Overview
 
-There are three actors to this workflow:
+This NIP defines "application handlers", which are events intended to advertise support for a certain event kind. These handlers may be for several different types of nostr-related applications, including:
 
-* application that handles a specific event kind (note that an application doesn't necessarily need to be a distinct entity and it could just be the same pubkey as user A)
-    * Publishes `kind:31990`, detailing how apps should redirect to it
-* user A, who recommends an app that handles a specific event kind
-    * Publishes `kind:31989`
-* user B, who seeks a recommendation for an app that handles a specific event kind
-    * Queries for `kind:31989` and, based on results, queries for `kind:31990`
+- `31990` for nostr clients
+- `31991` for nostr DVMs
+- `31992` for nostr relays
 
-## Events
+This NIP also defines a `kind:31989` recommendation event which allows users to endorse application handlers.
 
-### Recommendation event
-```jsonc
-{
-  "kind": 31989,
-  "pubkey": <recommender-user-pubkey>,
-  "tags": [
-    ["d", <supported-event-kind>],
-    ["a", "31990:app1-pubkey:<d-identifier>", "wss://relay1", "ios"],
-    ["a", "31990:app2-pubkey:<d-identifier>", "wss://relay2", "web"]
-  ],
-  // other fields...
-}
-```
+## Client Handler
 
-The `d` tag in `kind:31989` is the supported event kind this event is recommending.
+A "client handler" is a `kind:31990` event which includes details about which event kinds are supported by a client, and how to send users to the application.
 
-Multiple `a` tags can appear on the same `kind:31989`.
+* `content` is an optional `metadata`-like stringified JSON object, as described in NIP-01. This content is useful when the pubkey creating the `kind:31990` is not an application. If `content` is empty, the `kind:0` of the pubkey should be used to display application information (e.g. name, picture, web, LUD16, etc.)
+* One or more `k` tags indicate the event kind(s) that are supported by this client.
+* One or more handler tags (`web|ios|android|<other>`) MUST be included, indicating url templates that other applications can use to redirect users to the client in question. The string `<bech32>` in a URL MUST be replaced by clients with the NIP-19-encoded entity that should be loaded by the application. An optional second argument indicates the type of NIP 19 entity expected.
 
-The second value of the tag SHOULD be a relay hint.
-The third value of the tag SHOULD be the platform where this recommendation might apply.
-
-## Handler information
 ```jsonc
 {
   "kind": 31990,
   "pubkey": "<application-pubkey>",
   "content": "<optional-kind:0-style-metadata>",
   "tags": [
-    ["d", <random-id>],
-    ["k", <supported-event-kind>],
+    ["d", 'EvAX3S1smP8'],
+    ["k", 1],
+    ["k", 20],
     ["web", "https://..../a/<bech32>", "nevent"],
     ["web", "https://..../p/<bech32>", "nprofile"],
     ["web", "https://..../e/<bech32>"],
@@ -65,19 +49,150 @@ The third value of the tag SHOULD be the platform where this recommendation migh
 }
 ```
 
+## DVM Handler
+
+A "DVM handler" is a `kind:31991` event which includes details about which event kinds are supported by a DVM, and how to send requests to the service.
+
 * `content` is an optional `metadata`-like stringified JSON object, as described in NIP-01. This content is useful when the pubkey creating the `kind:31990` is not an application. If `content` is empty, the `kind:0` of the pubkey should be used to display application information (e.g. name, picture, web, LUD16, etc.)
-* `k` tags' value is the event kind that is supported by this `kind:31990`.
-Using a `k` tag(s) (instead of having the kind of the `d` tag) provides:
-    * Multiple `k` tags can exist in the same event if the application supports more than one event kind and their handler URLs are the same.
-    * The same pubkey can have multiple events with different apps that handle the same event kind.
-* `bech32` in a URL MUST be replaced by clients with the NIP-19-encoded entity that should be loaded by the application.
+* One or more `k` tags indicate the event kind(s) that are supported by this DVM.
+* One or more `relay` tags MUST be included indicating relays that the DVM receives requests on.
 
-Multiple tags might be registered by the app, following NIP-19 nomenclature as the second value of the array.
+Example:
 
-A tag without a second value in the array SHOULD be considered a generic handler for any NIP-19 entity that is not handled by a different tag.
+```jsonc
+{
+  "kind": 31991,
+  "pubkey": "<application-pubkey>",
+  "content": "<optional-kind:0-style-metadata>",
+  "tags": [
+    ["d", 'lLrjDuVXfgk'],
+    ["k", 5300],
+    ["relay", "wss://my-dmv-relay.example.com/"],
+    ["relay", "wss://my-other-dmv-relay.example.com/"]
+  ],
+  // other fields...
+}
+```
 
-# Client tag
-When publishing events, clients MAY include a `client` tag. Identifying the client that published the note. This tag is a tuple of `name`, `address` identifying a handler event and, a relay `hint` for finding the handler event. This has privacy implications for users, so clients SHOULD allow users to opt-out of using this tag.
+## Relay Handler
+
+A "Relay handler" is a `kind:31992` event which includes details about how to reach the relay.
+
+* `content` is an optional `metadata`-like stringified JSON object, as described in NIP-01. This content is useful when the pubkey creating the `kind:31990` is not an application. If `content` is empty, the `kind:0` of the pubkey should be used to display application information (e.g. name, picture, web, LUD16, etc.)
+* One or more `r` tags MUST be included indicating urls that the relay is accessible on.
+
+Example:
+
+```jsonc
+{
+  "kind": 31991,
+  "pubkey": "<application-pubkey>",
+  "content": "<optional-kind:0-style-metadata>",
+  "tags": [
+    ["d", 'Ti2E8pDpt4k'],
+    ["r", "wss://nostr.sovbit.host/"],
+    ["r", "ws://sovbitgz5uqyh7jwcsudq4sspxlj4kbnurvd3xarkkx2use3k6rlibqd.onion/"],
+    ["r", "gnunet://fs/ksk/gpl"]
+  ],
+  // other fields...
+}
+```
+
+## Handler Recommendations
+
+A "handler recommendation" is an event that indicates that a given application is a good fit for handling some nostr kind in a certain context.
+
+- Its `d` tag MUST BE the supported event kind this event is recommending.
+- One or more `a` tags indicate recommended apps by nostr address. A relay hint MUST be included. If the recommended application is a client, the third tag argument SHOULD be a platform string.
+
+In order to recommend handlers for multiple kinds, users must publish multiple `kind:31989` events.
+
+```jsonc
+{
+  "kind": 31989,
+  "pubkey": <recommender-user-pubkey>,
+  "tags": [
+    ["d", <supported-event-kind>],
+    ["a", "31990:app1-pubkey:<d-identifier>", "wss://relay1", "ios"],
+    ["a", "31990:app2-pubkey:<d-identifier>", "wss://relay2", "web"],
+    ["a", "31991:app2-pubkey:<d-identifier>", "wss://relay3"]
+  ],
+  // other fields...
+}
+```
+
+## Example Flow
+
+There are three actors to this workflow:
+
+* A client that handles a specific event kind
+  * Publishes `kind:31990`, detailing how apps should redirect to it
+* User A, who recommends an app that handles a specific event kind
+  * Publishes `kind:31989`
+* User B, who seeks a recommendation for an app that handles a specific event kind
+  * Queries for `kind:31989` and, based on results, queries for `kind:31990`
+
+Let's say Alice has found a `kind:20` event in the wild, quoted in a kind 1 and her client doesn't render it except by showing its `alt` tag. In order to find recommendations from her social graph for clients that support `kind:20`, her client might send out a request with a filter something like this:
+
+```jsonc
+{
+  "authors": [<alice's follow list>],
+  "kinds": [31989],
+  "#d": [20]
+}
+```
+
+This will retrieve trusted recommendations for clients that support kind 20. One of them might look like this:
+
+```
+{
+  "kind": 31989,
+  "tags": [
+    ["d", "20"],
+    ["a", "31990:1743058db7078661b94aaf4286429d97ee5257d14a86d6bfa54cb0482b876fb0:Ebic0qwOQZ0", "wss://relay.example.com/", "web"]
+  ],
+  // other fields...
+}
+```
+
+Alice's client can them retrieve the referenced handler from `wss://relay.example.com/` (or the address pubkey's 10002 write relays) using the following filter:
+
+```
+{
+  "authors": ["1743058db7078661b94aaf4286429d97ee5257d14a86d6bfa54cb0482b876fb0"],
+  "kinds": [31990],
+  "#d": ["Ebic0qwOQZ0"]
+}
+```
+
+This would turn up an application handler that might look something like this:
+
+```
+{
+  "kind": 31990,
+  "pubkey": "<application-pubkey>",
+  "content": "<optional-kind:0-style-metadata>",
+  "tags": [
+    ["d", 'EvAX3S1smP8'],
+    ["k", 20],
+    ["web", "https://my-nostr-client.com/e/<bech32>"],
+    ["ios", ".../<bech32>"]
+  ],
+  // other fields...
+}
+```
+
+Alice's client can now show some indication that another client might be better suited to hande this event. She can then click a button (or something), and the client can fill out a template and redirect Alice. For example the `web` template might look like this:
+
+```
+https://my-nostr-client.com/e/nevent1qvzqqqqqzspzpq35r7yzkm4te5460u00jz4djcw0qa90zku7739qn7wj4ralhe4zqyvhwumn8ghj7urjv4kkjatd9ec8y6tdv9kzumn9wshsz9nhwden5te0wfjkccte9ekk7um5wgh8qatz9uq3wamnwvaz7tmjv4kxz7fwwpexjmtpdshxuet59uqzqu58spynxnvuxf75r6ayua69cpv02k8ehur3zplmt7t7w8ayaguaaxlhuq
+```
+
+Alternatively, users might choose to query directly for `kind:31990` for an event kind. Clients SHOULD be careful doing this and use spam-prevention mechanisms or querying high-quality restricted relays to avoid directing users to malicious handlers.
+
+# Appendix: Client Tag
+
+When publishing events, clients MAY include a `client` tag. Identifying the client or DVM that published the note on behalf of the user. This tag is a tuple of `name`, `address` identifying a handler event, and a relay `hint` for finding the handler event. This has privacy implications for users, so clients SHOULD allow users to opt-out of using this tag.
 
 ```jsonc
 {
@@ -87,47 +202,4 @@ When publishing events, clients MAY include a `client` tag. Identifying the clie
   ]
   // other fields...
 }
-```
-
-## User flow
-A user A who uses a non-`kind:1`-centric nostr app could choose to announce/recommend a certain kind-handler application.
-
-When user B sees an unknown event kind, e.g. in a social-media centric nostr client, the client would allow user B to interact with the unknown-kind event (e.g. tapping on it).
-
-The client MIGHT query for the user's and the user's follows handler.
-
-## Example
-
-### User A recommends a `kind:31337`-handler
-User A might be a user of Zapstr, a `kind:31337`-centric client (tracks). Using Zapstr, user A publishes an event recommending Zapstr as a `kind:31337`-handler.
-
-```jsonc
-{
-  "kind": 31989,
-  "tags": [
-    ["d", "31337"],
-    ["a", "31990:1743058db7078661b94aaf4286429d97ee5257d14a86d6bfa54cb0482b876fb0:abcd", <relay-url>, "web"]
-  ],
-  // other fields...
-}
-```
-
-### User B interacts with a `kind:31337`-handler
-User B might see in their timeline an event referring to a `kind:31337` event (e.g. a `kind:1` tagging a `kind:31337`).
-
-User B's client, not knowing how to handle a `kind:31337` might display the event using its `alt` tag (as described in NIP-31). When the user clicks on the event, the application queries for a handler for this `kind`:
-
-```
-["REQ", <id>, { "kinds": [31989], "#d": ["31337"], "authors": [<user>, <users-contact-list>] }]
-```
-
-User B, who follows User A, sees that `kind:31989` event and fetches the `a`-tagged event for the app and handler information.
-
-User B's client sees the application's `kind:31990` which includes the information to redirect the user to the relevant URL with the desired entity replaced in the URL.
-
-### Alternative query bypassing `kind:31989`
-Alternatively, users might choose to query directly for `kind:31990` for an event kind. Clients SHOULD be careful doing this and use spam-prevention mechanisms or querying high-quality restricted relays to avoid directing users to malicious handlers.
-
-```
-["REQ", <id>, { "kinds": [31990], "#k": [<desired-event-kind>], "authors": [...] }]
 ```

--- a/89.md
+++ b/89.md
@@ -17,33 +17,38 @@ This NIP provides a simple way for clients to discover applications that handle 
 
 This NIP defines "application handlers", which are events intended to advertise support for a certain event kind. These handlers may be for several different types of nostr-related applications, including:
 
-- `31990` for nostr clients
-- `31991` for nostr DVMs
-- `31992` for nostr relays
+- `11991` for nostr clients
+- `11992` for nostr DVMs
+- `11993` for nostr relays
+
+Applications SHOULD have their own nostr identity, and SHOULD publish a kind 0 profile, a kind 10002 relay list, and any other metadata events that may be helpful for consumers of the applications.
 
 This NIP also defines a `kind:31989` recommendation event which allows users to endorse application handlers.
 
 ## Client Handler
 
-A "client handler" is a `kind:31990` event which includes details about which event kinds are supported by a client, and how to send users to the application.
+A "client handler" is a `kind:11991` event which includes details about which event kinds are supported by a client, and how to send users to the application.
 
-* `content` is an optional `metadata`-like stringified JSON object, as described in NIP-01. This content is useful when the pubkey creating the `kind:31990` is not an application. If `content` is empty, the `kind:0` of the pubkey should be used to display application information (e.g. name, picture, web, LUD16, etc.)
+* `content` should be a human-readable description of the application
 * One or more `k` tags indicate the event kind(s) that are supported by this client.
-* One or more handler tags (`web|ios|android|<other>`) MUST be included, indicating url templates that other applications can use to redirect users to the client in question. The string `<bech32>` in a URL MUST be replaced by clients with the NIP-19-encoded entity that should be loaded by the application. An optional second argument indicates the type of NIP 19 entity expected.
+* One or more handler tags (`web|ios|android|<other>`) SHOULD be included, indicating url templates that other applications can use to redirect users to the client in question. The string `<bech32>` in a URL MUST be replaced by clients with the NIP-19-encoded entity that should be loaded by the application. An optional second argument indicates the type of NIP 19 entity expected.
+* Additional tags MAY be included for classifying the handler, pointing to secondary web resources, etc.
 
 ```jsonc
 {
-  "kind": 31990,
+  "kind": 11991,
   "pubkey": "<application-pubkey>",
-  "content": "<optional-kind:0-style-metadata>",
+  "content": "Xorx is a nostr app focused on short form and image posts.",
   "tags": [
-    ["d", 'EvAX3S1smP8'],
     ["k", 1],
     ["k", 20],
     ["web", "https://..../a/<bech32>", "nevent"],
     ["web", "https://..../p/<bech32>", "nprofile"],
     ["web", "https://..../e/<bech32>"],
-    ["ios", ".../<bech32>"]
+    ["ios", ".../<bech32>"],
+    ["t", "breakfast"],
+    ["r", "https://github.com/hzrd149/cherry-tree", "source"],
+    ["zap", "266815e0c9210dfa324c6cba3573b14bee49da4209a9456f9484e5106cd408a5", "wss://relay.nostr.band", "9"]
   ],
   // other fields...
 }
@@ -51,24 +56,20 @@ A "client handler" is a `kind:31990` event which includes details about which ev
 
 ## DVM Handler
 
-A "DVM handler" is a `kind:31991` event which includes details about which event kinds are supported by a DVM, and how to send requests to the service.
+A "DVM handler" is a `kind:11991` event which includes details about which event kinds are supported by a DVM, and how to send requests to the service.
 
-* `content` is an optional `metadata`-like stringified JSON object, as described in NIP-01. This content is useful when the pubkey creating the `kind:31990` is not an application. If `content` is empty, the `kind:0` of the pubkey should be used to display application information (e.g. name, picture, web, LUD16, etc.)
+* `content` should be a human-readable description of the application
 * One or more `k` tags indicate the event kind(s) that are supported by this DVM.
-* One or more `relay` tags MUST be included indicating relays that the DVM receives requests on.
 
 Example:
 
 ```jsonc
 {
-  "kind": 31991,
+  "kind": 11991,
   "pubkey": "<application-pubkey>",
-  "content": "<optional-kind:0-style-metadata>",
+  "content": "Xorx is a nostr DVM that provides content recommendations.",
   "tags": [
-    ["d", 'lLrjDuVXfgk'],
-    ["k", 5300],
-    ["relay", "wss://my-dmv-relay.example.com/"],
-    ["relay", "wss://my-other-dmv-relay.example.com/"]
+    ["k", 5300]
   ],
   // other fields...
 }
@@ -76,21 +77,21 @@ Example:
 
 ## Relay Handler
 
-A "Relay handler" is a `kind:31992` event which includes details about how to reach the relay.
+A "Relay handler" is a `kind:11992` event which includes details about how to reach the relay.
 
-* `content` is an optional `metadata`-like stringified JSON object, as described in NIP-01. This content is useful when the pubkey creating the `kind:31990` is not an application. If `content` is empty, the `kind:0` of the pubkey should be used to display application information (e.g. name, picture, web, LUD16, etc.)
+* `content` should be a human-readable description of the application
 * One or more `r` tags MUST be included indicating urls that the relay is accessible on.
 
 Example:
 
 ```jsonc
 {
-  "kind": 31991,
+  "kind": 11991,
   "pubkey": "<application-pubkey>",
-  "content": "<optional-kind:0-style-metadata>",
+  "content": "Xorx is a nostr relay.",
   "tags": [
-    ["d", 'Ti2E8pDpt4k'],
     ["r", "wss://nostr.sovbit.host/"],
+    ["r", "ws://127.0.0.1:8000/"],
     ["r", "ws://sovbitgz5uqyh7jwcsudq4sspxlj4kbnurvd3xarkkx2use3k6rlibqd.onion/"],
     ["r", "gnunet://fs/ksk/gpl"]
   ],
@@ -113,9 +114,9 @@ In order to recommend handlers for multiple kinds, users must publish multiple `
   "pubkey": <recommender-user-pubkey>,
   "tags": [
     ["d", <supported-event-kind>],
-    ["a", "31990:app1-pubkey:<d-identifier>", "wss://relay1", "ios"],
-    ["a", "31990:app2-pubkey:<d-identifier>", "wss://relay2", "web"],
-    ["a", "31991:app2-pubkey:<d-identifier>", "wss://relay3"]
+    ["a", "11991:<app1-pubkey>", "wss://relay1", "ios"],
+    ["a", "11991:<app2-pubkey>", "wss://relay2", "web"],
+    ["a", "11992:<app2-pubkey>", "wss://relay3"]
   ],
   // other fields...
 }
@@ -126,11 +127,11 @@ In order to recommend handlers for multiple kinds, users must publish multiple `
 There are three actors to this workflow:
 
 * A client that handles a specific event kind
-  * Publishes `kind:31990`, detailing how apps should redirect to it
+  * Publishes `kind:11991`, detailing how apps should redirect to it
 * User A, who recommends an app that handles a specific event kind
   * Publishes `kind:31989`
 * User B, who seeks a recommendation for an app that handles a specific event kind
-  * Queries for `kind:31989` and, based on results, queries for `kind:31990`
+  * Queries for `kind:31989` and, based on results, queries for `kind:11991`
 
 Let's say Alice has found a `kind:20` event in the wild, quoted in a kind 1 and her client doesn't render it except by showing its `alt` tag. In order to find recommendations from her social graph for clients that support `kind:20`, her client might send out a request with a filter something like this:
 
@@ -149,7 +150,7 @@ This will retrieve trusted recommendations for clients that support kind 20. One
   "kind": 31989,
   "tags": [
     ["d", "20"],
-    ["a", "31990:1743058db7078661b94aaf4286429d97ee5257d14a86d6bfa54cb0482b876fb0:Ebic0qwOQZ0", "wss://relay.example.com/", "web"]
+    ["a", "11991:1743058db7078661b94aaf4286429d97ee5257d14a86d6bfa54cb0482b876fb0", "wss://relay.example.com/", "web"]
   ],
   // other fields...
 }
@@ -160,8 +161,7 @@ Alice's client can them retrieve the referenced handler from `wss://relay.exampl
 ```
 {
   "authors": ["1743058db7078661b94aaf4286429d97ee5257d14a86d6bfa54cb0482b876fb0"],
-  "kinds": [31990],
-  "#d": ["Ebic0qwOQZ0"]
+  "kinds": [11991]
 }
 ```
 
@@ -169,11 +169,10 @@ This would turn up an application handler that might look something like this:
 
 ```
 {
-  "kind": 31990,
+  "kind": 11991,
   "pubkey": "<application-pubkey>",
-  "content": "<optional-kind:0-style-metadata>",
+  "content": "Xorx is an application that supports kind 20 image posts.",
   "tags": [
-    ["d", 'EvAX3S1smP8'],
     ["k", 20],
     ["web", "https://my-nostr-client.com/e/<bech32>"],
     ["ios", ".../<bech32>"]
@@ -188,7 +187,7 @@ Alice's client can now show some indication that another client might be better 
 https://my-nostr-client.com/e/nevent1qvzqqqqqzspzpq35r7yzkm4te5460u00jz4djcw0qa90zku7739qn7wj4ralhe4zqyvhwumn8ghj7urjv4kkjatd9ec8y6tdv9kzumn9wshsz9nhwden5te0wfjkccte9ekk7um5wgh8qatz9uq3wamnwvaz7tmjv4kxz7fwwpexjmtpdshxuet59uqzqu58spynxnvuxf75r6ayua69cpv02k8ehur3zplmt7t7w8ayaguaaxlhuq
 ```
 
-Alternatively, users might choose to query directly for `kind:31990` for an event kind. Clients SHOULD be careful doing this and use spam-prevention mechanisms or querying high-quality restricted relays to avoid directing users to malicious handlers.
+Alternatively, users might choose to query directly for `kind:11991` for an event kind. Clients SHOULD be careful doing this and use spam-prevention mechanisms or querying high-quality restricted relays to avoid directing users to malicious handlers.
 
 # Appendix: Client Tag
 
@@ -198,8 +197,34 @@ When publishing events, clients MAY include a `client` tag. Identifying the clie
 {
   "kind": 1,
   "tags": [
-    ["client", "My Client", "31990:app1-pubkey:<d-identifier>", "wss://relay1"]
+    ["client", "My Client", "11991:<app1-pubkey>", "wss://relay1"]
   ]
+  // other fields...
+}
+```
+
+# Appendix: Legacy Handlers
+
+In the past, handlers were designed to be self-contained metadata events published by application developers, rather than a dedicated application pubkey. This section describes the legacy `kind:31990` "legacy handler" event.
+
+* `content` is an optional `metadata`-like stringified JSON object, as described in NIP-01. This content is useful when the pubkey creating the `kind:31990` is not an application. If `content` is empty, the `kind:0` of the pubkey should be used to display application information (e.g. name, picture, web, LUD16, etc.)
+* One or more `k` tags indicate the event kind(s) that are supported by this client.
+* One or more handler tags (`web|ios|android|<other>`) MUST be included, indicating url templates that other applications can use to redirect users to the client in question. The string `<bech32>` in a URL MUST be replaced by clients with the NIP-19-encoded entity that should be loaded by the application. An optional second argument indicates the type of NIP 19 entity expected.
+
+```jsonc
+{
+  "kind": 31990,
+  "pubkey": "<application-pubkey>",
+  "content": "<kind0-style-metadata>",
+  "tags": [
+    ["d", 'EvAX3S1smP8'],
+    ["k", 1],
+    ["k", 20],
+    ["web", "https://..../a/<bech32>", "nevent"],
+    ["web", "https://..../p/<bech32>", "nprofile"],
+    ["web", "https://..../e/<bech32>"],
+    ["ios", ".../<bech32>"]
+  ],
   // other fields...
 }
 ```

--- a/89.md
+++ b/89.md
@@ -1,8 +1,8 @@
 NIP-89
 ======
 
-Recommended Application Handlers
---------------------------------
+Application Handlers
+--------------------
 
 `draft` `optional`
 
@@ -23,7 +23,7 @@ This NIP defines "application handlers", which are events intended to advertise 
 
 Applications SHOULD have their own nostr identity, and SHOULD publish a kind 0 profile, a kind 10002 relay list, and any other metadata events that may be helpful for consumers of the applications.
 
-This NIP also defines a `kind:31989` recommendation event which allows users to endorse application handlers.
+This NIP also defines a `kind:31989` application selection event which allows users to configure their default application handlers.
 
 ## Client Handler
 
@@ -40,8 +40,8 @@ A "client handler" is a `kind:11991` event which includes details about which ev
   "pubkey": "<application-pubkey>",
   "content": "Xorx is a nostr app focused on short form and image posts.",
   "tags": [
-    ["k", 1],
-    ["k", 20],
+    ["k", "1"],
+    ["k", "20"],
     ["web", "https://..../a/<bech32>", "nevent"],
     ["web", "https://..../p/<bech32>", "nprofile"],
     ["web", "https://..../e/<bech32>"],
@@ -69,7 +69,7 @@ Example:
   "pubkey": "<application-pubkey>",
   "content": "Xorx is a nostr DVM that provides content recommendations.",
   "tags": [
-    ["k", 5300]
+    ["k", "5300"]
   ],
   // other fields...
 }
@@ -99,19 +99,19 @@ Example:
 }
 ```
 
-## Handler Recommendations
+## Handler selections
 
-A "handler recommendation" is an event that indicates that a given application is a good fit for handling some nostr kind in a certain context.
+A "handler selection" is an event that indicates that a given application is a good fit for handling some nostr kind in a certain context.
 
-- Its `d` tag MUST BE the supported event kind this event is recommending.
-- One or more `a` tags indicate recommended apps by nostr address. A relay hint MUST be included. If the recommended application is a client, the third tag argument SHOULD be a platform string.
+- Its `d` tag MUST BE the supported event kind this event is selecting applications for.
+- One or more `a` tags indicate selected apps by nostr address. A relay hint MUST be included. If the selected application is a client, the third tag argument SHOULD be a platform string.
 
-In order to recommend handlers for multiple kinds, users must publish multiple `kind:31989` events.
+In order to select handlers for multiple kinds, users must publish multiple `kind:31989` events.
 
 ```jsonc
 {
   "kind": 31989,
-  "pubkey": <recommender-user-pubkey>,
+  "pubkey": <user-pubkey>,
   "tags": [
     ["d", <supported-event-kind>],
     ["a", "11991:<app1-pubkey>", "wss://relay1", "ios"],
@@ -122,28 +122,30 @@ In order to recommend handlers for multiple kinds, users must publish multiple `
 }
 ```
 
-## Example Flow
+## Recommendation Flow
 
-There are three actors to this workflow:
+Kind `31989` selection events MAY be used to recommend applications to other users, but they SHOULD NOT be treated as unqualified endorsements.
+
+There are three actors in this workflow:
 
 * A client that handles a specific event kind
   * Publishes `kind:11991`, detailing how apps should redirect to it
-* User A, who recommends an app that handles a specific event kind
+* User A, who selects an app that handles a specific event kind
   * Publishes `kind:31989`
-* User B, who seeks a recommendation for an app that handles a specific event kind
+* User B, who is looking an app that handles a specific event kind
   * Queries for `kind:31989` and, based on results, queries for `kind:11991`
 
-Let's say Alice has found a `kind:20` event in the wild, quoted in a kind 1 and her client doesn't render it except by showing its `alt` tag. In order to find recommendations from her social graph for clients that support `kind:20`, her client might send out a request with a filter something like this:
+Let's say Alice has found a `kind:20` event in the wild, quoted in a kind 1 and her client doesn't render it except by showing its `alt` tag. In order to find people in her social graph who use clients that support `kind:20`, her client might send out a request with a filter something like this:
 
 ```jsonc
 {
   "authors": [<alice's follow list>],
   "kinds": [31989],
-  "#d": [20]
+  "#d": ["20"]
 }
 ```
 
-This will retrieve trusted recommendations for clients that support kind 20. One of them might look like this:
+This will retrieve usage data for clients that support kind 20. One of them might look like this:
 
 ```
 {
@@ -173,7 +175,7 @@ This would turn up an application handler that might look something like this:
   "pubkey": "<application-pubkey>",
   "content": "Xorx is an application that supports kind 20 image posts.",
   "tags": [
-    ["k", 20],
+    ["k", "20"],
     ["web", "https://my-nostr-client.com/e/<bech32>"],
     ["ios", ".../<bech32>"]
   ],
@@ -218,8 +220,8 @@ In the past, handlers were designed to be self-contained metadata events publish
   "content": "<kind0-style-metadata>",
   "tags": [
     ["d", 'EvAX3S1smP8'],
-    ["k", 1],
-    ["k", 20],
+    ["k", "1"],
+    ["k", "20"],
     ["web", "https://..../a/<bech32>", "nevent"],
     ["web", "https://..../p/<bech32>", "nprofile"],
     ["web", "https://..../e/<bech32>"],

--- a/90.md
+++ b/90.md
@@ -209,22 +209,5 @@ Service Providers MAY begin processing a subsequent job the moment they see the 
 This gives a higher level of flexibility to service providers (which sophisticated service providers would take anyway).
 
 # Appendix 2: Service provider discoverability
-Service Providers MAY use NIP-89 announcements to advertise their support for job kinds:
 
-```jsonc
-{
-  "kind": 31990,
-  "pubkey": "<pubkey>",
-  "content": "{
-    \"name\": \"Translating DVM\",
-    \"about\": \"I'm a DVM specialized in translating Bitcoin content.\"
-  }",
-  "tags": [
-    ["k", "5005"], // e.g. translation
-    ["t", "bitcoin"] // e.g. optionally advertises it specializes in bitcoin audio transcription that won't confuse "Drivechains" with "Ridechains"
-  ],
-  // other fields...
-}
-```
-
-Customers can use NIP-89 to see what service providers their follows use.
+Service Providers MAY use a [NIP-89](89.md) DVM handler to advertise their support for job kinds. For historical reasons, there may also be DVMs listed via the "client handler" event kind as well.

--- a/README.md
+++ b/README.md
@@ -227,7 +227,10 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `31924`       | Calendar                        | [52](52.md)                            |
 | `31925`       | Calendar Event RSVP             | [52](52.md)                            |
 | `31989`       | Handler recommendation          | [89](89.md)                            |
-| `31990`       | Handler information             | [89](89.md)                            |
+| `31990`       | Legacy handler                  | [89](89.md)                            |
+| `31991`       | Client handler                  | [89](89.md)                            |
+| `31992`       | DVM handler                     | [89](89.md)                            |
+| `31993`       | Relay handler                   | [89](89.md)                            |
 | `32267`       | Software Application            |                                        |
 | `34235`       | Video Event                     | [71](71.md)                            |
 | `34236`       | Short-form Portrait Video Event | [71](71.md)                            |

--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `10050`       | Relay list to receive DMs       | [51](51.md), [17](17.md)               |
 | `10063`       | User server list                | [Blossom][blossom]                     |
 | `10096`       | File storage server list        | [96](96.md)                            |
+| `11991`       | Client handler                  | [89](89.md)                            |
+| `11992`       | DVM handler                     | [89](89.md)                            |
+| `11993`       | Relay handler                   | [89](89.md)                            |
 | `13194`       | Wallet Info                     | [47](47.md)                            |
 | `21000`       | Lightning Pub RPC               | [Lightning.Pub][lnpub]                 |
 | `22242`       | Client Authentication           | [42](42.md)                            |
@@ -228,9 +231,6 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `31925`       | Calendar Event RSVP             | [52](52.md)                            |
 | `31989`       | Handler recommendation          | [89](89.md)                            |
 | `31990`       | Legacy handler                  | [89](89.md)                            |
-| `31991`       | Client handler                  | [89](89.md)                            |
-| `31992`       | DVM handler                     | [89](89.md)                            |
-| `31993`       | Relay handler                   | [89](89.md)                            |
 | `32267`       | Software Application            |                                        |
 | `34235`       | Video Event                     | [71](71.md)                            |
 | `34236`       | Short-form Portrait Video Event | [71](71.md)                            |


### PR DESCRIPTION
This is a just a draft/RFC. Most of the changes are just a re-write of what already was there, but I've added two new event kinds for DVMs and relays.

I added a new kind for DVMs for a few reasons:

- DVMs aren't really clients in the same way as software with a UI is. It would be valid for a client to specialize in generating kind 5300 requests and displaying kind 6300 events. If such a listing existed, there would be ambiguity about what was a DVM and what was a client, since "handling" here is overloaded.
- Implicit in the current (31990) spec is that DVMs need to publish a kind 10002 list of relays. But since multiple app handlers may be published by the same pubkey (which might belong to a normal user), we've now overloaded the kind 10002 relays to be both for personal use and service fulfillment.

I added a new kind for relays because:

- There has been some talk recently about addressing relays by pubkey rather than by url, since there may be multiple ways of addressing a single relay (clear net, onion, etc). A "relay handler" listing would be a first step toward enabling this.

Neither of the additions is supported yet, so this should wait until some DVMs and/or relays have implemented the changes. But I'm interested to see what people think.