### PR TITLE
NIP-73: add git permalinks

### DIFF
--- a/73.md
+++ b/73.md
@@ -13,17 +13,18 @@ There are certain established global content identifiers such as [Book ISBNs](ht
 
 ## Supported IDs
 
-| Type               | `i` tag                             | `k` tag                  |
-| ---                | ---                                 | ---                      |
-| URLs               | "`<URL, normalized, no fragment>`"  | "web"                    |
-| Hashtags           | "#`<topic, lowercase>`"             | "#"                      |
-| Geohashes          | "geo:`<geohash, lowercase>`"        | "geo"                    |
-| Books              | "isbn:`<id, without hyphens>`"      | "isbn"                   |
-| Podcast Feeds      | "podcast:guid:`<guid>`"             | "podcast:guid"           |
-| Podcast Episodes   | "podcast:item:guid:`<guid>`"        | "podcast:item:guid"      |
-| Podcast Publishers | "podcast:publisher:guid:`<guid>`"   | "podcast:publisher:guid" |
-| Movies             | "isan:`<id, without version part>`" | "isan"                   |
-| Papers             | "doi:`<id, lowercase>`"             | "doi"                    |
+| Type               | `i` tag                                | `k` tag                  |
+| ---                | ---                                    | ---                      |
+| URLs               | "`<URL, normalized, no fragment>`"     | "web"                    |
+| Hashtags           | "#`<topic, lowercase>`"                | "#"                      |
+| Geohashes          | "geo:`<geohash, lowercase>`"           | "geo"                    |
+| Books              | "isbn:`<id, without hyphens>`"         | "isbn"                   |
+| Podcast Feeds      | "podcast:guid:`<guid>`"                | "podcast:guid"           |
+| Podcast Episodes   | "podcast:item:guid:`<guid>`"           | "podcast:item:guid"      |
+| Podcast Publishers | "podcast:publisher:guid:`<guid>`"      | "podcast:publisher:guid" |
+| Movies             | "isan:`<id, without version part>`"    | "isan"                   |
+| Papers             | "doi:`<id, lowercase>`"                | "doi"                    |
+| Git Permalinks     | "git:`<commit-id>`/`<path>`#L`<line>`" | "git"                    |
 
 ---
 
@@ -57,6 +58,29 @@ Book ISBNs MUST be referenced _**without hyphens**_ as many book search APIs ret
 - Movie ISAN: `["i", "isan:0000-0000-401A-0000-7"]` - https://web.isan.org/public/en/isan/0000-0000-401A-0000-7
 
 Movie ISANs SHOULD be referenced  _**without the version part**_ as the versions / edits of movies are not relevant. More info on ISAN parts here -  https://support.isan.org/hc/en-us/articles/360002783131-Records-relations-and-hierarchies-in-the-ISAN-Registry
+
+### Git Permalinks
+
+- for nip34 repositories:
+
+```jsonc
+[
+  ["i", "git:f155696514dc6774cec6092ddcde4bb1af844a6b/src/lib/components/Navbar.svelte#L45", "30617:a008def15796fba9a0d6fab04e8fd57089285d9fd505da5a83fe8aad57a3564d:gitworkshop"]
+]
+```
+
+- for all other git repositories:
+```jsonc
+[
+  ["i", "git:0619f370bca3485bb9c5870bc2defa03c7c3d10e/73.md#L14", "https://github.com/nostr-protocol/nips.git"]
+]
+```
+
+`path` and `line` are both optional making these also valid: 
+```jsonc
+  ["i", "git:0619f370bca3485bb9c5870bc2defa03c7c3d10e/73.md", "https://github.com/nostr-protocol/nips.git"]
+  ["i", "git:0619f370bca3485bb9c5870bc2defa03c7c3d10e", "https://github.com/nostr-protocol/nips.git"]
+```
 
 ---
 


### PR DESCRIPTION
Enable references to commits, files and lines for both nip34 repositories and other git repositories.

Useful for code reviews of nip34 patches, the forthcoming nip95 code snippets and referencing specific code more generally.

Context @pleb5 and I were looking for ways to show code snippets from git permalinks in community converations. Having a consistant way of referencing specific code that isn't using the github proprietary API would be a real win.