### PR TITLE
fix: Fix NIP-66 title and description format

### DIFF
--- a/66.md
+++ b/66.md
@@ -1,4 +1,8 @@
-# NIP-66: Relay Discovery and Liveness Monitoring
+NIP-66
+======
+
+Relay Discovery and Liveness Monitoring
+-------------------
 
 `draft` `optional`
 


### PR DESCRIPTION
Make it like all other NIP titles and descriptions