### PR TITLE
add gift wrap search exclusion

### DIFF
--- a/50.md
+++ b/50.md
@@ -45,6 +45,8 @@ client's use case, and MAY stop querying relays that have low precision.
 
 Relays SHOULD exclude spam from search results by default if they support some form of spam filtering.
 
+Relays MUST NOT perform matching against `content` event field of Gift Wrap events (NIP-59), as it is encrypted and therefore cannot be meaningfully indexed.
+
 ## Extensions
 
 Relay MAY support these extensions:


### PR DESCRIPTION
Relays MUST NOT perform matching against content event field of Gift Wrap events (NIP-59), as it is encrypted and therefore cannot be meaningfully indexed.