### PR TITLE
nip-86: updating methods, adding new ones.

### DIFF
--- a/86.md
+++ b/86.md
@@ -17,7 +17,7 @@ When a relay receives an HTTP(s) request with a `Content-Type` header of `applic
 }
 ```
 
-Then it should return a response in the format
+Then it should return a response in the below format:
 
 ```json
 {
@@ -26,65 +26,383 @@ Then it should return a response in the format
 }
 ```
 
-This is the list of **methods** that may be supported:
+## Standard Methods
 
-* `supportedmethods`:
-  - params: `[]`
-  - result: `["<method-name>", "<method-name>", ...]` (an array with the names of all the other supported methods)
-* `banpubkey`:
-  - params: `["<32-byte-hex-public-key>", "<optional-reason>"]`
-  - result: `true` (a boolean always set to `true`)
-* `listbannedpubkeys`:
-  - params: `[]`
-  - result: `[{"pubkey": "<32-byte-hex>", "reason": "<optional-reason>"}, ...]`, an array of objects
-* `allowpubkey`:
-  - params: `["<32-byte-hex-public-key>", "<optional-reason>"]`
-  - result: `true` (a boolean always set to `true`)
-* `listallowedpubkeys`:
-  - params: `[]`
-  - result: `[{"pubkey": "<32-byte-hex>", "reason": "<optional-reason>"}, ...]`, an array of objects
-* `listeventsneedingmoderation`:
-  - params: `[]`
-  - result: `[{"id": "<32-byte-hex>", "reason": "<optional-reason>"}]`, an array of objects
-* `allowevent`:
-  - params: `["<32-byte-hex-event-id>", "<optional-reason>"]`
-  - result: `true` (a boolean always set to `true`)
-* `banevent`:
-  - params: `["<32-byte-hex-event-id>", "<optional-reason>"]`
-  - result: `true` (a boolean always set to `true`)
-* `listbannedevents`:
-  - params: `[]`
-  - result: `[{"id": "<32-byte hex>", "reason": "<optional-reason>"}, ...]`, an array of objects
-* `changerelayname`:
-  - params: `["<new-name>"]`
-  - result: `true` (a boolean always set to `true`)
-* `changerelaydescription`:
-  - params: `["<new-description>"]`
-  - result: `true` (a boolean always set to `true`)
-* `changerelayicon`:
-  - params: `["<new-icon-url>"]`
-  - result: `true` (a boolean always set to `true`)
-* `allowkind`:
-  - params: `[<kind-number>]`
-  - result: `true` (a boolean always set to `true`)
-* `disallowkind`:
-  - params: `[<kind-number>]`
-  - result: `true` (a boolean always set to `true`)
-* `listallowedkinds`:
-  - params: `[]`
-  - result: `[<kind-number>, ...]`, an array of numbers
-* `blockip`:
-  - params: `["<ip-address>", "<optional-reason>"]`
-  - result: `true` (a boolean always set to `true`)
-* `unblockip`:
-  - params: `["<ip-address>"]`
-  - result: `true` (a boolean always set to `true`)
-* `listblockedips`:
-  - params: `[]`
-  - result: `[{"ip": "<ip-address>", "reason": "<optional-reason>"}, ...]`, an array of objects
+Here is a list of **methods** that MAY be supported:
+
+### System
+
+* Supported methods
+
+**name:** `supported_methods`
+
+**params:** `[]`
+
+**result:**
+
+```json
+["<method-name>", "<method-name>", /* rest of method names... */ ] 
+```
+
+---
+
+* Stats
+
+**name:** `stats`
+
+**params:** `[]`
+
+**result:**
+
+```jsonc
+[
+  {
+    "num_connections": <number>,
+    "uptime": <uptime-in-seconds>,
+    "bytes_received": <number>,
+    "bytes_sent": <number>,
+    "num_events": <number>,
+    "event_bytes": <number>,
+    "num_files": <number>,
+    "file_bytes": <number>
+    // and more...
+  }
+]
+```
+
+Extra fields MAY be sent from relay depending on implementation.
+
+---
+
+* Set NIP11
+
+**name:** `set_nip11`
+
+**params:** 
+
+```jsonc
+[
+  {
+    "name": "new name",
+    "description": "new description",
+    "icon": null // removes icon. 
+    // and more...
+  }
+]
+```
+
+**result:**
+
+```jsonc
+true
+```
+
+The provided input is a potentially incomplete json object of [NIP-11](./11.md) document. 
+Relay SHOULD replace provides fields with new ones, add non existing fields and remove fields set to null.
+
+---
+
+* List Events Needing Moderation
+
+**name:** `list_events_needing_moderation`
+
+**params:** `[]`
+
+**result:**
+
+```json
+[{"id": "<32-byte-hex>", "reason": "<optional-reason>"}]
+```
+
+Relay MAY return reported, muted profiles and similar events as result.
+
+* Write Policy
+
+* Ban pubkey
+
+**name:** `ban_pubkey`
+
+**params:** 
+
+```json
+["<32-byte-hex-public-key>", "<optional-reason>"]
+```
+
+**result:**
+
+```json
+true
+```
+
+Relay MAY remove events sent by `pubkey` and prevent new events from them to be written.
+
+---
+
+* List Banned Pubkeys
+
+**name:** `list_banned_pubkeys`
+
+**params:** `[]`
+
+**result:**
+
+```json
+[{"pubkey": "<32-byte-hex>", "reason": "<optional-reason>"}, /* and more... */]
+```
+
+---
+
+* Allow Pubkey
+
+**name:** `allow_pubkey`
+
+**params:** 
+
+```json
+["<32-byte-hex-public-key>", "<optional-reason>"]
+```
+
+**result:**
+
+```json
+true
+```
+
+---
+
+* List Allowed Pubkeys
+
+**name:** `list_allowed_pubkeys`
+
+**params:** `[]`
+
+**result:**
+
+```json
+[{"pubkey": "<32-byte-hex>", "reason": "<optional-reason>"}, /* and more... */]
+```
+
+---
+
+* Allow Event
+
+**name:** `allow_event`
+
+**params:** 
+
+```json
+["<32-byte-hex-event-id>", "<optional-reason>"]
+```
+
+**result:**
+
+```json
+true
+```
+
+---
+
+* Ban Event
+
+**name:** `ban_event`
+
+**params:** 
+
+```json
+["<32-byte-hex-event-id>", "<optional-reason>"]
+```
+
+**result:**
+
+```json
+true
+```
+
+Relay SHOULD delete and prevent re-broadcasting of event.
+
+---
+
+* List Banned Events
+
+**name:** `list_banned_events`
+
+**params:** `[]`
+
+**result:**
+
+```json
+[{"id": "<32-byte hex>", "reason": "<optional-reason>"}, ...]
+```
+
+---
+
+* Allow Kinds
+
+**name:** `allow_kinds`
+
+**params:** 
+
+```json
+[<kind-number>, <another-kind-number>, /* and more... */]
+```
+
+**result:**
+
+```json
+true
+```
+
+---
+
+* Disallow Kinds
+
+**name:** `disallow_kinds`
+
+**params:** 
+
+```json
+[<kind-number>, <another-kind-number>, /* and more... */]
+```
+
+**result:**
+
+```json
+true
+```
+
+---
+
+* List Disallowed Kinds
+
+**name:** `list_disallow_kinds`
+
+**params:** `[]`
+
+**result:**
+
+```json
+[<kind-number>, <another-kind-number>, /* and more... */]
+```
+
+---
+
+* List Allowed Kinds
+
+**name:** `list_allowed_kinds`
+
+**params:** `[]`
+
+**result:**
+
+```json
+[<kind-number>, <another-kind-number>, /* and more... */]
+```
+
+---
+
+* Block IP
+
+**name:** `block_ip`
+
+**params:** 
+
+```json
+["<ip-address>", "<optional-reason>"]
+```
+
+**result:**
+
+```json
+true
+```
+
+---
+
+* Unblock IP
+
+**name:** `unblock_ip`
+
+**params:** 
+
+```json
+["<ip-address>"]
+```
+
+**result:**
+
+```json
+true
+```
+
+---
+
+* List Blocked IPs
+
+**name:** `list_blocked_ips`
+
+**params:** `[]`
+
+**result:**
+
+```json
+[{"ip": "<ip-address>", "reason": "<optional-reason>"}, /* and more... */]
+```
+
+### Access control
+
+---
+
+* Grant Admin
+
+**name:** `grant_admin`
+
+**params:** 
+
+```jsonc
+["<32-byte-hex-public-key>", {
+  "allowed_methods": [
+    "method-name",
+    // an array of method names.
+  ]
+}]
+```
+
+**result:**
+
+```json
+true
+```
+
+If admin right is already granted, allowed methods list must be rewritten.
+
+---
+
+* Revoke Admin
+
+**name:** `revoke_admin`
+
+
+**params:** 
+
+```jsonc
+["<32-byte-hex-public-key>", {
+  "disallowed_methods": [
+    "method-name",
+    // an array of method names.
+  ]
+}]
+```
+
+**result:**
+
+```json
+true
+```
+
+If resulting `allowed_methods` list for admin was empty, admin can be removed.
 
 ### Authorization
 
