### PR TITLE
Add birth field to NIP-24 for birth date representation

### DIFF
--- a/24.md
+++ b/24.md
@@ -17,7 +17,7 @@ These are extra fields not specified in NIP-01 that may be present in the string
   - `website`: a web URL related in any way to the event author.
   - `banner`: an URL to a wide (~1024x768) picture to be optionally displayed in the background of a profile screen.
   - `bot`: a boolean to clarify that the content is entirely or partially the result of automation, such as with chatbots or newsfeeds.
-  - `birth`: an object representing the author's birth date. The format is { "year": yyyy, "month": mm, "day": dd }. If a field is optional and omitted, it may be excluded or set to null. For example, if the "year" is omitted, only the "month" and "day" fields should be considered. The same applies to other optional fields.
+  - `birth`: an object representing the author's birth date. The format is { "year": yyyy, "month": mm, "day": dd }. Each field MAY be omitted.
 
 ### Deprecated fields
 

--- a/24.md
+++ b/24.md
@@ -17,6 +17,7 @@ These are extra fields not specified in NIP-01 that may be present in the string
   - `website`: a web URL related in any way to the event author.
   - `banner`: an URL to a wide (~1024x768) picture to be optionally displayed in the background of a profile screen.
   - `bot`: a boolean to clarify that the content is entirely or partially the result of automation, such as with chatbots or newsfeeds.
+  - `birth`: an array representing the author's birth date. The format is [day, month, year (optional)]. If the year is omitted, only the day and month should be considered.
 
 ### Deprecated fields
 

--- a/24.md
+++ b/24.md
@@ -17,7 +17,7 @@ These are extra fields not specified in NIP-01 that may be present in the string
   - `website`: a web URL related in any way to the event author.
   - `banner`: an URL to a wide (~1024x768) picture to be optionally displayed in the background of a profile screen.
   - `bot`: a boolean to clarify that the content is entirely or partially the result of automation, such as with chatbots or newsfeeds.
-  - `birth`: an object representing the author's birth date. The format is { "year": yyyy, "month": mm, "day": dd }. Each field MAY be omitted.
+  - `birth`: an object representing the author's birth date. The format is { "year": number, "month": number, "day": number }. Each field MAY be omitted.
 
 ### Deprecated fields
 

--- a/24.md
+++ b/24.md
@@ -17,7 +17,7 @@ These are extra fields not specified in NIP-01 that may be present in the string
   - `website`: a web URL related in any way to the event author.
   - `banner`: an URL to a wide (~1024x768) picture to be optionally displayed in the background of a profile screen.
   - `bot`: a boolean to clarify that the content is entirely or partially the result of automation, such as with chatbots or newsfeeds.
-  - `birth`: an object representing the author's birth date. The format is { "year": number, "month": number, "day": number }. Each field MAY be omitted.
+  - `birthday`: an object representing the author's birth date. The format is { "year": number, "month": number, "day": number }. Each field MAY be omitted.
 
 ### Deprecated fields
 

--- a/24.md
+++ b/24.md
@@ -17,7 +17,7 @@ These are extra fields not specified in NIP-01 that may be present in the string
   - `website`: a web URL related in any way to the event author.
   - `banner`: an URL to a wide (~1024x768) picture to be optionally displayed in the background of a profile screen.
   - `bot`: a boolean to clarify that the content is entirely or partially the result of automation, such as with chatbots or newsfeeds.
-  - `birth`: an array representing the author's birth date. The format is [day, month, year (optional)]. If the year is omitted, only the day and month should be considered.
+  - `birth`: an object representing the author's birth date. The format is { "year": yyyy, "month": mm, "day": dd }. If the year is omitted, the "year" field may be excluded or set to null, and only the "month" and "day" fields should be considered.
 
 ### Deprecated fields
 

--- a/24.md
+++ b/24.md
@@ -17,7 +17,7 @@ These are extra fields not specified in NIP-01 that may be present in the string
   - `website`: a web URL related in any way to the event author.
   - `banner`: an URL to a wide (~1024x768) picture to be optionally displayed in the background of a profile screen.
   - `bot`: a boolean to clarify that the content is entirely or partially the result of automation, such as with chatbots or newsfeeds.
-  - `birth`: an object representing the author's birth date. The format is { "year": yyyy, "month": mm, "day": dd }. If the year is omitted, the "year" field may be excluded or set to null, and only the "month" and "day" fields should be considered.
+  - `birth`: an object representing the author's birth date. The format is { "year": yyyy, "month": mm, "day": dd }. If a field is optional and omitted, it may be excluded or set to null. For example, if the "year" is omitted, only the "month" and "day" fields should be considered. The same applies to other optional fields.
 
 ### Deprecated fields
 


### PR DESCRIPTION
This PR introduces the birth field to NIP-24, allowing users to specify their birth date. The goal is to enable applications to celebrate users' birthdays and allow other users to notice and join in the celebration, enhancing social interactions.

Defined the format as [day, month, year (optional)].
The year is optional to accommodate users who prefer not to disclose their age.