### PR TITLE
NIP-22: Adds relay hints for i tags

### DIFF
--- a/22.md
+++ b/22.md
@@ -22,7 +22,7 @@ and `p` for the author of the parent item.
   content: '<comment>',
   tags: [
     // root scope: event addresses, event ids, or I-tags.
-    ["<A, E, I>", "<address, id or I-value>", "<relay or web page hint>", "<root event's pubkey, if an E tag>"],
+    ["<A, E, I>", "<address, id or I-value>", "<relay hint>", "<root event's pubkey, if an E tag>"],
     // the root item kind
     ["K", "<root kind>"],
 
@@ -30,7 +30,7 @@ and `p` for the author of the parent item.
     ["P", "<root-pubkey>", "relay-url-hint"],
 
     // parent item: event addresses, event ids, or i-tags.
-    ["<a, e, i>", "<address, id or i-value>", "<relay or web page hint>", "<parent event's pubkey, if an e tag>"],
+    ["<a, e, i>", "<address, id or i-value>", "<relay hint>", "<parent event's pubkey, if an e tag>"],
     // parent item kind
     ["k", "<parent comment kind>"],
 
@@ -43,7 +43,8 @@ and `p` for the author of the parent item.
 
 Tags `K` and `k` MUST be present to define the event kind of the root and the parent items.
 
-`I` and `i` tags create scopes for hashtags, geohashes, URLs, and other external identifiers.
+`I` and `i` tags create scopes for hashtags, geohashes, URLs, and other external identifiers. 
+The relay hint on `i` and `I` tags refers to the relay storing the current discussion or branch of the thread.
 
 The possible values for `i` tags – and `k` tags, when related to an extenal identity – are listed on [NIP-73](73.md).
 Their uppercase versions use the same type of values but relate to the root item instead of the parent one.


### PR DESCRIPTION
The first reply to an `I` tag determines which relay will be used to store the discussion.