### PR TITLE
Remove "relay" tag from auth

### DIFF
--- a/42.md
+++ b/42.md
@@ -36,13 +36,12 @@ And, when sent by clients, the following form:
 
 ### Canonical authentication event
 
-The signed event is an ephemeral event not meant to be published or queried, it must be of `kind: 22242` and it should have at least two tags, one for the relay URL and one for the challenge string as received from the relay. Relays MUST exclude `kind: 22242` events from being broadcasted to any client. `created_at` should be the current time. Example:
+The signed event is an ephemeral event not meant to be published or queried, it MUST be of `kind: 22242` and it MUST have a `challenge` tag containing the string received from the relay. Relays MUST exclude `kind: 22242` events from being broadcasted to any client. `created_at` should be the current time. Example:
 
 ```jsonc
 {
   "kind": 22242,
   "tags": [
-    ["relay", "wss://relay.example.com/"],
     ["challenge", "challengestringhere"]
   ],
   // other fields...
@@ -101,5 +100,3 @@ To verify `AUTH` messages, relays must ensure:
   - that the `kind` is `22242`;
   - that the event `created_at` is close (e.g. within ~10 minutes) of the current time;
   - that the `"challenge"` tag matches the challenge sent before;
-  - that the `"relay"` tag matches the relay URL:
-    - URL normalization techniques can be applied. For most cases just checking if the domain name is correct should be enough.


### PR DESCRIPTION
The `relay` tag is unnecessary: it does not provide a secure cryptographic binding.  
The actual binding is ensured by the random `challenge` string, which the relay generates and validates, and whose length can be defined by the relay operator for adequate security.

Additionally, requiring the `relay` tag introduces friction in several environments:

- local testing setups  
- private or internal networks  
- relays behind reverse proxies or without stable domain names  

Removing the `relay` tag simplifies implementations without reducing the security of the authentication process.
