### PR TITLE
nip60/61 updates and simplifications

### DIFF
--- a/60.md
+++ b/60.md
@@ -37,12 +37,8 @@ This NIP doesn't deal with users' *receiving* money from someone else, it's just
 The wallet event is an addressable event `kind:17375`.
 
 Tags:
-* `d` - wallet ID.
 * `mint` - Mint(s) this wallet uses -- there MUST be one or more mint tags.
 * `privkey` - Private key used to unlock P2PK ecash. MUST be stored encrypted in the `.content` field. **This is a different private key exclusively used for the wallet, not associated in any way to the user's Nostr private key** -- This is only used for receiving [NIP-61](61.md) nutzaps.
-
-### Deleting a wallet event
-Due to addressable event being hard to delete, if a user wants to delete a wallet, they should empty the event and keep just the `d` identifier and add a `deleted` tag.
 
 ## Token Event
 Token events are used to record unspent proofs.

--- a/60.md
+++ b/60.md
@@ -1,5 +1,9 @@
-# NIP-60
-## Cashu Wallet
+NIP-60
+======
+
+Cashu Wallets
+-------------
+
 `draft` `optional`
 
 This NIP defines the operations of a cashu-based wallet.
@@ -22,19 +26,18 @@ This NIP doesn't deal with users' *receiving* money from someone else, it's just
 {
     "kind": 37375,
     "content": nip44_encrypt([
-        [ "balance", "100", "sat" ],
-        [ "privkey", "hexkey" ] // explained in NIP-61
+        [ "privkey", "hexkey" ],
+        [ "name", "my shitposting wallet" ],
+        [ "description", "a wallet for my day-to-day shitposting" ],
+        [ "mint", "https://mint1" ]
+        // optionally "mint" and "unit" could go here
     ]),
     "tags": [
         [ "d", "my-wallet" ],
-        [ "mint", "https://mint1" ],
         [ "mint", "https://mint2" ],
         [ "mint", "https://mint3" ],
-        [ "name", "my shitposting wallet" ],
-        [ "unit", "sat" ],
-        [ "description", "a wallet for my day-to-day shitposting" ],
-        [ "relay", "wss://relay1" ],
-        [ "relay", "wss://relay2" ],
+        [ "unit", "sat" ]
+        // optionally "name" and "description" could go here
     ]
 }
 ```
@@ -44,14 +47,13 @@ The wallet event is an addressable event `kind:37375`.
 Tags:
 * `d` - wallet ID.
 * `mint` - Mint(s) this wallet uses -- there MUST be one or more mint tags.
-* `relay` - Relays where the wallet and related events can be found. -- one ore more relays SHOULD be specified. If missing, clients should follow [[NIP-65]].
 * `unit` - Base unit of the wallet (e.g. "sat", "usd", etc).
 * `name` - Optional human-readable name for the wallet.
 * `description` - Optional human-readable description of the wallet.
 * `balance` - Optional best-effort balance of the wallet that can serve as a placeholder while an accurate balance is computed from fetching all unspent proofs.
-* `privkey` - Private key used to unlock P2PK ecash. MUST be stored encrypted in the `.content` field. **This is a different private key exclusively used for the wallet, not associated in any way to the user's nostr private key** -- This is only used when receiving funds from others, described in NIP-61.
+* `privkey` - Private key used to unlock P2PK ecash. MUST be stored encrypted in the `.content` field. **This is a different private key exclusively used for the wallet, not associated in any way to the user's Nostr private key** -- This is only used for receiving [NIP-61](61.md) nutzaps.
 
-Any tag, other than the `d` tag, can be [[NIP-44]] encrypted into the `.content` field.
+The client or user MAY decide to put some tags either inside the encrypted `.content` or under the public `.tags`, `name` and `description`, for example. However, `d` MUST always be a public tag, and `mint` and `unit` must be public if the user intends to receive [NIP-61](61.md) nutzaps.
 
 ### Deleting a wallet event
 Due to addressable event being hard to delete, if a user wants to delete a wallet, they should empty the event and keep just the `d` identifier and add a `deleted` tag.
@@ -67,6 +69,7 @@ There can be multiple `kind:7375` events for the same mint, and multiple proofs 
     "content": nip44_encrypt({
         "mint": "https://stablenut.umint.cash",
         "proofs": [
+            // one or more proofs in the default cashu format
             {
                 "id": "005c2502034d4f12",
                 "amount": 1,
@@ -74,8 +77,8 @@ There can be multiple `kind:7375` events for the same mint, and multiple proofs 
                 "C": "0241d98a8197ef238a192d47edf191a9de78b657308937b4f7dd0aa53beae72c46"
             }
         ],
-        // tokens that were destroyed in the creation of this token
-        "del": [ "token-id-1" ]
+        // tokens that were destroyed in the creation of this token (helps on wallet state transitions)
+        "del": [ "token-event-id-1", "token-event-id-2" ]
     }),
     "tags": [
         [ "a", "37375:<pubkey>:my-wallet" ]
@@ -84,13 +87,15 @@ There can be multiple `kind:7375` events for the same mint, and multiple proofs 
 ```
 
  * `a` an optional tag linking the token to a specific wallet.
