### PR TITLE
Increase kind limit

### DIFF
--- a/01.md
+++ b/01.md
@@ -19,7 +19,7 @@ The only object type that exists is the `event`, which has the following format 
   "id": <32-bytes lowercase hex-encoded sha256 of the serialized event data>,
   "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>,
   "created_at": <unix timestamp in seconds>,
-  "kind": <integer between 0 and 65535>,
+  "kind": <integer between 0 and 4,294,967,295>,
   "tags": [
     [<arbitrary string>...],
     // ...


### PR DESCRIPTION
Increased the upper bound kind number to 2^32 - 1 according to #636.

With this change, a dev can pick a random number with much lower chance of collision.

Without this change, one may be working on a new app idea using kind:xyz for months with many events already in the wild then they may find out someone else had just reserved same kind:xyz by merging a PR here.