### PR TITLE
NIP 60: add amount to kind 7374

### DIFF
--- a/60.md
+++ b/60.md
@@ -177,7 +177,8 @@ However, application developers SHOULD use local state when possible and only pu
     "content": nip44_encrypt("quote-id"),
     "tags": [
         [ "expiration", "<expiration-timestamp>" ],
-        [ "mint", "<mint-url>" ]
+        [ "mint", "<mint-url>" ],
+        [ "amount", "<requested-amount>" ]
     ]
 }
 ```


### PR DESCRIPTION
The purpose of the wallet is to manage the user's cashu money and because of nostr the wallet can be accessible across many different applications.  

So, if someone intends to implement a fully wallet, then all steps cannot be depended on third party storage or something, it has to be through nostr.  

Anyways, currently the only thing I see that is missing is the amount from the [quote request](https://github.com/cashubtc/nuts/blob/main/04.md#mint-quote). The `description` is also missing but I think it's irrelevant to have it.  

For now, what I am doing to get the amount is to use the lightning invoice created by the mint and extract the amount from it.  
This approach will work in most cases but in some cases the mint could give less cashu than the user has paid in lightning.  

Example: I pay 10 sats to Mint A and Mint A gives me blind signatures whose total amount is 8 sats.  

If the example above is not possible, then this merge request is not needed...

https://njump.me/nevent1qqsw4mnyv43q2ml0nw3uk7esn330tsgtfusm89lg2nkahfjjasxcaxqzyrwlqwk2skk7qw0xwsk4hmea7dfd7xvap5c7y2uctrn7m2zukwamuqcyqqqqqqgnj44rk

@pablof7z @fiatjaf @eskema 