### PR TITLE
add terms to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [Criteria for acceptance of NIPs](#criteria-for-acceptance-of-nips)
 - [Is this repository a centralizing factor?](#is-this-repository-a-centralizing-factor)
 - [How this repository works](#how-this-repository-works)
+- [Terminology](#terminology)
 - [Breaking Changes](#breaking-changes)
 - [License](#license)
 
@@ -360,6 +361,15 @@ There is a list of notable Nostr software developers who have commit access to t
 Standards may emerge in two ways: the first way is that someone starts doing something, then others copy it; the second way is that someone has an idea of a new standard that could benefit multiple clients and the protocol in general without breaking **backwards-compatibility** and the principle of having **a single way of doing things**, then they write that idea and submit it to this repository, other interested parties read it and give their feedback, then once most people reasonably agree we codify that in a NIP which client and relay developers that are interested in the feature can proceed to implement.
 
 These two ways of standardizing things are supported by this repository. Although the second is preferred, an effort will be made to codify standards emerged outside this repository into NIPs that can be later referenced and easily understood and implemented by others -- but obviously as in any human system discretion may be applied when standards are considered harmful.
+
+## Terminology
+
+Here is a list of common terms between NIPs defined to prevent misunderstanding:
+
+- **Relay**: An independent websocket server which stores and retrieves events.
+- **Client**: A software which allows a **user** to interact with **relay**s.
+- **User**: An individual using a **client** to interact with a relay.
+- **Pubkey**: A cryptography public key which a **user** uses within their **client** to sign their events.
 
 ## Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ These two ways of standardizing things are supported by this repository. Althoug
 
 Here is a list of common terms between NIPs defined to prevent misunderstanding:
 
-- **Relay**: An independent websocket server which stores and retrieves events.
+- **Relay**: An independent websocket server which stores and serves events.
 - **Client**: A software which allows a **user** to interact with **relay**s.
 - **User**: An individual using a **client** to interact with a relay.
 - **Pubkey**: A cryptography public key which a **user** uses within their **client** to sign their events.


### PR DESCRIPTION
the reason im adding this is to clreaify the relation between terms `user`, `client` and `pubkey` for who read or write standards about nostr.

im not sure if we have any nips using these terms interchangeably, but i think these can be confusing and used interchangeably in some texts.