### PR TITLE
fix(nip-57): update relays tag in Appendix D to "MUST" for consistency (#1858)

### DIFF
--- a/57.md
+++ b/57.md
@@ -108,7 +108,7 @@ When a client sends a `zap request` event to a server's lnurl-pay callback URL, 
 2. It MUST have tags
 3. It MUST have only one `p` tag
 4. It MUST have 0 or 1 `e` tags
-5. There should be a `relays` tag with the relays to send the `zap receipt` to.
+5. There MUST be a `relays` tag with the relays to send the `zap receipt` to.
 6. If there is an `amount` tag, it MUST be equal to the `amount` query parameter.
 7. If there is an `a` tag, it MUST be a valid event coordinate
 8. There MUST be 0 or 1 `P` tags. If there is one, it MUST be equal to the `zap receipt`'s `pubkey`.


### PR DESCRIPTION
### Summary

This pull request updates the **relays** tag in **Appendix D** of `nips/57.md` from `"SHOULD"` to `"MUST"` for consistency with the rest of the document and the intended specification behavior.

### Related Issue

Closes #1858


### Changes Made

- Updated `relays` tag requirement in Appendix D from `SHOULD` ➝ `MUST`

### Reasoning

The change ensures that the specification aligns with the strict expectations described in the main body of NIP-57. It avoids confusion for implementers and enforces consistency across clients.