### PR TITLE
Simple Kanban Boards

### DIFF
--- a/CB.md
+++ b/CB.md
@@ -21,19 +21,14 @@ A Kanban Board is a replaceable `kind 37733` event, which includes a list of col
     // For example a GitRepositoryAnnouncement:
     ["A", "30617:<pubkey>:<repo-identifier>"],
 
-    // Columns have the format `["a", "<coordinate>", "<name>", "<purpose>", "<optional-relay-hint>"]` 
+    // Columns have the format `["a", "<coordinate>", "<title>", "<optional-relay-hint>"]` 
     // and are arranged in the intended order. 
-    ["a", "<column-kind>:<pubkey>:<d-identifier>", "To Do", "OPEN", "wss://relay.lol"],
-    ["a", "<column-kind>:<pubkey>:<d-identifier>", "In Progress", "OPEN", ""],
-    ["a", "<column-kind>:<pubkey>:<d-identifier>", "Done", "CLOSED"],
+    ["a", "<column-kind>:<pubkey>:<d-identifier>", "To Do", "wss://relay.lol"],
+    ["a", "<column-kind>:<pubkey>:<d-identifier>", "In Progress", ""],
+    ["a", "<column-kind>:<pubkey>:<d-identifier>", "Done"],
   ]
 }
 ```
-
-The column purpose can be either `"OPEN"`, `"CLOSED"` or `"REJECTED"`.
-An empty purpose string should be interpreted as `"OPEN"`.
-Clients may customize the rendering of columns based on their designated purpose 
-or trigger specific actions when adding cards to columns with a particular purpose.
 
 ## Columns 
 
@@ -57,7 +52,6 @@ Clients are expected to only support a subset of event kinds when rendering Kanb
   
 ## Possible extentions to add later
 
-- Add more column purposes
-- Define additional actions a client should perform when adding cards to certain columns 
+- Different column types
 - Dedicated event kind for Kanban cards
 - Multi-user support

--- a/CB.md
+++ b/CB.md
@@ -6,7 +6,14 @@ Kanban Boards
 
 `draft` `optional`
 
-A Kanban Board is a replaceable `kind 37733` event, which includes a list of column events.
+A Kanban Board is a replaceable `kind 37733` event, which includes a list of column names and a mapping to their associated content.
+
+Columns can contain any nostr event.
+
+Clients are expected to only support a subset of event kinds when rendering Kanban cards.
+
+When a column holds a large number of cards, these cards SHOULD be placed into a `kind 37734 Column reserve` event to prevent the `kind 37733` event from getting too large.
+
 
 ```json
 {
@@ -21,19 +28,28 @@ A Kanban Board is a replaceable `kind 37733` event, which includes a list of col
     // For example a GitRepositoryAnnouncement:
     ["A", "30617:<pubkey>:<repo-identifier>"],
 
-    // Columns have the format `["a", "<coordinate>", "<title>", "<optional-relay-hint>"]` 
-    // and are arranged in the intended order. 
-    ["a", "<column-kind>:<pubkey>:<d-identifier>", "To Do", "wss://relay.lol"],
-    ["a", "<column-kind>:<pubkey>:<d-identifier>", "In Progress", ""],
-    ["a", "<column-kind>:<pubkey>:<d-identifier>", "Done"],
+    // Columns arranged in the intended order. 
+    // Column IDs should be lowercase and alphanumeric.
+    ["col", "col-id-1", "To Do"],
+    ["col", "col-id-2", "In Progress"],
+    ["col", "col-id-2", "Done"],
+
+    // Column items `["e/a", "<event-id/coordinate>", "<col-id>", "<optional-relay-hint>"]` arranged in the intended order
+    ["e", "<event-id>", "col-id-1", "wss://relay.lol"],
+    ["a", "<event-coordinate>", "col-id-1", ""],
+    ["e", "<event-id>", "col-id-2"],
+    ["e", "<event-id>", "col-id-3"],
+
+    // Optional column reserve for holding large amount of cards 
+    // `["r", "37734:<pubkey>:<d-identifier", "<col-id>", "<optional-relay-hint>"]`
+    ["r", "37734:<pubkey>:<d-identifier", "col-id-3", "wss://relay.lol"],
   ]
 }
 ```
 
-## Columns 
+## Column reserve
 
-Columns are `kind 37734` events containing a list of Kanban cards, which can be of any event kind.
-Clients are expected to only support a subset of event kinds when rendering Kanban cards.
+A column reserve is a replaceable `kind 37734` event that contains a list of Kanban cards, used to offload and reduce the size of the original `kind 37733` event. Its usage is optional but recommended for columns with a large amount of cards.
 
 ```json
 {

--- a/CB.md
+++ b/CB.md
@@ -6,10 +6,7 @@ Kanban Boards
 
 `draft` `optional`
 
-A Kanban Board is a replaceable `kind 37733` event, which includes a list of column names and a mapping to their associated content.
-Columns can contain any nostr event.
-Clients are expected to only support a subset of event kinds when rendering Kanban cards.
- 
+A Kanban Board is a replaceable `kind 37733` event, which includes a list of column events.
 
 ```json
 {
@@ -24,22 +21,33 @@ Clients are expected to only support a subset of event kinds when rendering Kanb
     // For example a GitRepositoryAnnouncement:
     ["A", "30617:<pubkey>:<repo-identifier>"],
 
-    // Columns arranged in the intended order. 
-    // Column IDs should be lowercase and alphanumeric.
-    ["col", "col-id-1", "To Do"],
-    ["col", "col-id-2", "In Progress"],
-    ["col", "col-id-2", "Done"],
-
-    // Mapping of events to Column IDs.
-    // Tags arranged in the intended order.
-    ["e", "b7804254d1ae143aeacb50b2504398a43e2f39abd87141036b7f1cc8aec4069e", "col-id-1"],
-    ["a", "<kind>:<pubkey>:<d-identifier>", "col-id-1"],
-    ["e", "71cfeb1171960e4ad6f65d7f87c5bf41be9ef4aaf4452fd2f6968c0b340f79d7", "col-id-2"],
+    // Columns have the format `["a", "<coordinate>", "<name>", "<optional-relay-hint>"]` 
+    // and are arranged in the intended order. 
+    ["a", "<column-kind>:<pubkey>:<d-identifier>", "To Do", "wss://relay.lol"],
+    ["a", "<column-kind>:<pubkey>:<d-identifier>", "In Progress", ""],
+    ["a", "<column-kind>:<pubkey>:<d-identifier>", "Done"],
   ]
 }
 ```
 
+Columns are `kind 37734` events containing a list of Kanban cards, which can be of any event kind.
+Clients are expected to only support a subset of event kinds when rendering Kanban cards.
+
+```json
+{
+  "kind": 37734,
+  "content": "",
+  "tags": [
+    // Tags arranged in the intended order.
+    ["e", "b7804254d1ae143aeacb50b2504398a43e2f39abd87141036b7f1cc8aec4069e", "<relay-hint>"],
+    ["a", "<kind>:<pubkey>:<d-identifier>", "<relay-hint>"],
+    ["e", "71cfeb1171960e4ad6f65d7f87c5bf41be9ef4aaf4452fd2f6968c0b340f79d7", "<relay-hint>"],
+  ]
+}
+```
+  
 ## Possible extentions to add later
 
-- Dedicated event kind for Kanban Cards
+- Define additional actions a client should perform when adding cards to certain columns 
+- Dedicated event kind for Kanban cards
 - Multi-user support

--- a/CB.md
+++ b/CB.md
@@ -21,14 +21,21 @@ A Kanban Board is a replaceable `kind 37733` event, which includes a list of col
     // For example a GitRepositoryAnnouncement:
     ["A", "30617:<pubkey>:<repo-identifier>"],
 
-    // Columns have the format `["a", "<coordinate>", "<name>", "<optional-relay-hint>"]` 
+    // Columns have the format `["a", "<coordinate>", "<name>", "<purpose>", "<optional-relay-hint>"]` 
     // and are arranged in the intended order. 
-    ["a", "<column-kind>:<pubkey>:<d-identifier>", "To Do", "wss://relay.lol"],
-    ["a", "<column-kind>:<pubkey>:<d-identifier>", "In Progress", ""],
-    ["a", "<column-kind>:<pubkey>:<d-identifier>", "Done"],
+    ["a", "<column-kind>:<pubkey>:<d-identifier>", "To Do", "OPEN", "wss://relay.lol"],
+    ["a", "<column-kind>:<pubkey>:<d-identifier>", "In Progress", "OPEN", ""],
+    ["a", "<column-kind>:<pubkey>:<d-identifier>", "Done", "CLOSED"],
   ]
 }
 ```
+
+The column purpose can be either `"OPEN"`, `"FINISHED"` or `"REJECTED"`.
+An empty purpose string should be interpreted as `"OPEN"`.
+Clients may customize the rendering of columns based on their designated purpose 
+or trigger specific actions when adding cards to columns with a particular purpose.
+
+## Columns 
 
 Columns are `kind 37734` events containing a list of Kanban cards, which can be of any event kind.
 Clients are expected to only support a subset of event kinds when rendering Kanban cards.
@@ -48,6 +55,7 @@ Clients are expected to only support a subset of event kinds when rendering Kanb
   
 ## Possible extentions to add later
 
+- Add more column purposes
 - Define additional actions a client should perform when adding cards to certain columns 
 - Dedicated event kind for Kanban cards
 - Multi-user support

--- a/CB.md
+++ b/CB.md
@@ -30,7 +30,7 @@ A Kanban Board is a replaceable `kind 37733` event, which includes a list of col
 }
 ```
 
