### PR TITLE
Add cryptocurrency_addresses field

### DIFF
--- a/24.md
+++ b/24.md
@@ -17,6 +17,7 @@ These are extra fields not specified in NIP-01 that may be present in the string
   - `website`: a web URL related in any way to the event author.
   - `banner`: an URL to a wide (~1024x768) picture to be optionally displayed in the background of a profile screen.
   - `bot`: a boolean to clarify that the content is entirely or partially the result of automation, such as with chatbots or newsfeeds.
+  - `cryptocurrency_addresses`: A JSON object containing cryptocurrency names and their corresponding addresses, like the following example: `{"bitcoin":"bc1q...","monero":"888tN...",...}`
 
 ### Deprecated fields
 


### PR DESCRIPTION
Used in 2 applications to show the user crypto currencies. Right now they are only using it to add a monero field and zap with monero
Added this here since there are multiple people doing the same thing in different ways