### PR TITLE
nip25: recommend that reactions do not include a million tags

### DIFF
--- a/25.md
+++ b/25.md
@@ -31,7 +31,7 @@ The SHOULD be a `p` tag set to the `pubkey` of the event being reacted to. If a 
 
 If the event being reacted to is an addressable event, an `a` SHOULD be included together with the `e` tag, it must be set to the coordinates (`kind:pubkey:d-tag`) of the event being reacted to.
 
-If the target event is not a `kind:1`, then the reaction MAY include a `k` tag with the stringified kind number of the reacted event as its value.
+The reaction SHOULD include a `k` tag with the stringified kind number of the reacted event as its value.
 
 **Example code**
 
@@ -39,9 +39,7 @@ If the target event is not a `kind:1`, then the reaction MAY include a `k` tag w
 func make_like_event(pubkey: String, privkey: String, liked: NostrEvent) -> NostrEvent {
     tags.append(["e", liked.id, liked.source_relays.first ?? ""])
     tags.append(["p", liked.pubkey])
-    if liked.kind != 1 {
-        tags.append(["k", liked.kind])
-    }
+    tags.append(["k", String(liked.kind)])
     let ev = NostrEvent(content: "+", pubkey: pubkey, kind: 7, tags: tags)
     ev.calculate_id()
     ev.sign(privkey: privkey)

--- a/25.md
+++ b/25.md
@@ -25,26 +25,23 @@ consider it a "+".
 Tags
 ----
 
-The reaction event SHOULD include `e` and `p` tags from the note the user is reacting to (and optionally `a` tags if the target is a replaceable event). This allows users to be notified of reactions to posts they were mentioned in. Including the `e` tags enables clients to pull all the reactions associated with individual posts or all the posts in a thread. `a` tags enables clients to seek reactions for all versions of a replaceable event.
+There MUST be always an `e` tag set to the `id` of the event that is being reacted to. The `e` tag SHOULD include a relay hint pointing to a relay where the event being reacted to can be found. If a client decides to include other `e`, which not recommended, the target event `id` should be last of the `e` tags.
 
-The last `e` tag MUST be the `id` of the note that is being reacted to.
+The SHOULD be a `p` tag set to the `pubkey` of the event being reacted to. If a client decides to include other `p` tags, which not recommended, the target event `pubkey` should be last the `p` tags.
 
-The last `p` tag MUST be the `pubkey` of the event being reacted to.
+If the event being reacted to is an addressable event, an `a` SHOULD be included together with the `e` tag, it must be set to the coordinates (`kind:pubkey:d-tag`) of the event being reacted to.
 
-The `a` tag MUST contain the coordinates (`kind:pubkey:d-tag`) of the replaceable being reacted to.
+If the target event is not a `kind:1`, then the reaction MAY include a `k` tag with the stringified kind number of the reacted event as its value.
 
-The reaction event MAY include a `k` tag with the stringified kind number of the reacted event as its value.
-
-Example code
+**Example code**
 
 ```swift
 func make_like_event(pubkey: String, privkey: String, liked: NostrEvent) -> NostrEvent {
-    var tags: [[String]] = liked.tags.filter {
-    	tag in tag.count >= 2 && (tag[0] == "e" || tag[0] == "p")
-    }
-    tags.append(["e", liked.id])
+    tags.append(["e", liked.id, liked.source_relays.first ?? ""])
     tags.append(["p", liked.pubkey])
-    tags.append(["k", liked.kind])
+    if liked.kind != 1 {
+        tags.append(["k", liked.kind])
+    }
     let ev = NostrEvent(content: "+", pubkey: pubkey, kind: 7, tags: tags)
     ev.calculate_id()
     ev.sign(privkey: privkey)


### PR DESCRIPTION
Based on all the events I could glance at randomly, it seems that clients are already doing this, thankfully, because having to download a million likes to events you don't care about just to get the ones you care about would be very sad.