### PR TITLE
[NIP-55] - Add the rejected permission check in the code samples

### DIFF
--- a/55.md
+++ b/55.md
@@ -339,6 +339,8 @@ If the user chose to always reject the event, signer application will return the
       ```kotlin
         if (result == null) return
 
+        if (it.getColumnIndex("rejected") > -1) return
+
         if (result.moveToFirst()) {
             val index = it.getColumnIndex("result")
             if (index < 0) return
@@ -363,6 +365,8 @@ If the user chose to always reject the event, signer application will return the
 
       ```kotlin
         if (result == null) return
+
+        if (it.getColumnIndex("rejected") > -1) return
 
         if (result.moveToFirst()) {
             val index = it.getColumnIndex("result")
@@ -390,6 +394,8 @@ If the user chose to always reject the event, signer application will return the
       ```kotlin
         if (result == null) return
 
+        if (it.getColumnIndex("rejected") > -1) return
+
         if (result.moveToFirst()) {
             val index = it.getColumnIndex("result")
             val encryptedText = it.getString(index)
@@ -413,6 +419,8 @@ If the user chose to always reject the event, signer application will return the
 
       ```kotlin
         if (result == null) return
+
+        if (it.getColumnIndex("rejected") > -1) return
 
         if (result.moveToFirst()) {
             val index = it.getColumnIndex("result")
@@ -438,6 +446,8 @@ If the user chose to always reject the event, signer application will return the
       ```kotlin
         if (result == null) return
 
+        if (it.getColumnIndex("rejected") > -1) return
+
         if (result.moveToFirst()) {
             val index = it.getColumnIndex("result")
             val encryptedText = it.getString(index)
@@ -461,6 +471,8 @@ If the user chose to always reject the event, signer application will return the
 
       ```kotlin
         if (result == null) return
+
+        if (it.getColumnIndex("rejected") > -1) return
 
         if (result.moveToFirst()) {
             val index = it.getColumnIndex("result")
@@ -486,6 +498,8 @@ If the user chose to always reject the event, signer application will return the
       ```kotlin
         if (result == null) return
 
+        if (it.getColumnIndex("rejected") > -1) return
+
         if (result.moveToFirst()) {
             val index = it.getColumnIndex("result")
             val relayJsonText = it.getString(index)
@@ -509,6 +523,8 @@ If the user chose to always reject the event, signer application will return the
 
       ```kotlin
         if (result == null) return
+
+        if (it.getColumnIndex("rejected") > -1) return
 
         if (result.moveToFirst()) {
             val index = it.getColumnIndex("result")


### PR DESCRIPTION
Most people that implements nip 55 don't implement this check since it's just written in the text at the start of the content resolver section and was not in any of the examples