-The request must contain an `Authorization` header with a valid [NIP-98](./98.md) event, except the `payload` tag is required. The `u` tag is the relay URL.
+The request MUST contain an `Authorization` header with a valid [NIP-98](./98.md) event, except the `payload` tag is required. The `u` tag is the relay URL.
 
-If `Authorization` is not provided or is invalid, the endpoint should return a 401 response.
+If `Authorization` is not provided or is invalid, the endpoint should return a response with 401 status code.

--- a/86.md
+++ b/86.md
@@ -135,13 +135,13 @@ Relay SHOULD delete and prevent re-broadcasting of event.
 
 * `listdisallowedkinds`: 
   - **params:** `[]`
-  - **result:** `(<kind-number>, <another-kind-number>, /* and more... */)` (an array of objects)
+  - **result:** `[<kind-number>, <another-kind-number>, /* and more... */]` (an array of objects)
 
 ---
 
 * `listallowedkinds`: 
   - **params:** `[]`
-  - **result:** `(<kind-number>, <another-kind-number>, /* and more... */)` (an array of objects)
+  - **result:** `[<kind-number>, <another-kind-number>, /* and more... */]` (an array of objects)
 
 ---
 

--- a/86.md
+++ b/86.md
@@ -63,7 +63,9 @@ Extra fields MAY be sent from the relay depending on implementation.
 
 * `listeventsneedingmoderation`: 
   - **params:** `[]`
