### PR TITLE
added blockchain transactions and addresses to NIP-73

### DIFF
--- a/73.md
+++ b/73.md
@@ -13,21 +13,79 @@ There are certain established global content identifiers such as [Book ISBNs](ht
 
 ## Supported IDs
 
-| Type               | `i` tag                             | `k` tag                  |
-| ---                | ---                                 | ---                      |
-| URLs               | "`<URL, normalized, no fragment>`"  | "web"                    |
-| Hashtags           | "#`<topic, lowercase>`"             | "#"                      |
-| Geohashes          | "geo:`<geohash, lowercase>`"        | "geo"                    |
-| Books              | "isbn:`<id, without hyphens>`"      | "isbn"                   |
-| Podcast Feeds      | "podcast:guid:`<guid>`"             | "podcast:guid"           |
-| Podcast Episodes   | "podcast:item:guid:`<guid>`"        | "podcast:item:guid"      |
-| Podcast Publishers | "podcast:publisher:guid:`<guid>`"   | "podcast:publisher:guid" |
-| Movies             | "isan:`<id, without version part>`" | "isan"                   |
-| Papers             | "doi:`<id, lowercase>`"             | "doi"                    |
+| Type                   | `i` tag                                                    | `k` tag                  |
+| ---                    | ---                                                        | ---                      |
+| Blockchain Transaction | "`<blockchain>`:[`<chainId>`:]tx:`<txid, hex, lowercase>`" | "`<blockchain>`:tx"      |
+| Blockchain Address     | "`<blockchain>`:[`<chainId>`:]address:`<address>`"         | "`<blockchain>`:address" |
+| Books                  | "isbn:`<id, without hyphens>`"                             | "isbn"                   |
+| Geohashes              | "geo:`<geohash, lowercase>`"                               | "geo"                    |
+| Hashtags               | "#`<topic, lowercase>`"                                    | "#"                      |
+| Movies                 | "isan:`<id, without version part>`"                        | "isan"                   |
+| Papers                 | "doi:`<id, lowercase>`"                                    | "doi"                    |
+| Podcast Feeds          | "podcast:guid:`<guid>`"                                    | "podcast:guid"           |
+| Podcast Episodes       | "podcast:item:guid:`<guid>`"                               | "podcast:item:guid"      |
+| Podcast Publishers     | "podcast:publisher:guid:`<guid>`"                          | "podcast:publisher:guid" |
+| URLs                   | "`<URL, normalized, no fragment>`"                         | "web"                    |
 
 ---
 
 ## Examples
+
+### Blockchain
+
+`<blockchain>` can be any level 1 chain (`bitcoin`, `ethereum`, `solana`, ...). If necessary (e.g. for ethereum), you can specify a `<chainId>`.
+
+#### Bitcoin
+
+```
+bitcoin:address:<bech32, lowercase | base58, case sensitive>
+bitcoin:tx:<txid, hex, lowercase>
+```
+
+E.g. https://blockstream.info/tx/a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d
+
+```jsonc
+[
+  ["i", "bitcoin:tx:a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d"],
+  ["k", "bitcoin:tx"]
+]
+```
+
+E.g. https://blockstream.info/address/1HQ3Go3ggs8pFnXuHVHRytPCq5fGG8Hbhx
+
+```jsonc
+[
+  ["i", "bitcoin:address:1HQ3Go3ggs8pFnXuHVHRytPCq5fGG8Hbhx"],
+  ["k", "bitcoin:address"]
+]
+```
+
+#### Ethereum (and other EVM chains)
+
+```
+ethereum:<chainId, integer>:tx:<txHash, hex, lowercase>
+ethereum:<chainId, integer>:address:<hex, lowercase>
+```
+
+E.g. https://etherscan.io/address/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+
+```jsonc
+[
+  ["i", "ethereum:1:address:0xd8da6bf26964af9d7eed9e03e53415d37aa96045"],
+  ["k", "ethereum:address"]
+]
+```
+
+E.g. https://gnosisscan.io/tx/0x98f7812be496f97f80e2e98d66358d1fc733cf34176a8356d171ea7fbbe97ccd
+
+```jsonc
+[
+  ["i", "ethereum:100:tx:0x98f7812be496f97f80e2e98d66358d1fc733cf34176a8356d171ea7fbbe97ccd"],
+  ["k", "ethereum:tx"]
+]
+```
+
+
 
 ### Webpages
 
@@ -35,7 +93,7 @@ For the webpage "https://myblog.example.com/post/2012-03-27/hello-world" the "i"
 
 ```jsonc
 [
-  ["i","https://myblog.example.com/post/2012-03-27/hello-world"],
+  ["i", "https://myblog.example.com/post/2012-03-27/hello-world"],
   ["k", "web"]
 ]
 ```

--- a/73.md
+++ b/73.md
@@ -33,7 +33,7 @@ There are certain established global content identifiers such as [Book ISBNs](ht
 
 ### Blockchain
 
-`<blockchain>` can be any level 1 chain (`bitcoin`, `ethereum`, `solana`, ...). If necessary (e.g. for ethereum), you can specify a `<chainId>`.
+`<blockchain>` can be any layer 1 chain (`bitcoin`, `ethereum`, `solana`, ...). If necessary (e.g. for ethereum), you can specify a `<chainId>`.
 
 #### Bitcoin
 


### PR DESCRIPTION
Added Blockchain Transactions and Addresses with some examples to NIP-73 (following up on https://github.com/nostr-protocol/nips/pull/1844)


```
bitcoin:address:<bech32, lowercase | base58, case sensitive>
bitcoin:tx:<txid, hex, lowercase>

ethereum:<chainId, integer>:tx:<txHash, hex, lowercase>
ethereum:<chainId, integer>:address:<hex, lowercase>
```

\+ small cosmetic changes (e.g. ordered the table by alphabetical order)