- * `.content` is a [[NIP-44]] encrypted payload:
+ * `.content` is a [NIP-44](44.md) encrypted payload:
    * `mint`: The mint the proofs belong to.
    * `proofs`: unecoded proofs
    * `del`: token-ids that were destroyed by the creation of this token. This assists with state transitions.
 
 ### Spending proofs
-When one or more proofs of a token are spent, the token event should be [[NIP-09]]-deleted and, if some proofs are unspent from the same token event, a new token event should be created rolling over the unspent proofs and adding any change outputs to the new token event.
+When one or more proofs of a token are spent, the token event should be [NIP-09](09.md)-deleted and, if some proofs are unspent from the same token event, a new token event should be created rolling over the unspent proofs and adding any change outputs to the new token event (the change output should include a `del` field).
+
+The `kind:5` _delete event_ created in the [NIP-09](09.md) process MUST have a tag `["k", "7375"]` to allow easy filtering by clients interested in state transitions.
 
 ## Spending History Event
 Clients SHOULD publish `kind:7376` events to create a transaction history when their balance changes.
@@ -115,14 +120,14 @@ Clients SHOULD publish `kind:7376` events to create a transaction history when t
 Clients MUST add `e` tags to create references of destroyed and created token events along with the marker of the meaning of the tag:
 * `created` - A new token event was created.
 * `destroyed` - A token event was destroyed.
-* `redeemed` - A [[NIP-61]] nutzap was redeemed.
+* `redeemed` - A [NIP-61](61.md) nutzap was redeemed.
 
-All tags can be [[NIP-44]] encrypted. Clients SHOULD leave `e` tags with a `redeemed` marker unencrypted.
+like on Wallet events, clients or users may choose to encrypt all tags except for `a` tags and `e` tags with a `redeemed` marker unencrypted.
 
 Multiple `e` tags can be added to a `kind:7376` event.
 
 # Flow
-A client that wants to check for user's wallets information starts by fetching `kind:10019` events from the user's relays, if no event is found, it should fall back to using the user's [[NIP-65]] relays.
+A client that wants to check for user's wallets information starts by fetching `kind:10019` events from the user's relays, if no event is found, it should fall back to using the user's [NIP-65](65.md) relays.
 
 ## Fetch wallet and token list
 From those relays, the client should fetch wallet and token events.
@@ -130,7 +135,7 @@ From those relays, the client should fetch wallet and token events.
 `"kinds": [37375, 7375], "authors": ["<my-pubkey>"]`
 
 ## Fetch proofs
-While the client is fetching (and perhaps validating) proofs it can use the optional `balance` tag of the wallet event to display a estimate of the balance of the wallet.
+While the client is fetching (and perhaps validating) proofs it can use the optional `balance` tag of the _wallet event_ to display a estimate of the balance of the wallet.
 
 ## Spending token
 If Alice spends 4 sats from this token event
