### PR TITLE
remove get_relays from signers

### DIFF
--- a/07.md
+++ b/07.md
@@ -17,7 +17,6 @@ async window.nostr.signEvent(event: { created_at: number, kind: number, tags: st
 
 Aside from these two basic above, the following functions can also be implemented optionally:
 ```
-async window.nostr.getRelays(): { [url: string]: {read: boolean, write: boolean} } // returns a basic map of relay urls to relay policies
 async window.nostr.nip04.encrypt(pubkey, plaintext): string // returns ciphertext and iv as specified in nip-04 (deprecated)
 async window.nostr.nip04.decrypt(pubkey, ciphertext): string // takes ciphertext and iv as specified in nip-04 (deprecated)
 async window.nostr.nip44.encrypt(pubkey, plaintext): string // returns ciphertext as specified in nip-44

--- a/46.md
+++ b/46.md
@@ -100,7 +100,6 @@ Each of the following are methods that the _client_ sends to the _remote-signer_
 | `connect`                | `[<remote-signer-pubkey>, <optional_secret>, <optional_requested_permissions>]`        | "ack" OR `<required-secret-value>`                                                                  |
 | `sign_event`             | `[<{kind, content, tags, created_at}>]`                                       | `json_stringified(<signed_event>)`                                     |
 | `ping`                   | `[]`                                                                          | "pong"                                                                 |
-| `get_relays`             | `[]`                                                                          | `json_stringified({<relay_url>: {read: <boolean>, write: <boolean>}})` |
 | `get_public_key`         | `[]`                                                                          | `<user-pubkey>`                                                         |
 | `nip04_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`                              | `<nip04_ciphertext>`                                                   |
 | `nip04_decrypt`          | `[<third_party_pubkey>, <nip04_ciphertext_to_decrypt>]`                       | `<plaintext>`                                                          |

--- a/55.md
+++ b/55.md
@@ -262,29 +262,6 @@ launcher.launch(intent)
       val id = intent.data?.getStringExtra("id")
       ```
 
-- **get_relays**
-  - params:
-
-    ```kotlin
-    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("nostrsigner:"))
-    intent.`package` = "com.example.signer"
-    intent.putExtra("type", "get_relays")
-    // to control the result in your application in case you are not waiting the result before sending another intent
-    intent.putExtra("id", "some_id")
-    // Send the current logged in user pubkey
-    intent.putExtra("current_user", account.keyPair.pubkey)
-
-    context.startActivity(intent)
-    ```
-  - result:
-    - If the user approved intent it will return the **result** and **id** fields
-
-      ```kotlin
-      val relayJsonText = intent.data?.getStringExtra("result")
-      // the id you sent
-      val id = intent.data?.getStringExtra("id")
-      ```
-
 - **decrypt_zap_event**
   - params:
 
@@ -480,32 +457,6 @@ If the user chose to always reject the event, signer application will return the
         }
       ```
 
-- **get_relays**
-  - params:
-
-    ```kotlin
-    val result = context.contentResolver.query(
-        Uri.parse("content://com.example.signer.GET_RELAYS"),
-        listOf("${logged_in_user_pubkey}"),
-        null,
-        null,
-        null
-    )
-    ```
-  - result:
-    - Will return the **result** column
-
-      ```kotlin
-        if (result == null) return
-
-        if (it.getColumnIndex("rejected") > -1) return
-
-        if (result.moveToFirst()) {
-            val index = it.getColumnIndex("result")
-            val relayJsonText = it.getString(index)
-        }
-      ```
-
 - **decrypt_zap_event**
   - params:
 
@@ -586,13 +537,6 @@ Android intents and browser urls have limitations, so if you are using the `retu
 
     ```js
     window.href = `nostrsigner:${encryptedText}?pubkey=${hex_pub_key}&compressionType=none&returnType=signature&type=nip44_decrypt&callbackUrl=https://example.com/?event=`;
-    ```
-
-- **get_relays**
-  - params:
-
-    ```js
-    window.href = `nostrsigner:?compressionType=none&returnType=signature&type=get_relays&callbackUrl=https://example.com/?event=`;
     ```
 
 - **decrypt_zap_event**


### PR DESCRIPTION
It makes no sense to a signer manage user relays, specially now that we have multiple kinds of relay lists.
What is the point of those relays?
Inbox?
outbox?
dms?
bootstrap?