### PR TITLE
NIP-88: rename `endsAt` tag to `ends`

### DIFF
--- a/88.md
+++ b/88.md
@@ -21,7 +21,7 @@ Major tags in the poll event are:
 - **option**: The option tags contain an OptionId(any alphanumeric) field, followed by an option label field.
 - **relay**: One or multiple tags that the poll is expecting respondents to respond on.
 - **polltype**: can be "singlechoice" or "multiplechoice". Polls that do not have a polltype should be considered a "singlechoice" poll.
-- **endsAt**: signifying at which unix timestamp the poll is meant to end.
+- **ends**: signifying at which unix timestamp the poll is meant to end.
 
 Example Event
 
@@ -39,7 +39,7 @@ Example Event
     ["relay", "<relay url1>"],
     ["relay", "<relay url2>"],
     ["polltype", "singlechoice"],
-    ["endsAt", "<unix timestamp in seconds>"]
+    ["ends", "<unix timestamp in seconds>"]
   ]
 }
 ```

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -5,6 +5,7 @@ reverse chronological order.
 
 | Date        | Commit    | NIP      | Change |
 | ----------- | --------- | -------- | ------ |
+| 2025-05-27  | [125c7b98](https://github.com/nostr-protocol/nips/commit/125c7b98) | [88](88.md) | rename `endsAt` tag to `ends` |
 | 2025-02-14  | [81908b6e](https://github.com/nostr-protocol/nips/commit/81908b6e) | [07](07.md), [46](46.md), [55](55.md) | `getRelays` and `get_relays` were removed |
 | 2025-02-07  | [0023ca81](https://github.com/nostr-protocol/nips/commit/0023ca81) | [10](10.md) | `"mention"` marker was removed |
 | 2025-01-31  | [6a4b125a](https://github.com/nostr-protocol/nips/commit/6a4b125a) | [71](71.md) | video events were changed to regular |

--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `description`     | description                          | --                              | [34](34.md), [57](57.md), [58](58.md), [C0](C0.md) |
 | `emoji`           | shortcode, image URL                 | --                              | [30](30.md)                                        |
 | `encrypted`       | --                                   | --                              | [90](90.md)                                        |
+| `ends`            | unix timestamp (string)              | --                              | [53](53.md), [88](88.md)                           |
 | `extension`       | File extension                       | --                              | [C0](C0.md)                                        |
 | `expiration`      | unix timestamp (string)              | --                              | [40](40.md)                                        |
 | `file`            | full path (string)                   | --                              | [35](35.md)                                        |


### PR DESCRIPTION
This change renames the `endsAt` tag to `ends` in the NIP-88, as the `ends` tag is already used in NIP-53. This avoids unnecessary duplicate tags definition in the code, for who supports both NIP-53 and NIP-88.