@@ -192,9 +197,9 @@ Her client:
 ```
 
 ## Redeeming a quote (optional)
-When creating a quote at a mint, an event can be used to keep the state of the quote ID, which will be used to check when the quote has been paid. These events should be created with an expiration tag [[NIP-40]] matching the expiration of the bolt11 received from the mint; this signals to relays when they can safely discard these events.
+When creating a quote at a mint, an event can be used to keep the state of the quote ID, which will be used to check when the quote has been paid. These events should be created with an expiration tag [NIP-40](40.md) of 2 weeks (which is around the maximum amount of time a Lightning payment may be pending).
 
-Application developers are encouraged to use local state when possible and only publish this event when it makes sense in the context of their application.
+However, application developers SHOULD use local state when possible and only publish this event when it makes sense in the context of their application.
 
 ```jsonc
 {

--- a/60.md
+++ b/60.md
@@ -17,42 +17,29 @@ The purpose of this NIP is:
 This NIP doesn't deal with users' *receiving* money from someone else, it's just to keep state of the user's wallet.
 
 # High-level flow
-1. A user has a `kind:37375` event that represents a wallet.
+1. A user has a `kind:17375` event that represents a wallet.
 2. A user has `kind:7375` events that represent the unspent proofs of the wallet. -- The proofs are encrypted with the user's private key.
 3. A user has `kind:7376` events that represent the spending history of the wallet -- This history is for informational purposes only and is completely optional.
 
 ## Wallet Event
 ```jsonc
 {
-    "kind": 37375,
+    "kind": 17375,
     "content": nip44_encrypt([
         [ "privkey", "hexkey" ],
-        [ "name", "my shitposting wallet" ],
-        [ "description", "a wallet for my day-to-day shitposting" ],
-        [ "mint", "https://mint1" ]
-        // optionally "mint" and "unit" could go here
+        [ "mint", "https://mint1" ],
+        [ "mint", "https://mint2" ]
     ]),
-    "tags": [
-        [ "d", "my-wallet" ],
-        [ "mint", "https://mint2" ],
-        [ "mint", "https://mint3" ],
-        [ "unit", "sat" ]
-        // optionally "name" and "description" could go here
-    ]
+    "tags": []
 }
 ```
 
-The wallet event is an addressable event `kind:37375`.
+The wallet event is an addressable event `kind:17375`.
 
 Tags:
 * `d` - wallet ID.
 * `mint` - Mint(s) this wallet uses -- there MUST be one or more mint tags.
-* `unit` - Base unit of the wallet (e.g. "sat", "usd", etc).
-* `name` - Optional human-readable name for the wallet.
-* `description` - Optional human-readable description of the wallet.
 * `privkey` - Private key used to unlock P2PK ecash. MUST be stored encrypted in the `.content` field. **This is a different private key exclusively used for the wallet, not associated in any way to the user's Nostr private key** -- This is only used for receiving [NIP-61](61.md) nutzaps.
-
-The client or user MAY decide to put some tags either inside the encrypted `.content` or under the public `.tags`, `name` and `description`, for example. However, `d` MUST always be a public tag, and `mint` and `unit` must be public if the user intends to receive [NIP-61](61.md) nutzaps.
 
 ### Deleting a wallet event
 Due to addressable event being hard to delete, if a user wants to delete a wallet, they should empty the event and keep just the `d` identifier and add a `deleted` tag.
@@ -79,13 +66,10 @@ There can be multiple `kind:7375` events for the same mint, and multiple proofs 
         // tokens that were destroyed in the creation of this token (helps on wallet state transitions)
         "del": [ "token-event-id-1", "token-event-id-2" ]
     }),
-    "tags": [
-        [ "a", "37375:<pubkey>:my-wallet" ]
-    ]
+    "tags": []
 }
 ```
 
- * `a` an optional tag linking the token to a specific wallet.
  * `.content` is a [NIP-44](44.md) encrypted payload:
    * `mint`: The mint the proofs belong to.
    * `proofs`: unecoded proofs
@@ -104,26 +88,23 @@ Clients SHOULD publish `kind:7376` events to create a transaction history when t
     "kind": 7376,
     "content": nip44_encrypt([
         [ "direction", "in" ], // in = received, out = sent
-        [ "amount", "1", "sat" ],
-        [ "e", "<event-id-of-created-token>", "<relay-hint>", "created" ],
+        [ "amount", "1" ],
+        [ "e", "<event-id-of-created-token>", "", "created" ]
     ]),
     "tags": [
-        [ "a", "37375:<pubkey>:my-wallet" ],
+        [ "e", "<event-id-of-created-token>", "", "redeemed" ]
     ]
 }
 ```
 
 * `direction` - The direction of the transaction; `in` for received funds, `out` for sent funds.
-* `a` - The wallet the transaction is related to.
 
 Clients MUST add `e` tags to create references of destroyed and created token events along with the marker of the meaning of the tag:
 * `created` - A new token event was created.
 * `destroyed` - A token event was destroyed.
 * `redeemed` - A [NIP-61](61.md) nutzap was redeemed.
 
