### PR TITLE
NIP-17: Removes the need for markers and adds the use of `q` tags.

### DIFF
--- a/17.md
+++ b/17.md
@@ -21,7 +21,7 @@ Kind `14` is a chat message. `p` tags identify one or more receivers of the mess
   "tags": [
     ["p", "<receiver-1-pubkey>", "<relay-url>"],
     ["p", "<receiver-2-pubkey>", "<relay-url>"],
-    ["e", "<kind-14-id>", "<relay-url>", "reply"] // if this is a reply
+    ["e", "<kind-14-id>", "<relay-url>"] // if this is a reply
     ["subject", "<conversation-title>"],
     // rest of tags...
   ],
@@ -31,7 +31,13 @@ Kind `14` is a chat message. `p` tags identify one or more receivers of the mess
 
 `.content` MUST be plain text. Fields `id` and `created_at` are required.
 
-Tags that mention, quote and assemble threading structures MUST follow [NIP-10](10.md).
+An `e` tag denotes the direct parent message this post is replying to. 
+
+`q` tags MAY be used when citing events in the `.content` with [NIP-21](21.md).
+
+```json
+["q", "<event-id> or <event-address>", "<relay-url>", "<pubkey-if-a-regular-event>"]
+```
 
 Kind `14`s MUST never be signed. If it is signed, the message might leak to relays and become **fully public**.
 


### PR DESCRIPTION
There are no threading requirements for NIP-17, markers are not needed. 