### PR TITLE
NIP-05: add dynamic server recommendation

### DIFF
--- a/05.md
+++ b/05.md
@@ -101,3 +101,9 @@ Users should ensure that their `/.well-known/nostr.json` is served with the HTTP
 The `/.well-known/nostr.json` endpoint MUST NOT return any HTTP redirects.
 
 Fetchers MUST ignore any HTTP redirects given by the `/.well-known/nostr.json` endpoint.
+
+### Implementing a NIP-05 server
+
+NIP-05 is designed so that `nostr.json` can be hosted as a static file. But some services may allow users to sign up and be granted a NIP-05. The `nostr.json` is then served dynamically, depending on the `name` query parameter.
+
+For these servers, the **case** of the localpart should be considered. It is recommended to make the lowercase representation unique in the database, so that two people cannot reserve the same name in different cases (eg `chad` vs `Chad`). Servers may then serve any case variation of the name to the given pubkey, allowing users to freely change the case of their name. However, the server MUST match the case provided by the `name` query parameter.


### PR DESCRIPTION
NIP-05 services who let people sign up for a NIP-05 name are recommended to make the names unique _case insensitive_.