### PR TITLE
NIP-B8: Replaceable Event IDs in Request Filters

### DIFF
--- a/B8.md
+++ b/B8.md
@@ -1,0 +1,82 @@
+NIP-B8
+======
+
+Replaceable Event IDs in Request Filters
+----------------------------------------
+
+`draft` `optional`
+
+This NIP defines an extension to the subscription filter mechanism that allows relays to recognize and match replaceable (including parameterizable replaceable) event identifiers in the `ids` property of a request filter. This enables clients to efficiently query multiple replaceable events without creating separate filters or requests for each one.
+
+## Motivation
+
+The current protocol requires clients to query parameterized replaceable events by creating a separate filter or request for each combination of (pubkey, kind, d-tag). This becomes inefficient when a client needs to fetch a large number of replaceable events.
+
+For example, a client needing to query 100 multiple replaceable events currently has limited options:
+
+  - Send 100 multiple separate requests
+  - Send one request with 100 request filters
+  - Implement a custom NIP-50 search (which breaks interoperability)
+  - Modify the application to use `a` tags in target events (not feasible if the events are not under control of one entity)
+
+All these approaches have significant drawbacks, leading to excessive roundtrips or breaking interoperability.
+
+## Definitions
+
+### Replaceable Event ID Format
+
+A replaceable event ID in the `ids` property MUST follow this format:
+
+`<kind>:<32-bytes lowercase hex of a pubkey>:` or `<kind>:<32-bytes lowercase hex of a pubkey>:<d-identifier>`
+
+This format for referencing addressable/replaceable events is defined in [NIP-01](01.md).
+
+## Relay Behavior
+
+When a relay receives a request with the `ids` property containing one or more entries in the above format, it MUST:
+
+  - Parse each entry to extract the kind, pubkey, and d-identifier (if present)
+  - Query the database for the latest event matching the (pubkey, kind, d-identifier) tuple
+  - Return this event as if it were requested by its regular event ID
+
+For example, given the filter:
+
+```jsonc
+{
+  "ids": [
+    "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:article-1",
+    "30023:a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee286ddf9fda919:article-2",
+    "10002:3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d:",
+    "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3"
+  ]
+}
+```
+
+The relay would:
+
+  - Identify that the first two entries are replaceable event identifiers for kind 30023 events
+  - Identify the third entry as a non-parameterized replaceable event identifier for kind 10002
+  - Recognize the fourth entry as a regular event ID
+  - Query and return the matching events accordingly
+
+Regular event IDs in the same ids array MUST continue to be processed as before.
+
+Relays SHOULD clearly indicate support for this NIP in their [NIP-11](11.md) information document.
+
+## Client Behavior
+
+Clients implementing this NIP SHOULD detect relay support and optimize queries accordingly.
+
+## Backwards Compatibility
+
+This NIP is fully backwards compatible:
+
+  - Clients that do not implement this NIP will continue to work with relays that do implement it by using standard query mechanisms.
+  - Clients that implement this NIP will gracefully fall back to multiple request filters when communicating with relays that do not support this feature.
+  - Relays not implementing this NIP will simply reject or ignore filters with non-standard ID formats, allowing clients to detect and fall back to the standard approach.
+
+## Further Considerations
+
+  - Relays SHOULD implement appropriate error handling for, or completely ignore, malformed replaceable event IDs just as they do with regular IDs.
+  - Relays SHOULD implement appropriate rate limiting to prevent abuse of this feature.
+  - Clients SHOULD be careful not to generate excessive replaceable event ID queries.


### PR DESCRIPTION
[Rendered](https://github.com/nostr-protocol/nips/blob/0b86596fef9cf6aa63269d177896a4edeea29de7/B8.md)

This NIP defines an extension to the subscription filter mechanism that allows relays to recognize and match replaceable (including parameterizable replaceable) event identifiers in the `ids` property of a request filter.

This enables clients to efficiently query multiple replaceable events without creating separate filters or requests for each one.