-The column purpose can be either `"OPEN"`, `"FINISHED"` or `"REJECTED"`.
+The column purpose can be either `"OPEN"`, `"CLOSED"` or `"REJECTED"`.
 An empty purpose string should be interpreted as `"OPEN"`.
 Clients may customize the rendering of columns based on their designated purpose 
 or trigger specific actions when adding cards to columns with a particular purpose.

--- a/CB.md
+++ b/CB.md
@@ -45,6 +45,8 @@ Clients are expected to only support a subset of event kinds when rendering Kanb
   "kind": 37734,
   "content": "",
   "tags": [
+    ["d", "<column-identifier>"],
+    
     // Tags arranged in the intended order.
     ["e", "b7804254d1ae143aeacb50b2504398a43e2f39abd87141036b7f1cc8aec4069e", "<relay-hint>"],
     ["a", "<kind>:<pubkey>:<d-identifier>", "<relay-hint>"],

--- a/CB.md
+++ b/CB.md
@@ -13,7 +13,7 @@ Clients are expected to only support a subset of event kinds when rendering Kanb
 
 ```json
 {
-  "kind": 34469,
+  "kind": 37733,
   "content": "",
   "tags": [
     ["d", "<board-identifier>"],
@@ -30,7 +30,7 @@ Clients are expected to only support a subset of event kinds when rendering Kanb
     ["col", "col-id-2", "In Progress"],
     ["col", "col-id-2", "Done"],
 
-    // Mapping events to Column IDs.
+    // Mapping of events to Column IDs.
     // Tags arranged in the intended order.
     ["e", "b7804254d1ae143aeacb50b2504398a43e2f39abd87141036b7f1cc8aec4069e", "col-id-1"],
     ["a", "<kind>:<pubkey>:<d-identifier>", "col-id-1"],

--- a/CB.md
+++ b/CB.md
@@ -1,0 +1,45 @@
+NIP-CB
+======
+
+Kanban Boards
+-------
+
+`draft` `optional`
+
+A Kanban Board is a replaceable `kind 37733` event, which includes a list of column names and a mapping to their associated content.
+Columns can contain any nostr event.
+Clients are expected to only support a subset of event kinds when rendering Kanban cards.
+ 
+
+```json
+{
+  "kind": 34469,
+  "content": "",
+  "tags": [
+    ["d", "<board-identifier>"],
+    ["title", "Board Title"],
+    ["description", "Board Description"],
+
+    // Use an `E` or `A` tag to associate the board with another event. 
+    // For example a GitRepositoryAnnouncement:
+    ["A", "30617:<pubkey>:<repo-identifier>"],
+
+    // Columns arranged in the intended order. 
+    // Column IDs should be lowercase and alphanumeric.
+    ["col", "col-id-1", "To Do"],
+    ["col", "col-id-2", "In Progress"],
+    ["col", "col-id-2", "Done"],
+
+    // Mapping events to Column IDs.
+    // Tags arranged in the intended order.
+    ["e", "b7804254d1ae143aeacb50b2504398a43e2f39abd87141036b7f1cc8aec4069e", "col-id-1"],
+    ["a", "<kind>:<pubkey>:<d-identifier>", "col-id-1"],
+    ["e", "71cfeb1171960e4ad6f65d7f87c5bf41be9ef4aaf4452fd2f6968c0b340f79d7", "col-id-2"],
+  ]
+}
+```
+
+## Possible extentions to add later
+
+- Dedicated event kind for Kanban Cards
+- Multi-user support


### PR DESCRIPTION
A simple way to do Kanban Boards because https://github.com/nostr-protocol/nips/pull/1665 is too complex.
I intend to implement this in GitPlaza soonish but I hope I can get some feedback first.

@vivganes @vitorpamplona @SilberWitch @cypherhoodlum 