-  - **result:** `[{ "id": "<32-byte-hex>", "reason": "<optional-reason>" }, ...]` (Relay MAY return reported, muted profiles and similar events as a result.)
+  - **result:** `[{ "id": "<32-byte-hex>", "reason": "<optional-reason>" }, ...]`
+
+Relay MAY return reported, muted profiles, and similar events as a result.
 
 ---
 
@@ -119,14 +121,14 @@ Relay SHOULD delete and prevent re-broadcasting of event.
 
 ---
 
-* `allowkinds`: 
-  - **params:** `(<kind-number>, <another-kind-number>, /* and more... */)`
+* `allowkind`: 
+  - **params:** `<kind-number>`
   - **result:** `true` (a boolean always set to `true`)
 
 ---
 
-* `disallowkinds`: 
-  - **params:** `(<kind-number>, <another-kind-number>, /* and more... */)`
+* `disallowkind`: 
+  - **params:** `<kind-number>`
   - **result:** `true` (a boolean always set to `true`)
 
 ---

--- a/86.md
+++ b/86.md
@@ -30,7 +30,7 @@ Then it should return a response in the below format:
 
 Here is a list of **methods** that MAY be supported:
 
-* `supported_methods`: 
+* `supportedmethods`: 
   - **params:** `[]`
   - **result:** `["<method-name>", "<method-name>", /* rest of method names... */ ]`
 
@@ -61,32 +61,13 @@ Extra fields MAY be sent from the relay depending on implementation.
 
 ---
 
-* `set_nip11`: 
-  - **params:** 
-    ```jsonc
-    [
-      {
-        "name": "new name",
-        "description": "new description",
-        "icon": null // remove icon. 
-        // and more...
-      }
-    ]
-    ```
-  - **result:** `true` (a boolean always set to `true`)
-
-The provided input is a potentially incomplete json object of [NIP-11](./11.md) document. 
-Relay SHOULD replace provided fields with new ones, add non-existing fields, and remove fields set to null.
-
----
-
-* `list_events_needing_moderation`: 
+* `listeventsneedingmoderation`: 
   - **params:** `[]`
   - **result:** `[{ "id": "<32-byte-hex>", "reason": "<optional-reason>" }, ...]` (Relay MAY return reported, muted profiles and similar events as a result.)
 
 ---
 