-like on Wallet events, clients or users may choose to encrypt all tags except for `a` tags and `e` tags with a `redeemed` marker unencrypted.
-
-Multiple `e` tags can be added to a `kind:7376` event.
+Multiple `e` tags can be added, and should be encrypted, except for tags with the `redeemed` marker.
 
 # Flow
 A client that wants to check for user's wallets information starts by fetching `kind:10019` events from the user's relays, if no event is found, it should fall back to using the user's [NIP-65](65.md) relays.
@@ -131,7 +112,7 @@ A client that wants to check for user's wallets information starts by fetching `
 ## Fetch wallet and token list
 From those relays, the client should fetch wallet and token events.
 
-`"kinds": [37375, 7375], "authors": ["<my-pubkey>"]`
+`"kinds": [17375, 7375], "authors": ["<my-pubkey>"]`
 
 ## Fetch proofs
 
@@ -150,9 +131,7 @@ If Alice spends 4 sats from this token event
             { "id": "4", "amount": 8 },
         ]
     }),
-    "tags": [
-        [ "a", "37375:<pubkey>:my-wallet" ]
-    ]
+    "tags": []
 }
 ```
 
@@ -171,9 +150,7 @@ Her client:
         ],
         "del": [ "event-id-1" ]
     }),
-    "tags": [
-        [ "a", "37375:<pubkey>:my-wallet" ]
-    ]
+    "tags": []
 }
 ```
 * MUST delete event `event-id-1`
@@ -185,17 +162,15 @@ Her client:
     "content": nip44_encrypt([
         [ "direction", "out" ],
         [ "amount", "4", "sats" ],
-        [ "e", "<event-id-1>", "<relay-hint>", "destroyed" ],
-        [ "e", "<event-id-2>", "<relay-hint>", "created" ],
+        [ "e", "<event-id-1>", "", "destroyed" ],
+        [ "e", "<event-id-2>", "", "created" ],
     ]),
-    "tags": [
-        [ "a", "37375:<pubkey>:my-wallet" ],
-    ]
+    "tags": []
 }
 ```
 
 ## Redeeming a quote (optional)
-When creating a quote at a mint, an event can be used to keep the state of the quote ID, which will be used to check when the quote has been paid. These events should be created with an expiration tag [NIP-40](40.md) of 2 weeks (which is around the maximum amount of time a Lightning payment may be pending).
+When creating a quote at a mint, an event can be used to keep the state of the quote ID, which will be used to check when the quote has been paid. These events should be created with an expiration tag [NIP-40](40.md) of 2 weeks (which is around the maximum amount of time a Lightning payment may be in-flight).
 
 However, application developers SHOULD use local state when possible and only publish this event when it makes sense in the context of their application.
 
@@ -205,8 +180,7 @@ However, application developers SHOULD use local state when possible and only pu
     "content": nip44_encrypt("quote-id"),
     "tags": [
         [ "expiration", "<expiration-timestamp>" ],
-        [ "mint", "<mint-url>" ],
-        [ "a", "37375:<pubkey>:my-wallet" ]
+        [ "mint", "<mint-url>" ]
     ]
 }
 ```

--- a/60.md
+++ b/60.md
@@ -134,7 +134,6 @@ From those relays, the client should fetch wallet and token events.
 `"kinds": [37375, 7375], "authors": ["<my-pubkey>"]`
 
 ## Fetch proofs
-While the client is fetching (and perhaps validating) proofs it can use the optional `balance` tag of the _wallet event_ to display a estimate of the balance of the wallet.
 
 ## Spending token
 If Alice spends 4 sats from this token event

--- a/60.md
+++ b/60.md
@@ -50,7 +50,6 @@ Tags:
 * `unit` - Base unit of the wallet (e.g. "sat", "usd", etc).
 * `name` - Optional human-readable name for the wallet.
 * `description` - Optional human-readable description of the wallet.
-* `balance` - Optional best-effort balance of the wallet that can serve as a placeholder while an accurate balance is computed from fetching all unspent proofs.
 * `privkey` - Private key used to unlock P2PK ecash. MUST be stored encrypted in the `.content` field. **This is a different private key exclusively used for the wallet, not associated in any way to the user's Nostr private key** -- This is only used for receiving [NIP-61](61.md) nutzaps.
 
 The client or user MAY decide to put some tags either inside the encrypted `.content` or under the public `.tags`, `name` and `description`, for example. However, `d` MUST always be a public tag, and `mint` and `unit` must be public if the user intends to receive [NIP-61](61.md) nutzaps.

