### PR TITLE
Added optional signString() method

### DIFF
--- a/07.md
+++ b/07.md
@@ -21,7 +21,7 @@ async window.nostr.nip04.encrypt(pubkey, plaintext): string // returns ciphertex
 async window.nostr.nip04.decrypt(pubkey, ciphertext): string // takes ciphertext and iv as specified in nip-04 (deprecated)
 async window.nostr.nip44.encrypt(pubkey, plaintext): string // returns ciphertext as specified in nip-44
 async window.nostr.nip44.decrypt(pubkey, ciphertext): string // takes ciphertext as specified in nip-44
-async window.nostr.signSchnorr(message: string): string // Returns `sig` for the SHA256 hash of `message`
+async window.nostr.signString(message: string): { hash: string, sig: string, pubkey: string } // return SHA256 `hash` of `message`, Schnorr `sig` of `hash`, `pubkey` of signer
 ```
 
 ### Recommendation to Extension Authors

--- a/07.md
+++ b/07.md
@@ -21,6 +21,7 @@ async window.nostr.nip04.encrypt(pubkey, plaintext): string // returns ciphertex
 async window.nostr.nip04.decrypt(pubkey, ciphertext): string // takes ciphertext and iv as specified in nip-04 (deprecated)
 async window.nostr.nip44.encrypt(pubkey, plaintext): string // returns ciphertext as specified in nip-44
 async window.nostr.nip44.decrypt(pubkey, ciphertext): string // takes ciphertext as specified in nip-44
+async window.nostr.signSchnorr(message: string): string // Returns `sig` for the SHA256 hash of `message`
 ```
 
 ### Recommendation to Extension Authors

--- a/07.md
+++ b/07.md
@@ -24,6 +24,8 @@ async window.nostr.nip44.decrypt(pubkey, ciphertext): string // takes ciphertext
 async window.nostr.signString(message: string): { hash: string, sig: string, pubkey: string } // return SHA256 `hash` of `message`, Schnorr `sig` of `hash`, `pubkey` of signer
 ```
 
+To ensure signEvent() permission checks are not bypassed, the optional signString() function MUST NOT sign any message that is a valid stringified event.
+
 ### Recommendation to Extension Authors
 To make sure that the `window.nostr` is available to nostr clients on page load, the authors who create Chromium and Firefox extensions should load their scripts by specifying `"run_at": "document_end"` in the extension's manifest.
 

--- a/46.md
+++ b/46.md
@@ -105,7 +105,7 @@ Each of the following are methods that the _client_ sends to the _remote-signer_
 | `nip04_decrypt`          | `[<third_party_pubkey>, <nip04_ciphertext_to_decrypt>]`                       | `<plaintext>`                                                          |
 | `nip44_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`                              | `<nip44_ciphertext>`                                                   |
 | `nip44_decrypt`          | `[<third_party_pubkey>, <nip44_ciphertext_to_decrypt>]`                       | `<plaintext>`                                                          |
-| `sign_schnorr`           | `[<message_string_to_sign>]`                                                  | `<sig_for_sha256_hash_of_message>`                                     |
+| `sign_string`           | `[<message_string_to_sign>]`                                                  | `json_stringified({ hash: <sha256_of_message>, sig: <schnorr_of_hash>, pubkey: <pubkey> })`               |
 
 ### Requested permissions
 

--- a/46.md
+++ b/46.md
@@ -105,6 +105,7 @@ Each of the following are methods that the _client_ sends to the _remote-signer_
 | `nip04_decrypt`          | `[<third_party_pubkey>, <nip04_ciphertext_to_decrypt>]`                       | `<plaintext>`                                                          |
 | `nip44_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`                              | `<nip44_ciphertext>`                                                   |
 | `nip44_decrypt`          | `[<third_party_pubkey>, <nip44_ciphertext_to_decrypt>]`                       | `<plaintext>`                                                          |
+| `sign_schnorr`           | `[<message_string_to_sign>]`                                                  | `<sig_for_sha256_hash_of_message>`                                     |
 
 ### Requested permissions
 


### PR DESCRIPTION
Allows Nostr users to sign/authenticate messages for external apps without compromising their private key (nsec).

It opens up a more generic and flexible challenge-response style external authentication method, using the same Schnorr signature mechanism that Nostr uses to sign events natively.

External apps need only understand Schnorr signatures - they do not need to understand Nostr's event structure. This widens interoperability.

A concrete example of where this would be useful is [P2PK locking of Cashu ecash tokens](https://github.com/cashubtc/nuts/blob/main/11.md) to a Nostr pubkey (npub). Decoding the token requires a Scnorr signature on a structured message string. This method would allow a signer to handle It cleanly.

Would close: https://github.com/nostr-protocol/nips/issues/292