-* `ban_pubkey`: 
+* `banpubkey`: 
   - **params:** `["<32-byte-hex-public-key>", "<optional-reason>"]`
   - **result:** `true` (a boolean always set to `true`)
 
@@ -94,25 +75,25 @@ The relay MAY remove events sent by `pubkey` and prevent new events from being w
 
 ---
 
-* `list_banned_pubkeys`: 
+* `listbannedpubkeys`: 
   - **params:** `[]`
   - **result:** `[{"pubkey": "<32-byte-hex>", "reason": "<optional-reason>"}, ...]` (an array of objects)
 
 ---
 
-* `allow_pubkey`: 
+* `allowpubkey`: 
   - **params:** `["<32-byte-hex-public-key>", "<optional-reason>"]`
   - **result:** `true` (a boolean always set to `true`)
 
 ---
 
-* `list_allowed_pubkeys`: 
+* `listallowedpubkeys`: 
   - **params:** `[]`
   - **result:** `[{"pubkey": "<32-byte-hex>", "reason": "<optional-reason>"}, ...]` (an array of objects)
 
 ---
 
-* `ban_event`: 
+* `banevent`: 
   - **params:** `["<32-byte-hex-event-id>", "<optional-reason>"]`
   - **result:** `true` (a boolean always set to `true`)
 
@@ -120,67 +101,67 @@ Relay SHOULD delete and prevent re-broadcasting of event.
 
 ---
 
-* `list_banned_events`: 
+* `listbannedevents`: 
   - **params:** `[]`
   - **result:** `[{"id": "<32-byte-hex>", "reason": "<optional-reason>"}, ...]` (an array of objects)
 
 ---
 
-* `allow_event`: 
+* `allowevent`: 
   - **params:** `["<32-byte-hex-event-id>", "<optional-reason>"]`
   - **result:** `true` (a boolean always set to `true`)
 
 ---
 
-* `list_allowed_events`: 
+* `listallowedevents`: 
   - **params:** `[]`
   - **result:** `[{"id": "<32-byte-hex>", "reason": "<optional-reason>"}, ...]` (an array of objects)
 
 ---
 
-* `allow_kinds`: 
+* `allowkinds`: 
   - **params:** `(<kind-number>, <another-kind-number>, /* and more... */)`
   - **result:** `true` (a boolean always set to `true`)
 
 ---
 
-* `disallow_kinds`: 
+* `disallowkinds`: 
   - **params:** `(<kind-number>, <another-kind-number>, /* and more... */)`
   - **result:** `true` (a boolean always set to `true`)
 
 ---
 
-* `list_disallowed_kinds`: 
+* `listdisallowedkinds`: 
   - **params:** `[]`
   - **result:** `(<kind-number>, <another-kind-number>, /* and more... */)` (an array of objects)
 
 ---
 
-* `list_allowed_kinds`: 
+* `listallowedkinds`: 
   - **params:** `[]`
   - **result:** `(<kind-number>, <another-kind-number>, /* and more... */)` (an array of objects)
 
 ---
 
-* `block_ip`: 
+* `blockip`: 
   - **params:** `["<ip-address>", "<optional-reason>"]`
   - **result:** `true` (a boolean always set to `true`)
 
 ---
 
-* `unblock_ip`: 
+* `unblockip`: 
   - **params:** `["<ip-address>"]`
   - **result:** `true` (a boolean always set to `true`)
 
 ---
 
-* `list_blocked_ips`: 
+* `listblockedips`: 
   - **params:** `[]`
   - **result:** `[{"ip": "<ip-address>", "reason": "<optional-reason>"}, ...]` (an array of objects)
 
 ---
 
-* `grant_admin`: 
+* `grantadmin`: 
   - **params:** `["<32-byte-hex-public-key>", { "allowed_methods": [...]}]`
   - **result:** `true` (a boolean always set to `true`)
 
@@ -188,7 +169,7 @@ If the admin right is already granted, the allowed methods list must be rewritte
 
 ---
 
