### PR TITLE
NIP-77 - Localised Events

### DIFF
--- a/77.md
+++ b/77.md
@@ -1,0 +1,41 @@
+NIP-77
+======
+
+Localised Events
+----------------
+
+`draft` `optional`
+
+This NIP defines an event with `kind: -1` that can represent a non-public interaction with the relay that demands some sort of response from local IoT devices.
+
+```json
+{
+    "kind": -1,
+    "tags": [
+        ["p", <iot-device-key>] // optional
+    ],
+    "content": {
+        "event": "beer-dispensed",
+        "amount": "500"
+    }
+    ...
+}
+```
+
+These events MUST NOT be readable or writeable from devices outside the local network. If external access is desired, it is best implemented by a device operating on the local network or loopback interface. 
+
+These events MAY be subject to a blacklist or whitelist of pubkeys. These events MAY be subject to external logic which determines whether the event will be successfully published to the relay.
+
+## Example Uses
+
+### Door Control
+
+Define selective access to a space by associating membership with a keyfob (or potentially a NFC-enabled signing device) and requesting access by querying the local central relay.
+
+### Jukebox
+
+Post an event to the relay which will trigger a listening audio server to play a particular song, album, or playlist.
+
+### Light Toggling
+
+Send an event with a nostr application to change the color of smart lighting. Can be limited to one event every `x` seconds.


### PR DESCRIPTION
# NIP-77 - Localised Events

## Abstract

[Event Storage](https://en.wikipedia.org/wiki/Event_store) is a common design pattern across modern applications. Maintaining a consistent, append-only log of events is helpful to build applications with easily replicable system states. Relying on the robust event-loggin system established by the nostr community is an excellent way to extend the nostr ecosystem in novel and interesting ways.

## Background

While initially designed as a means of decentralizing social interaction, progress over the last couple years has shown that there is clear potential for the nostr protocol to be used for much more. One potential avenue for progress on this front is using a nostr relay as a single source of truth for hardware interaction in a local environment.

**Example 1** - The Makerspace is a fictional community which runs a member-operated space with 24/7 access. In order to keep track of who uses the space and when, a fob-operated door control is installed into the space. These fobs contain unique codes which are registered via signed events posted to the relay. When a member taps their fob, the door control sends an event to the relay which has been signed by the door control. This event would be picked up by a membership validator, which would verify that the member holding the relevant fob is in good standing with the community. Upon verification, the validator would send an event to the relay to open the door, and the door controller would respond by activating the relevant mechanism.

**Example 2** - The Makerspace wants to implement smart lighting within the space. In order to prevent signal spamming, they want to limit lighting signals to once every 10 seconds. A relay can be configured to reject new lighting events within this timeframe, while any smart lighting controllers will be listening to the relay for any lightning events posted by active members.

In both of these cases, events are published to the relay which are not intended for the general public. These events are only relevant to clients within the local network, and should only be accessible to clients querying from specific subnets. Additionally, these events should be subject to different rules regarding how and when they can be read and written.

## Proposal

This proposal suggests the addition of localised events which would be relevant and accessible only to devices on the local network. These events would be denoted as kind `-1` and implement all standard features indicated in NIP-01. Localised events would always include a stringified JSON object in the `content` field. The only mandatory property of this object would be the `event` field, a string used to indicate what kind of action was taken in the space (e.g. 'door-opened', 'light-toggled'). Other properties would include values useful for further processing, such as the toggled value of the lights or the id of the door which was opened. `p` tags could be used to direct signals to specific listeners, `e` tags could be used to indicate that an event occured in response to another event, etc.

## Rationale

IoT systems which rely on a nostr relay as a single source of truth should have a simple way to subscribe to events which are relevant to how they function. There should be specific rules around how these events are shared which keep them separate from social data which is available on the relay. The simplest way to implement this would be for IoT devices to subscribe only to one kind of event, potentially including a `p` filter if necessary.

This NIP reinforces the notion of real-world, nostr-enabled spaces. Having communities which use the nostr protocol as a means of interacting with hardware gives tangible, practical examples for how the protocol can be used for more than social interaction.

## Discussion Points

1. Does it make sense to unify the 'public' and 'private' aspects of a relay? Should the relay responsible for propagating these events remain separate from the one used to share social data?
2. Is this NIP important and useful enough to be canonized? Is enough of this functionality already implemented in existing NIPs to make this spec unnecessary?
3. Is `-1` an effective kind for indicating that the data is not meant to be published to the wider network? Are there any major relays which only use unsigned ints for kind?
