### PR TITLE
add "global" relay lists

### DIFF
--- a/51.md
+++ b/51.md
@@ -29,6 +29,7 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | Public chats      | 10005 | [NIP-28](28.md) chat channels the user is in                | `"e"` (kind:40 channel definitions)                                                                 |
 | Blocked relays    | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                                              |
 | Search relays     | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                                              |
+| Global relays     | 10008 | relays considered a good target for unfiltered discovery    | `"relay"` (relay URLs)                                                                              |
 | Simple groups     | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group id + relay URL + optional group name), `"r"` for each relay in use |
 | Interests         | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a"` (kind:30015 interest set)                                                |
 | Emojis            | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                                    |

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `10005`       | Public chats list               | [51](51.md)                            |
 | `10006`       | Blocked relays list             | [51](51.md)                            |
 | `10007`       | Search relays list              | [51](51.md)                            |
+| `10008`       | Global relays list              | [51](51.md)                            |
 | `10009`       | User groups                     | [51](51.md), [29](29.md)               |
 | `10013`       | Private event relay list        | [37](37.md)                            |
 | `10015`       | Interests list                  | [51](51.md)                            |


### PR DESCRIPTION
I may be going crazy, but this is an attempt at a proposal to address some "discovery" issues Nostr has.

For the microblogging, DM, mentioning and any use cases where you know from whom you're reading it's clear to clients the relays they should read from or publish to, but this is not true in some other instances.

I've long been wanting to promote the idea of specialized relays,  community-operated relays, whitelisted relays of any kind, but one thing that is missing is a list of relays known to be **public squares** where (basically) anything goes. Not a relay you're signaling to others to be your main place where you publish stuff, but perhaps a place where you _also_ publish your stuff just in case. Or maybe this list includes known "aggregators" that slurp content from other places.

If hopefully Nostr grows a little more even these public squares tend to become more spreaded, and even today there is a natural distinction (even enshrined in apps codebases) of the "default" relays being different if you're in Japan, Thailand or Brazil.

---

### Use case 1:

For example, if you want to browse comments made about some random website, to what relays do you connect for reading?

a) do the outbox model and connect to relays your friends publish to;
b) connect to hardcoded relays defined by the app (some developers may be tempted to hardcode a ton of relay URLs here);
c) give the user the option to define their own list, starting with some defaults (which will often be nos.lol, relay.damus.io, relay.nostr.band, I don't know);
d) use _relay sets_ -- and the user has to pick one or create one.

This new proposed list streamlines the b/c process by standardizing it across multiple apps and also by allowing these lists to be shared, so when the relays that were hardcoded (and that were, at the time of the hardcoding, known to be such public squares) get shut down then clients can automatically or manually switch to new ones.

---

### Use case 2:

There are relays and DVMs out there today trying to promote "discovery" by categorizing notes and creating personalized feeds. Although other approaches would be possible, they tend to rely on hardcoded big lists of relays, which is not very wise.

In this case, having some key users define what is the "global" would make it easier to find a source for filtering content to be recommended.

---

Clarifications: 
- no, I'm not saying we should all just use a set of centralized relays for everything.
- any relay that emerges as part of this "global" set will naturally be full of spam, so in most cases it won't safe to be browsed directly.