-* `revoke_admin`: 
+* `revokeadmin`: 
   - **params:** `["<32-byte-hex-public-key>", { "disallowed_methods": [...]}]`
   - **result:** `true` (a boolean always set to `true`)
 

--- a/86.md
+++ b/86.md
@@ -162,7 +162,7 @@ Relay SHOULD delete and prevent re-broadcasting of event.
 
 ---
 
-* `bloc_kip`: 
+* `block_ip`: 
   - **params:** `["<ip-address>", "<optional-reason>"]`
   - **result:** `true` (a boolean always set to `true`)
 

--- a/86.md
+++ b/86.md
@@ -42,7 +42,6 @@ Extra fields MAY be sent from the relay depending on implementation.
   - **params:** `[]`
   - **result:**
     ```jsonc
-    [
       {
         "num_connections": <number>,
         "uptime": <uptime-in-seconds>,
@@ -54,7 +53,6 @@ Extra fields MAY be sent from the relay depending on implementation.
         "file_bytes": <number>
         // and more...
       }
-    ]
     ```
 
 Extra fields MAY be sent from the relay depending on implementation.

--- a/86.md
+++ b/86.md
@@ -122,13 +122,13 @@ Relay SHOULD delete and prevent re-broadcasting of event.
 ---
 
 * `allowkind`: 
-  - **params:** `<kind-number>`
+  - **params:** `[<kind-number>]`
   - **result:** `true` (a boolean always set to `true`)
 
 ---
 
 * `disallowkind`: 
-  - **params:** `<kind-number>`
+  - **params:** `[<kind-number>]`
   - **result:** `true` (a boolean always set to `true`)
 
 ---

--- a/86.md
+++ b/86.md
@@ -32,7 +32,9 @@ Here is a list of **methods** that MAY be supported:
 
 * `supported_methods`: 
   - **params:** `[]`
-  - **result:** `["<method-name>", "<method-name>", /* rest of method names... */ ]` (Extra fields MAY be sent from relay depending on implementation.)
+  - **result:** `["<method-name>", "<method-name>", /* rest of method names... */ ]`
+
+Extra fields MAY be sent from the relay depending on implementation.
 
 ---
 
