### PR TITLE
NIP-101h: Health and Fitness Metrics

### DIFF
--- a/101h.md
+++ b/101h.md
@@ -1,0 +1,175 @@
+NIP-101h
+========
+
+Health and Fitness Metrics
+--------------------------
+
+`draft` `optional`
+
+This NIP defines a standardized framework for sharing granular health and fitness metrics on the Nostr network. It enables interoperability between health-focused Nostr applications while empowering users with control over their sensitive health data.
+
+## Abstract
+
+NIP-101h provides a structured approach for publishing, consuming, and managing health-related data on Nostr. It reserves specific event kinds for health metrics and defines common patterns for encryption, tagging, and data export.
+
+## Motivation
+
+As health and fitness applications integrate with Nostr, there's a need for standardization to ensure:
+- Interoperability between different health applications
+- User privacy and control over sensitive health data
+- Consistent data formats for reliable interpretation
+- Extensibility for future health metrics
+
+Current implementations include RUNSTR and Npub.Health, both in alpha testing.
+
+## Event Kinds
+
+NIP-101h reserves the following event kind ranges:
+
+- **Primary Health Metrics**: `1351` - `1399`
+- **Paired/Secondary Metrics**: `2351` - `2399` (e.g., for paired metrics like Calories Consumed/Expended)
+
+Each specific health metric is assigned a unique kind number within these ranges.
+
+## Common Event Structure
+
+All NIP-101h events follow this structure:
+
+### Content Field
+
+The `content` field contains the primary value of the metric as a string (e.g., "70" for weight in kg, "10520" for step count).
+
+**Privacy Requirement**: The content field **SHOULD** be encrypted using NIP-44 by default. Users must explicitly opt-in to publish unencrypted health data.
+
+### Required Tags
+
+All NIP-101h events MUST include these tags:
+
+- `["t", "health"]` - General health data categorization
+- `["t", <metric-specific-tag>]` - Specific metric identifier (e.g., `["t", "weight"]`, `["t", "step_count"]`)
+- `["unit", <unit-of-measurement>]` - Unit for the value in content (e.g., `["unit", "kg"]`, `["unit", "steps"]`)
+
+### Common Optional Tags
+
+- `["timestamp", <ISO8601-date>]` - When the metric was measured/recorded
+- `["converted_value", <value>, <unit>]` - Alternative unit representation
+- `["source", <application-name or device-name>]` - Data source
+- Additional metric-specific tags as defined in individual NIP-101h.X specifications
+
+## Example Event Structure
+
+### Unencrypted Example (Step Count)
+```json
+{
+  "kind": 1359,
+  "pubkey": "<user_pubkey_hex>",
+  "created_at": 1678886400,
+  "tags": [
+    ["unit", "steps"],
+    ["t", "health"],
+    ["t", "step_count"],
+    ["period", "daily"],
+    ["timestamp", "2025-03-15T23:59:59Z"],
+    ["source", "MyPedometerApp"]
+  ],
+  "content": "10520",
+  "id": "<event_id>",
+  "sig": "<event_signature>"
+}
+```
+
+### Encrypted Example (Weight)
+```json
+{
+  "kind": 1351,
+  "pubkey": "<user_pubkey_hex>",
+  "created_at": 1678886400,
+  "tags": [
+    ["unit", "kg"],
+    ["t", "health"],
+    ["t", "weight"],
+    ["timestamp", "2025-03-15T08:00:00Z"],
+    ["source", "SmartScale"],
+    ["p", "<user_pubkey_hex>"],
+    ["encrypted"]
+  ],
+  "content": "<nip44_encrypted_payload>",
+  "id": "<event_id>",
+  "sig": "<event_signature>"
+}
+```
+
+## Currently Defined Metrics
+
+The following metrics are initially defined:
+
+| Metric | Kind | Metric Tag | Description |
+|--------|------|------------|-------------|
+| Weight | 1351 | weight | Body weight measurement |
+| Height | 1352 | height | Height measurement |
+| Blood Pressure | 1353 | blood_pressure | Systolic/diastolic pressure |
+| Heart Rate | 1354 | heart_rate | Heart rate in BPM |
+| Body Temperature | 1355 | body_temperature | Core body temperature |
+| Blood Glucose | 1356 | blood_glucose | Blood sugar levels |
+| Sleep Duration | 1357 | sleep_duration | Hours of sleep |
+| Activity Duration | 1358 | activity_duration | Exercise/activity time |
+| Step Count | 1359 | step_count | Number of steps |
+| Calories Expended | 1360 | calories_expended | Energy expenditure |
+| Distance | 1361 | distance | Distance traveled |
+| Calories Consumed | 2360 | calories_consumed | Caloric intake (paired with 1360) |
+
+Additional metrics can be defined through individual NIP-101h.X specifications.
+
+## Privacy and Encryption
+
+Given the sensitive nature of health data:
+
+1. **Default Encryption**: Clients **SHOULD** encrypt the content field using NIP-44 by default
+2. **User Consent**: Explicit user consent **MUST** be obtained before publishing any health data
+3. **Encryption Tags**: When encrypted, events **MUST** include appropriate NIP-44 tags
+4. **Clear UI/UX**: Applications **MUST** clearly indicate when health data is being recorded or published
+
+## Data Export
+
+NIP-101h supports data export for backup and interoperability:
+
+### JSON Export
+Events can be exported as standard Nostr event arrays, maintaining encryption if present.
+
+### CSV Export
+For flattened export, include columns:
+- Common: `id`, `kind`, `created_at`, `value`, `unit`, `encrypted`
+- Metric-specific columns from tags
+
+## Extensibility
+
+New health metrics can be proposed as NIP-101h.X specifications by:
+
+1. Selecting an unused kind number from the reserved ranges
+2. Defining the metric clearly with:
+   - Content format
+   - Required tags
+   - Optional tags
+   - Examples
+3. Discussing with the Nostr community for consensus
+
+## Implementation Guidelines
+
+1. **Privacy First**: Implement NIP-44 encryption by default
+2. **Data Minimization**: Only handle necessary health data
+3. **Clear Consent**: Always obtain explicit user consent
+4. **Error Handling**: Validate data against specifications
+5. **User Control**: Provide easy management/deletion options
+
+## Security Considerations
+
+- Health data is highly sensitive and personally identifiable
+- Relay selection matters for unencrypted data
+- Metadata (tags) remains visible even with encryption
+- Consider legal requirements (HIPAA, GDPR) in your jurisdiction
+
+## References
+
+- [NIP-01: Basic protocol flow description](01.md)
+- [NIP-44: Encrypted Payloads](44.md)
+- [NIP-101h User Guide](https://github.com/HealthNoteLabs/Modular-Health-NIPs/blob/main/NIP101h-User-Guide.md) 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-96: HTTP File Storage Integration](96.md)
 - [NIP-98: HTTP Auth](98.md)
 - [NIP-99: Classified Listings](99.md)
+- [NIP-101h: Health and Fitness Metrics](101h.md)
 - [NIP-7D: Threads](7D.md)
 - [NIP-C0: Code Snippets](C0.md)
 - [NIP-C7: Chats](C7.md)
@@ -150,6 +151,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `1111`        | Comment                         | [22](22.md)                            |
 | `1311`        | Live Chat Message               | [53](53.md)                            |
 | `1337`        | Code Snippet                    | [C0](C0.md)                            |
+| `1351`-`1399` | Health Metrics (Primary)        | [101h](101h.md)                        |
 | `1617`        | Patches                         | [34](34.md)                            |
 | `1621`        | Issues                          | [34](34.md)                            |
 | `1622`        | Git Replies (deprecated)        | [34](34.md)                            |
@@ -162,6 +164,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `2003`        | Torrent                         | [35](35.md)                            |
 | `2004`        | Torrent Comment                 | [35](35.md)                            |
 | `2022`        | Coinjoin Pool                   | [joinstr][joinstr]                     |
+| `2351`-`2399` | Health Metrics (Secondary)      | [101h](101h.md)                        |
 | `4550`        | Community Post Approval         | [72](72.md)                            |
 | `5000`-`5999` | Job Request                     | [90](90.md)                            |
 | `6000`-`6999` | Job Result                      | [90](90.md)                            |
@@ -352,8 +355,13 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `thumb`           | badge thumbnail                      | dimensions in pixels            | [58](58.md)                                        |
 | `title`           | article title                        | --                              | [23](23.md)                                        |
 | `tracker`         | torrent tracker URL                  | --                              | [35](35.md)                                        |
+| `unit`            | unit of measurement                  | --                              | [101h](101h.md)                                    |
 | `web`             | webpage URL                          | --                              | [34](34.md)                                        |
 | `zap`             | pubkey (hex), relay URL              | weight                          | [57](57.md)                                        |
+| `converted_value` | alternative unit value               | unit                            | [101h](101h.md)                                    |
+| `period`          | time period for metric               | --                              | [101h](101h.md)                                    |
+| `source`          | data source/application              | --                              | [101h](101h.md)                                    |
+| `timestamp`       | ISO8601 measurement time             | --                              | [101h](101h.md)                                    |
 
 Please update these lists when proposing new NIPs.
 


### PR DESCRIPTION
NIP-101h provides a structured approach for publishing, consuming, and managing health and fitness data on Nostr. It reserves specific event kinds for health metrics and defines common patterns for encryption, tagging, and data export.

As health and fitness applications integrate with Nostr, there's a need for standardization to ensure:
- Interoperability between different health applications
- User privacy and control over sensitive health data
- Consistent data formats for reliable interpretation
- Extensibility for future health metrics

Implementation
- [RUNSTR](https://github.com/HealthNoteLabs/Runstr) : A cardio tracker available on zapstore in alpha

## Event Kinds

NIP-101h reserves the following event kind ranges:

- **Primary Health Metrics**: `1351` - `1399`
- **Paired/Secondary Metrics**: `2351` - `2399` (e.g., for paired metrics like Calories Consumed/Expended)

Each specific health metric is assigned a unique kind number within these ranges.

## Common Event Structure

All NIP-101h events follow this structure:

### Content Field

The `content` field contains the primary value of the metric as a string (e.g., "70" for weight in kg, "10520" for step count).

**Privacy Requirement**: The content field **SHOULD** be encrypted using NIP-44 by default. Users must explicitly opt-in to publish unencrypted health data.

### Required Tags

All NIP-101h events MUST include these tags:

- `["t", "health"]` - General health data categorization
- `["t", <metric-specific-tag>]` - Specific metric identifier (e.g., `["t", "weight"]`, `["t", "step_count"]`)
- `["unit", <unit-of-measurement>]` - Unit for the value in content (e.g., `["unit", "kg"]`, `["unit", "steps"]`)

### Common Optional Tags

- `["timestamp", <ISO8601-date>]` - When the metric was measured/recorded
- `["converted_value", <value>, <unit>]` - Alternative unit representation
- `["source", <application-name or device-name>]` - Data source
- Additional metric-specific tags as defined in individual NIP-101h.X specifications

## Example Event Structure

### Unencrypted Example (Step Count)
```json
{
  "kind": 1359,
  "pubkey": "<user_pubkey_hex>",
  "created_at": 1678886400,
  "tags": [
    ["unit", "steps"],
    ["t", "health"],
    ["t", "step_count"],
    ["period", "daily"],
    ["timestamp", "2025-03-15T23:59:59Z"],
    ["source", "MyPedometerApp"]
  ],
  "content": "10520",
  "id": "<event_id>",
  "sig": "<event_signature>"
}
```

### Encrypted Example (Weight)
```json
{
  "kind": 1351,
  "pubkey": "<user_pubkey_hex>",
  "created_at": 1678886400,
  "tags": [
    ["unit", "kg"],
    ["t", "health"],
    ["t", "weight"],
    ["timestamp", "2025-03-15T08:00:00Z"],
    ["source", "SmartScale"],
    ["p", "<user_pubkey_hex>"],
    ["encrypted"]
  ],
  "content": "<nip44_encrypted_payload>",
  "id": "<event_id>",
  "sig": "<event_signature>"
}
```

More information can be found in the [Modular Health NIPs](https://github.com/HealthNoteLabs/Modular-Health-NIPs) Repo from HealthNote Labs. 