### PR TITLE
Add Diff and Permalink kinds

### DIFF
--- a/34.md
+++ b/34.md
@@ -167,23 +167,43 @@ The Status of a patch-revision defaults to either that of the root-patch, or `16
 
 ## Permalinks
 
-Permalinks represent a link to one or more lines of a specific file in a repository. Client should render the content tag as preformatted text or can fetch and parse the original file's content for greater accuracy.
+Permalink events (`kind: 1623`) represent a permanent reference to specific lines within a file from a Git repository. They are intended to directly reference code or documentation precisely and immutably. Clients should render the event's `content` field as preformatted text (code blocks).
 
 ```jsonc
 {
   "kind": 1623,
-  "content": "<referenced code or text>",
+  "content": "<referenced code or text excerpt>",
   "tags": [
-    ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"],
-    ["l", "markdown"],
+    // Reference to the repo's 30617 event if one exists 
+    ["a", "30617:<repo-owner-pubkey>:<repo-id>"],
+    // Explicit repository URL (optional if resolvable via 'a' tag, recommended for interoperability)
     ["repo", "https://github.com/nostr-protocol/nostr.git"],
-    ["branch", "permalink"],
+    // refs associated with the repository (mandatory)
     ["refs/<heads|tags>/<branch-or-tag-name>","<commit-id>"]
+
+    // Specific commit identifier referencing the repository state (mandatory)
+    ["commit", "<commit-id>"],
+    // Path to the specific file in the repository (mandatory)
     ["file", "34.md"],
-    ["lines", 170, 183]
+
+    // Start and end lines referenced within the file (optional, otherwise the event refers to the complete file)
+    ["lines", "172", "196"],
+    // Language identifier for syntax highlighting (optional but recommended)
+    ["l", "markdown"],
+    // Optional description providing context or purpose of permalink
+    ["description", "Specification for permalink events within NIP-34"]
   ]
 }
 ```
+
+### Client Recommendations
+
+Clients rendering permalink events SHOULD:
+
+- Fetch and display the exact lines from the referenced commit and file if the content is not explicitly included or for verification.
+- Display provided code/text using syntax highlighting according to the specified language tag (`l`).
+- Offer navigation or direct links to view the file within external repository browsers or clients.
+
 
 ## Possible things to be added later
 

--- a/34.md
+++ b/34.md
@@ -169,15 +169,14 @@ The Status of a patch-revision defaults to either that of the root-patch, or `16
 
 Permalinks represent a link to one or more lines of a specific file in a repository. Client should render the content tag as preformatted text or can fetch and parse the original file's content for greater accuracy.
 
