### PR TITLE
nip-97: white-listed events.

### DIFF
--- a/51.md
+++ b/51.md
@@ -35,7 +35,7 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | DM relays         | 10050 | Where to receive [NIP-17](17.md) direct messages            | `"relay"` (see [NIP-17](17.md))                                                                     |
 | Good wiki authors | 10101 | [NIP-54](54.md) user recommended wiki authors               | `"p"` (pubkeys)                                                                                     |
 | Good wiki relays  | 10102 | [NIP-54](54.md) relays deemed to only host useful articles  | `"relay"` (relay URLs)                                                                              |
-| White-listed Followers  | 10103 | [NIP-97](97.md) white-listed followers, who are able to request white-listed only notes from kind `10103` owner.  | `"p"` ‍‍|
+| White-listed Access  | 10103 | [NIP-97](97.md) list of pubkeys who are authorized to download white-listed events from the author  | `"p"` ‍‍|
 
 ### Sets
 

--- a/51.md
+++ b/51.md
@@ -35,7 +35,7 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | DM relays         | 10050 | Where to receive [NIP-17](17.md) direct messages            | `"relay"` (see [NIP-17](17.md))                                                                     |
 | Good wiki authors | 10101 | [NIP-54](54.md) user recommended wiki authors               | `"p"` (pubkeys)                                                                                     |
 | Good wiki relays  | 10102 | [NIP-54](54.md) relays deemed to only host useful articles  | `"relay"` (relay URLs)                                                                              |
-| White-listed Access  | 10103 | [NIP-97](97.md) list of pubkeys who are authorized to download white-listed events from the author  | `"p"` ‍‍|
+| White-listed Followers  | 10103 | [NIP-97](97.md) white-listed followers, who are able to request white-listed only notes from kind `10103` owner.  | `"p"` (pubkeys) `"relay"` (relays supporting [white-listed events](97.md)) ‍‍|
 
 ### Sets
 

--- a/51.md
+++ b/51.md
@@ -35,6 +35,7 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | DM relays         | 10050 | Where to receive [NIP-17](17.md) direct messages            | `"relay"` (see [NIP-17](17.md))                                                                     |
 | Good wiki authors | 10101 | [NIP-54](54.md) user recommended wiki authors               | `"p"` (pubkeys)                                                                                     |
 | Good wiki relays  | 10102 | [NIP-54](54.md) relays deemed to only host useful articles  | `"relay"` (relay URLs)                                                                              |
+| Private Followers  | 10103 | A list of followers controlled by pubkey owner. Relays MAY restrict reading some pubkey notes to AUTHed ([NIP-98](98.md)) users presented in this list.   | `"p"` ‍‍|
 
 ### Sets
 

--- a/51.md
+++ b/51.md
@@ -35,7 +35,7 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | DM relays         | 10050 | Where to receive [NIP-17](17.md) direct messages            | `"relay"` (see [NIP-17](17.md))                                                                     |
 | Good wiki authors | 10101 | [NIP-54](54.md) user recommended wiki authors               | `"p"` (pubkeys)                                                                                     |
 | Good wiki relays  | 10102 | [NIP-54](54.md) relays deemed to only host useful articles  | `"relay"` (relay URLs)                                                                              |
-| Private Followers  | 10103 | A list of followers controlled by pubkey owner. Relays MAY restrict reading some pubkey notes to AUTHed ([NIP-98](98.md)) users presented in this list.   | `"p"` ‍‍|
+| White-listed Followers  | 10103 | [NIP-97](97.md) white-listed followers, who are able to request white-listed only notes from kind `10103` owner.  | `"p"` ‍‍|
 
 ### Sets
 

--- a/97.md
+++ b/97.md
@@ -16,7 +16,7 @@ Example of white-listed event:
   "kind": 1,
   "tags": [
     ["!"],
-    ["relays", "wss://private-notes.example.com", "wss://secret-notes.example.com", /*...*/],
+    ["relay", "wss://private-notes.example.com"],
   ],
   "content": "You can't see it before i grant you this permission!",
   // other fields...
