### PR TITLE
Add timehashes to nip 52

### DIFF
--- a/52.md
+++ b/52.md
@@ -29,6 +29,7 @@ The list of tags are as follows:
 * `title` (required) title of the calendar event
 * `start` (required) inclusive start date in ISO 8601 format (YYYY-MM-DD). Must be less than `end`, if it exists.
 * `end` (optional) exclusive end date in ISO 8601 format (YYYY-MM-DD). If omitted, the calendar event ends on the same date as `start`.
+* `T` (required) a [timehash](#timehashes) overlapping with the event's scheduled duration. Multiple tags SHOULD be included to cover the event's duration at different resolutions.
 * `location` (optional, repeated) location of the calendar event. e.g. address, GPS coordinates, meeting room name, link to video call
 * `g` (optional) [geohash](https://en.wikipedia.org/wiki/Geohash) to associate calendar event with a searchable physical location
 * `p` (optional, repeated) 32-bytes hex pubkey of a participant, optional recommended relay URL, and participant's role in the meeting
@@ -53,6 +54,11 @@ The following tags are deprecated:
     // Dates
     ["start", "<YYYY-MM-DD>"],
     ["end", "<YYYY-MM-DD>"],
+
+    // Timehashes
+    ["T", "dy"],
+    ["T", "dyj"],
+    ["T", "dyju"],
 
     // Location
     ["location", "<location>"],
@@ -90,6 +96,7 @@ The list of tags are as follows:
 * `end` (optional) exclusive end Unix timestamp in seconds. If omitted, the calendar event ends instantaneously.
 * `start_tzid` (optional) time zone of the start timestamp, as defined by the IANA Time Zone Database. e.g., `America/Costa_Rica`
 * `end_tzid` (optional) time zone of the end timestamp, as defined by the IANA Time Zone Database. e.g., `America/Costa_Rica`. If omitted and `start_tzid` is provided, the time zone of the end timestamp is the same as the start timestamp.
+* `T` (required) a [timehash](#timehashes) overlapping with the event's scheduled duration. Multiple tags SHOULD be included to cover the event's duration at different resolutions.
 * `summary` (optional) brief description of the calendar event
 * `image` (optional) url of an image to use for the event
 * `location` (optional, repeated) location of the calendar event. e.g. address, GPS coordinates, meeting room name, link to video call
@@ -122,6 +129,11 @@ The following tags are deprecated:
 
     ["start_tzid", "<IANA Time Zone Database identifier>"],
     ["end_tzid", "<IANA Time Zone Database identifier>"],
+
+    // Timehashes
+    ["T", "dy"],
+    ["T", "dyj"],
+    ["T", "dyju"],
 
     // Location
     ["location", "<location>"],
@@ -223,9 +235,49 @@ The list of tags are as follows:
 }
 ```
 
-## Unsolved Limitations
+## Timehashes
 
-* No private events
+A timehash is an adaptation of [geohashes](https://en.wikipedia.org/wiki/Geohash) to nostr timestamps.
+
+Here's some example code in javascript for calculating them:
+
+```javascript
+function timeHash(seconds, precision = 32) {
+  const alphabet = '0123456789bcdefghjkmnpqrstuvwxyz'
+  const uint32 = Math.min(seconds >>> 0, 0xFFFFFFFF)
+  const binary = uint32.toString(2).padStart(32, '0')
+  const chunks = Math.min(Math.floor(precision / 5), 6)
+
+  let hash = ''
+
+  for (let i = 0; i < chunks * 5; i += 5) {
+    const chunk = binary.slice(i, i + 5)
+    const index = parseInt(chunk, 2)
+
+    hash += alphabet[index]
+  }
+
+  return hash
+}
+```
+
+For the purposes of this NIP, including hashes at precisions of 10 (~month granularity), 15 (~day granularity), and 20 (~hour granularity) should be sufficient. This will result in hashes of between 2 and 4 characters. If an event spans a longer period of time, multiple hashes at the same granularity should be included.
+
+For example, for an event spanning 3 hours from `1738774800` to `1738785600`, the following hashes would be valid: `dy, dyj, dyjt, dyju, dyjv, dyjw`. Here's a function for calculating that:
+
+```javascript
+function timeHashesBetween(start, end) {
+  const hashes = new Set()
+
+  for (let seconds = start; seconds <= end; seconds += 1800) {
+    for (const precision of [10, 15, 20]) {
+      hashes.add(timeHash(seconds, precision))
+    }
+  }
+
+  return Array.from(hashes).sort()
+}
+```
 
 ## Intentionally Unsupported Scenarios
 


### PR DESCRIPTION
This does the same thing for timestamps as geohashes does for locations. There's likely a better way to accomplish the task, so feel suggestions on the code snippets and algorithm are welcome.