### PR TITLE
NWC Deep Links

### DIFF
--- a/47.md
+++ b/47.md
@@ -511,3 +511,21 @@ This NIP does not specify any requirements on the type of relays used. However, 
   "sig": "31f57b369459b5306a5353aa9e03be7fbde169bc881c3233625605dd12f53548179def16b9fe1137e6465d7e4d5bb27ce81fd6e75908c46b06269f4233c845d8"
 }
 ```
+
+### Deep-links
+
+Wallet applications can register deeplinks in mobile systems to make it possible to create a linking UX that doesn't require the user scanning a QR code or pasting some code.
+
+`nostrnwc://connect` and `nostrnwc+{app_name}://connect` can be registered by wallet apps and queried by apps that want to receive an NWC pairing code.
+
+All URI parameters, MUST be URI-encoded.
+
+URI parameters:
+ * `appicon` -- URL to an icon of the client that wants to create a connection.
+ * `appname` -- Name of the client that wants to create a connection.
+ * `callback` -- URI schema the wallet should open with the connection string
+
+Once a connection has been created by the wallet, it should be returned to the client by opening the callback with the following parameters
+ * `value` -- NWC pairing code (e.g. `nostr+walletconnect://...`)
+
+


### PR DESCRIPTION
This PR documents a standard for using deeplinks to communicate between a wallet and a nostr client.

The mobile app checks if there is a handler for nostrnwc:// or a handful of nostrnwc+{known_nwc-capable_wallets}://  -- if one is found, the app can open the app via a deeplink and receive the NWC pairing code back from the wallet.