### PR TITLE
NIP-72: prefer kind 11 events for text notes

### DIFF
--- a/72.md
+++ b/72.md
@@ -41,13 +41,13 @@ The goal of this NIP is to enable public communities. It defines the replaceable
 
 # Posting to a community
 
-Any Nostr event can be posted to a community. Clients MUST add one or more community `a` tags, each with a recommended relay.
+Kind 11 events SHOULD be used for text notes posted to a community. Any Nostr event can be posted to a community. Clients MUST add one or more community `a` tags, each with a recommended relay.
 
 ```jsonc
 {
-  "kind": 1,
+  "kind": 11,
   "tags": [
-    ["a", "34550:<community event author pubkey>:<community-d-identifier>", "<optional-relay-url>"],
+    ["a", "34550:<community-event-author-pubkey>:<community-d-identifier>", "<optional-relay-url>"],
   ],
   "content": "hello world",
   // other fields...
@@ -71,7 +71,7 @@ Moderators MAY request deletion of their approval of a post at any time using [N
   "tags": [
     ["a", "34550:<event-author-pubkey>:<community-d-identifier>", "<optional-relay-url>"],
     ["e", "<post-id>", "<optional-relay-url>"],
-    ["p", "<port-author-pubkey>", "<optional-relay-url>"],
+    ["p", "<post-author-pubkey>", "<optional-relay-url>"],
     ["k", "<post-request-kind>"]
   ],
   "content": "<the full approved event, JSON-encoded>",


### PR DESCRIPTION
NIP-72 uses kind 1 events for text notes, so there is no way to filter them out of regular feeds. NIP-29 groups solved this by using kind 11 which is more appropriate.