### PR TITLE
Add A Generic Raitng/Review NIP

### DIFF
--- a/R1.md
+++ b/R1.md
@@ -1,0 +1,96 @@
+# Ratings
+
+This NIP defines a standard format for rating any entity within the Nostr ecosystem—such as events, profiles, relays, hashtags, or even external content like books and movies. Ratings are recorded against a unique identifier (ID) and can be used to build reputation systems, recommendations, or filtering mechanisms.
+## Definitions
+- Rating: A numerical score from the user that reflects the perceived quality, usefulness, or relevance of an entity. This must be a normalized float between 0 and 1, where 0 represents the lowest possible rating and 1 the highest.
+- m (optional): A (m)ark tag indicating the type of entity being rated. Supported values include but are not limited to: event, profile, relay, hashtag, book, movie, etc.
+
+## Event Kind
+
+A new event kind is introduced for submitting ratings:
+Kind: 34259
+
+## Event Structure
+
+A rating is represented as a Nostr event with the following structure:
+
+```json
+{
+  "kind": 34259,
+  "content": "Optional comment about the rating.",
+  "tags": [
+    ["d", "<target-id>"],
+    ["m", "<entity-type>"],
+    ["rating", "<float-between-0-and-1>"]
+  ]
+}
+```
+Required Tags
+
+    ["d", "<target-id>"]: The unique identifier of the entity being rated. See ID Construction below for details.
+
+    ["rating", "<float>"]: The rating value. Must be a number strictly between 0 and 1.
+
+    ["m", "<entity-type>"]:  Describes what is being rated (e.g., event, profile, relay, etc.)
+
+## ID Construction
+
+To avoid ambiguity, especially when dealing with non-event entities like hashtags, a consistent namespacing format is required for the d (target ID) tag.
+Namespaced Format
+
+For non-event entities (or when IDs may conflict), prefix the ID with the entity type (the m value), separated by a colon:
+
+`<entity-type:<id>`
+
+| Entity Type | Raw ID                | `d` Tag Value                     |
+|-------------|-----------------------|-----------------------------------|
+| event       | c9dd213f...           | event:c9dd213f... or c9dd213f... |
+| hashtag     | books                 | hashtag:books                     |
+| relay       | wss://example.com     | relay:wss://example.com           |
+| movie       | tt1375666 (IMDb ID)   | movie:tt1375666                   |
+
+## Parsing Guidelines
+The colon (:) after the type is mandatory for namespacing.
+When parsing a d tag:
+If a colon is present, the substring before the first colon is considered the type.
+Everything after the first colon is treated as the identifier.
+If no colon is found, assume the type is event.
+
+Parsing Example (pseudocode)
+
+```py
+def parse_d_tag(d_tag_value):
+    if ':' in d_tag_value:
+        m, entity_id = d_tag_value.split(':', 1)
+    else:
+        m = 'event'
+        entity_id = d_tag_value
+    return m, entity_id
+```
+
+## Example Event
+
+```json
+{
+  "content": "Rated via Nostr",
+  "created_at": 1746630838,
+  "id": "d9e2f36649296430b632291fa25b620df8a2f01946e40d81f1635f3f8fa35e11",
+  "kind": 34259,
+  "pubkey": "fd208ee8c8f283780a9552896e4823cc9dc6bfd442063889577106940fd927c1",
+  "sig": "d96647a55d31bb8d259c9087efe54051b08949229bd190bb7819262cd3732920a950194c3b89362a857a7be2168f5fe9d2ab9b703510b54376fa0e2af698f48b",
+  "tags": [
+    [
+      "d",
+      "hashtag:asknostr"
+    ],
+    [
+      "m",
+      "hashtag"
+    ],
+    [
+      "rating",
+      "0.600"
+    ]
+  ]
+}
+```

--- a/R1.md
+++ b/R1.md
@@ -23,6 +23,7 @@ A rating is represented as a Nostr event with the following structure:
     ["m", "<entity-type>"],
     ["rating", "<float-between-0-and-1>"]
   ]
+  ...
 }
 ```
 Required Tags

--- a/R1.md
+++ b/R1.md
@@ -4,6 +4,7 @@ This NIP defines a standard format for rating any entity within the Nostr ecosys
 ## Definitions
 - Rating: A numerical score from the user that reflects the perceived quality, usefulness, or relevance of an entity. This must be a normalized decimal (stored as a string) between 0 and 1, where 0 represents the lowest possible rating and 1 the highest.
 - m (optional): A (m)ark tag indicating the type of entity being rated. Supported values include but are not limited to: event, profile, relay, hashtag, book, movie, etc.
+- Content: The content of the review.
 
 ## Event Kind
 
@@ -31,6 +32,8 @@ Required Tags
     ["d", "<target-id>"]: The unique identifier of the entity being rated. See ID Construction below for details.
 
     ["rating", "<float>"]: The rating value. Must be a number strictly between 0 and 1.
+
+Optional
 
     ["m", "<entity-type>"]:  Describes what is being rated (e.g., event, profile, relay, etc.)
 

--- a/R1.md
+++ b/R1.md
@@ -2,7 +2,7 @@
 
 This NIP defines a standard format for rating any entity within the Nostr ecosystem—such as events, profiles, relays, hashtags, or even external content like books and movies. Ratings are recorded against a unique identifier (ID) and can be used to build reputation systems, recommendations, or filtering mechanisms.
 ## Definitions
-- Rating: A numerical score from the user that reflects the perceived quality, usefulness, or relevance of an entity. This must be a normalized float between 0 and 1, where 0 represents the lowest possible rating and 1 the highest.
+- Rating: A numerical score from the user that reflects the perceived quality, usefulness, or relevance of an entity. This must be a normalized decimal (stored as a string) between 0 and 1, where 0 represents the lowest possible rating and 1 the highest.
 - m (optional): A (m)ark tag indicating the type of entity being rated. Supported values include but are not limited to: event, profile, relay, hashtag, book, movie, etc.
 
 ## Event Kind


### PR DESCRIPTION
Builds top of https://github.com/nostr-protocol/nips/pull/879

Different classes don't warrant different kinds, so created a generic nip, that's meant to handle all categories of things via namespaced Ids. 

Implementations: https://pollerama.fun
