### PR TITLE
Include advice on where to contact DVMs at

### DIFF
--- a/90.md
+++ b/90.md
@@ -228,3 +228,5 @@ Service Providers MAY use NIP-89 announcements to advertise their support for jo
 ```
 
 Customers can use NIP-89 to see what service providers their follows use.
+
+Unlike other NIP-89 handlers, DVM handlers don't offer a URL where they can be accessed. Instead they SHOULD publish a `kind:10002` [NIP-65](65.md) relay list indicating which relays they will be listening on for job requests.


### PR DESCRIPTION
Unlike other NIP-89 handlers which may include web links or application links,  kind 31990 for DVMs offer no information about where the DVM is at.

But upon inspection I discovered that all the DVMs I checked publish kind:10002 relay lists.

So I thought it would be a good idea to mention this in the NIP so other people don't have to probe around and figure it out.