### PR TITLE
Add guidelines tag to NIP-29 group metadata

### DIFF
--- a/29.md
+++ b/29.md
@@ -153,6 +153,7 @@ When this event is not found, clients may still connect to the group, but treat 
     ["name", "Pizza Lovers"],
     ["picture", "https://pizza.com/pizza.png"],
     ["about", "a group for people who love pizza"],
+    ["guidelines", "Rule #1: No pineapple"]
     ["public"], // or ["private"]
     ["open"] // or ["closed"]
   ]
@@ -160,7 +161,7 @@ When this event is not found, clients may still connect to the group, but treat 
 }
 ```
 
-`name`, `picture` and `about` are basic metadata for the group for display purposes. `public` signals the group can be _read_ by anyone, while `private` signals that only AUTHed users can read. `open` signals that anyone can request to join and the request will be automatically granted, while `closed` signals that members must be pre-approved or that requests to join will be manually handled.
+`name`, `picture`, `about`, and `guidelines` are basic metadata for the group for display purposes. `public` signals the group can be _read_ by anyone, while `private` signals that only AUTHed users can read. `open` signals that anyone can request to join and the request will be automatically granted, while `closed` signals that members must be pre-approved or that requests to join will be manually handled.
 
 - *group admins* (`kind:39001`) (optional)
 


### PR DESCRIPTION
This adds another tag to the group metadata to include community guidelines or rules for participating in the group. Our research has shown that communicating social norms is an essential component of a healthy community, so I think it deserves to be included as an example in the NIP here, not as a required tag necessarily, but as a standard field that we hope will be adopted by other NIP-29 clients.

`[Link PR to implementation in Plur and groups_relay coming soon]`