### PR TITLE
Deprecate stringified JSON in favor of tags on user metadata kind 0 events

### DIFF
--- a/01.md
+++ b/01.md
@@ -89,7 +89,11 @@ Kinds specify how clients should interpret the meaning of each event and the oth
 
 This NIP defines one basic kind:
 
-- `0`: **user metadata**: the `content` is set to a stringified JSON object `{name: <nickname or full name>, about: <short bio>, picture: <url of the image>}` describing the user who created the event. [Extra metadata fields](24.md#kind-0) may be set. A relay may delete older events once it gets a new one for the same pubkey.
+- `0`: **user metadata**: a basic set of metadata `tags` describing the user who created the event. [Extra metadata fields](24.md#kind-0) may be set. A relay may delete older events once it gets a new one for the same pubkey. These tags include:
+  - `name`: `<nickname or full name>`
+  - `about`: `<short bio>`
+  - `picture`: `<url of the image>`
+  - **DEPRECATED**: the `content` field has been used to store the stringified JSON of metadata fields in the format of `{name: <nickname or full name>, about: <short bio>, picture: <url of the image>}`. Clients SHOULD write metadata as both tags and legacy stringified JSON until a reasonable number of SDKs and popular clients on each operating system platform have adopted using tags on the user metadata event to avoid introducing breaking changes.
 
 And also a convention for kind ranges that allow for easier experimentation and flexibility of relay implementation:
 

--- a/24.md
+++ b/24.md
@@ -11,7 +11,7 @@ This NIP keeps track of extra optional fields that can added to events which are
 kind 0
 ======
 
-These are extra fields not specified in NIP-01 that may be present in the stringified JSON of metadata events:
+These are extra fields not specified in NIP-01 that may be present in the tags of metadata events:
 
   - `display_name`: an alternative, bigger name with richer characters than `name`. `name` should always be set regardless of the presence of `display_name` in the metadata.
   - `website`: a web URL related in any way to the event author.
@@ -24,6 +24,8 @@ These are fields that should be ignored or removed when found in the wild:
 
   - `displayName`: use `display_name` instead.
   - `username`: use `name` instead.
+
+The `content` field has been used to store the stringified JSON of metadata fields. It has been deprecated in favor of using tags. Clients SHOULD write metadata as both tags and legacy stringified JSON until a reasonable number of SDKs and popular clients on each platform have adopted using tags on the user metadata event to avoid introducing breaking changes.
 
 kind 3
 ======


### PR DESCRIPTION
I feel like this change is long overdue. The general convention for any kind is to use tags over stringified JSON. The fact that kind 0 uses stringified JSON is an artifact of a legacy spec from long ago before conventions were established, and makes reading and writing kind 0 harder than it should be.

As of creating this PR, I do not believe any existing Nostr client implements support for kind 0 tags, but that can change, and should happen so that the PR can meet acceptance criteria of being implemented in at least 2 clients.

I acknowledge that this will introduce a breaking change for ALL Nostr clients, but I believe it's worthwhile and doable to fix while Nostr is still relatively early.