### PR TITLE
Secure hll

### DIFF
--- a/45.md
+++ b/45.md
@@ -43,11 +43,11 @@ This is so it enables merging results from multiple relays and yielding a reason
 
 This section describes the steps a relay should take in order to return HLL values to clients.
 
-1. Upon receiving a filter, if it has a single `#e`, `#p`, `#a` or `#q` item, read its 32th ascii character as a byte and take its modulo over 24 to obtain an `offset` -- in the unlikely case that the filter doesn't meet these conditions, set `offset` to the number 16;
-2. Initialize 256 registers to 0 for the HLL value;
+1. Upon receiving a filter, if it has a single `#e`, `#p`, `#a` or `#q` item, read its 32th ascii character as a nibble (a half-byte, a number between 0 and 16) and add `8` to it to obtain an `offset` -- in the unlikely case that the filter doesn't meet these conditions, set `offset` to the number `16`;
+2. Initialize 256 registers to `0` for the HLL value;
 3. For all the events that are to be counted according to the filter, do this:
     1. Read byte at position `offset` of the event `pubkey`, its value will be the register index `ri`;
-    2. Count the number of leading zero bits starting at position `offset+1` of the event `pubkey`;
+    2. Count the number of leading zero bits starting at position `offset+1` of the event `pubkey` and add `1`;
     3. Compare that with the value stored at register `ri`, if the new number is bigger, store it.
 
 That is all that has to be done on the relay side, and therefore the only part needed for interoperability.

--- a/45.md
+++ b/45.md
@@ -56,6 +56,10 @@ On the client side, these HLL values received from different relays can be merge
 
 And finally the absolute count can be estimated by running some methods I don't dare to describe here in English, it's better to check some implementation source code (also, there can be different ways of performing the estimation, with different quirks applied on top of the raw registers).
 
+### Attack vectors
+
+One could mine a pubkey with a certain number of zero bits in the exact place where the HLL algorithm described above would look for them in order to artificially make its reaction or follow "count more" than others. For this to work a different pubkey would have to be created for each different target (event id, followed profile etc). This approach is not very different than creating tons of new pubkeys and using them all to send likes or follow someone in order to inflate their number of followers. The solution is the same in both cases: clients should not fetch these reaction counts from open relays that accept everything, they should base their counts on relays that perform some form of filtering that makes it more likely that only real humans are able to publish there and not bots or artificially-generated pubkeys.
+
 ### `hll` encoding
 
 The value `hll` value must be the concatenation of the 256 registers, each being a uint8 value (i.e. a byte). Therefore `hll` will be a 512-character hex string.

--- a/45.md
+++ b/45.md
@@ -41,13 +41,14 @@ This is so it enables merging results from multiple relays and yielding a reason
 
 ### Algorithm
 
-The HLL value must be calculated with a precision of `8`, i.e. with 256 registers.
+This section describes the steps a relay should take in order to return HLL values to clients.
 
-To compute HLL values, first initi the 256 registers to `0` each; then, for on every event to be counted,
-
-  1. take byte `16` of the `id` and use it to determine the register index;
-  2. count the number of leading zero bits in the following bytes `17..24` of the `id`;
-  3. if the number of leading zeros is bigger than what was previously stored in that register, overwrite it.
+1. Upon receiving a filter, if it has a single `#e`, `#p`, `#a` or `#q` item, read its 32th ascii character as a byte and take its modulo over 24 to obtain an `offset` -- in the unlikely case that the filter doesn't meet these conditions, set `offset` to the number 16;
+2. Initialize 256 registers to 0 for the HLL value;
+3. For all the events that are to be counted according to the filter, do this:
+    1. Read byte at position `offset` of the event `pubkey`, its value will be the register index `ri`;
+    2. Count the number of leading zero bits starting at position `offset+1` of the event `pubkey`;
+    3. Compare that with the value stored at register `ri`, if the new number is bigger, store it.
 
 That is all that has to be done on the relay side, and therefore the only part needed for interoperability.
 

--- a/45.md
+++ b/45.md
@@ -43,10 +43,10 @@ This is so it enables merging results from multiple relays and yielding a reason
 
 This section describes the steps a relay should take in order to return HLL values to clients.
 
-1. Upon receiving a filter, if it has a single `#e`, `#p`, `#a` or `#q` item, read its 32th ascii character as a nibble (a half-byte, a number between 0 and 16) and add `8` to it to obtain an `offset` -- in the unlikely case that the filter doesn't meet these conditions, set `offset` to the number `16`;
+1. Upon receiving a filter, if it is eligible (see below) for HyperLogLog, compute the deterministic `offset` for that filter (see below);
 2. Initialize 256 registers to `0` for the HLL value;
 3. For all the events that are to be counted according to the filter, do this:
