### PR TITLE
[NIP-55] Make it clear how to use the package name and what is the purpose of the intents and content resolvers

### DIFF
--- a/55.md
+++ b/55.md
@@ -66,7 +66,7 @@ Create the Intent using the **nostrsigner** scheme:
 val intent = Intent(Intent.ACTION_VIEW, Uri.parse("nostrsigner:$content"))
 ```
 
-Set the Signer package name:
+Set the Signer package name after you receive the response from **get_public_key** method:
 
 ```kotlin
 intent.`package` = "com.example.signer"
@@ -114,7 +114,6 @@ launcher.launch(intent)
 
     ```kotlin
     val intent = Intent(Intent.ACTION_VIEW, Uri.parse("nostrsigner:"))
-    intent.`package` = "com.example.signer"
     intent.putExtra("type", "get_public_key")
     // You can send some default permissions for the user to authorize for ever
     val permissions = listOf(
@@ -130,7 +129,7 @@ launcher.launch(intent)
     context.startActivity(intent)
     ```
   - result:
-    - If the user approved intent it will return the **pubkey** in the result field
+    - If the user approved the intent it will return the **pubkey** in the result field and the signer packageName in the **package** field
 
       ```kotlin
       val pubkey = intent.data?.getStringExtra("result")

--- a/55.md
+++ b/55.md
@@ -10,7 +10,7 @@ This NIP describes a method for 2-way communication between an Android signer an
 
 # Usage for Android applications
 
-The Android signer uses Intents and Content Resolvers to communicate between applications.
+The Android signer uses Intents (to accept/reject permissions manually) and Content Resolvers (to accept/reject permissions automatically in background if the user allowed it) to communicate between applications.
 
 To be able to use the Android signer in your application you should add this to your AndroidManifest.xml:
 


### PR DESCRIPTION
* Most devs misses the content resolver section and think the signer will just stop appearing automatically when the user chooses the remember my choice option
* Most clients are using a fixed package name. By not using a fixed package name allows the user to use other signers and helps debugging