@@ -33,8 +33,6 @@ A user can request to be added to a pubkey kind `10103` list using a kind `819` 
 {
   "kind": 819,
   "tags": [
-    ["relay", "wss://private-notes.example.com"],
-    ["relay", "wss://bob-friends.example.com"],
     ["expiration", "1738988143"],
     ["p", "abc...def"]
   ],

--- a/97.md
+++ b/97.md
@@ -27,13 +27,15 @@ Clients SHOULD publish private events with a protected tag (`"-"`) to relays who
 
 ### Private Follow Request
 
-A user can request to be added to a pubkey kind `10103` list using a kind `5030` event containing the target pubkey in a `"p"` tag:
+A user can request to be added to a pubkey kind `10103` list using a kind `819` event containing the target pubkey in a `"p"` tag:
 
 ```jsonc
 {
-  "kind": 5030,
+  "kind": 819,
   "tags": [
-    ["relays", "wss://private-notes.example.com", "wss://secret-notes.example.com", /*...*/],
+    ["relay", "wss://private-notes.example.com"],
+    ["relay", "wss://bob-friends.example.com"],
+    ["expiration", "1738988143"],
     ["p", "abc...def"]
   ],
   "content": "Please let me in.",
@@ -42,8 +44,8 @@ A user can request to be added to a pubkey kind `10103` list using a kind `5030`
 ```
 
 Clients MAY show `.content` to user as a request message.
-Its RECOMMENDED for clients to add a `"expiration"` tag to kind `5030` since they won't be useful after being accepted or rejected.
-Its RECOMMENDED for relays to cleanup kind `5030` after a reasonable amount of time since they won't be useful after being accepted or rejected.
+Clients MUST add a `"expiration"` tag to kind `819` since they won't be useful after being accepted or rejected.
+Its RECOMMENDED for relays to cleanup kind `819` after a reasonable amount of time since they won't be useful after being accepted or rejected.
 
 ### Clients
 

--- a/97.md
+++ b/97.md
@@ -1,0 +1,54 @@
+NIP-97
+======
+
+Private Events
+--------------
+
+`draft` `optional`
+
+
+An event containing `"!"` tag means a private event. A relay supporting private events MUST server private notes only to [NIP-98](98.md) AUTHed pubkeys presented in users kind `10103` [NIP-51](51.md) list.
+
+Example of private event:
+
+```jsonc
+{
+  "kind": 1,
+  "tags": [
+    ["!"],
+    ["relays", "wss://private-notes.example.com", "wss://secret-notes.example.com", /*...*/],
+  ],
+  "content": "You can't see it before i grant you this permission!",
+  // other fields...
+}
+```
+
+Clients SHOULD publish private events with a protected tag (`"-"`) to relays who implement and respect this spec.
+
+### Private Follow Request
+
+A user can request to be added to a pubkey kind `10103` list using a kind `5030` event containing the target pubkey in a `"p"` tag:
+
+```jsonc
+{
+  "kind": 5030,
+  "tags": [
+    ["relays", "wss://private-notes.example.com", "wss://secret-notes.example.com", /*...*/],
+    ["p", "abc...def"]
+  ],
+  "content": "Please let me in.",
+  // other fields...
+}
+```
+
+Clients MAY show `.content` to user as a request message.
+Its RECOMMENDED for clients to add a `"expiration"` tag to kind `5030` since they won't be useful after being accepted or rejected.
+Its RECOMMENDED for relays to cleanup kind `5030` after a reasonable amount of time since they won't be useful after being accepted or rejected.
+
+### Clients
+
+Clients SHOULD keep sending reactions, comments and replies to this events to same relays with protected and private tags, keeping the rest of information private.
+
+#### Warning
+
+The events could be downloaded by private followers and saved locally.

--- a/97.md
+++ b/97.md
@@ -1,7 +1,7 @@
 NIP-97
 ======
 
-Private Events
+White-listed Events
 --------------
 
 `draft` `optional`

--- a/97.md
+++ b/97.md
@@ -2,14 +2,14 @@ NIP-97
 ======
 
 White-listed Events
---------------
+-------------------
 
 `draft` `optional`
 
 
-An event containing an `"!"` tag means a private event. Relays supporting private events MUST serve private notes only to [NIP-98](98.md) AUTHed pubkeys presented in users' kind `10103` [NIP-51](51.md) list.
+An event containing an `"!"` tag means a white-listed event. Relays supporting white-listed events MUST serve these notes only to [NIP-98](98.md) AUTHed pubkeys presented in users' kind `10103` [NIP-51](51.md) list.
 
-Example of private event:
+Example of white-listed event:
 
 ```jsonc
 {
@@ -23,7 +23,7 @@ Example of private event:
 }
 ```
 
-Clients SHOULD publish private events with a protected tag (`"-"`) to relays who implement and respect this spec.
+Clients SHOULD publish white-listed events with a protected tag (`"-"`) to relays who implement and respect this spec.
 
 ### Private Follow Request
 
@@ -49,7 +49,7 @@ Its RECOMMENDED for relays to cleanup kind `819` after a reasonable amount of ti
 
 ### Clients
 
-Clients SHOULD keep sending reactions, comments and replies to this events to same relays with protected and private tags, keeping the rest of information private.
+Clients SHOULD keep sending reactions, comments and replies to this events to same relays with protected (`"-"`) and white-listed only (`"!"`) tags, keeping the rest of information private.
 
 #### Warning
 

--- a/97.md
+++ b/97.md
@@ -7,7 +7,7 @@ Private Events
 `draft` `optional`
 
 
-An event containing `"!"` tag means a private event. A relay supporting private events MUST server private notes only to [NIP-98](98.md) AUTHed pubkeys presented in users kind `10103` [NIP-51](51.md) list.
+An event containing an `"!"` tag means a private event. Relays supporting private events MUST serve private notes only to [NIP-98](98.md) AUTHed pubkeys presented in users' kind `10103` [NIP-51](51.md) list.
 
 Example of private event:
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `10050`       | Relay list to receive DMs       | [51](51.md), [17](17.md)               |
 | `10063`       | User server list                | [Blossom][blossom]                     |
 | `10096`       | File storage server list        | [96](96.md)                            |
+| `10101`       | Good wiki authors               | [51](51.md)                            |
+| `10102`       | Good wiki relays                | [51](51.md)                            |
+| `10103`       | Private Followers               | [51](51.md)                            |
 | `13194`       | Wallet Info                     | [47](47.md)                            |
 | `21000`       | Lightning Pub RPC               | [Lightning.Pub][lnpub]                 |
 | `22242`       | Client Authentication           | [42](42.md)                            |

--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `31924`       | Calendar                        | [52](52.md)                            |
 | `31925`       | Calendar Event RSVP             | [52](52.md)                            |
 | `31989`       | Handler recommendation          | [89](89.md)                            |
-| `31990`       | Handler information             | [89](89.md)                            |                         |
-| `32267`       | Software Application            |                                        |                        |
+| `31990`       | Handler information             | [89](89.md)                            |
+| `32267`       | Software Application            |                                        |
 | `34550`       | Community Definition            | [72](72.md)                            |
 | `37375`       | Cashu Wallet Event              | [60](60.md)                            |
 | `38383`       | Peer-to-peer Order events       | [69](69.md)                            |

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-92: Media Attachments](92.md)
 - [NIP-94: File Metadata](94.md)
 - [NIP-96: HTTP File Storage Integration](96.md)
