### PR TITLE
NIP-24: Add 'moved_to' tag to support identity migration

### DIFF
--- a/24.md
+++ b/24.md
@@ -18,6 +18,7 @@ These are extra fields not specified in NIP-01 that may be present in the string
   - `banner`: an URL to a wide (~1024x768) picture to be optionally displayed in the background of a profile screen.
   - `bot`: a boolean to clarify that the content is entirely or partially the result of automation, such as with chatbots or newsfeeds.
   - `birthday`: an object representing the author's birth date. The format is { "year": number, "month": number, "day": number }. Each field MAY be omitted.
+  - `moved_to`: a public key indicating that the user has migrated to a new identity. Clients MAY display this field to inform users that the current profile is no longer active and that a new public key should be used to follow or interact with the author. Clients MAY also automatically update the user’s follow list by unfollowing the old public key and following the new one.
 
 ### Deprecated fields
 


### PR DESCRIPTION
Clients may show this info to users and optionally update follow lists by replacing the old pubkey with the new one.