### PR TITLE
Fix NIPs refs

### DIFF
--- a/31.md
+++ b/31.md
@@ -12,4 +12,4 @@ The intent is that social clients, used to display only `kind:1` notes, can stil
 
 These clients that only know `kind:1` are not expected to ask relays for events of different kinds, but users could still reference these weird events on their notes, and without proper context these could be nonsensical notes. Having the fallback text makes that situation much better -- even if only for making the user aware that they should try to view that custom event elsewhere.
 
-`kind:1`-centric clients can make interacting with these event kinds more functional by supporting [NIP-89](https://github.com/nostr-protocol/nips/blob/master/89.md).
+`kind:1`-centric clients can make interacting with these event kinds more functional by supporting [NIP-89](89.md).

--- a/47.md
+++ b/47.md
@@ -82,7 +82,7 @@ If the command was successful, the `error` field must be null.
 
 The notification event SHOULD contain one `p` tag, the public key of the **user**.
 
-The content of notifications is encrypted with [NIP04](https://github.com/nostr-protocol/nips/blob/master/04.md), and is a JSON-RPCish object with a semi-fixed structure:
+The content of notifications is encrypted with [NIP04](04.md), and is a JSON-RPCish object with a semi-fixed structure:
 
 ```jsonc
 {

--- a/64.md
+++ b/64.md
@@ -44,7 +44,7 @@ Clients SHOULD publish PGN notes in ["export format"][pgn_export_format] ("stric
 
 Clients SHOULD check whether the formatting is valid and all moves comply with chess rules.
 
-Clients MAY include additional tags (e.g. like [`"alt"`](https://github.com/nostr-protocol/nips/blob/master/31.md)) in order to represent the note to users of non-supporting clients.
+Clients MAY include additional tags (e.g. like [`"alt"`](31.md)) in order to represent the note to users of non-supporting clients.
 
 ## Relay Behavior
 

--- a/69.md
+++ b/69.md
@@ -12,7 +12,7 @@ This NIP defines a simple standard for peer-to-peer order events, which enables 
 
 ## The event
 
-Events are [addressable events](https://github.com/nostr-protocol/nips/blob/master/01.md#kinds) and use `38383` as event kind, a p2p event look like this:
+Events are [addressable events](01.md#kinds) and use `38383` as event kind, a p2p event look like this:
 
 ```json
 {
@@ -65,7 +65,7 @@ Events are [addressable events](https://github.com/nostr-protocol/nips/blob/mast
 - `name` [Name]: The name of the maker.
 - `g` [Geohash]: The geohash of the operation, it can be useful in a face to face trade.
 - `bond` [Bond]: The bond amount, the bond is a security deposit that both parties must pay.
-- `expiration` < Expiration\>: The expiration date of the order ([NIP-40](https://github.com/nostr-protocol/nips/blob/master/40.md)).
+- `expiration` < Expiration\>: The expiration date of the order ([NIP-40](40.md)).
 - `y` < Platform >: The platform that created the order.
 - `z` < Document >: `order`.
 

--- a/90.md
+++ b/90.md
@@ -70,7 +70,7 @@ All tags are optional.
 
 ## Encrypted Params
 
-If the user wants to keep the input parameters a secret, they can encrypt the `i` and `param` tags with the service provider's 'p' tag and add it to the content field. Add a tag `encrypted` as tags. Encryption for private tags will use [NIP-04 - Encrypted Direct Message encryption](https://github.com/nostr-protocol/nips/blob/master/04.md), using the user's private and service provider's public key for the shared secret
+If the user wants to keep the input parameters a secret, they can encrypt the `i` and `param` tags with the service provider's 'p' tag and add it to the content field. Add a tag `encrypted` as tags. Encryption for private tags will use [NIP-04 - Encrypted Direct Message encryption](04.md), using the user's private and service provider's public key for the shared secret
 
 ```json
 [


### PR DESCRIPTION
It's better to have a consistent style for referencing other NIPs. This makes it
easier for documentation sites like nips-nostr.com and nips.nostr.com to link to
other NIPs within the same site, without redirecting to GitHub.