--- a/60.md
+++ b/60.md
@@ -34,7 +34,7 @@ This NIP doesn't deal with users' *receiving* money from someone else, it's just
 }
 ```
 
-The wallet event is an addressable event `kind:17375`.
+The wallet event is an replaceable event `kind:17375`.
 
 Tags:
 * `mint` - Mint(s) this wallet uses -- there MUST be one or more mint tags.
@@ -157,7 +157,7 @@ Her client:
     "kind": 7376,
     "content": nip44_encrypt([
         [ "direction", "out" ],
-        [ "amount", "4", "sats" ],
+        [ "amount", "4" ],
         [ "e", "<event-id-1>", "", "destroyed" ],
         [ "e", "<event-id-2>", "", "created" ],
     ]),

--- a/61.md
+++ b/61.md
@@ -1,14 +1,19 @@
-# NIP-61:
-## Nut Zaps
+NIP-61
+======
 
-A Nut Zap is a P2PK cashu token where the payment itself is the receipt.
+Nutzaps
+-------
+
+`draft` `optional`
+
+A Nutzap is a P2PK Cashu token in which the payment itself is the receipt.
 
 # High-level flow
 Alice wants to nutzap 1 sat to Bob because of an event `event-id-1` she liked.
 
 ## Alice nutzaps Bob
 1. Alice fetches event `kind:10019` from Bob to see the mints Bob trusts.
-2. She mints a token at that mint (or swaps some tokens she already had in that mint) p2pk-locked to the pubkey Bob has listed in his `kind:10019`.
+2. She mints a token at that mint (or swaps some tokens she already had in that mint) P2PK-locked to the pubkey Bob has listed in his `kind:10019`.
 3. She publishes a `kind:9321` event to the relays Bob indicated with the proofs she minted.
 
 ## Bob receives the nutzap
@@ -29,16 +34,15 @@ Alice wants to nutzap 1 sat to Bob because of an event `event-id-1` she liked.
 }
 ```
 
-`kind:10019` is an event that is useful for others to know how to send money to the user.
-
-* `relay` - Relays where the user will be reading token events from. If a user wants to send money to the user, they should write to these relays.
-* `mint` - Mints the user is explicitly agreeing to use to receive funds on. Clients SHOULD not send money on mints not listed here or risk burning their money. Additional markers can be used to list the supported base units of the mint.
-* `pubkey` - Pubkey that SHOULD be used to P2PK-lock receiving nutzaps. If not present, clients SHOULD use the pubkey of the recipient. This is explained in Appendix 1.
+* `kind:10019` is an event that is useful for others to know how to send money to the user.
+* `relay`: relays where the user will be reading token events from. If a user wants to send money to the user, they should write to these relays.
+* `mint`: mints the user is explicitly agreeing to use to receive funds on. Clients SHOULD not send money on mints not listed here or risk burning their money. Additional markers can be used to list the supported base units of the mint.
+* `pubkey`: Public key that MUST be used to P2PK-lock receiving nutzaps -- implementations MUST NOT use the target user's main Nostr public key. This public key corresponds to the `privkey` field encrypted in a user's [nip-60](60.md) _wallet event_.
 
 ## Nutzap event
-Event `kind:9321` is a nutzap event published by the sender, p-tagging the recipient. The outputs are P2PK-locked to the pubkey the recipient indicated in their `kind:10019` event or to the recipient pubkey if the `kind:10019` event doesn't have a explicit pubkey.
+Event `kind:9321` is a nutzap event published by the sender, p-tagging the recipient. The outputs are P2PK-locked to the public key the recipient indicated in their `kind:10019` event.
 
-Clients MUST prefix the pubkey they p2pk-lock with `"02"` (for nostr<>cashu pubkey compatibility).
+Clients MUST prefix the public key they P2PK-lock with `"02"` (for nostr<>cashu compatibility).
 
 ```jsonc
 {
@@ -51,43 +55,40 @@ Clients MUST prefix the pubkey they p2pk-lock with `"02"` (for nostr<>cashu pubk
         [ "proof", "{\"amount\":1,\"C\":\"02277c66191736eb72fce9d975d08e3191f8f96afb73ab1eec37e4465683066d3f\",\"id\":\"000a93d6f8a1d2c4\",\"secret\":\"[\\\"P2PK\\\",{\\\"nonce\\\":\\\"b00bdd0467b0090a25bdf2d2f0d45ac4e355c482c1418350f273a04fedaaee83\\\",\\\"data\\\":\\\"02eaee8939e3565e48cc62967e2fde9d8e2a4b3ec0081f29eceff5c64ef10ac1ed\\\"}]\"}" ],
         [ "u", "https://stablenut.umint.cash", ],
         [ "e", "<zapped-event-id>", "<relay-hint>" ],
-        [ "p", "e9fbced3a42dcf551486650cc752ab354347dd413b307484e4fd1818ab53f991" ], // recipient of nut zap
+        [ "p", "e9fbced3a42dcf551486650cc752ab354347dd413b307484e4fd1818ab53f991" ], // recipient of nutzap
     ]
 }
 ```
 
 * `.content` is an optional comment for the nutzap
