### PR TITLE
A way for relays to be honest about their algos

### DIFF
--- a/01.md
+++ b/01.md
@@ -144,7 +144,7 @@ All conditions of a filter that are specified must match for an event for it to 
 
 A `REQ` message may contain multiple filters. In this case, events that match any of the filters are to be returned, i.e., multiple filters are to be interpreted as `||` conditions.
 
-The `limit` property of a filter is only valid for the initial query and MUST be ignored afterwards. When `limit: n` is present it is assumed that the events returned in the initial query will be the last `n` events ordered by the `created_at`. Newer events should appear first, and in the case of ties the event with the lowest id (first in lexical order) should be first. It is safe to return less events than `limit` specifies, but it is expected that relays do not return (much) more events than requested so clients don't get unnecessarily overwhelmed by data.
+The `limit` property of a filter is only valid for the initial query and MUST be ignored afterwards. When `limit: n` is present it is assumed that the events returned in the initial query will be the last `n` events ordered by the the `provided` algo. and if some events have equile weight in their chosen order, they will be returned ordered by the `created_at`. In the case of ties the event with the lowest id (first in lexical order) should be first. It is safe to return less events than `limit` specifies, but it is expected that relays do not return (much) more events than requested so clients don't get unnecessarily overwhelmed by data.
 
 ### From relay to client: sending events and notices
 

--- a/11.md
+++ b/11.md
@@ -4,7 +4,7 @@ NIP-11
 Relay Information Document
 --------------------------
 
-`draft` `optional' `author:fiatjaf` `author:scsibug` `author:doc-hex` `author:cameri` `author:victorvsk` `author:snazzybytes` `author:suhailsaqan` `author:unclebob` `author:alltheseas` `author:securitybrahh`
+`draft` `optional`
 
 Relays may provide server metadata to clients to inform them of capabilities, administrative contacts, and various server attributes.  This is made available as a JSON document over HTTP, on the same URI as the relay's websocket.
 
@@ -12,7 +12,7 @@ When a relay receives an HTTP(s) request with an `Accept` header of `application
 
 ```json
 {
-  "type": <aggregator | simple>
+  "type": <simple | aggregator>
   "name": <string identifying relay>,
   "description": <string with detailed information>,
   "banner": <a link to an image (e.g. in .jpg, or .png format)>,

--- a/11.md
+++ b/11.md
@@ -4,7 +4,7 @@ NIP-11
 Relay Information Document
 --------------------------
 
-`draft` `optional`
+`draft` `optional' `author:fiatjaf` `author:scsibug` `author:doc-hex` `author:cameri` `author:victorvsk` `author:snazzybytes` `author:suhailsaqan` `author:unclebob` `author:alltheseas` `author:securitybrahh`
 
 Relays may provide server metadata to clients to inform them of capabilities, administrative contacts, and various server attributes.  This is made available as a JSON document over HTTP, on the same URI as the relay's websocket.
 
