### PR TITLE
Remove NOTICE relay messages from NIP-01

### DIFF
--- a/01.md
+++ b/01.md
@@ -146,17 +146,14 @@ A `REQ` message may contain multiple filters. In this case, events that match an
 
 The `limit` property of a filter is only valid for the initial query and MUST be ignored afterwards. When `limit: n` is present it is assumed that the events returned in the initial query will be the last `n` events ordered by the `created_at`. Newer events should appear first, and in the case of ties the event with the lowest id (first in lexical order) should be first. It is safe to return less events than `limit` specifies, but it is expected that relays do not return (much) more events than requested so clients don't get unnecessarily overwhelmed by data.
 
-### From relay to client: sending events and notices
+### From relay to client: fulfilling subscriptions
 
-Relays can send 5 types of messages, which must also be JSON arrays, according to the following patterns:
+Relays can send 4 types of messages, which must also be JSON arrays, according to the following patterns:
 
   * `["EVENT", <subscription_id>, <event JSON as defined above>]`, used to send events requested by clients.
   * `["OK", <event_id>, <true|false>, <message>]`, used to indicate acceptance or denial of an `EVENT` message.
   * `["EOSE", <subscription_id>]`, used to indicate the _end of stored events_ and the beginning of events newly received in real-time.
   * `["CLOSED", <subscription_id>, <message>]`, used to indicate that a subscription was ended on the server side.
-  * `["NOTICE", <message>]`, used to send human-readable error messages or other things to clients.
-
-This NIP defines no rules for how `NOTICE` messages should be sent or treated.
 
 - `EVENT` messages MUST be sent only with a subscription ID related to a subscription previously initiated by the client (using the `REQ` message above).
 - `OK` messages MUST be sent in response to `EVENT` messages received from clients, they must have the 3rd parameter set to `true` when an event has been accepted by the relay, `false` otherwise. The 4th parameter MUST always be present, but MAY be an empty string when the 3rd is `true`, otherwise it MUST be a string formed by a machine-readable single-word prefix followed by a `:` and then a human-readable message. Some examples:


### PR DESCRIPTION
`NOTICE` is practically useless. I argue it has been superseded by a combination of NIP-11 and relay `CLOSED` messages that were introduced 2 years ago in https://github.com/nostr-protocol/nips/pull/902.

I am implementing a relay. There are 2 beautiful flows of Nostr:

- **Getting events**: the client sends a `REQ`, to which the relay responds to with `EVENT`, `EOSE`, and/or `CLOSED`.
- **Posting events**: the client sends an `EVENT`, to which the relay responds with an `OK` (which can be true or false).

These are request/response flows, which map very well to async functions in code. But `NOTICE` exists outside of that - it's a callback with no useful destination.

- In some legacy relays (https://github.com/hoytech/strfry/issues/135), `NOTICE` was used to respond to subscription errors. However, it's **impossible to parse, and therefore useless** because it doesn't contain a subscription ID. The correct thing to use today is a `CLOSED` message, with the subscription ID and reason.

- In the past, `NOTICE` may have been useful to tell users certain things about the relay. However, this was superseded by [NIP-11](https://github.com/nostr-protocol/nips/blob/master/11.md), which is a superior way to find out relay information.

- Relays are not consistent in how they use `NOTICE`, so it cannot even be trusted by clients to display prominently to the user. Even for display in logs, there is basically nothing useful a ` NOTICE` message could actually say that wouldn't be communicated better with a CLOSED message or through NIP-11.

I've built multiple relay server and client implementations, and none of them have ever supported `NOTICE`. There is no clear place for it because it's not part of any flow. It's not useful enough to display to users, and not even useful enough to display in logs. It has been totally superseded by far superior solutions. Since it's useless, there's no point in promoting it to people. So let's remove it.