-```json
+```jsonc
 {
   "kind": 1623,
   "content": "<referenced code or text>",
   "tags": [
     ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"],
     ["l", "markdown"],
-    ["extension", "md"],
-    ["repo", "https://github.com/nostr-protocol/nostr"],
+    ["repo", "https://github.com/nostr-protocol/nostr.git"],
     ["branch", "permalink"],
     ["refs/<heads|tags>/<branch-or-tag-name>","<commit-id>"]
     ["file", "34.md"],

--- a/34.md
+++ b/34.md
@@ -165,6 +165,26 @@ The Status event with the largest created_at date is valid.
 
 The Status of a patch-revision defaults to either that of the root-patch, or `1632` (Closed) if the root-patch's Status is `1631` and the patch-revision isn't tagged in the `1631` event.
 
+## Permalinks
+
+Permalinks represent a link to one or more lines of a specific file in a repository. Client should render the content tag as preformatted text or can fetch and parse the original file's content for greater accuracy.
+
+```json
+{
+  "kind": 1623,
+  "content": "<referenced code or text>",
+  "tags": [
+    ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"],
+    ["l", "markdown"],
+    ["extension", "md"],
+    ["repo", "https://github.com/nostr-protocol/nostr"],
+    ["branch", "permalink"],
+    ["refs/<heads|tags>/<branch-or-tag-name>","<commit-id>"]
+    ["file", "34.md"],
+    ["lines", 170, 183]
+  ]
+}
+```
 
 ## Possible things to be added later
 

--- a/34.md
+++ b/34.md
@@ -165,6 +165,51 @@ The Status event with the largest created_at date is valid.
 
 The Status of a patch-revision defaults to either that of the root-patch, or `1632` (Closed) if the root-patch's Status is `1631` and the patch-revision isn't tagged in the `1631` event.
 
+
+## Git Diffs
+
+Git Diff events (`kind: 1622`) represent changes between two commits within a Git repository, encapsulated as a unified diff. This event type is distinct from Git patches as it explicitly represents the state difference between two specific commits rather than modifications intended for direct application.
+
+Clients should render the event's `content` field as preformatted unified diff text (commonly displayed with diff highlighting).
+
+### Event Format
+
+```jsonc
+{
+  "kind": 1622,
+  "content": "<git unified-diff content>",
+  "tags": [
+    // Addressing tag for repository identification
+    ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"],
+    // Explicit commit ID this diff represents (mandatory)
+    ["commit", "<current-commit-id>"],
+    // Parent commit ID from which the diff is generated (mandatory)
+    ["parent-commit", "<parent-commit-id>"],
+
+    // Optional specification of repository URL for interoperability
+    ["repo", "https://github.com/user/repo.git"],
+    // Optional branch or reference for context
+    ["branch", "feature/update-nip34"],
+    // File path within the repository affected by this diff (optional but recommended if diff is single-file)
+    ["file", "src/module/example.ts"],
+    // Optional start and end lines in the diff context (recommended for precise referencing)
+    ["lines", "172", "196"],
+    // Optional description for context or explanation of changes
+    ["description", "Implements new diff handling in NIP-34"]
+  ]
+}
+```
+
+Clients rendering Git Diff events SHOULD:
+
+- Display the unified diff content with syntax highlighting for added/removed lines.
+- Provide options to view or open the diff context within external repository browsers or local Git clients.
+- Use commit and parent-commit identifiers for querying or fetching the exact commit state.
+- Clearly indicate repository, branch, and file context if provided.
+
+This detailed structure improves clarity, usability, and interoperability, providing clients with comprehensive context and ensuring precise referencing and rendering.
+The first patch in a series MAY be a cover letter in the format produced by `git format-patch`.
+
 ## Permalinks
 
 Permalink events (`kind: 1623`) represent a permanent reference to specific lines within a file from a Git repository. They are intended to directly reference code or documentation precisely and immutably. Clients should render the event's `content` field as preformatted text (code blocks).
@@ -177,26 +222,22 @@ Permalink events (`kind: 1623`) represent a permanent reference to specific line
     // Reference to the repo's 30617 event if one exists 
     ["a", "30617:<repo-owner-pubkey>:<repo-id>"],
     // Explicit repository URL (optional if resolvable via 'a' tag, recommended for interoperability)
-    ["repo", "https://github.com/nostr-protocol/nostr.git"],
+    ["repo", "<repo.url>"],
     // refs associated with the repository (mandatory)
     ["refs/<heads|tags>/<branch-or-tag-name>","<commit-id>"]
-
     // Specific commit identifier referencing the repository state (mandatory)
     ["commit", "<commit-id>"],
     // Path to the specific file in the repository (mandatory)
-    ["file", "34.md"],
+    ["file", "<fully-qualified-filepath>"],
 
     // Start and end lines referenced within the file (optional, otherwise the event refers to the complete file)
-    ["lines", "172", "196"],
+    ["lines", "<start-line>", "<optional-end-line>"],
     // Language identifier for syntax highlighting (optional but recommended)
-    ["l", "markdown"],
-    // Optional description providing context or purpose of permalink
-    ["description", "Specification for permalink events within NIP-34"]
+    ["l", "<language>"],
+    ["description", "<short-text-description>"]
   ]
 }
 ```
-
-### Client Recommendations
 
 Clients rendering permalink events SHOULD:
 

--- a/34.md
+++ b/34.md
@@ -165,33 +165,30 @@ The Status event with the largest created_at date is valid.
 
 The Status of a patch-revision defaults to either that of the root-patch, or `1632` (Closed) if the root-patch's Status is `1631` and the patch-revision isn't tagged in the `1631` event.
 
-
 ## Git Diffs
 
 Git Diff events (`kind: 1622`) represent changes between two commits within a Git repository, encapsulated as a unified diff. This event type is distinct from Git patches as it explicitly represents the state difference between two specific commits rather than modifications intended for direct application.
 
 Clients should render the event's `content` field as preformatted unified diff text (commonly displayed with diff highlighting).
 
-### Event Format
-
 ```jsonc
 {
   "kind": 1622,
   "content": "<git unified-diff content>",
   "tags": [
-    // Addressing tag for repository identification
+    // Reference to the repo's 30617 event if one exists 
     ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"],
     // Explicit commit ID this diff represents (mandatory)
     ["commit", "<current-commit-id>"],
     // Parent commit ID from which the diff is generated (mandatory)
     ["parent-commit", "<parent-commit-id>"],
 
-    // Optional specification of repository URL for interoperability
+    // Explicit repository URL (optional if resolvable via 'a' tag, recommended for interoperability)
     ["repo", "https://github.com/user/repo.git"],
-    // Optional branch or reference for context
-    ["branch", "feature/update-nip34"],
+    // refs associated with the repository
+    ["refs/<heads|tags>/<branch-or-tag-name>","<commit-id>"]
     // File path within the repository affected by this diff (optional but recommended if diff is single-file)
-    ["file", "src/module/example.ts"],
+    ["file", "<fully-qualified-filepath>"],
     // Optional start and end lines in the diff context (recommended for precise referencing)
     ["lines", "172", "196"],
     // Optional description for context or explanation of changes
@@ -208,7 +205,6 @@ Clients rendering Git Diff events SHOULD:
 - Clearly indicate repository, branch, and file context if provided.
 
 This detailed structure improves clarity, usability, and interoperability, providing clients with comprehensive context and ensuring precise referencing and rendering.
-The first patch in a series MAY be a cover letter in the format produced by `git format-patch`.
 
 ## Permalinks
 
@@ -244,7 +240,6 @@ Clients rendering permalink events SHOULD:
 - Fetch and display the exact lines from the referenced commit and file if the content is not explicitly included or for verification.
 - Display provided code/text using syntax highlighting according to the specified language tag (`l`).
 - Offer navigation or direct links to view the file within external repository browsers or clients.
-
 
 ## Possible things to be added later
 


### PR DESCRIPTION
This PR introduces two new kinds of git events, intended to be drop-in replacements for GitHub permalinks and diff links respectively. The purpose of these kinds is to enable conversations and comments about specific lines of code, either in a given commit or the diff of two commits. These kinds are distinct from the code snippet kind introduced in NIP-C0 as the content of the events are not intended to be executable rather to directly reference code or documentation in a Git repo precisely and immutably.

These kinds are already in use by the Flotilla-Budabit fork.