### PR TITLE
job result -> job feedback

### DIFF
--- a/90.md
+++ b/90.md
@@ -185,7 +185,7 @@ Any job feedback event MIGHT include results in the `.content` field, as describ
 * Customer publishes a job request (e.g. `kind:5000` speech-to-text).
 * Service Providers MAY submit `kind:7000` job-feedback events (e.g. `payment-required`, `processing`, `error`, etc.).
 * Upon completion, the service provider publishes the result of the job with a `kind:6000` job-result event.
-* At any point, if there is an `amount` pending to be paid as instructed by the service provider, the user can pay the included `bolt11` or zap the job result event the service provider has sent to the user.
+* At any point, if there is an `amount` pending to be paid as instructed by the service provider, the user can pay the included `bolt11` or zap the job feedback event the service provider has sent to the user.
 
 Job feedback (`kind:7000`) and Job Results (`kind:6000-6999`) events MAY include an `amount` tag, this can be interpreted as a suggestion to pay. Service Providers MUST use the `payment-required` feedback event to signal that a payment is required and no further actions will be performed until the payment is sent.
 


### PR DESCRIPTION
If I understood correctly: 

1. the user announces a service it wants fulfilled
2. the service provider gives a feedback requiring a payment before proceeding
3. once the payment is complete, the service provider gives the desired output.  

It doesn't make sense to zap after the output is performed, because people could just ask for services and never pay them back.  

The zap should be to the job feedback, no?

Of course step 2 is not required but I think this will happen in 90% of the cases