### PR TITLE
NIP90: Add Ping/Pong to DVMs

### DIFF
--- a/90.md
+++ b/90.md
@@ -18,6 +18,7 @@ This NIP reserves the range `5000-7000` for data vending machine use.
 | 5000-5999 | Job request kinds |
 | 6000-6999 | Job result        |
 | 7000      | Job feedback      |
+| 7007      | Ping              |
 
 Job results always use a kind number that is `1000` higher than the job request kind. (e.g. request: `kind:5001` gets a result: `kind:6001`).
 
@@ -176,8 +177,12 @@ Service providers can give feedback about a job back to the customer.
 | `error`            | Service Provider was unable to process the job.                                                             |
 | `success`          | Service Provider successfully processed the job.                                                            |
 | `partial`          | Service Provider partially processed the job. The `.content` might include a sample of the partial results. |
+| `pong`             | Service Provider signals it's alive in response to a Kind 7007 Ping Request                                 |
 
 Any job feedback event MIGHT include results in the `.content` field, as described in the [Job Result](#job-result-kind6000-6999) section. This is useful for service providers to provide a sample of the results that have been processed so far.
+
+### DVM Ping request
+DVMs should implement a listener for Kind 7007, which is defined as a Ping command. The DVM should reply to a ping command with a Kind 7000 feedback event with status "pong" and optional more details about the DVM in the content field. This allows clients to check if a DVM is currently running, without sending an actual job request to the DVM (triggering a job, requesting an invoice etc). 
 
 
 # Protocol Flow


### PR DESCRIPTION
- rationale: This introduces kind 7007 (ping) to send a small request to a dvm to check if it is alive. The DVM replies with a kind 7000 feedback event and status pong, and optional information in content. This allows clients to test if a dvm is alive without sending an actual job request to the dvm.