@@ -12,12 +12,14 @@ When a relay receives an HTTP(s) request with an `Accept` header of `application
 
 ```json
 {
+  "type": <aggregator | simple>
   "name": <string identifying relay>,
   "description": <string with detailed information>,
   "banner": <a link to an image (e.g. in .jpg, or .png format)>,
   "icon": <a link to an icon (e.g. in .jpg, or .png format>,
   "pubkey": <administrative contact pubkey>,
   "contact": <administrative alternate contact>,
+  "algos": <a list of algos supported by the relay"
   "supported_nips": <a list of NIP numbers supported by the relay>,
   "software": <string identifying relay software URL>,
   "version": <string version identifier>
@@ -28,6 +30,10 @@ Any field may be omitted, and clients MUST ignore any additional fields they do 
 
 Field Descriptions
 ------------------
+
+### Type
+
+An aggregator relay gets events from more than 1 relay. 
 
 ### Name
 
@@ -61,6 +67,12 @@ Relay operators have no obligation to respond to direct messages.
 ### Contact
 
 An alternative contact may be listed under the `contact` field as well, with the same purpose as `pubkey`.  Use of a Nostr public key and direct message SHOULD be preferred over this.  Contents of this field SHOULD be a URI, using schemes such as `mailto` or `https` to provide users with a means of contact.
+
+### Provided Algos
+
+A relay SHOULD be honest about how the events are provided hence it SHOULD list all the algos it provides. Examples would include ["desc", "events in chronological order", "created_at"]
+
+Name should be self-evident, description clear, and an optional formula may be provided. 
 
 ### Supported NIPs
 

--- a/41.md
+++ b/41.md
@@ -1,4 +1,4 @@
-NIP-34
+NIP-41
 ======
 
 Algorithm
@@ -13,6 +13,8 @@ This NIP introduces a way for relays to be honest about how they are filtering t
 ## Querying
 
 For each algorithm, the `relay` MUST allow `clients` to specify the algo as an `algo` query param on the connection URL string.
+
+`/r1`, `/r2` etc will be there in a type 2 i.e. aggregator relay. 
 
 In other words, a `relay` whose regular URL is `wss://relay.url/r1` MUST also respond at `wss://relay.url/r1/asc` and `wss://relay.url/r1/seen_at`.
 

--- a/41.md
+++ b/41.md
@@ -1,0 +1,23 @@
+NIP-34
+======
+
+Algorithm
+------------------
+
+`draft` `mendatory` `author:securitybrahh`
+
+This NIP introduces a way for relays to be honest about how they are filtering the events when a client asks for them
+
+`Relays` MUST advertize thier supported algo's name, its decription in plain english, name MUST be self-evident and not a branding
+
+## Querying
+
+For each algorithm, the `relay` MUST allow `clients` to specify the algo as an `algo` query param on the connection URL string.
+
+In other words, a `relay` whose regular URL is `wss://relay.url/r1` MUST also respond at `wss://relay.url/r1/asc` and `wss://relay.url/r1/seen_at`.
+
+Upon replying to such requests, the supporting `relay` MUST sort the events according to their algo, and if some events have equil weight in the order, they will be returned in **descending** order According to [NIP-01](01.md), filters with `limit` attribute are replied with events
+
+## Algorithms
+
+The relay is at the libity to set any criteria for each of their algo GIVEN the name is self-description, description is in clear language, and a `optional` formula is given if possible. 

--- a/41.md
+++ b/41.md
@@ -8,18 +8,18 @@ Algorithm
 
 This NIP introduces a way for relays to be honest about how they are filtering the events when a client asks for them
 
-`Relays` MUST advertize thier supported algo's name, its decription in plain english, name MUST be self-evident and not a branding
+`Relays` MUST advertize thier supported algo's name, name MUST be self-evident (and not a branding), description clear, and a `optional` formula is given if possible
 
 ## Querying
 
-For each algorithm, the `relay` MUST allow `clients` to specify the algo as an `algo` query param on the connection URL string.
+For each algorithm, the `relay` MUST allow `clients` to specify the algo as an `algo` query param on the connection URL string
 
-`/r1`, `/r2` etc will be there in a type 2 i.e. aggregator relay. 
+`/r1`, `/r2` etc will be there in a type 2 i.e. aggregator relay
 
 In other words, a `relay` whose regular URL is `wss://relay.url/r1` MUST also respond at `wss://relay.url/r1/asc` and `wss://relay.url/r1/seen_at`.
 
-Upon replying to such requests, the supporting `relay` MUST sort the events according to their algo, and if some events have equil weight in the order, they will be returned in **descending** order According to [NIP-01](01.md), filters with `limit` attribute are replied with events
+Upon replying to such requests, the supporting `relay` MUST sort the events according to their algo, `limit` accordimng to [NIP-01](01.md) shall be applied.
 
-## Algorithms
+## Algorithm
 
-The relay is at the libity to set any criteria for each of their algo GIVEN the name is self-description, description is in clear language, and a `optional` formula is given if possible. 
+The relay is at the libity to set any criteria for each of their algo GIVEN Name should be self-evident, description clear, and a `optional` formula is given if possible


### PR DESCRIPTION
this PR introduces [NIP-41](https://github.com/securitybrahh/nips/blob/choose-agency/41.md), a way for relays to be honest about their algos, edits [01.md](0.1.md) to account for changes in `limt` when algo is provided, appends [11.md] for relays to advertize whether they are an [aggregator](https://github.com/securitybrahh/nips/blob/b06e8d5bb9acc38f32f3659cdabdc2054b836be8/11.md?plain=1#L34) or not and their [provided algos](https://github.com/securitybrahh/nips/blob/b06e8d5bb9acc38f32f3659cdabdc2054b836be8/11.md?plain=1#L71).

solves https://github.com/nostr-protocol/nips/issues/522, supersedes https://github.com/nostr-protocol/nips/pull/579

I think about this a lot - [In other words, the only vocabulary in the system is that of a pubkey.](https://github.com/nostr-protocol/nips/issues/522#issuecomment-1610243431)