### PR TITLE
Updates NIP-53 live chat to remove markers and add `q` tags

### DIFF
--- a/53.md
+++ b/53.md
@@ -62,7 +62,7 @@ This feature is important to avoid malicious event owners adding large account h
 
 ### Live Chat Message
 
-Event `kind:1311` is live chat's channel message. Clients MUST include the `a` tag of the activity with a `root` marker. Other Kind-1 tags such as `reply` and `mention` can also be used.
+Event `kind:1311` is live chat's channel message. Clients MUST include the `a` tag of the activity. `e` tags denote the parent message this post is replying to. 
 
 ```jsonc
 {
@@ -73,6 +73,12 @@ Event `kind:1311` is live chat's channel message. Clients MUST include the `a` t
   "content": "Zaps to live streams is beautiful.",
   // other fields...
 }
+```
+
+`q` tags MAY be used when citing events in the `.content` with [NIP-21](21.md).
+
+```json
+["q", "<event-id> or <event-address>", "<relay-url>", "<pubkey-if-a-regular-event>"]
 ```
 
 ## Use Cases

--- a/53.md
+++ b/53.md
@@ -62,7 +62,7 @@ This feature is important to avoid malicious event owners adding large account h
 
 ### Live Chat Message
 
-Event `kind:1311` is live chat's channel message. Clients MUST include the `a` tag of the activity. `e` tags denote the parent message this post is replying to. 
+Event `kind:1311` is live chat's channel message. Clients MUST include the `a` tag of the activity. An `e` tag denotes the direct parent message this post is replying to. 
 
 ```jsonc
 {


### PR DESCRIPTION
Updates live chat messages to remove the need for markers (they are not necessary) and use `q` tags for quotes.