### PR TITLE
NIP-65: Add note about re-publishing kind 10002

### DIFF
--- a/65.md
+++ b/65.md
@@ -32,6 +32,7 @@ When publishing an event, clients SHOULD:
 
 - Send the event to the **write** relays of the author
 - Send the event to all **read** relays of each tagged user
+- Ensure the author `kind:10002` event are available in all **read** relays of each tagged user
 
 ### Size
 

--- a/65.md
+++ b/65.md
@@ -32,7 +32,7 @@ When publishing an event, clients SHOULD:
 
 - Send the event to the **write** relays of the author
 - Send the event to all **read** relays of each tagged user
-- Ensure the author `kind:10002` event are available in all **read** relays of each tagged user
+- Send the author's `kind:10002` event to all relays the event was published to
 
 ### Size
 


### PR DESCRIPTION
Why:

Because the author will send their reply to the users tagged in the note. Let's assume the publisher of the note to which the author replied is followed by someone who doesn't follow the author. This user won't find the author's inbox to reply to unless they find their relays list. Also, this user's client won't be able to view the author's profile picture next to their note because they don't find their outbox.

Note:

This was added in d5907d094b4eace1d2269935202f8d4fbcc4c524 and removed in 45f6d598a19321a98592e1f4fdf0b40707871f26 by mistake