### PR TITLE
FEATURES command

### DIFF
--- a/C1.md
+++ b/C1.md
@@ -1,0 +1,20 @@
+NIP-C1
+======
+
+Relay Features
+--------------
+
+`draft` `optional`
+
+Upon connection, and at any point during the connection, the Relay can send a `FEATURES` payload to the Client reflecting the available commands to the client.
+
+```json
+["FEATURES", "<feature 1>", "<feature 2>", "<feature 3>", ...]
+``` 
+
+Where `feature` includes the following conventions:   
+
+- `COUNT`, The relay will reply to [NIP-45](45.md) Count commands. 
+- `NEG`, the relay supports Negentropy's `NEG-OPEN`, `NEG-MSG`, `NEG-ERR`, `NEG-CLOSE` commands
+
+Clients should use the information to determine which Relay Client implementation they will use with each specific relay.


### PR DESCRIPTION
This NIP adds a command message to let Clients know which features are available on each relay and collect conventions for features and their labels. 

Instead of "negotiating" the connection, this model simply lets clients know what they can use at any point of time.

More specifically, it currently allows clients to know when they can switch their regular EOSE-based filters for a Negentropy sync and when they can use COUNT. 