### PR TITLE
Add 2 prefixes, and define them all

### DIFF
--- a/01.md
+++ b/01.md
@@ -174,4 +174,15 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
   * `["CLOSED", "sub1", "unsupported: filter contains unknown elements"]`
   * `["CLOSED", "sub1", "error: could not connect to the database"]`
   * `["CLOSED", "sub1", "error: shutting down idle subscription"]`
-- The standardized machine-readable prefixes for `OK` and `CLOSED` are: `duplicate`, `pow`, `blocked`, `rate-limited`, `invalid`, `restricted`, and `error` for when none of that fits.
+  * `["CLOSED", "sub1", "redacted: some matching events were not served because you are not authorized or authenticated"]`
+- The standardized machine-readable prefixes are:
+  * `blocked` - for EVENT, when the relay rejects the event for any reason not better described by another prefix
+  * `deleted` - for EVENT, when the relay rejects the event because it has been deleted
+  * `duplicate` - for EVENT, when the relay already has the event
+  * `error` - for EVENT or CLOSED, used for relay errors and also when no other prefix suits
+  * `invalid` - for EVENT or CLOSED, when the request is somehow invalid
+  * `pow` - for EVENT, when the event does not reach the minimum proof-of-work threshold. See [NIP-13](13.md)
+  * `rate-limited` - for EVENT, when the relay rejects the event due to rate limiting, or too many subscriptions being open
+  * `redacted` - for CLOSED, when some matching events were not served due to the requester not being authenticated or authorized.
+  * `restricted` - for EVENT, when the relay rejects the event due to the author or submitter not being authenticated or authorized.
+

--- a/01.md
+++ b/01.md
@@ -182,7 +182,7 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
   * `error` - for OK or CLOSED, used for relay errors and also when no other prefix suits
   * `invalid` - for OK or CLOSED, when the request is somehow invalid
   * `pow` - for OK, when the event does not reach the minimum proof-of-work threshold. See [NIP-13](13.md)
-  * `rate-limited` - for OK, when the relay rejects the event due to rate limiting, or too many subscriptions being open
+  * `rate-limited` - for OK or CLOSED, when the relay rejects the event due to rate limiting, or too many subscriptions being open
 - The [NIP-42](42.md) extensions are:
   * `auth-required` - for OK or CLOSED, when a client has not performed `AUTH` and the relay requires that to fulfill the query or write the event.
   * `redacted` - for CLOSED, when some matching events were not served due to the requester not being authenticated or authorized.

--- a/01.md
+++ b/01.md
@@ -176,13 +176,14 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
   * `["CLOSED", "sub1", "error: shutting down idle subscription"]`
   * `["CLOSED", "sub1", "redacted: some matching events were not served because you are not authorized or authenticated"]`
 - The standardized machine-readable prefixes are:
-  * `blocked` - for EVENT, when the relay rejects the event for any reason not better described by another prefix
-  * `deleted` - for EVENT, when the relay rejects the event because it has been deleted
-  * `duplicate` - for EVENT, when the relay already has the event
-  * `error` - for EVENT or CLOSED, used for relay errors and also when no other prefix suits
-  * `invalid` - for EVENT or CLOSED, when the request is somehow invalid
-  * `pow` - for EVENT, when the event does not reach the minimum proof-of-work threshold. See [NIP-13](13.md)
-  * `rate-limited` - for EVENT, when the relay rejects the event due to rate limiting, or too many subscriptions being open
+  * `blocked` - for OK, when the relay rejects the event for any reason not better described by another prefix
+  * `deleted` - for OK, when the relay rejects the event because it has been deleted
+  * `duplicate` - for OK, when the relay already has the event
+  * `error` - for OK or CLOSED, used for relay errors and also when no other prefix suits
+  * `invalid` - for OK or CLOSED, when the request is somehow invalid
+  * `pow` - for OK, when the event does not reach the minimum proof-of-work threshold. See [NIP-13](13.md)
+  * `rate-limited` - for OK, when the relay rejects the event due to rate limiting, or too many subscriptions being open
+- The [NIP-42](42.md) extensions are:
+  * `auth-required` - for OK or CLOSED, when a client has not performed `AUTH` and the relay requires that to fulfill the query or write the event.
   * `redacted` - for CLOSED, when some matching events were not served due to the requester not being authenticated or authorized.
-  * `restricted` - for EVENT, when the relay rejects the event due to the author or submitter not being authenticated or authorized.
-
+  * `restricted` - for OK or CLOSED, when a client has already performed `AUTH` but the key used to perform it is still not allowed by the relay or is exceeding its authorization.

--- a/42.md
+++ b/42.md
@@ -55,6 +55,7 @@ This NIP defines two new prefixes that can be used in `OK` (in response to event
 
 - `"auth-required: "` - for when a client has not performed `AUTH` and the relay requires that to fulfill the query or write the event.
 - `"restricted: "` - for when a client has already performed `AUTH` but the key used to perform it is still not allowed by the relay or is exceeding its authorization.
+- `"redacted: "` - on `CLOSED` for when some matching events were not served due to the requester not being authenticated or authorized.
 
 ## Protocol flow
 


### PR DESCRIPTION
Here I'm proposing 2 new prefixes:

> `deleted` - for EVENT, when the relay rejects the event because it has been deleted
> `redacted` - for CLOSED, when some matching events were not served due to the requester not being authenticated or authorized.

I'm also defining what the prefixes mean, and what contexts they are used in (either EVENT or CLOSED or both).
