### PR TITLE
adds that clients shouldn't publish contradictory handlers

### DIFF
--- a/89.md
+++ b/89.md
@@ -85,6 +85,8 @@ For example: an event with:
 
 where the `web` + `nevent` duple is duplicated with contradictory values is invalid and clients SHOULD ignore it.
 
+Applications that have different URLs should use different `kind:31990` to announce the different URLs that should be used per kind.
+
 A tag without a second value in the array SHOULD be considered a generic handler for any NIP-19 entity that is not handled by a different tag.
 
 # Client tag

--- a/89.md
+++ b/89.md
@@ -74,6 +74,17 @@ Using a `k` tag(s) (instead of having the kind of the `d` tag) provides:
 
 Multiple tags might be registered by the app, following NIP-19 nomenclature as the second value of the array.
 
+No contradictory hints can appear. Apps should not publish handlers with the same `platform:type` duple.
+
+For example: an event with:
+
+```jsonc
+["web", "https://.../path1/<bech32>", "nevent"],
+["web", "https://.../path2/<bech32>", "nevent"],
+```
+
+where the `web` + `nevent` duple is duplicated with contradictory values is invalid and clients SHOULD ignore it.
+
 A tag without a second value in the array SHOULD be considered a generic handler for any NIP-19 entity that is not handled by a different tag.
 
 # Client tag


### PR DESCRIPTION
I saw an event in the wild with contradictory NIP-89:

```
[ "web", "https://yakihonne.com/article/<bech32>", "naddr" ],
[ "web", "https://yakihonne.com/curations/<bech32>", "naddr" ],
[ "web", "https://yakihonne.com/videos/<bech32>", "naddr" ],
```

there's no way to make sense of this, this PR amends the NIP to make it explicit that this shouldn't be done.