-    1. Read byte at position `offset` of the event `pubkey`, its value will be the register index `ri`;
+    1. Read the byte at position `offset` of the event `pubkey`, its value will be the register index `ri`;
     2. Count the number of leading zero bits starting at position `offset+1` of the event `pubkey` and add `1`;
     3. Compare that with the value stored at register `ri`, if the new number is bigger, store it.
 
@@ -55,6 +55,13 @@ That is all that has to be done on the relay side, and therefore the only part n
 On the client side, these HLL values received from different relays can be merged (by simply going through all the registers in HLL values from each relay and picking the highest value for each register, regardless of the relay).
 
 And finally the absolute count can be estimated by running some methods I don't dare to describe here in English, it's better to check some implementation source code (also, there can be different ways of performing the estimation, with different quirks applied on top of the raw registers).
+
+### Filter eligibility and `offset` computation
+
+This NIP defines (for now) two filters eligible for HyperLogLog:
+
+- `{"#p": ["<pubkey>"], "kinds": [3]}`, i.e. a filter for `kind:3` events with a single `"p"` tag, which means the client is interested in knowing how many people "follow" the target `<pubkey>`. In this case the `offset` will be given by reading the character at the position `32` of the hex `<pubkey>` value as a base-16 number then adding `8` to it.
+- `{"#e": ["<id>"], "kinds": [7]}`, i.e. a filter for `kind:7` events with a single `"e"` tag, which means the client is interested in knowing how many people have reacted to the target event `<id>`. In this case the `offset` will be given by reading the character at the position `32` of the hex `<id>` value as a base-16 number then adding `8` to it.
 
 ### Attack vectors
 

--- a/45.md
+++ b/45.md
@@ -29,14 +29,37 @@ In case a relay uses probabilistic counts, it MAY indicate it in the response wi
 
 Whenever the relay decides to refuse to fulfill the `COUNT` request, it MUST return a `CLOSED` message.
 
+## HyperLogLog
+
+Relays may return an HyperLogLog value together with the count, hex-encoded.
+
+```
+["COUNT", <subscription_id>, {"count": <integer>, "hll": "<hex>"}]
+```
+
+This is so it enables merging results from multiple relays and yielding a reasonable estimate of reaction counts, comment counts and follower counts, while saving many millions of bytes of bandwidth for everybody.
+
+### Algorithm
+
+The HLL value must be calculated with a precision of `8`, i.e. with 256 registers.
+
+To compute HLL values, first initi the 256 registers to `0` each; then, for on every event to be counted,
+
+  1. take byte `16` of the `id` and use it to determine the register index;
+  2. count the number of leading zero bits in the following bytes `17..24` of the `id`;
+  3. if the number of leading zeros is bigger than what was previously stored in that register, overwrite it.
+
+That is all that has to be done on the relay side, and therefore the only part needed for interoperability.
+
+On the client side, these HLL values received from different relays can be merged (by simply going through all the registers in HLL values from each relay and picking the highest value for each register, regardless of the relay).
+
+And finally the absolute count can be estimated by running some methods I don't dare to describe here in English, it's better to check some implementation source code (also, there can be different ways of performing the estimation, with different quirks applied on top of the raw registers).
+
+### `hll` encoding
+
+The value `hll` value must be the concatenation of the 256 registers, each being a uint8 value (i.e. a byte). Therefore `hll` will be a 512-character hex string.
+
 ## Examples
-
-### Followers count
-
-```
-["COUNT", <subscription_id>, {"kinds": [3], "#p": [<pubkey>]}]
-["COUNT", <subscription_id>, {"count": 238}]
-```
 
 ### Count posts and reactions
 
@@ -45,11 +68,19 @@ Whenever the relay decides to refuse to fulfill the `COUNT` request, it MUST ret
 ["COUNT", <subscription_id>, {"count": 5}]
 ```
 
+
 ### Count posts approximately
 
 ```
 ["COUNT", <subscription_id>, {"kinds": [1]}]
 ["COUNT", <subscription_id>, {"count": 93412452, "approximate": true}]
