### PR TITLE
adds branch `b` tag to NIP-22

### DIFF
--- a/22.md
+++ b/22.md
@@ -54,6 +54,12 @@ Their uppercase versions use the same type of values but relate to the root item
 ["q", "<event-id> or <event-address>", "<relay-url>", "<pubkey-if-a-regular-event>"]
 ```
 
+`b` tags SHOULD be used to list all events in a thread branch, sorted from root to the direct parent. `b` tags help clients load an entire branch in a single filter.
+
+```json
+["b", "<event-id> or <event-address>", "<relay-url>", "<pubkey-if-a-regular-event>"]
+```
+
 `p` tags SHOULD be used when mentioning pubkeys in the `.content` with [NIP-21](21.md).
 
 Comments MUST NOT be used to reply to kind 1 notes. [NIP-10](10.md) should instead be followed.

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | ----------------- | ------------------------------------ | ------------------------------- | -------------------------------------------------- |
 | `a`               | coordinates to an event              | relay URL                       | [01](01.md)                                        |
 | `A`               | root address                         | relay URL                       | [22](22.md)                                        |
+| `b`               | event id or event address            | relay URL, pubkey (hex if id)   | [22](22.md)                                        |
 | `d`               | identifier                           | --                              | [01](01.md)                                        |
 | `e`               | event id (hex)                       | relay URL, marker, pubkey (hex) | [01](01.md), [10](10.md)                           |
 | `E`               | root event id                        | relay URL                       | [22](22.md)                                        |


### PR DESCRIPTION
Looking for feedback on the need for this. Amethyst loads the entire thread from the root scope `A/E/I`, but I think loading just the branch could be really useful for some other apps. 