-* `amount` is a shorthand for the combined amount of all outputs. -- Clients SHOULD validate that the sum of the amounts in the outputs matches.
-* `unit` is the base unit of the amount.
-* `proof` is one ore more proofs p2pk-locked to the pubkey the recipient specified in their `kind:10019` event.
-* `u` is the mint the URL of the mint EXACTLY as specified by the recipient's `kind:10019`.
-* `e` zero or one event that is being nutzapped.
-* `p` exactly one pubkey, specifying the recipient of the nutzap.
-
-WIP: Clients SHOULD embed a DLEQ proof in the nutzap event to make it possible to verify nutzaps without talking to the mint.
+* `.tags`:
+  * `amount` is a shorthand for the combined amount of all outputs. -- Clients SHOULD validate that the sum of the amounts in the outputs matches.
+  * `unit` is the base unit of the amount.
+  * `proof` is one ore more proofs P2PK-locked to the public key the recipient specified in their `kind:10019` event and including a DLEQ proof.
+  * `u` is the mint the URL of the mint EXACTLY as specified by the recipient's `kind:10019`.
+  * `p` is the Nostr identity public key of nutzap recipient.
+  * `e` is the event that is being nutzapped, if any.
 
 # Sending a nutzap
 
 * The sender fetches the recipient's `kind:10019`.
 * The sender mints/swaps ecash on one of the recipient's listed mints.
-* The sender p2pk locks to the recipient's specified pubkey in their `kind:10019`
+* The sender P2PK-locks to the recipient's specified public key in their `kind:10019`
 
 # Receiving nutzaps
 
-Clients should REQ for nut zaps:
+Clients should REQ for nutzaps:
 * Filtering with `#u` for mints they expect to receive ecash from.
   * this is to prevent even interacting with mints the user hasn't explicitly signaled.
 * Filtering with `since` of the most recent `kind:7376` event the same user has created.
-  * this can be used as a marker of the nut zaps that have already been swaped by the user -- clients might choose to use other kinds of markers, including internal state -- this is just a guidance of one possible approach.
+  * this can be used as a marker of the nutzaps that have already been swaped by the user -- clients might choose to use other kinds of markers, including internal state -- this is just a guidance of one possible approach.
 
-Clients MIGHT choose to use some kind of filtering (e.g. WoT) to ignore spam.
+`{ "kinds": [9321], "#p": ["my-pubkey"], "#u": ["<mint-1>", "<mint-2>"], "since": <latest-created_at-of-kind-7376> }`.
 
-`{ "kinds": [9321], "#p": "my-pubkey", "#u": [ "<mint-1>", "<mint-2>"], "since": <latest-created_at-of-kind-7376> }`.
-
-Upon receiving a new nut zap, the client should swap the tokens into a wallet the user controls, either a [[NIP-60]] wallet, their own LN wallet or anything else.
+Upon receiving a new nutzap, the client should swap the tokens into a wallet the user controls, either a [NIP-60](60.md) wallet, their own LN wallet or anything else.
 
 ## Updating nutzap-redemption history