@@ -55,7 +57,7 @@ Here is a list of **methods** that MAY be supported:
     ]
     ```
 
-Extra fields MAY be sent from relay depending on implementation.
+Extra fields MAY be sent from the relay depending on implementation.
 
 ---
 
@@ -66,7 +68,7 @@ Extra fields MAY be sent from relay depending on implementation.
       {
         "name": "new name",
         "description": "new description",
-        "icon": null // removes icon. 
+        "icon": null // remove icon. 
         // and more...
       }
     ]
@@ -74,13 +76,13 @@ Extra fields MAY be sent from relay depending on implementation.
   - **result:** `true` (a boolean always set to `true`)
 
 The provided input is a potentially incomplete json object of [NIP-11](./11.md) document. 
-Relay SHOULD replace provides fields with new ones, add non existing fields and remove fields set to null.
+Relay SHOULD replace provided fields with new ones, add non-existing fields, and remove fields set to null.
 
 ---
 
 * `list_events_needing_moderation`: 
   - **params:** `[]`
-  - **result:** `[{ "id": "<32-byte-hex>", "reason": "<optional-reason>" }, ...]` (Relay MAY return reported, muted profiles and similar events as result.)
+  - **result:** `[{ "id": "<32-byte-hex>", "reason": "<optional-reason>" }, ...]` (Relay MAY return reported, muted profiles and similar events as a result.)
 
 ---
 
@@ -88,7 +90,7 @@ Relay SHOULD replace provides fields with new ones, add non existing fields and 
   - **params:** `["<32-byte-hex-public-key>", "<optional-reason>"]`
   - **result:** `true` (a boolean always set to `true`)
 
-Relay MAY remove events sent by `pubkey` and prevent new events from them to be written.
+The relay MAY remove events sent by `pubkey` and prevent new events from being written.
 
 ---
 
@@ -182,7 +184,7 @@ Relay SHOULD delete and prevent re-broadcasting of event.
   - **params:** `["<32-byte-hex-public-key>", { "allowed_methods": [...]}]`
   - **result:** `true` (a boolean always set to `true`)
 
-If admin right is already granted, allowed methods list must be rewritten.
+If the admin right is already granted, the allowed methods list must be rewritten.
 
 ---
 
@@ -190,7 +192,7 @@ If admin right is already granted, allowed methods list must be rewritten.
   - **params:** `["<32-byte-hex-public-key>", { "disallowed_methods": [...]}]`
   - **result:** `true` (a boolean always set to `true`)
 
-If resulting `allowed_methods` list for admin was empty, admin can be removed.
+If the resulting `allowed_methods` list for admin was empty, admin can be removed.
 
 ---
 
@@ -198,4 +200,4 @@ If resulting `allowed_methods` list for admin was empty, admin can be removed.
 
 The request MUST contain an `Authorization` header with a valid [NIP-98](./98.md) event, except the `payload` tag is REQUIRED. The `u` tag is the relay URL.
 
-If `Authorization` is not provided or is invalid, the endpoint should return a response with 401 status code.
+If `Authorization` is not provided or is invalid, the endpoint should return a response with a 401 status code.

--- a/86.md
+++ b/86.md
@@ -150,7 +150,7 @@ Relay SHOULD delete and prevent re-broadcasting of event.
 
 ---
 
-* `list_disallow_kinds`: 
+* `list_disallowed_kinds`: 
   - **params:** `[]`
   - **result:** `(<kind-number>, <another-kind-number>, /* and more... */)` (an array of objects)
 

--- a/86.md
+++ b/86.md
@@ -30,379 +30,172 @@ Then it should return a response in the below format:
 
 Here is a list of **methods** that MAY be supported:
 
-### System
-
-* Supported methods
-
-**name:** `supported_methods`
-
-**params:** `[]`
-
-**result:**
-
-```json
-["<method-name>", "<method-name>", /* rest of method names... */ ] 
-```
+* `supported_methods`: 
+  - **params:** `[]`
+  - **result:** `["<method-name>", "<method-name>", /* rest of method names... */ ]` (Extra fields MAY be sent from relay depending on implementation.)
 
 ---
 
-* Stats
-
-**name:** `stats`
-
-**params:** `[]`
-
-**result:**
-
-```jsonc
-[
-  {
-    "num_connections": <number>,
-    "uptime": <uptime-in-seconds>,
-    "bytes_received": <number>,
-    "bytes_sent": <number>,
-    "num_events": <number>,
-    "event_bytes": <number>,
-    "num_files": <number>,
-    "file_bytes": <number>
-    // and more...
-  }
-]
-```
+* `stats`: 
+  - **params:** `[]`
+  - **result:**
+    ```jsonc
+    [
+      {
+        "num_connections": <number>,
+        "uptime": <uptime-in-seconds>,
+        "bytes_received": <number>,
+        "bytes_sent": <number>,
+        "num_events": <number>,
+        "event_bytes": <number>,
+        "num_files": <number>,
+        "file_bytes": <number>
+        // and more...
+      }
+    ]
+    ```
 
 Extra fields MAY be sent from relay depending on implementation.
 
 ---
 
-* Set NIP11
-
-**name:** `set_nip11`
-
-**params:** 
-
-```jsonc
-[
-  {
-    "name": "new name",
-    "description": "new description",
-    "icon": null // removes icon. 
-    // and more...
-  }
-]
-```
-
-**result:**
-
-```jsonc
-true
-```
+* `set_nip11`: 
+  - **params:** 
+    ```jsonc
+    [
+      {
+        "name": "new name",
+        "description": "new description",
+        "icon": null // removes icon. 
+        // and more...
+      }
+    ]
+    ```
+  - **result:** `true` (a boolean always set to `true`)
 
 The provided input is a potentially incomplete json object of [NIP-11](./11.md) document. 
 Relay SHOULD replace provides fields with new ones, add non existing fields and remove fields set to null.
 
 ---
 
-* List Events Needing Moderation
+* `list_events_needing_moderation`: 
+  - **params:** `[]`
+  - **result:** `[{ "id": "<32-byte-hex>", "reason": "<optional-reason>" }, ...]` (Relay MAY return reported, muted profiles and similar events as result.)
 
-**name:** `list_events_needing_moderation`
+---
 
-**params:** `[]`
-
-**result:**
-
-```json
-[{"id": "<32-byte-hex>", "reason": "<optional-reason>"}]
-```
-
-Relay MAY return reported, muted profiles and similar events as result.
-
-* Write Policy
-
-* Ban pubkey
-
-**name:** `ban_pubkey`
-
-**params:** 
-
-```json
-["<32-byte-hex-public-key>", "<optional-reason>"]
-```
-
-**result:**
-
-```json
-true
-```
+* `ban_pubkey`: 
+  - **params:** `["<32-byte-hex-public-key>", "<optional-reason>"]`
+  - **result:** `true` (a boolean always set to `true`)
 
 Relay MAY remove events sent by `pubkey` and prevent new events from them to be written.
 
 ---
 
-* List Banned Pubkeys
-
-**name:** `list_banned_pubkeys`
-
-**params:** `[]`
-
-**result:**
-
-```json
-[{"pubkey": "<32-byte-hex>", "reason": "<optional-reason>"}, /* and more... */]
-```
+* `list_banned_pubkeys`: 
+  - **params:** `[]`
+  - **result:** `[{"pubkey": "<32-byte-hex>", "reason": "<optional-reason>"}, ...]` (an array of objects)
 
 ---
 
-* Allow Pubkey
-
-**name:** `allow_pubkey`
-
-**params:** 
-
-```json
-["<32-byte-hex-public-key>", "<optional-reason>"]
-```
-
-**result:**
-
-```json
-true
-```
+* `allow_pubkey`: 
+  - **params:** `["<32-byte-hex-public-key>", "<optional-reason>"]`
+  - **result:** `true` (a boolean always set to `true`)
 
 ---
 
-* List Allowed Pubkeys
-
-**name:** `list_allowed_pubkeys`
-
-**params:** `[]`
-
-**result:**
-
-```json
-[{"pubkey": "<32-byte-hex>", "reason": "<optional-reason>"}, /* and more... */]
-```
+* `list_allowed_pubkeys`: 
+  - **params:** `[]`
+  - **result:** `[{"pubkey": "<32-byte-hex>", "reason": "<optional-reason>"}, ...]` (an array of objects)
 
 ---
 
-* Allow Event
-
-**name:** `allow_event`
-
-**params:** 
-
-```json
-["<32-byte-hex-event-id>", "<optional-reason>"]
-```
-
-**result:**
-
-```json
-true
-```
-
----
-
-* Ban Event
-
-**name:** `ban_event`
-
-**params:** 
-
-```json
-["<32-byte-hex-event-id>", "<optional-reason>"]
-```
-
-**result:**
-
-```json
-true
-```
+* `ban_event`: 
+  - **params:** `["<32-byte-hex-event-id>", "<optional-reason>"]`
+  - **result:** `true` (a boolean always set to `true`)
 
 Relay SHOULD delete and prevent re-broadcasting of event.
 
 ---
 
-* List Banned Events
-
-**name:** `list_banned_events`
-
-**params:** `[]`
-
-**result:**
-
-```json
-[{"id": "<32-byte hex>", "reason": "<optional-reason>"}, ...]
-```
+* `list_banned_events`: 
+  - **params:** `[]`
+  - **result:** `[{"id": "<32-byte-hex>", "reason": "<optional-reason>"}, ...]` (an array of objects)
 
 ---
 
-* Allow Kinds
-
-**name:** `allow_kinds`
-
-**params:** 
-
-```json
-[<kind-number>, <another-kind-number>, /* and more... */]
-```
-
-**result:**
-
-```json
-true
-```
+* `allow_event`: 
+  - **params:** `["<32-byte-hex-event-id>", "<optional-reason>"]`
+  - **result:** `true` (a boolean always set to `true`)
 
 ---
 
-* Disallow Kinds
-
-**name:** `disallow_kinds`
-
-**params:** 
-
-```json
-[<kind-number>, <another-kind-number>, /* and more... */]
-```
-
-**result:**
-
-```json
-true
-```
+* `list_allowed_events`: 
+  - **params:** `[]`
+  - **result:** `[{"id": "<32-byte-hex>", "reason": "<optional-reason>"}, ...]` (an array of objects)
 
 ---
 
-* List Disallowed Kinds
-
-**name:** `list_disallow_kinds`
-
-**params:** `[]`
-
-**result:**
-
-```json
-[<kind-number>, <another-kind-number>, /* and more... */]
-```
+* `allow_kinds`: 
+  - **params:** `(<kind-number>, <another-kind-number>, /* and more... */)`
+  - **result:** `true` (a boolean always set to `true`)
 
 ---
 
-* List Allowed Kinds
-
-**name:** `list_allowed_kinds`
-
-**params:** `[]`
-
-**result:**
-
-```json
-[<kind-number>, <another-kind-number>, /* and more... */]
-```
+* `disallow_kinds`: 
+  - **params:** `(<kind-number>, <another-kind-number>, /* and more... */)`
+  - **result:** `true` (a boolean always set to `true`)
 
 ---
 
-* Block IP
-
-**name:** `block_ip`
-
-**params:** 
-
-```json
-["<ip-address>", "<optional-reason>"]
-```
-
-**result:**
-
-```json
-true
-```
+* `list_disallow_kinds`: 
+  - **params:** `[]`
+  - **result:** `(<kind-number>, <another-kind-number>, /* and more... */)` (an array of objects)
 
 ---
 
-* Unblock IP
-
-**name:** `unblock_ip`
-
-**params:** 
-
-```json
-["<ip-address>"]
-```
-
-**result:**
-
-```json
-true
-```
+* `list_allowed_kinds`: 
+  - **params:** `[]`
+  - **result:** `(<kind-number>, <another-kind-number>, /* and more... */)` (an array of objects)
 
 ---
 
-* List Blocked IPs
-
-**name:** `list_blocked_ips`
-
-**params:** `[]`
-
-**result:**
-
-```json
-[{"ip": "<ip-address>", "reason": "<optional-reason>"}, /* and more... */]
-```
-
-### Access control
+* `bloc_kip`: 
+  - **params:** `["<ip-address>", "<optional-reason>"]`
+  - **result:** `true` (a boolean always set to `true`)
 
 ---
 
-* Grant Admin
+* `unblock_ip`: 
+  - **params:** `["<ip-address>"]`
+  - **result:** `true` (a boolean always set to `true`)
 
-**name:** `grant_admin`
+---
 
-**params:** 
+* `list_blocked_ips`: 
+  - **params:** `[]`
+  - **result:** `[{"ip": "<ip-address>", "reason": "<optional-reason>"}, ...]` (an array of objects)
 
-```jsonc
-["<32-byte-hex-public-key>", {
-  "allowed_methods": [
-    "method-name",
-    // an array of method names.
-  ]
-}]
-```
+---
 
-**result:**
-
-```json
-true
-```
+* `grant_admin`: 
+  - **params:** `["<32-byte-hex-public-key>", { "allowed_methods": [...]}]`
+  - **result:** `true` (a boolean always set to `true`)
 
 If admin right is already granted, allowed methods list must be rewritten.
 
 ---
 
-* Revoke Admin
-
-**name:** `revoke_admin`
-
-
-**params:** 
-
-```jsonc
-["<32-byte-hex-public-key>", {
-  "disallowed_methods": [
-    "method-name",
-    // an array of method names.
-  ]
-}]
-```
-
-**result:**
-
-```json
-true
-```
+* `revoke_admin`: 
+  - **params:** `["<32-byte-hex-public-key>", { "disallowed_methods": [...]}]`
+  - **result:** `true` (a boolean always set to `true`)
 
 If resulting `allowed_methods` list for admin was empty, admin can be removed.
 
+---
+
 ### Authorization
 
-The request MUST contain an `Authorization` header with a valid [NIP-98](./98.md) event, except the `payload` tag is required. The `u` tag is the relay URL.
+The request MUST contain an `Authorization` header with a valid [NIP-98](./98.md) event, except the `payload` tag is REQUIRED. The `u` tag is the relay URL.
 
 If `Authorization` is not provided or is invalid, the endpoint should return a response with 401 status code.


### PR DESCRIPTION
[read parsed version](https://github.com/nostr-protocol/nips/blob/77eaaf077a0ae58216c154ec820187d35ad7f93f/86.md).

these changes are based on discussions on: https://github.com/mikedilger/chorus/issues/39.

and methods needed by the mangostr client: https://github.com/dezh-tech/mangostr.

method names are used to use snake_case since they are much more readable.