### PR TITLE
docs: add state to NIP-47 transactions

### DIFF
--- a/47.md
+++ b/47.md
@@ -295,6 +295,7 @@ Response:
     "result_type": "make_invoice",
     "result": {
         "type": "incoming", // "incoming" for invoices, "outgoing" for payments
+        "state": "pending",
         "invoice": "string", // encoded invoice, optional
         "description": "string", // invoice's description, optional
         "description_hash": "string", // invoice's description hash, optional
@@ -328,6 +329,7 @@ Response:
     "result_type": "lookup_invoice",
     "result": {
         "type": "incoming", // "incoming" for invoices, "outgoing" for payments
+        "state": "pending", // can be "pending", "settled", or "failed"
         "invoice": "string", // encoded invoice, optional
         "description": "string", // invoice's description, optional
         "description_hash": "string", // invoice's description hash, optional
@@ -376,6 +378,7 @@ Response:
         "transactions": [
             {
                "type": "incoming", // "incoming" for invoices, "outgoing" for payments
+               "state": "pending", // can be "pending", "settled", or "failed"
                "invoice": "string", // encoded invoice, optional
                "description": "string", // invoice's description, optional
                "description_hash": "string", // invoice's description hash, optional
@@ -452,6 +455,7 @@ Notification:
     "notification_type": "payment_received",
     "notification": {
         "type": "incoming",
+        "state": "settled",
         "invoice": "string", // encoded invoice
         "description": "string", // invoice's description, optional
         "description_hash": "string", // invoice's description hash, optional
@@ -477,6 +481,7 @@ Notification:
     "notification_type": "payment_sent",
     "notification": {
         "type": "outgoing",
+        "state": "settled",
         "invoice": "string", // encoded invoice
         "description": "string", // invoice's description, optional
         "description_hash": "string", // invoice's description hash, optional


### PR DESCRIPTION
It's good to have the state information in the transaction struct.