### PR TITLE
Add notifiers nip

### DIFF
--- a/xx.md
+++ b/xx.md
@@ -8,30 +8,39 @@ An alert provider is a nostr application whose job is to monitor the nostr netwo
 
 # Alert
 
-An alert is a `kind 32830` event which specifies how a user would like to be notified, and by whom. It MUST have the following tags, and no others:
+An alert is an event which specifies how a user would like to be notified, and by whom. It MUST have the following tags, and no others:
 
 - A `d` tag set to an arbitrary string
 - A `p` tag indicating the provider the alert is addressed to
 
 All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NIP 44. The following tags are defined:
 
-- `channel` indicates how the user would like to be notified. May be one of `email`, `push`
 - `feed` (one or more) indicates [NIP-FE](https://github.com/nostr-protocol/nips/pull/1554) feeds that the user wants to be notified about.
-- `cron` (optional) indicates using cron syntax how often the user would like to be notified, if not immediately.
-- `handler` (zero or more) is the address of a [NIP 89](./89.md) handler event, for example `["handler", "31990:<pubkey>:<identifier>", "wss://relay.com", "web"]`
 - `description` (optional) is a human-readable description of the alert
 - `timezone` (optional) is the user's ISO 8601 timezone (e.g. `+03:00`)
 - `locale` (optional) is the user's ISO 3166/639 locale (e.g. `en-US`)
 - `claim` (optional) is a relay url and an invite code that may be used to request access (https://github.com/nostr-protocol/nips/pull/1079). This should only be used to provide access to the alert provider, not for selecting relays when fetching feeds (the outbox model or relay feeds should be used instead).
 
-If channel is set to `push`, the following tags are also required:
+## Email Alerts
+
+Email alerts are `kind 32830` events which specify a requested email digest.
+
+The following additional tags are defined:
+
+- `email` indicates the user's email address
+- `cron` indicates using cron syntax how often the user would like to be notified
+- `handler` (zero or more) is the address of a [NIP 89](./89.md) handler event, for example `["handler", "31990:<pubkey>:<identifier>", "wss://relay.com", "web"]`
+
+## Push Alerts
+
+Push alerts are `kind 32832` events which can be used to request push notifications to be delivered to a specific app.
+
+The following additional tags are defined:
 
 - `token` indicates a push notification token
 - `platform` indicates the user's app platform (`ios|android|web`)
 
-If channel is set to `email`, the following tags are also required:
-
-- `email` indicates the user's email address
+Providers SHOULD validate that the `token` is one that they are capable of sending push notifications to.
 
 ## Unsubscribing
 

--- a/xx.md
+++ b/xx.md
@@ -1,17 +1,17 @@
 NIP-46
 ======
 
-Notifiers
----------
+Alerts
+------
 
-A notifier is a nostr application whose job is to monitor the nostr network and notify users of updates via email, push, SMS, DM, etc.
+An alert provider is a nostr application whose job is to monitor the nostr network and notify users of updates via email, push, SMS, DM, etc.
 
-# Notification Subscription
+# Alert
 
-A notification subscription is a `kind 32830` event which specifies how a user would like to be notified, and by whom. It MUST have the following tags, and no others:
+An alert is a `kind 32830` event which specifies how a user would like to be notified, and by whom. It MUST have the following tags, and no others:
 
 - A `d` tag set to an arbitrary string
-- A `p` tag indicating the notifier the subscription is addressed to
+- A `p` tag indicating the provider the alert is addressed to
 
 All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NIP 44. The following tags are defined:
 
@@ -20,7 +20,7 @@ All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NI
 - `filter` (one or more) indicates a filter matching events that the user wants to be notified about
 - `cron` (optional) indicates using cron syntax how often the user would like to be notified, if not immediately.
 - `bunker_url` (optional) with permission to sign `kind 22242` AUTH requests (for access to auth-gated relays)
-- `pause_until` (optional) indicates how long the notifier should wait from the event's `created_at` before sending `immediate` mode notifications.
+- `pause_until` (optional) indicates how long the provider should wait from the event's `created_at` before sending `immediate` mode alerts.
 - `handler` (zero or more) is the address of a [NIP 89](./89.md) handler event, for example `["handler", "31990:<pubkey>:<identifier>", "wss://relay.com", "web"]`
 
 If channel is set to `push`, the following tags are also required:
@@ -34,11 +34,11 @@ If channel is set to `email`, the following tags are also required:
 
 ## Unsubscribing
 
-When a user no longer wants to be notified, they may delete the subscription event by address following [NIP 09](./09.md).
+When a user no longer wants to be notified, they may delete the alert by address, as specified in [NIP 09](./09.md).
 
 ## Pausing while online
 
-When a user becomes active, their client SHOULD automatically update all relevant `kind 32930` events with a current `pause_until` timestamp. This allows the notifier to know the user is online and avoid sending push notifications. When a client knows it's about to go offline, it MAY update the `pause_until` timestamp to the current time.
+When a user becomes active, their client SHOULD automatically update all relevant `kind 32930` events with a current `pause_until` timestamp. This allows the provider to know the user is online and avoid sending push notifications. When a client knows it's about to go offline, it MAY update the `pause_until` timestamp to the current time.
 
 ## Example
 
@@ -58,18 +58,18 @@ Below is an example tag array (the entire event is not shown because the tags ar
 ]
 ```
 
-# Notification Subscription Status
+# Alerts Status
 
-A notifier SHOULD publish a `kind 32831` event which details the status of the user's subscription. A non-existent subscription event indicates that no action has been taken. It MUST have the following tags, and no others:
+A provider SHOULD publish a `kind 32831` event which details the status of the user's alert. A non-existent alert status event indicates that no action has been taken. It MUST have the following tags, and no others:
 
-- An `a` tag set to the address of the `kind 32830` it refers to
-- A `p` tag indicating the notifier the subscription is addressed to
+- A `d` tag set to the address of the `kind 32830` it refers to
+- A `p` tag indicating the author of the `kind 32830` alert event
 
 All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NIP 44. The following tags are defined:
 
-- `status` SHOULD be one of `ok`, `payment-required`, `error`
-- `message` SHOULD include human-readable information explaining the status of the subscription
+- `status` SHOULD be one of `ok`, `pending`, `payment-required`, `error`
+- `message` SHOULD include human-readable information explaining the status of the alert
 
 # Discovery
 
-A notifier MAY advertise its services via NIP 89 client listing.
+A provider MAY advertise its services via NIP 89 client listing.

--- a/xx.md
+++ b/xx.md
@@ -16,10 +16,11 @@ An alert is a `kind 32830` event which specifies how a user would like to be not
 All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NIP 44. The following tags are defined:
 
 - `channel` indicates how the user would like to be notified. May be one of `email`, `push`
-- `feed` indicates a [NIP-FE](https://github.com/nostr-protocol/nips/pull/1554) feed that the user wants to be notified about.
+- `feed` (one or more) indicates [NIP-FE](https://github.com/nostr-protocol/nips/pull/1554) feeds that the user wants to be notified about.
 - `cron` (optional) indicates using cron syntax how often the user would like to be notified, if not immediately.
 - `nip46` (optional) client secret, bunker url tuple with permission to sign `kind 22242` AUTH requests (for access to auth-gated relays), for example `["nip46", "<client-private-key>", "<bunker-url>"]`
 - `handler` (zero or more) is the address of a [NIP 89](./89.md) handler event, for example `["handler", "31990:<pubkey>:<identifier>", "wss://relay.com", "web"]`
+- `description` (optional) is a human-readable description of the alert
 - `timezone` (optional) is the user's timezone
 - `locale` (optional) is the user's locale
 

--- a/xx.md
+++ b/xx.md
@@ -22,6 +22,8 @@ All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NI
 - `bunker_url` (optional) with permission to sign `kind 22242` AUTH requests (for access to auth-gated relays)
 - `pause_until` (optional) indicates how long the provider should wait from the event's `created_at` before sending `immediate` mode alerts.
 - `handler` (zero or more) is the address of a [NIP 89](./89.md) handler event, for example `["handler", "31990:<pubkey>:<identifier>", "wss://relay.com", "web"]`
+- `timezone` (optional) is the user's timezone
+- `locale` (optional) is the user's locale
 
 If channel is set to `push`, the following tags are also required:
 

--- a/xx.md
+++ b/xx.md
@@ -19,7 +19,7 @@ All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NI
 - `relay` (one or more) indicates relays where notifications may be discovered
 - `filter` (one or more) indicates a filter matching events that the user wants to be notified about
 - `cron` (optional) indicates using cron syntax how often the user would like to be notified, if not immediately.
-- `bunker_url` (optional) with permission to sign `kind 22242` AUTH requests (for access to auth-gated relays)
+- `nip46` (optional) client secret, bunker url tuple with permission to sign `kind 22242` AUTH requests (for access to auth-gated relays), for example `["nip46", "<client-private-key>", "<bunker-url>"]`
 - `pause_until` (optional) indicates how long the provider should wait from the event's `created_at` before sending `immediate` mode alerts.
 - `handler` (zero or more) is the address of a [NIP 89](./89.md) handler event, for example `["handler", "31990:<pubkey>:<identifier>", "wss://relay.com", "web"]`
 - `timezone` (optional) is the user's timezone

--- a/xx.md
+++ b/xx.md
@@ -112,9 +112,9 @@ All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NI
 
 # Heartbeats
 
-Clients MAY send `kind 23830` heartbeat events to the notifier when the user is online so that notifiers can avoid sending unnecessary notifications. Heartbeats should be one minute apart.
+Clients MAY send `kind 23830` heartbeat events to the notifier when the user is online so that notifiers can avoid sending unnecessary notifications. Heartbeats SHOULD be one minute apart.
 
-In order to protect user privacy, heartbeats MUST be signed using the `secret` provided by the `kind 32831` alert status event. The `content` should contain a [NIP-44](./44.md) encrypted JSON-encoded tag array with one or more `a` tags which indicate an alert request address.
+In order to protect user privacy, heartbeats MUST be signed using the `secret` provided by the `kind 32831` alert status event. If no secret is provided, heartbeats MUST NOT be sent. The `content` should contain a [NIP-44](./44.md) encrypted JSON-encoded tag array with one or more `a` tags which indicate an alert request address.
 
 ```jsonc
 {

--- a/xx.md
+++ b/xx.md
@@ -1,0 +1,74 @@
+NIP-46
+======
+
+Notifiers
+---------
+
+A notifier is a nostr application whose job is to monitor the nostr network and notify users of updates via email, push, SMS, DM, etc.
+
+# Notification Subscription
+
+A notification subscription is a `kind 32830` event which specifies how a user would like to be notified, and by whom. It MUST have the following tags, and no others:
+
+- A `d` tag set to an arbitrary string
+- A `p` tag indicating the notifier the subscription is addressed to
+
+All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NIP 44. The following tags are defined:
+
+- `channel` indicates how the user would like to be notified. May be one of `email`, `push`
+- `relay` (one or more) indicates relays where notifications may be discovered
+- `filter` (one or more) indicates a filter matching events that the user wants to be notified about
+- `cadence` (optional) indicates (roughly) how often the user would like to be notified. May be one of `weekly`, `daily`, `immediate`
+- `bunker_url` (optional) with permission to sign `kind 22242` AUTH requests (for access to auth-gated relays)
+- `pause_until` (optional) indicates how long the notifier should wait from the event's `created_at` before sending `immediate` mode notifications.
+
+If channel is set to `push`, the following tags are also required:
+
+- `token` indicates a push notification token
+- `platform` indicates the user's app platform (`ios|android|web`)
+
+If channel is set to `email`, the following tags are also required:
+
+- `email` indicates the user's email address
+
+## Unsubscribing
+
+When a user no longer wants to be notified, they may delete the subscription event by address following [NIP 09](./09.md).
+
+## Pausing while online
+
+When a user becomes active, their client SHOULD automatically update all relevant `kind 32930` events with a current `pause_until` timestamp. This allows the notifier to know the user is online and avoid sending push notifications. When a client knows it's about to go offline, it MAY update the `pause_until` timestamp to the current time.
+
+## Example
+
+Below is an example tag array (the entire event is not shown because the tags are encrypted and placed in `content`).
+
+```jsonc
+[
+  ["channel", "email"],
+  ["cadence", "weekly"],
+  ["bunker_url", "bunker://9ee57420bac3db5f1d7f43e1ed5f8bb6b81bf6df6350eb3377961da229eaab22?relay=wss://r.example.com&secret=9393"],
+  ["pause_until", "1740002930"],
+  ["relay", "wss://relay1.example.com/"],
+  ["relay", "wss://relay2.example.com/"],
+  ["filter", "{\"#p\":[\"c90b4e622a3a5c38aebd5ba3cbb22e4ab5a20056b499f8d2e3d25ff47f589a6b\"]}"],
+  ["filter", "{\"#h\":[\"b3ce4a9f\"]}"],
+  ["email", "email@example.com"]
+]
+```
+
+# Notification Subscription Status
+
+A notifier SHOULD publish a `kind 32831` event which details the status of the user's subscription. A non-existent subscription event indicates that no action has been taken. It MUST have the following tags, and no others:
+
+- An `a` tag set to the address of the `kind 32830` it refers to
+- A `p` tag indicating the notifier the subscription is addressed to
+
+All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NIP 44. The following tags are defined:
+
+- `status` SHOULD be one of `ok`, `payment-required`, `error`
+- `message` SHOULD include human-readable information explaining the status of the subscription
+
+# Discovery
+
+A notifier MAY advertise its services via NIP 89 client listing.

--- a/xx.md
+++ b/xx.md
@@ -47,6 +47,32 @@ The push notification payload SHOULD be a JSON object with the following fields:
 - `body` - notification body text
 - `event` - a nostr event
 - `relays` - a list of nostr relays
+-
+## Android Push Alerts
+
+Android push alert requests are `kind 32833` events which can be used to request Android push notifications.
+
+The following additional tags are defined:
+
+- `device_token` indicates a Firebase Cloud Messaging token
+
+The push notification SHOULD include the following JSON-encoded data:
+
+- `event` - a nostr event
+- `relays` - a list of nostr relays
+
+## iOS Push Alerts
+
+iOS push alert requests are `kind 32834` events which can be used to request iOS push notifications.
+
+The following additional tags are defined:
+
+- `device_token` indicates a push token
+
+The push notification SHOULD include the following JSON-encoded data:
+
+- `event` - a nostr event
+- `relays` - a list of nostr relays
 
 ## Unsubscribing
 

--- a/xx.md
+++ b/xx.md
@@ -21,6 +21,7 @@ All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NI
 - `cron` (optional) indicates using cron syntax how often the user would like to be notified, if not immediately.
 - `bunker_url` (optional) with permission to sign `kind 22242` AUTH requests (for access to auth-gated relays)
 - `pause_until` (optional) indicates how long the notifier should wait from the event's `created_at` before sending `immediate` mode notifications.
+- `handler` (zero or more) is the address of a [NIP 89](./89.md) handler event, for example `["handler", "31990:<pubkey>:<identifier>", "wss://relay.com", "web"]`
 
 If channel is set to `push`, the following tags are also required:
 

--- a/xx.md
+++ b/xx.md
@@ -16,11 +16,9 @@ An alert is a `kind 32830` event which specifies how a user would like to be not
 All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NIP 44. The following tags are defined:
 
 - `channel` indicates how the user would like to be notified. May be one of `email`, `push`
-- `relay` (one or more) indicates relays where notifications may be discovered
-- `filter` (one or more) indicates a filter matching events that the user wants to be notified about
+- `feed` indicates a [NIP-FE](https://github.com/nostr-protocol/nips/pull/1554) feed that the user wants to be notified about.
 - `cron` (optional) indicates using cron syntax how often the user would like to be notified, if not immediately.
 - `nip46` (optional) client secret, bunker url tuple with permission to sign `kind 22242` AUTH requests (for access to auth-gated relays), for example `["nip46", "<client-private-key>", "<bunker-url>"]`
-- `pause_until` (optional) indicates how long the provider should wait from the event's `created_at` before sending `immediate` mode alerts.
 - `handler` (zero or more) is the address of a [NIP 89](./89.md) handler event, for example `["handler", "31990:<pubkey>:<identifier>", "wss://relay.com", "web"]`
 - `timezone` (optional) is the user's timezone
 - `locale` (optional) is the user's locale
@@ -38,10 +36,6 @@ If channel is set to `email`, the following tags are also required:
 
 When a user no longer wants to be notified, they may delete the alert by address, as specified in [NIP 09](./09.md).
 
-## Pausing while online
-
-When a user becomes active, their client SHOULD automatically update all relevant `kind 32930` events with a current `pause_until` timestamp. This allows the provider to know the user is online and avoid sending push notifications. When a client knows it's about to go offline, it MAY update the `pause_until` timestamp to the current time.
-
 ## Example
 
 Below is an example tag array (the entire event is not shown because the tags are encrypted and placed in `content`).
@@ -50,13 +44,9 @@ Below is an example tag array (the entire event is not shown because the tags ar
 [
   ["channel", "email"],
   ["cron", "0 15 * * 1"],
-  ["bunker_url", "bunker://9ee57420bac3db5f1d7f43e1ed5f8bb6b81bf6df6350eb3377961da229eaab22?relay=wss://r.example.com&secret=9393"],
-  ["pause_until", "1740002930"],
-  ["relay", "wss://relay1.example.com/"],
-  ["relay", "wss://relay2.example.com/"],
-  ["filter", "{\"#p\":[\"c90b4e622a3a5c38aebd5ba3cbb22e4ab5a20056b499f8d2e3d25ff47f589a6b\"]}"],
-  ["filter", "{\"#h\":[\"b3ce4a9f\"]}"],
-  ["email", "email@example.com"]
+  ["email", "email@example.com"],
+  ["feed", "[\"intersection\",[\"relay\",\"wss://relay.example.com/\"],[\"scope\",\"network\"]]"],
+  ["bunker_url", "bunker://9ee57420bac3db5f1d7f43e1ed5f8bb6b81bf6df6350eb3377961da229eaab22?elay=wss://r.example.com&secret=9393"]
 ]
 ```
 

--- a/xx.md
+++ b/xx.md
@@ -21,8 +21,8 @@ All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NI
 - `nip46` (optional) client secret, bunker url tuple with permission to sign `kind 22242` AUTH requests (for access to auth-gated relays), for example `["nip46", "<client-private-key>", "<bunker-url>"]`
 - `handler` (zero or more) is the address of a [NIP 89](./89.md) handler event, for example `["handler", "31990:<pubkey>:<identifier>", "wss://relay.com", "web"]`
 - `description` (optional) is a human-readable description of the alert
-- `timezone` (optional) is the user's timezone
-- `locale` (optional) is the user's locale
+- `timezone` (optional) is the user's ISO 8601 timezone (e.g. `+03:00`)
+- `locale` (optional) is the user's ISO 3166/639 locale (e.g. `en-US`)
 
 If channel is set to `push`, the following tags are also required:
 

--- a/xx.md
+++ b/xx.md
@@ -18,7 +18,7 @@ All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NI
 - `channel` indicates how the user would like to be notified. May be one of `email`, `push`
 - `relay` (one or more) indicates relays where notifications may be discovered
 - `filter` (one or more) indicates a filter matching events that the user wants to be notified about
-- `cadence` (optional) indicates (roughly) how often the user would like to be notified. May be one of `weekly`, `daily`, `immediate`
+- `cron` (optional) indicates using cron syntax how often the user would like to be notified, if not immediately.
 - `bunker_url` (optional) with permission to sign `kind 22242` AUTH requests (for access to auth-gated relays)
 - `pause_until` (optional) indicates how long the notifier should wait from the event's `created_at` before sending `immediate` mode notifications.
 
@@ -46,7 +46,7 @@ Below is an example tag array (the entire event is not shown because the tags ar
 ```jsonc
 [
   ["channel", "email"],
-  ["cadence", "weekly"],
+  ["cron", "0 15 * * 1"],
   ["bunker_url", "bunker://9ee57420bac3db5f1d7f43e1ed5f8bb6b81bf6df6350eb3377961da229eaab22?relay=wss://r.example.com&secret=9393"],
   ["pause_until", "1740002930"],
   ["relay", "wss://relay1.example.com/"],

--- a/xx.md
+++ b/xx.md
@@ -69,6 +69,7 @@ Android push alert requests are `kind 32833` events which can be used to request
 The following additional tags are defined:
 
 - `device_token` indicates a Firebase Cloud Messaging token
+- `silent` indicates whether silent push notifications should be used
 
 The push notification SHOULD include the following JSON-encoded data:
 
@@ -83,6 +84,7 @@ The following additional tags are defined:
 
 - `device_token` indicates an APNs token
 - `bundle_identifier` indicates a iOS app bundle identifier
+- `silent` indicates whether silent push notifications should be used
 
 The push notification SHOULD include the following JSON-encoded data:
 

--- a/xx.md
+++ b/xx.md
@@ -6,9 +6,9 @@ Alerts
 
 An alert provider is a nostr application whose job is to monitor the nostr network and notify users of updates via email, push, SMS, DM, etc.
 
-# Alert
+# Alert Request
 
-An alert is an event which specifies how a user would like to be notified, and by whom. It MUST have the following tags, and no others:
+An alert request is an event which specifies how a user would like to be notified, and by whom. It MUST have the following tags, and no others:
 
 - A `d` tag set to an arbitrary string
 - A `p` tag indicating the provider the alert is addressed to
@@ -16,14 +16,14 @@ An alert is an event which specifies how a user would like to be notified, and b
 All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NIP 44. The following tags are defined:
 
 - `feed` (one or more) indicates [NIP-FE](https://github.com/nostr-protocol/nips/pull/1554) feeds that the user wants to be notified about.
-- `description` (optional) is a human-readable description of the alert
+- `description` (optional) is a human-readable description of the alert request
 - `timezone` (optional) is the user's ISO 8601 timezone (e.g. `+03:00`)
 - `locale` (optional) is the user's ISO 3166/639 locale (e.g. `en-US`)
 - `claim` (optional) is a relay url and an invite code that may be used to request access (https://github.com/nostr-protocol/nips/pull/1079). This should only be used to provide access to the alert provider, not for selecting relays when fetching feeds (the outbox model or relay feeds should be used instead).
 
 ## Email Alerts
 
-Email alerts are `kind 32830` events which specify a requested email digest.
+Email alert requests are `kind 32830` events which specify a requested email digest.
 
 The following additional tags are defined:
 
@@ -31,16 +31,22 @@ The following additional tags are defined:
 - `cron` indicates using cron syntax how often the user would like to be notified
 - `handler` (zero or more) is the address of a [NIP 89](./89.md) handler event, for example `["handler", "31990:<pubkey>:<identifier>", "wss://relay.com", "web"]`
 
-## Push Alerts
+## Web Push Alerts
 
-Push alerts are `kind 32832` events which can be used to request push notifications to be delivered to a specific app.
+Web push alert requests are `kind 32832` events which can be used to request web push notifications.
 
 The following additional tags are defined:
 
-- `token` indicates a push notification token
-- `platform` indicates the user's app platform (`ios|android|web`)
+- `endpoint` indicates a push notification endpoint
+- `p256dh` indicates the p256dh key
+- `auth` indicates the auth key
 
-Providers SHOULD validate that the `token` is one that they are capable of sending push notifications to.
+The push notification payload SHOULD be a JSON object with the following fields:
+
+- `title` - notification title text
+- `body` - notification body text
+- `event` - a nostr event
+- `relays` - a list of nostr relays
 
 ## Unsubscribing
 

--- a/xx.md
+++ b/xx.md
@@ -55,6 +55,7 @@ Below is an example tag array (the entire event is not shown because the tags ar
   ["channel", "email"],
   ["cron", "0 15 * * 1"],
   ["email", "email@example.com"],
+  ["claim", "wss://relay.example.com/", "MYACCESSCODE"],
   ["feed", "[\"intersection\",[\"relay\",\"wss://relay.example.com/\"],[\"scope\",\"network\"]]"],
   ["bunker_url", "bunker://9ee57420bac3db5f1d7f43e1ed5f8bb6b81bf6df6350eb3377961da229eaab22?elay=wss://r.example.com&secret=9393"]
 ]

--- a/xx.md
+++ b/xx.md
@@ -18,11 +18,11 @@ All other tags MUST be encrypted to the pubkey indicated by the `p` tag using NI
 - `channel` indicates how the user would like to be notified. May be one of `email`, `push`
 - `feed` (one or more) indicates [NIP-FE](https://github.com/nostr-protocol/nips/pull/1554) feeds that the user wants to be notified about.
 - `cron` (optional) indicates using cron syntax how often the user would like to be notified, if not immediately.
-- `nip46` (optional) client secret, bunker url tuple with permission to sign `kind 22242` AUTH requests (for access to auth-gated relays), for example `["nip46", "<client-private-key>", "<bunker-url>"]`
 - `handler` (zero or more) is the address of a [NIP 89](./89.md) handler event, for example `["handler", "31990:<pubkey>:<identifier>", "wss://relay.com", "web"]`
 - `description` (optional) is a human-readable description of the alert
 - `timezone` (optional) is the user's ISO 8601 timezone (e.g. `+03:00`)
 - `locale` (optional) is the user's ISO 3166/639 locale (e.g. `en-US`)
+- `claim` (optional) is a relay url and an invite code that may be used to request access (https://github.com/nostr-protocol/nips/pull/1079). This should only be used to provide access to the alert provider, not for selecting relays when fetching feeds (the outbox model or relay feeds should be used instead).
 
 If channel is set to `push`, the following tags are also required:
 


### PR DESCRIPTION
This is a generalization/update of https://github.com/0xchat-app/0xchat-core/blob/main/doc/nofitications.md with the following differences:

- It uses parameterized replaceable events, which allows for multiple subscriptions to exist at the same time
- It uses NIP 44 encryption rather than NIP 04
- It uses filters rather than ad-hoc targets
- It uses [delegated authentication](https://github.com/nostr-protocol/nips/pull/1795) in order to gain access to gated relays
- It uses a different mechanism for pausing notifications and auto-expiring pauses