### PR TITLE
A4 Citations NIP

### DIFF
--- a/A4.md
+++ b/A4.md
@@ -1,0 +1,150 @@
+NIP-A4
+======
+
+Citations
+-------------------------------
+
+`draft`
+
+This NIP defines the basic structure of citations required for embedded quotes, footnotes, endnotes, in-line references, appendices, and prompt records.
+
+It covers internal (to Nostr addresses) and external (to the wider web or printed material) citations.
+
+## In-Event References
+
+The fixed citations MAY be documented in-event, in whichever format the event normally handles, such as plain-text, Markdown, or Asciidoc. In-event references to nostr addresses MUST be formulated with similar information as in `kind:30` (see below), according to the following format:
+
+```
+[author]. Nostr: "[title]". [published on].
+nostr:[npub]
+nostr:[event identifier, human-readable]
+```
+
+Example:
+```
+John Smith. Nostr: "The Truth About Time". 18 January 2024.
+nostr:npub11038193028767404737...
+nostr:naddr1992p01098091432700...
+```
+
+## Ex-Event References
+
+Ideally, citations SHOULD be documented ex-event, within the following structure, to ensure completeness, reusability, discoverability, and applicability of the citation.
+
+* `kind:30` internal reference,
+* `kind:31` external web reference,
+* `kind:32` hardcopy reference,
+* `kind:33` prompt reference
+
+### Event Structure
+
+*Internal Nostr reference*
+
+```jsonc
+{
+  "kind": 30,
+  "pubkey": "<citation-writer-pubkey>",
+  "tags": [
+    ["c", "<kind>:<pubkey>:<hex event id>", "<relay hint>"]
+    ["published_on", "<date-time in ISO 8601 format>"],
+    ["title", "<title to display for citation>"],
+    ["author", "<author to display for citation, such as a handle name or proper name of the npub>"],
+    // additional, optional tags
+    ["accessed_on", "<date-time in ISO 8601 format>"],
+    ["location", "<where was it written or published>"],
+    ["g", "<geohash of the precise location>"],
+    ["summary", "<short explanation of which topics the citation covers>"]
+  ],
+  "content": "<text cited>"
+}
+```
+
+*External Web Reference*
+
+```jsonc
+{
+  "kind": 31,
+  "pubkey": "<citation-writer-pubkey>",
+  "tags": [
+    // mandatory tags
+    ["u", "<URL where citation was accessed>"]
+    ["accessed_on", "<date-time in ISO 8601 format>"],
+    ["title", "<title to display for citation>"],
+    ["author", "<author to display for citation>"],
+    // additional, optional tags
+    ["published_on", "<date-time in ISO 8601 format>"],
+    ["published_by", "<who published the citation>"],
+    ["version", "<version or edition of the publication>"],
+    ["location", "<where was it written or published>"],
+    ["g", "<geohash of the precise location>"],
+    ["open_timestamp", "<`e` tag of kind 1040 event>"],
+    ["summary", "<short explanation of which topics the citation covers>"]
+  ],
+  "content": "<text cited>"
+}
+```
+
+*Hardcopy Reference*
+
+```jsonc
+{
+  "kind": 32,
+  "pubkey": "<citation-writer-pubkey>",
+  "tags": [
+    ["accessed_on", "<date-time in ISO 8601 format>"],
+    ["title", "<title to display for citation>"],
+    ["author", "<author to display for citation>"],
+    // additional, optional tags
+    ["page_range", "<pages the citation is found on>"],
+    ["chapter_title", "<chapter or section the citation is found within>"],
+    ["editor", "who edited the publication"],
+    ["published_on", "<date-time in ISO 8601 format>"],
+    ["published_by", "<who published the citation>"],
+    ["published_in", "<journal name>", "<volume>"],
+    ["doi", "<DOI number>"],
+    ["version", "<version or edition of the publication>"],
+    ["location", "<where was it written or published>"],
+    ["g", "<geohash of the precise location>"],
+    ["summary", "<short explanation of which topics the citation covers>"]
+  ],
+  "content": "<text cited>"
+}
+```
+
+*Prompt Reference*
+
+```jsonc
+{
+  "kind": 33,
+  "pubkey": "<citation-writer-pubkey>",
+  "tags": [
+    ["llm", "<language model used for the prompt, like ChatGPT>"]
+    ["accessed_on", "<date-time in ISO 8601 format"],
+    ["version", "<version or edition of the model>"],
+    ["summary", "<prompt conversation script>"],
+    // additional, optional tags
+    ["u", "<website llm was accessed from>"]
+  ],
+  "content": "<text cited>"
+}
+```
+
+### Markup Scheme
+
+#### Traditional Citations
+
+`[[citation::end::nevent018472...]]` Endnotes, placed in full, in the "References" section, at the end of the publication.
+
+`[[citation::foot::nevent018472...]]` Footnotes, placed next to the text they will reference, and replaced by the client with a superscript number or similar, and then listed in full at the bottom of the corresponding section.
+
+`[[citation::foot-end::nevent018472...]]` Footnotes that link to a corresponding endnote. Only a brief reference, at the bottom of the section.
+
+`[[citation::inline::nevent18478...]]` In-line reference, such as "(Jackson, 2005, p. 16)", placed within a paragraph, with the complete data listed under "References".
+
+`[[citation::quote::nevent018472...]]` Content quoted, with associated quote-header and corresponding endnote.
+
+#### AI Citations
+
+`[[citation::prompt-end::nevent018472...]]` AI citation, appearing in the "References" section, with full data listed.
+
+`[[citation::prompt-inline::nevent018472...]]` AI citation, appearing next to the text they reference, with full data listed under "References". E.g. "(OpenAI, 2023)".


### PR DESCRIPTION
This NIP defines the basic structure of citations required for embedded quotes, footnotes, endnotes, in-line references, appendices, and prompt records.
It covers internal (to Nostr addresses) and external (to the wider web or printed material) citations.