### PR TITLE
NIP-96: Server's public key

### DIFF
--- a/96.md
+++ b/96.md
@@ -41,6 +41,8 @@ File storage servers wishing to be accessible by nostr users should opt-in by ma
   // Optional
   "content_types": ["image/jpeg", "video/webm", "audio/*"],
   // Optional
+  "pubkey": "<server's own public key in hex>",
+  // Optional
   "plans": {
     // "free" is the only standardized plan key and
     // clients may use its presence to learn if server offers free storage


### PR DESCRIPTION
This adds the optional public key into nip96.json.

Motivation:
I would like to zap for the server on my client, assuming that the kind-0 event (including lud16) for the public key has been published.