+```
+
+### Followers count with HyperLogLog
+
+```
+["COUNT", <subscription_id>, {"kinds": [3], "#p": [<pubkey>]}]
+["COUNT", <subscription_id>, {"count": 16578, "hll": "0607070505060806050508060707070706090d080b0605090607070b07090606060b0705070709050807080805080407060906080707080507070805060509040a0b06060704060405070706080607050907070b08060808080b080607090a06060805060604070908050607060805050d05060906090809080807050e0705070507060907060606070708080b0807070708080706060609080705060604060409070a0808050a0506050b0810060a0908070709080b0a07050806060508060607080606080707050806080c0a0707070a080808050608080f070506070706070a0908090c080708080806090508060606090906060d07050708080405070708"}]
 ```
 
 ### Relay refuses to count

--- a/45.md
+++ b/45.md
@@ -65,7 +65,21 @@ This NIP defines (for now) two filters eligible for HyperLogLog:
 
 ### Attack vectors
 
-One could mine a pubkey with a certain number of zero bits in the exact place where the HLL algorithm described above would look for them in order to artificially make its reaction or follow "count more" than others. For this to work a different pubkey would have to be created for each different target (event id, followed profile etc). This approach is not very different than creating tons of new pubkeys and using them all to send likes or follow someone in order to inflate their number of followers. The solution is the same in both cases: clients should not fetch these reaction counts from open relays that accept everything, they should base their counts on relays that perform some form of filtering that makes it more likely that only real humans are able to publish there and not bots or artificially-generated pubkeys.
+One could mine a pubkey with a certain number of zero bits in the exact place where the HLL algorithm described above would look for them in order to artificially make its reaction or follow "count more" than others. For this to work a different pubkey would have to be created for each different target (event id, followed profile etc). This approach is not very different than creating tons of new pubkeys and using them all to send likes or follow someone in order to inflate their number of followers.
+
+The solution is the same in both cases: clients should not fetch these reaction counts from open relays that accept everything, they should base their counts on relays that perform some form of filtering that makes it more likely that only real humans are able to publish there and not bots or artificially-generated pubkeys.
+
+An alternative solution is Secure HyperLogLog:
+
+### Secure HyperLogLog
+
+Because the HyperLogLog input is deterministic (and must be for relays that do not store all of the counted events), there is some potential for gaming the system. Relays that do store all of the events may also return a Secure HyperLogLog value together with the regular HyperLogLog value:
+
+```
+["COUNT", <subscription_id>, {"count": <integer>, "hll": "<hex>", "shll": "<hex>"}]
+```
+
+The Secure HyperLogLog scheme is identical to the HyperLogLog scheme except that instead of operating on the event `pubkey`, the algorithm operates on `SHA256(concat(<subscription_id>, <event_pubkey>))`.  Clients will need to use the same `<subscription_id>` at each relay in order for the resulting data to properly combine.
 
 ### `hll` encoding
 

--- a/45.md
+++ b/45.md
@@ -63,6 +63,10 @@ This NIP defines (for now) two filters eligible for HyperLogLog:
 - `{"#p": ["<pubkey>"], "kinds": [3]}`, i.e. a filter for `kind:3` events with a single `"p"` tag, which means the client is interested in knowing how many people "follow" the target `<pubkey>`. In this case the `offset` will be given by reading the character at the position `32` of the hex `<pubkey>` value as a base-16 number then adding `8` to it.
 - `{"#e": ["<id>"], "kinds": [7]}`, i.e. a filter for `kind:7` events with a single `"e"` tag, which means the client is interested in knowing how many people have reacted to the target event `<id>`. In this case the `offset` will be given by reading the character at the position `32` of the hex `<id>` value as a base-16 number then adding `8` to it.
 
+### `hll` encoding
+
+The value `hll` value must be the concatenation of the 256 registers, each being a uint8 value (i.e. a byte). Therefore `hll` will be a 512-character hex string.
+
 ### Attack vectors
 
 One could mine a pubkey with a certain number of zero bits in the exact place where the HLL algorithm described above would look for them in order to artificially make its reaction or follow "count more" than others. For this to work a different pubkey would have to be created for each different target (event id, followed profile etc). This approach is not very different than creating tons of new pubkeys and using them all to send likes or follow someone in order to inflate their number of followers.
@@ -80,10 +84,6 @@ Because the HyperLogLog input is deterministic (and must be for relays that do n
 ```
 
 The Secure HyperLogLog scheme is identical to the HyperLogLog scheme except that instead of operating on the event `pubkey`, the algorithm operates on `SHA256(concat(<subscription_id>, <event_pubkey>))`.  Clients will need to use the same `<subscription_id>` at each relay in order for the resulting data to properly combine.
-
-### `hll` encoding
-
-The value `hll` value must be the concatenation of the 256 registers, each being a uint8 value (i.e. a byte). Therefore `hll` will be a 512-character hex string.
 
 ## Examples
 


### PR DESCRIPTION
This is my proposal for the "gaming" issue that so many people are worried about.  It is in-addition to the base `hll` so that relays do not need to store reaction events if they don't want to, and also clients can choose whether to use all the `shll` results, or fallback to the `hll` results based on what the actual relays are able to supply.