+- [NIP-97: White-listed Events](97.md)
 - [NIP-98: HTTP Auth](98.md)
 - [NIP-99: Classified Listings](99.md)
 - [NIP-7D: Threads](7D.md)
@@ -131,6 +132,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `44`          | Channel Mute User               | [28](28.md)                            |
 | `64`          | Chess (PGN)                     | [64](64.md)                            |
 | `818`         | Merge Requests                  | [54](54.md)                            |
+| `819`         | Private Follow Request          | [97](97.md)                            |
 | `1018`        | Poll Response                   | [88](88.md)                            |
 | `1021`        | Bid                             | [15](15.md)                            |
 | `1022`        | Bid confirmation                | [15](15.md)                            |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `44`          | Channel Mute User               | [28](28.md)                            |
 | `64`          | Chess (PGN)                     | [64](64.md)                            |
 | `818`         | Merge Requests                  | [54](54.md)                            |
-| `819`         | Private Follow Request          | [97](97.md)                            |
+| `819`         | White-listed Follow Request     | [97](97.md)                       |
 | `1018`        | Poll Response                   | [88](88.md)                            |
 | `1021`        | Bid                             | [15](15.md)                            |
 | `1022`        | Bid confirmation                | [15](15.md)                            |


### PR DESCRIPTION
this is basically some updates over fiatjafs lockbox. it was expected to be only an addition to nip-51 but i saw that it can be more complete.

i think the best client that can support this is jumble probably. if it got accepted, i would implement a khatru relay which supports it. also i would include it on immortal in future. 