### PR TITLE
NIP-22: Format should follow scope

### DIFF
--- a/22.md
+++ b/22.md
@@ -10,7 +10,7 @@ A comment is a threading note always scoped to a root event or an [`I`-tag](73.m
 
 It uses `kind:1111` with the comment on `.content`. 
 
-Content formatting must follow the rules specified in the scope. If no rules are specified, it should follow kind 1 rules (no HTML, Markdown, or other formatting).
+Content formatting MUST follow the rules specified in the scope. If no rules are specified, it SHOULD follow kind 1 rules (no HTML, Markdown, or other formatting).
 
 Comments MUST point to the root scope using uppercase tag names (e.g. `K`, `E`, `A` or `I`)
 and MUST point to the parent item with lowercase ones (e.g. `k`, `e`, `a` or `i`).


### PR DESCRIPTION
This adds some flexibility in formatting styles for NIP-22. Since this NIP is always used inside a scope (another NIP), formatting rules SHOULD be defined by that NIP. 

Examples: 
- If the Comment is replying to a markdown-based NIP, it should allow markdown. 
- If the Comment is replying to an asciidoc-based NIP, it should allow asciidoc. 