### PR TITLE
Allow multi-user AUTH

### DIFF
--- a/42.md
+++ b/42.md
@@ -32,7 +32,7 @@ And, when sent by clients, the following form:
 ["AUTH", <signed-event-json>]
 ```
 
-Clients MAY provide signed events from all logged-in users in a sequence of `AUTH` messages. Relays MUST consider the client is blending the feeds of all users in one screen and reply accordingly.
+Clients MAY provide signed events from multiple pubkeys in a sequence of `AUTH` messages. Relays MUST treat all pubkeys as authenticated accordingly.
 
 `AUTH` messages sent by clients MUST be answered with an `OK` message, like any `EVENT` message.
 

--- a/42.md
+++ b/42.md
@@ -32,6 +32,8 @@ And, when sent by clients, the following form:
 ["AUTH", <signed-event-json>]
 ```
 
+Clients MAY provide signed events from all logged-in users in a sequence of `AUTH` messages. Relays MUST consider the client is blending the feeds of all users in one screen and reply accordingly.
+
 `AUTH` messages sent by clients MUST be answered with an `OK` message, like any `EVENT` message.
 
 ### Canonical authentication event
@@ -69,7 +71,9 @@ relay: ["AUTH", "<challenge>"]
 client: ["REQ", "sub_1", {"kinds": [4]}]
 relay: ["CLOSED", "sub_1", "auth-required: we can't serve DMs to unauthenticated users"]
 client: ["AUTH", {"id": "abcdef...", ...}]
+client: ["AUTH", {"id": "abcde2...", ...}]
 relay: ["OK", "abcdef...", true, ""]
+relay: ["OK", "abcde2...", true, ""]
 client: ["REQ", "sub_1", {"kinds": [4]}]
 relay: ["EVENT", "sub_1", {...}]
 relay: ["EVENT", "sub_1", {...}]


### PR DESCRIPTION
I am adding multi-user feeds on Amethyst: I am blending all logged-in users as one in the interface. 

I can do one new connection for each user, but this may create 3-4 connections per IP for each relay and duplicate all filters, which feels very wasteful and may hit some of the anti-spam measures on relays. 

This PR reuses one connection for everyone by accepting multi-user logins on the relay side. 

It also standardizes what should happen when multiple AUTH messages are returned from clients instead of leaving it as undefined behavior. Today, most relays override the previous AUTH, which means I could keep rotating the authenticated user in the same connection. Others authenticate just the first AUTH ignore all the others. A few of the new ones already work with multiple users in the way that is described here. Which I think it is the correct way of properly implementing the current NIP-42 AUTH. This PR just formalizes it.