-When claiming a token the client SHOULD create a `kind:7376` event and `e` tag the original nut zap event. This is to record that this token has already been claimed (and shouldn't be attempted again) and as signaling to the recipient that the ecash has been redeemed.
+When claiming a token the client SHOULD create a `kind:7376` event and `e` tag the original nutzap event. This is to record that this token has already been claimed (and shouldn't be attempted again) and as signaling to the recipient that the ecash has been redeemed.
 
 Multiple `kind:9321` events can be tagged in the same `kind:7376` event.
 
@@ -107,26 +108,19 @@ Multiple `kind:9321` events can be tagged in the same `kind:7376` event.
 }
 ```
 
-Events that redeem a nutzap SHOULD be published to the sender's [[NIP-65]] relays.
+Events that redeem a nutzap SHOULD be published to the sender's [NIP-65](65.md) "read" relays.
 
 ## Verifying a Cashu Zap
-* Clients SHOULD check that the receiving user has issued a `kind:10019` tagging the mint where the cashu has been minted.
-* Clients SHOULD check that the token is locked to the pubkey the user has listed in their `kind:10019`.
+When listing or counting zaps received by any given event, observer clients SHOULD:
+
+* check that the receiving user has issued a `kind:10019` tagging the mint where the cashu has been minted.
+* check that the token is locked to the pubkey the user has listed in their `kind:10019`.
+* look at the `u` tag and check that the token is issued in one of the mints listed in the `kind:10019`.
+* locally verify the DLEQ proof of the tokens being sent.
+
+All these checks can be done offline (as long as the observer has the receiver mints' keyset and their `kind:10019` event), so the process should be reasonably fast.
 
 ## Final Considerations
-
-1. Clients SHOULD guide their users to use NUT-11 (P2PK) compatible-mints in their `kind:10019` event to avoid receiving nut zaps anyone can spend
-
+1. Clients SHOULD guide their users to use NUT-11 (P2PK) and NUT-12 (DLEQ proofs) compatible-mints in their `kind:10019` event to avoid receiving nutzaps anyone can spend.
 2. Clients SHOULD normalize and deduplicate mint URLs as described in NIP-65.
-
-3. A nut zap MUST be sent to a mint the recipient has listed in their `kind:10019` event or to the NIP-65 relays of the recipient, failure to do so may result in the recipient donating the tokens to the mint since the recipient might never see the event.
-
-## Appendix 1: Alternative P2PK pubkey
-Clients might not have access to the user's private key (i.e. NIP-07, NIP-46 signing) and, as such, the private key to sign cashu spends might not be available, which would make spending the P2PK incoming nutzaps impossible.
-
-For this scenarios clients can:
-
-* add a `pubkey` tag to the `kind:10019` (indicating which pubkey senders should P2PK to)
-* store the private key in the `kind:37375` event in the nip44-encrypted `content` field.
-
-This is to avoid depending on NIP-07/46 adaptations to sign cashu payloads.
+3. A nutzap MUST be sent to a mint the recipient has listed in their `kind:10019` event or to the NIP-65 relays of the recipient, failure to do so may result in the recipient donating the tokens to the mint since the recipient might never see the event.

--- a/61.md
+++ b/61.md
@@ -50,7 +50,6 @@ Clients MUST prefix the public key they P2PK-lock with `"02"` (for nostr<>cashu 
     content: "Thanks for this great idea.",
     pubkey: "sender-pubkey",
     tags: [
-        [ "amount", "1" ],
         [ "unit", "sat" ],
         [ "proof", "{\"amount\":1,\"C\":\"02277c66191736eb72fce9d975d08e3191f8f96afb73ab1eec37e4465683066d3f\",\"id\":\"000a93d6f8a1d2c4\",\"secret\":\"[\\\"P2PK\\\",{\\\"nonce\\\":\\\"b00bdd0467b0090a25bdf2d2f0d45ac4e355c482c1418350f273a04fedaaee83\\\",\\\"data\\\":\\\"02eaee8939e3565e48cc62967e2fde9d8e2a4b3ec0081f29eceff5c64ef10ac1ed\\\"}]\"}" ],
         [ "u", "https://stablenut.umint.cash", ],
@@ -62,7 +61,6 @@ Clients MUST prefix the public key they P2PK-lock with `"02"` (for nostr<>cashu 
 
 * `.content` is an optional comment for the nutzap
 * `.tags`:
-  * `amount` is a shorthand for the combined amount of all outputs. -- Clients SHOULD validate that the sum of the amounts in the outputs matches.
   * `unit` is the base unit of the amount.
   * `proof` is one ore more proofs P2PK-locked to the public key the recipient specified in their `kind:10019` event and including a DLEQ proof.
   * `u` is the mint the URL of the mint EXACTLY as specified by the recipient's `kind:10019`.

--- a/61.md
+++ b/61.md
@@ -52,7 +52,7 @@ Clients MUST prefix the public key they P2PK-lock with `"02"` (for nostr<>cashu 
     tags: [
         [ "unit", "sat" ],
         [ "proof", "{\"amount\":1,\"C\":\"02277c66191736eb72fce9d975d08e3191f8f96afb73ab1eec37e4465683066d3f\",\"id\":\"000a93d6f8a1d2c4\",\"secret\":\"[\\\"P2PK\\\",{\\\"nonce\\\":\\\"b00bdd0467b0090a25bdf2d2f0d45ac4e355c482c1418350f273a04fedaaee83\\\",\\\"data\\\":\\\"02eaee8939e3565e48cc62967e2fde9d8e2a4b3ec0081f29eceff5c64ef10ac1ed\\\"}]\"}" ],
-        [ "u", "https://stablenut.umint.cash", ],
+        [ "u", "https://stablenut.umint.cash" ],
         [ "e", "<zapped-event-id>", "<relay-hint>" ],
         [ "p", "e9fbced3a42dcf551486650cc752ab354347dd413b307484e4fd1818ab53f991" ], // recipient of nutzap
     ]

--- a/61.md
+++ b/61.md
@@ -50,7 +50,6 @@ Clients MUST prefix the public key they P2PK-lock with `"02"` (for nostr<>cashu 
     content: "Thanks for this great idea.",
     pubkey: "sender-pubkey",
     tags: [
-        [ "unit", "sat" ],
         [ "proof", "{\"amount\":1,\"C\":\"02277c66191736eb72fce9d975d08e3191f8f96afb73ab1eec37e4465683066d3f\",\"id\":\"000a93d6f8a1d2c4\",\"secret\":\"[\\\"P2PK\\\",{\\\"nonce\\\":\\\"b00bdd0467b0090a25bdf2d2f0d45ac4e355c482c1418350f273a04fedaaee83\\\",\\\"data\\\":\\\"02eaee8939e3565e48cc62967e2fde9d8e2a4b3ec0081f29eceff5c64ef10ac1ed\\\"}]\"}" ],
         [ "u", "https://stablenut.umint.cash" ],
         [ "e", "<zapped-event-id>", "<relay-hint>" ],
@@ -61,7 +60,6 @@ Clients MUST prefix the public key they P2PK-lock with `"02"` (for nostr<>cashu 
 
 * `.content` is an optional comment for the nutzap
 * `.tags`:
-  * `unit` is the base unit of the amount.
   * `proof` is one ore more proofs P2PK-locked to the public key the recipient specified in their `kind:10019` event and including a DLEQ proof.
   * `u` is the mint the URL of the mint EXACTLY as specified by the recipient's `kind:10019`.
   * `p` is the Nostr identity public key of nutzap recipient.
@@ -95,7 +93,7 @@ Multiple `kind:9321` events can be tagged in the same `kind:7376` event.
     "kind": 7376,
     "content": nip44_encrypt([
         [ "direction", "in" ], // in = received, out = sent
-        [ "amount", "1", "sat" ],
+        [ "amount", "1" ],
         [ "e", "<7375-event-id>", "relay-hint", "created" ] // new token event that was created
     ]),
     "tags": [

--- a/61.md
+++ b/61.md
@@ -119,4 +119,4 @@ All these checks can be done offline (as long as the observer has the receiver m
 ## Final Considerations
 1. Clients SHOULD guide their users to use NUT-11 (P2PK) and NUT-12 (DLEQ proofs) compatible-mints in their `kind:10019` event to avoid receiving nutzaps anyone can spend.
 2. Clients SHOULD normalize and deduplicate mint URLs as described in NIP-65.
-3. A nutzap MUST be sent to a mint the recipient has listed in their `kind:10019` event or to the NIP-65 relays of the recipient, failure to do so may result in the recipient donating the tokens to the mint since the recipient might never see the event.
+3. A nutzap event MUST include proofs in one of the mints the recipient has listed in their `kind:10019` and published to the NIP-65 relays of the recipient, failure to do so may result in the recipient donating the tokens to the mint since the recipient might never see the event.


### PR DESCRIPTION
Besides changing the text in many places unnecessarily, this PR:

- removes the temporary untrusted `"balance"` tag from _wallet events_.
- makes specifying `privkey` for _wallet events_ mandatory, together with the `pubkey` in `kind:10019` for nutzaps.
- removes `"relay"` from _wallet events_, as the same NIP was already declaring that wallet relays, if different from `kind:10002` relays, should be specified in `kind:10019`.
- mandates `["k", "7375"]` tags in `kind:5` token deletes.
- mandates DLEQ proofs and their verification in nutzaps.
- removes "amount" tag from nutzaps, as it has to be checked against the list of proofs anyway.
- renames "Nut Zaps" to "Nutzaps".

@pablof7z @patrickReiis @eskema