### PR TITLE
Added base "unit" tag to NutZap kind:9321 event

### DIFF
--- a/61.md
+++ b/61.md
@@ -51,6 +51,7 @@ Clients MUST prefix the public key they P2PK-lock with `"02"` (for nostr<>cashu 
     "pubkey": "<sender-pubkey>",
     "tags": [
         [ "proof", "{\"amount\":1,\"C\":\"02277c66191736eb72fce9d975d08e3191f8f96afb73ab1eec37e4465683066d3f\",\"id\":\"000a93d6f8a1d2c4\",\"secret\":\"[\\\"P2PK\\\",{\\\"nonce\\\":\\\"b00bdd0467b0090a25bdf2d2f0d45ac4e355c482c1418350f273a04fedaaee83\\\",\\\"data\\\":\\\"02eaee8939e3565e48cc62967e2fde9d8e2a4b3ec0081f29eceff5c64ef10ac1ed\\\"}]\"}" ],
+        [ "unit", "sat" ],
         [ "u", "https://stablenut.umint.cash" ],
         [ "e", "<nutzapped-event-id>", "<relay-hint>" ],
         [ "p", "e9fbced3a42dcf551486650cc752ab354347dd413b307484e4fd1818ab53f991" ], // recipient of nutzap
@@ -61,6 +62,7 @@ Clients MUST prefix the public key they P2PK-lock with `"02"` (for nostr<>cashu 
 * `.content` is an optional comment for the nutzap
 * `.tags`:
   * `proof` is one or more proofs P2PK-locked to the public key the recipient specified in their `kind:10019` event and including a DLEQ proof.
+  * `unit` is the base unit the proofs are denominated in (eg: `sat`, `usd`, `eur`)
   * `u` is the mint the URL of the mint EXACTLY as specified by the recipient's `kind:10019`.
   * `p` is the Nostr identity public key of nutzap recipient.
   * `e` is the event that is being nutzapped, if any.


### PR DESCRIPTION
Cashu `proofs` can be denominated in various base currencies, but this denomination is not stored in the proof, making it non-trivial for a Nostr client to determine the currency of a NutZap. 

This change adds a `unit` tag, as already [implemented in Nostr NDK ](https://github.com/nostr-dev-kit/ndk/blob/e75ff3e2f476c6b7679fcefc60f178f5eef09f3f/ndk-core/src/events/kinds/nutzap/index.ts#L129)