### PR TITLE
Explicitly state that the CLOSE message should not cancel the initial query

### DIFF
--- a/01.md
+++ b/01.md
@@ -132,7 +132,7 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
 }
 ```
 
-Upon receiving a `REQ` message, the relay SHOULD return events that match the filter. Any new events it receives SHOULD be sent to that same websocket until the connection is closed, a `CLOSE` event is received with the same `<subscription_id>`, or a new `REQ` is sent using the same `<subscription_id>` (in which case a new subscription is created, replacing the old one).
+Upon receiving a `REQ` message, the relay SHOULD return events that match the filter. Any new events it receives SHOULD be sent to that same websocket until the connection is closed, a `CLOSE` event is received with the same `<subscription_id>`, or a new `REQ` is sent using the same `<subscription_id>` (in which case a new subscription is created, replacing the old one). The `CLOSE` message or `REQ` with the same `<subscription_id>` cancels only the subscription after the `EOSE` message and does not cancel the initial query or the `EOSE` message.
 
 Filter attributes containing lists (`ids`, `authors`, `kinds` and tag filters like `#e`) are JSON arrays with one or more values. At least one of the arrays' values must match the relevant field in an event for the condition to be considered a match. For scalar event attributes such as `authors` and `kind`, the attribute from the event must be contained in the filter list. In the case of tag attributes such as `#e`, for which an event may have multiple values, the event and filter condition values must have at least one item in common.
 


### PR DESCRIPTION
Most of the relays return events and a EOSE message even if you send a CLOSE message right after sending a REQ, like in the following code:

```js
ws.send(`["REQ","test",{"limit":100}]`);
ws.send(`["CLOSE","test"]`);
```

This behavior is very useful when implementing a client. Many relays limit the number of concurrent subscriptions, but if you do not need to subscribe to newly arrived events, you can send a CLOSE right after sending a REQ and you don't have to worry about this limitation.

However, nostr-rs-relay cancels the initial query if you send the CLOSE message quickly enough and the filter is large enough.

NIP-01 should explicitly state that the `CLOSE` message should not cancel the initial query.