### PR TITLE
Associating HTML documents to Nostr entities with `<link>`

### DIFF
--- a/21.md
+++ b/21.md
@@ -12,9 +12,27 @@ The scheme is `nostr:`.
 
 The identifiers that come after are expected to be the same as those defined in [NIP-19](19.md) (except `nsec`).
 
-## Examples
+#### Examples
 
 - `nostr:npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9`
 - `nostr:nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p`
 - `nostr:note1fntxtkcy9pjwucqwa9mddn7v03wwwsu9j330jj350nvhpky2tuaspk6nqc`
 - `nostr:nevent1qqstna2yrezu5wghjvswqqculvvwxsrcvu7uc0f78gan4xqhvz49d9spr3mhxue69uhkummnw3ez6un9d3shjtn4de6x2argwghx6egpr4mhxue69uhkummnw3ez6ur4vgh8wetvd3hhyer9wghxuet5nxnepm`
+
+### Linking HTML pages to Nostr entities
+
+`<link>` tags with `rel="alternate"` can be used to associate webpages to Nostr events, in cases where the same content is served via the two mediums (for example, a web server that exposes Markdown articles both as HTML pages and as `kind:30023' events served under itself as a relay or through some other relay). For example:
+
+```
+<head>
+  <link rel="alternate" href="nostr:naddr1qqyrzwrxvc6ngvfkqyghwumn8ghj7enfv96x5ctx9e3k7mgzyqalp33lewf5vdq847t6te0wvnags0gs0mu72kz8938tn24wlfze6qcyqqq823cph95ag" />
+</head>
+```
+
+Likewise, `<link>` tags with `rel="me"` can be used to assign authorship of webpages to Nostr profiles. For example:
+
+```
+<head>
+  <link rel="alternate" href="nostr:nprofile1qyxhwumn8ghj7mn0wvhxcmmvqyd8wumn8ghj7un9d3shjtnhv4ehgetjde38gcewvdhk6qpq80cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwswpnfsn" />
+</head>
+```

--- a/84.md
+++ b/84.md
@@ -23,7 +23,7 @@ or obvious non-useful information from the query string.
 ### Attribution
 Clients MAY include one or more `p` tags, tagging the original authors of the material being highlighted; this is particularly
 useful when highlighting non-nostr content for which the client might be able to get a nostr pubkey somehow
-(e.g. prompting the user or reading a `<meta name="nostr:nprofile1..." />` tag on the document). A role MAY be included as the
+(e.g. prompting the user or reading a `<link rel="me" href="nostr:nprofile1..." />` tag on the document). A role MAY be included as the
 last value of the tag.
 
 ```jsonc


### PR DESCRIPTION
Inspired by https://nostr.kosmos.org/@raucao/link-rel-nostr.
Implemented also in https://fiatjaf.com and https://chromewebstore.google.com/detail/lantern/jjoijlenmgefkaeiomoaelcljfibpcgh.

Also I hope this subtle change in NIP-84 isn't breaking anything.

@raucao