### PR TITLE
Optional t tag to git repository announcements

### DIFF
--- a/34.md
+++ b/34.md
@@ -22,9 +22,10 @@ Git repositories are hosted in Git-enabled servers, but their existence can be a
     ["description", "brief human-readable project description>"],
     ["web", "<url for browsing>", ...], // a webpage url, if the git server being used provides such a thing
     ["clone", "<url for git-cloning>", ...], // a url to be given to `git clone` so anyone can clone it
-    ["relays", "<relay-url>", ...] // relays that this repository will monitor for patches and issues
-    ["r", "<earliest-unique-commit-id>", "euc"]
-    ["maintainers", "<other-recognized-maintainer>", ...]
+    ["relays", "<relay-url>", ...], // relays that this repository will monitor for patches and issues
+    ["r", "<earliest-unique-commit-id>", "euc"],
+    ["maintainers", "<other-recognized-maintainer>", ...],
+    ["t", "<arbitrary string>"], // hashtags labelling the repository
   ]
 }
 ```


### PR DESCRIPTION
- Adds an optional `t` tag to NIP-34 repository announcement events. The `t` tag stands for hashtag and can be used for labelling a repository. This is implemented on the yet to be released github-like client called Nestr.
- Added some missing commas between existing tags.