### PR TITLE
nip73: change "k" tags standard for webpage comments to a hardcoded `web`

### DIFF
--- a/73.md
+++ b/73.md
@@ -15,7 +15,7 @@ There are certain established global content identifiers such as [Book ISBNs](ht
 
 | Type               | `i` tag                             | `k` tag                  |
 | ---                | ---                                 | ---                      |
-| URLs               | "`<URL, normalized, no fragment>`"  | "www"                    |
+| URLs               | "`<URL, normalized, no fragment>`"  | "web"                    |
 | Hashtags           | "#`<topic, lowercase>`"             | "#"                      |
 | Geohashes          | "geo:`<geohash, lowercase>`"        | "geo"                    |
 | Books              | "isbn:`<id, without hyphens>`"      | "isbn"                   |
@@ -36,7 +36,7 @@ For the webpage "https://myblog.example.com/post/2012-03-27/hello-world" the "i"
 ```jsonc
 [
   ["i","https://myblog.example.com/post/2012-03-27/hello-world"],
-  ["k", "www"]
+  ["k", "web"]
 ]
 ```
 
@@ -67,4 +67,3 @@ Each `i` tag MAY have a url hint as the second argument to redirect people to a 
 `["i", "podcast:item:guid:d98d189b-dc7b-45b1-8720-d4b98690f31f", https://fountain.fm/episode/z1y9TMQRuqXl2awyrQxg]`
 
 `["i", "isan:0000-0000-401A-0000-7", https://www.imdb.com/title/tt0120737]`
-

--- a/73.md
+++ b/73.md
@@ -9,25 +9,36 @@ External Content IDs
 There are certain established global content identifiers such as [Book ISBNs](https://en.wikipedia.org/wiki/ISBN), [Podcast GUIDs](https://podcastnamespace.org/tag/guid), and [Movie ISANs](https://en.wikipedia.org/wiki/International_Standard_Audiovisual_Number) that are useful to reference in nostr events so that clients can query all the events assosiated with these ids.
 
 
-`i` tags are used for referencing these external content ids, with `k` tags representing the external content id kind so that clients can query all the events for a specific kind. 
+`i` tags are used for referencing these external content ids, with `k` tags representing the external content id kind so that clients can query all the events for a specific kind.
 
 ## Supported IDs
 
-| Type | `i` tag | `k` tag |
-|- | - | - |
-| URLs | "`<URL, normalized, no fragment>`" | "`<scheme-host, normalized>`" |
-| Hashtags | "#`<topic, lowercase>`" | "#" |
-| Geohashes| "geo:`<geohash, lowercase>`" | "geo" |
-| Books | "isbn:`<id, without hyphens>`" | "isbn" |
-| Podcast Feeds | "podcast:guid:`<guid>`" | "podcast:guid" |
-| Podcast Episodes | "podcast:item:guid:`<guid>`" | "podcast:item:guid" |
-| Podcast Publishers | "podcast:publisher:guid:`<guid>`" | "podcast:publisher:guid" |
-| Movies | "isan:`<id, without version part>`" | "isan" |
-| Papers | "doi:`<id, lowercase>`" | "doi" |
+| Type               | `i` tag                             | `k` tag                  |
+| ---                | ---                                 | ---                      |
+| URLs               | "`<URL, normalized, no fragment>`"  | "www"                    |
+| Hashtags           | "#`<topic, lowercase>`"             | "#"                      |
+| Geohashes          | "geo:`<geohash, lowercase>`"        | "geo"                    |
+| Books              | "isbn:`<id, without hyphens>`"      | "isbn"                   |
+| Podcast Feeds      | "podcast:guid:`<guid>`"             | "podcast:guid"           |
+| Podcast Episodes   | "podcast:item:guid:`<guid>`"        | "podcast:item:guid"      |
+| Podcast Publishers | "podcast:publisher:guid:`<guid>`"   | "podcast:publisher:guid" |
+| Movies             | "isan:`<id, without version part>`" | "isan"                   |
+| Papers             | "doi:`<id, lowercase>`"             | "doi"                    |
 
 ---
 
 ## Examples
+
+### Webpages
+
+For the webpage "https://myblog.example.com/post/2012-03-27/hello-world" the "i" and "k" tags are:
+
+```jsonc
+[
+  ["i","https://myblog.example.com/post/2012-03-27/hello-world"],
+  ["k", "www"]
+]
+```
 
 ### Books:
 
@@ -56,5 +67,4 @@ Each `i` tag MAY have a url hint as the second argument to redirect people to a 
 `["i", "podcast:item:guid:d98d189b-dc7b-45b1-8720-d4b98690f31f", https://fountain.fm/episode/z1y9TMQRuqXl2awyrQxg]`
 
 `["i", "isan:0000-0000-401A-0000-7", https://www.imdb.com/title/tt0120737]`
-
 


### PR DESCRIPTION
Currently the `k` for a website comment is defined to be the base URL of the website, without the path.

This seems arbitrary to me and useless because there is basically no circumstance in which someone would want to filter like "give me all comments made in this domain" (in which case it would be simpler to actually have the domain without the scheme as the "k" anyway).

The way the other "k" tags work makes sense, it's always

- "give me all comments made about books"; or
- "give me all comments made about movies"; or
- "give me all comments made about events of this specific kind I'm interested in".

To follow that pattern what we want is a "k" tag that allows

- "give me all comments made about webpages".

For that we just have to pick some arbitrary value that will always be the same for webpage comments, so here I picked `"www"` that.