### PR TITLE
make relays for nip-60 wallets explicit

### DIFF
--- a/60.md
+++ b/60.md
@@ -28,7 +28,9 @@ This NIP doesn't deal with users' *receiving* money from someone else, it's just
     "content": nip44_encrypt([
         [ "privkey", "hexkey" ],
         [ "mint", "https://mint1" ],
-        [ "mint", "https://mint2" ]
+        [ "mint", "https://mint2" ],
+        [ "relay", "wss://relay1" ],
+        [ "relay", "wss://relay2" ]
     ]),
     "tags": []
 }
@@ -39,6 +41,7 @@ The wallet event is an replaceable event `kind:17375`.
 Tags:
 * `mint` - Mint(s) this wallet uses -- there MUST be one or more mint tags.
 * `privkey` - Private key used to unlock P2PK ecash. MUST be stored encrypted in the `.content` field. **This is a different private key exclusively used for the wallet, not associated in any way to the user's Nostr private key** -- This is only used for receiving [NIP-61](61.md) nutzaps.
+* `relay` - Relay(s) where wallet events should be published. If present, clients SHOULD publish all wallet-related events (`kind:7375`, `kind:7376`, etc.) to these relays. There MAY be multiple `relay` entries. If no `relay` entries are present, clients SHOULD fall back to using the user's [NIP-65](65.md) relays.
 
 ## Token Event
 Token events are used to record unspent proofs.


### PR DESCRIPTION
Allows making the relays where to get wallet state from explict

cc @hzrd149 @verbiricha @fiatjaf @patrickReiis 