### PR TITLE
NIP-90 version 2.0

### DIFF
--- a/90.md
+++ b/90.md
@@ -6,225 +6,1200 @@ Data Vending Machine
 
 `draft` `optional`
 
-This NIP defines the interaction between customers and Service Providers for performing on-demand computation.
+## Table of Contents
 
-Money in, data out.
+- [Introduction](#introduction)
+  - [Purpose and Scope](#purpose-and-scope)
+  - [Relationship to Kind-Specific Specifications](#relationship-to-kind-specific-specifications)
+  - [DVMs vs APIs](#dvms-vs-apis)
+  - [DVMs and Relays](#dvms-and-relays)
+- [Event Kinds](#event-kinds)
+- [Discoverability](#discoverability)
+  - [DVM Announcement](#dvm-announcement)
+  - [Provider Announcement](#provider-announcement)
+  - [Discovery Patterns](#discovery-patterns)
+- [Using a DVM](#using-a-dvm)
+  - [Request](#request)
+  - [Response](#response)
+  - [Feedback/Intermediate/Error](#feedbackintermediateerror)
+  - [Common Job Feedback Status](#common-job-feedback-status)
+- [Common Protocol Flows](#common-protocol-flows)
+  - [Direct Request (Free)](#direct-request-free)
+  - [Direct Request (Paid)](#direct-request-paid)
+  - [Open Request (Free or Paid)](#open-request-free-or-paid)
+  - [Cancellation](#cancellation)
+- [Payment Examples](#payment-examples)
+  - [Implementation Best Practices](#implementation-best-practices)
+- [Heartbeat Events](#heartbeat-events)
+- [Comprehensive Flow Examples](#comprehensive-flow-examples)
+  - [Event Type Examples](#event-type-examples)
+  - [Protocol Flow Examples](#protocol-flow-examples)
+- [Privacy](#privacy)
+- [Guidance for Developers](#guidance-for-developers)
+  - [DVM Creators](#dvm-creators)
+  - [Client Developers](#client-developers)
+  - [Relay Operators](#relay-operators)
+- [Open Questions for the Broader Nostr Community](#open-questions-for-the-broader-nostr-community)
 
-## Kinds
-This NIP reserves the range `5000-7000` for data vending machine use.
 
-| Kind      | Description       |
-| ----      | -----------       |
-| 5000-5999 | Job request kinds |
-| 6000-6999 | Job result        |
-| 7000      | Job feedback      |
+This NIP defines the interaction between customers and Service Providers for performing on-demand computation on the Nostr network.
 
-Job results always use a kind number that is `1000` higher than the job request kind. (e.g. request: `kind:5001` gets a result: `kind:6001`).
+__Data Vending Machines__: Money in, data out. -*Pablo7z*
 
-Job request types are defined [separately](https://github.com/nostr-protocol/data-vending-machines/tree/master/kinds).
+## Introduction
 
-## Rationale
-Nostr can act as a marketplace for data processing, where users request jobs to be processed in certain ways (e.g., "speech-to-text", "summarization", etc.), but they don't necessarily care about "who" processes the data.
+This NIP defines a framework for Data Vending Machines (DVMs) on the Nostr network - services that perform computation on request and deliver results back to users. 
 
-This NIP is not to be confused with a 1:1 marketplace; instead, it describes a flow where a user announces a desired output, willingness to pay, and service providers compete to fulfill the job requirement in the best way possible.
+### Purpose and Scope
 
-### Actors
-There are two actors in the workflow described in this NIP:
-* Customers (npubs who request a job)
-* Service providers (npubs who fulfill jobs)
+The primary purpose of NIP-90 is to establish:
 
-## Job request (`kind:5000-5999`)
-A request to process data, published by a customer. This event signals that a customer is interested in receiving the result of some kind of compute.
+1. **How to announce a DVM**: Standard methods for providers to announce their services and make them discoverable
+2. **Basic protocol patterns**: Common interaction patterns between customers and DVMs
+3. **Design guidance**: Recommended approaches, not strict requirements
 
-```jsonc
-{
-    "kind": 5xxx, // kind in 5000-5999 range
-    "content": "",
-    "tags": [
-        [ "i", "<data>", "<input-type>", "<relay>", "<marker>" ],
-        [ "output", "<mime-type>" ],
-        [ "relays", "wss://..." ],
-        [ "bid", "<msat-amount>" ],
-        [ "t", "bitcoin" ]
-    ],
-    // other fields...
-}
-```
+Important: **This specification intentionally allows flexibility**. Unlike most NIPs which define strict protocols, NIP-90 establishes a framework while allowing considerable freedom in implementation details. This is by design, as different types of computation (represented by different event kinds) have different requirements.
 
-All tags are optional.
+### Relationship to Kind-Specific Specifications
 
-* `i` tag: Input data for the job (zero or more inputs)
-    * `<data>`: The argument for the input
-    * `<input-type>`: The way this argument should be interpreted. MUST be one of:
-        * `url`: A URL to be fetched of the data that should be processed.
-        * `event`: A Nostr event ID.
-        * `job`: The output of a previous job with the specified event ID. The dermination of which output to build upon is up to the service provider to decide (e.g. waiting for a signaling from the customer, waiting for a payment, etc.)
-        * `text`: `<data>` is the value of the input, no resolution is needed
-    * `<relay>`: If `event` or `job` input-type, the relay where the event/job was published, otherwise optional or empty string
-    * `<marker>`: An optional field indicating how this input should be used within the context of the job
-* `output`: Expected output format. Different job request `kind` defines this more precisely.
-* `param`: Optional parameters for the job as key (first argument)/value (second argument). Different job request `kind` defines this more precisely. (e.g. `[ "param", "lang", "es" ]`)
-* `bid`: Customer MAY specify a maximum amount (in millisats) they are willing to pay
-* `relays`: List of relays where Service Providers SHOULD publish responses to
-* `p`: Service Providers the customer is interested in. Other SPs MIGHT still choose to process the job
+Each specific DVM kind (e.g., AI text generation, feed curation, web-of-trust computation etc.) should have its own dedicated specification that builds upon this framework. These kind-specific specifications will define the exact requirements, schemas, and behaviors for that particular type of computation.
 
-## Encrypted Params
+When implementing a DVM, you should:
+1. Follow the announcement and discovery patterns in this specification
+2. Refer to the kind-specific specification for your computation type
+3. Use the protocol flows described here as design patterns, adapting them as needed
 
-If the user wants to keep the input parameters a secret, they can encrypt the `i` and `param` tags with the service provider's 'p' tag and add it to the content field. Add a tag `encrypted` as tags. Encryption for private tags will use [NIP-04 - Encrypted Direct Message encryption](04.md), using the user's private and service provider's public key for the shared secret
+This framework-based approach allows the DVM ecosystem to innovate and evolve while maintaining sufficient standardization for client compatibility.
+
+### DVMs vs APIs
+
+Data Vending Machines are similar in nature to Application Programming Interfaces (APIs): A `DVM provider` is analogous to an API provider recognized by their domain name (i.e. google.com) and individual `DVMs` are analagous to API endpoints (i.e. google.com/v1/endpointA).  
+However DVMs and APIs differ in many fundamental aspects:
+
+- `transport`: DVMs only use Nostr events, while APIs use a variety of transport mechanisms such as HTTP, gRPC, and WebSockets depending on the use case and communication pattern. 
+
+- `asynchronicity`: Unlike traditional APIs, which often enforce short timeouts (typically minutes), DVMs are inherently asynchronous and well-suited for long-running jobs. This works because customers and service providers communicate indirectly via one or more relays, rather than maintaining a direct connection.
+
+- `authentication`: APIs require users to register with contact info (like an email) and include an API key with every request. In contrast, DVMs inherently support authentication because requests are signed Nostr events.
+
+- `verifiable reputation`: Every DVM response is cryptographically signed by the provider’s private key, enabling users to verify the integrity of each computation, and build trust over time. On the other hand, API reputations mostly rely on the reputation of centrally controlled domain names.
+
+- `discoverability`: Unlike traditional APIs which are isolated and difficult to find, DVMs announce themselves and their schemas via Nostr events. This makes discovering computational services as easy as querying relays, which facilitate the emergence of the `free market competition`
+
+- `free market competition`: Because DVMs are easy to discover and use, market dynamics encourage providers to converge on common schemas for the same job kind, improving compatibility and interoperability across implementations.
+
+### DVMs and Relays
+
+Many DVMs *could* be replicated by specialized relays, while advanced relay features (like NIP-45 `COUNT`) *could* operate as DVMs instead. Despite this functional overlap, key design differences make each approach optimal for different use cases:
+
+- `asynchronicity`: Unlike relays which are expected to respond quickly, DVMs are inherently asynchronous and well-suited for long-running jobs.
+
+- `centralization risk`: Adding functionalities to relays makes it harder for users to switch between relays easily. This creates a potential centralization risk, because users may start using fewer and fewer relays, which can weaken the protocol’s decentralization.
+
+
+### Standards Convergence
+
+This specification embraces market-driven standardization. When multiple DVMs serve the same job type, competitive pressure naturally encourages:
+
+- Compatible input/output formats for easier client integration
+- Common response types for better user experience  
+- Shared documentation patterns for developer adoption
+
+DVMs that diverge significantly from emerging patterns risk reduced adoption, creating natural incentives for convergence without centralized control.
+
+
+
+## Event Kinds
+
+This NIP defines the following event types:
+
+| Event Type | New Kinds | Legacy Kinds | Description | 
+| ---------- | --------- | ------------ | ----------- | 
+| DVM Announcement | `31999` (addressable) | `31990` | Contains DVM-specific information |
+| Provider Announcement | `11999` (replaceable) | N/A | (Recommended) Lists multiple DVMs operated by a provider |
+| Request | `20000` - `29999` | `5000` - `5999` | Customer request for computation | 
+| Response | Any kind (specified in DVM announcement) | `6000` - `6999` | Result of the computation. The DVM can respond with any Nostr event kind, which MUST be specified in the DVM Announcement. **It is strongly recommended to use a response kind ` = request_kind + 1`** when you don't plan to re-use an existing kind. | 
+| Feedback/Error | `21999` | `7000` | Status updates about the computation | 
+| Heartbeat | `11998` | N/A | (Optional) Frequently replaced note that communicates a DVM is online |
+
+**Note on Response Kinds:** While the protocol allows any response kind, implementers must choose specific kind numbers when creating DVMs. Common patterns include using ephemeral kinds (request kind + 1) for temporary results or established kinds (1, 30023, 31808) for persistent content.
+
+### Migration from Existing Implementations
+
+Existing DVM implementations can migrate gradually:
+
+1. **Phase 1 - Dual Monitoring**: Update DVMs to monitor both legacy (5000-5999) and new (20000-29999) request kinds
+  
+    - When moving from a 5xxx kind to an ephemeral kind, you can simply add '2' in front to get the new request kind, so `5300` becomes `25300`. Then for the response kind, follow the new guidelines by adding 1 to the request kind, so the old response kind of `6300` becomes `25301`.
+2. **Phase 2 - Response Flexibility**: When receiving legacy format requests, respond with traditional response kinds (6000-6999). When receiving new format requests, use the response kind specified in your DVM announcement
+3. **Phase 3 - Client Updates**: Clients can begin sending new format requests once DVMs demonstrate dual support
+4. **Phase 4 - Gradual Transition**: Market forces will naturally drive convergence as implementations prove their effectiveness
+
+This approach ensures no existing functionality is broken while enabling innovation.
+
+## Discoverability
+
+### DVM Announcement
+
+DVMs follow the **reflection pattern**, meaning each DVM declares how it should be used directly within its announcement event. This makes key information, like the expected [JSON Input Schema](https://json-schema.org/), request and response kinds, immediately accessible to clients.
+
+This approach enables:
+- **Easy validation** of DVMs input parameters without out-of-band documentation.
+- **Extensibility**, allowing providers to add optional parameters to their input schemas and communicate them clearly to users.
+- **Convergence on kind standards**, as common patterns emerge from multiple DVMs competing per job kind.
+
+Documentation may be provided as URLs, Nostr wiki events (kind 30818), or other accessible formats. The key requirement is that clients can access usage information.
 
 ```json
-[
-  ["i", "what is the capital of France? ", "text"],
-  ["param", "model", "LLaMA-2"],
-  ["param", "max_tokens", "512"],
-  ["param", "temperature", "0.5"],
-  ["param", "top-k", "50"],
-  ["param", "top-p", "0.7"],
-  ["param", "frequency_penalty", "1"]
-]
-```
-
-This param data will be encrypted and added to the `content` field and `p` tag should be present
-
-```jsonc
-{
-  "content": "BE2Y4xvS6HIY7TozIgbEl3sAHkdZoXyLRRkZv4fLPh3R7LtviLKAJM5qpkC7D6VtMbgIt4iNcMpLtpo...",
+{  
+  "kind": 31999,
+  "pubkey": "<provider_pubkey>",
+  "created_at": 1000000000,
   "tags": [
-    ["p", "04f74530a6ede6b24731b976b8e78fb449ea61f40ff10e3d869a3030c4edc91f"],
-    ["encrypted"]
+    // required
+    ["d", "<dvm-identifier>"],
+    ["k", "<20000-29999>"],  // the request kind
+    ["response_kind", "<dvm-response-kind>"],  // the kind this DVM will use for responses
+
+    // recommended info
+    ["name", "<dvm_name>"],
+    ["about", "<dvm_description>"],
+    ["picture", "<dvm_logo_url>"],
+    ["documentation", "<nostr event naddr (decoded) or url>"],  // kind 31808 wiki page is recommended
   ],
-  // other fields...
+  "content": {
+    "input_schema": { /* input schema */ },
+    "output_schema": { /* output schema */ }
+  }
 }
 ```
 
 
-## Job result (`kind:6000-6999`)
 
-Service providers publish job results, providing the output of the job result. They should tag the original job request event id as well as the customer's pubkey.
+### Provider Announcement
 
-```jsonc
+A provider of one or more DVMs can publish a `Provider Announcement` to help clients find information about its services. This event lists references to multiple `DVM Announcements`. Provider announcements are optional and primarily useful for entities operating multiple DVMs. Single-DVM operators may skip this and rely solely on DVM announcements.
+
+```json
 {
-  "pubkey": "<service-provider pubkey>",
-  "content": "<payload>",
-  "kind": 6xxx,
+  "kind": 11999,
+  "pubkey": "<provider-pubkey>",
+  "created_at": 1000000000,
+  "content": "<provider_description>",
   "tags": [
-    ["request", "<job-request>"],
-    ["e", "<job-request-id>", "<relay-hint>"],
-    ["i", "<input-data>"],
-    ["p", "<customer's-pubkey>"],
-    ["amount", "requested-payment-amount", "<optional-bolt11>"]
-  ],
-  // other fields...
+    // list of DVM announcements (required)
+    ["a", "31999:<provider-pubkey>:<dvm1-d-tag>"],
+    ["a", "31999:<provider-pubkey>:<dvm2-d-tag>"],
+
+    // list of suported request kinds (required)
+    ["k", 26333], // the request kind for dvm1
+    ["k", 27171] // the request kind for dvm2
+
+    // provider info (recommended)
+    ["name", "<provider_name>"],
+    ["about", "<provider_description>"],
+    ["picture", "<provider_logo_url>"],
+    ["website", "<provider_website_url>"],
+    ["relays", "<provider-relay1>", "<provider-relay2>", "..."]
+  ]
 }
 ```
 
-* `request`: The job request event stringified-JSON.
-* `amount`: millisats that the Service Provider is requesting to be paid. An optional third value can be a bolt11 invoice.
-* `i`: The original input(s) specified in the request.
+The Provider Announcement enables a single entity to operate multiple DVMs under a unified identity. This helps providers build a verifiable reputation with users, supporting Web of Trust dynamics. It also allows providers to manage shared attributes like contact information and relay preferences in a single place, reducing duplication across multiple DVM announcements.
 
-## Encrypted Output
+### Discovery Patterns
 
-If the request has encrypted params, then output should be encrypted and placed in  `content` field. If the output is encrypted, then avoid including `i` tag with input-data as clear text.
-Add a tag encrypted to mark the output content as `encrypted`
+##### 1. Query for DVM Announcements
 
-```jsonc
+To get a list of all available DVMs for a particular job kind:
+
+```json
 {
-  "pubkey": "<service-provider pubkey>",
-  "content": "<encrypted payload>",
-  "kind": 6xxx,
-  "tags": [
-    ["request", "<job-request>"],
-    ["e", "<job-request-id>", "<relay-hint>"],
-    ["p", "<customer's-pubkey>"],
-    ["amount", "requested-payment-amount", "<optional-bolt11>"],
-    ["encrypted"]
-  ],
-  // other fields...
+  "kinds": [31999],
+  "#k": ["<job-kind>"],
+  "limit": 100
 }
 ```
 
-## Job feedback
+Clients can discover available DVMs through various methods described below.
 
-Service providers can give feedback about a job back to the customer.
+##### 2. Query for Provider Announcements
 
-```jsonc
+To get a list of providers that support a particular job kind, each with references to their DVMs:
+
+```json
 {
-  "kind": 7000,
-  "content": "<empty-or-payload>",
+  "kinds": [11999],
+  "#k": ["<job-kind>"],
+  "limit": 100
+}
+```
+
+##### 3. Query for Recently Updated DVMs
+
+```json
+{
+  "kinds": [31999],
+  "since": <current_time - 604800>,
+  "limit": 50
+}
+```
+
+This returns DVMs that have been announced or updated in the last week.
+
+## Using a DVM
+
+There are two ways in which users can interact with a DVM, depending on whether they have chosen a DVM to fulfill their request. 
+
+- `Direct Request`: If a user already knows which DVM they want they can include its `a` tag in the job request. The `a` tag contains the identifying information for a single DVM.
+
+- `Open Request`: If a user doesn't know which DVM they want he/she can publish a job request without an `a` tag. DVMs can respond with a `Feedback Event`(kind 21999), signalling their interest in fulfilling the job.
+The user can then select one or more DVMs that replied to the open request by publishing new `direct requests`, as per the previous point.
+
+### Request
+
+A computation request published by a customer:
+
+```json
+{
+  "kind": "<20000-29999>",
+  "pubkey": "<customer_pubkey>",
+  "created_at": 1000000000,
+  "content": "<json_payload>",
   "tags": [
+    // Target DVM (optional)
+    ["a", "31999:<provider-pubkey>:<dvm-identifier1>"],
+    
+    // Relays where the response should be published (optional)
+    ["relays", "<client-relay1>", "<client-relay2>", "..."],
+  ]
+}
+```
+
+**Note 1:** Input parameters SHOULD be passed in the JSON content field rather than tags, as this allows for complex nested parameters and better schema validation.
+
+### Response
+
+Service providers publish job results using the event kind specified in their DVM announcement:
+
+```json
+{
+  "kind": "<response_kind>",
+  "pubkey": "<provider_pubkey>",
+  "created_at": 1000000000,
+  "content": "<json_result>",
+  "tags": [
+    // required
+    ["e", "<request_id>"],
+    ["p", "<customer_pubkey>"],
+    
+    // (optional) expiration timestamp (NIP-40) if this event kind is not ephemeral
+    ["expiration", "<unix-timestamp>"]
+  ]
+}
+```
+
+**Note 1:** While responses can use any event kind, implementers must choose specific numbers when creating actual events. The flexibility exists at the protocol design level, but individual implementations require concrete values for proper event processing and relay storage. The response kind must match what the DVM declared in its announcement.
+
+**Note 2:** While responses can use any event kind, consistency within job types improves client compatibility. DVMs serving similar functions are encouraged to coordinate on response formats. 
+
+**Note 3:** DVMs may respond with either direct results (content contains the answer) or reference events (response references another event containing the result). The approach should be documented in the DVM announcement. Unless the response of the DVM needs to exist for a long period of time, it is recommended to use an ephemeral response kind that is +1 of the request kind. However, you could have the response kind be a kind 1 event for example; and you could have both: the DVM response kind is an ephemeral+1 that links to a kind 1 event. Direct responses (result in content) are preferred for simplicity. Reference responses should only be used when the result naturally fits another event type (e.g., long-form articles).
+
+**Note 4:** Response events MUST include an 'e' tag referencing the request event ID, regardless of whether the request was ephemeral. Clients should store request IDs locally for correlation since ephemeral events may not be retrievable from relays.
+
+### Feedback/Intermediate/Error
+
+Service providers can send intermediate events per job, such as requiring payment or letting the customer know there is an error:
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "<provider_pubkey>",
+  "created_at": 1000000000,
+  "content": "<message_details>",
+  "tags": [
+    // required
+    ["e", "<request_id>"],
+    ["p", "<customer_pubkey>"],
     ["status", "<status>", "<extra-info>"],
-    ["amount", "requested-payment-amount", "<bolt11>"],
-    ["e", "<job-request-id>", "<relay-hint>"],
-    ["p", "<customer's-pubkey>"],
-  ],
-  // other fields...
+
+    // optional
+    // add other tags here as needed
+  ]
 }
 ```
 
-* `content`: Either empty or a job-result (e.g. for partial-result samples)
-* `amount` tag: as defined in the [Job Result](#job-result-kind6000-6999) section.
-* `status` tag: Service Providers SHOULD indicate what this feedback status refers to. [Job Feedback Status](#job-feedback-status) defines status. Extra human-readable information can be added as an extra argument.
+### Common Job Feedback Status
 
-* NOTE: If the input params requires input to be encrypted, then `content` field will have encrypted payload with `p` tag as key.
-
-### Job feedback status
-
-| status             | description                                                                                                 |
-| --------           | -------------                                                                                               |
-| `payment-required` | Service Provider requires payment before continuing.                                                        |
-| `processing`       | Service Provider is processing the job.                                                                     |
-| `error`            | Service Provider was unable to process the job.                                                             |
-| `success`          | Service Provider successfully processed the job.                                                            |
-| `partial`          | Service Provider partially processed the job. The `.content` might include a sample of the partial results. |
-
-Any job feedback event MIGHT include results in the `.content` field, as described in the [Job Result](#job-result-kind6000-6999) section. This is useful for service providers to provide a sample of the results that have been processed so far.
+The following are common `status` events of kind `21999`, however new DVMs can use a custom one if needed. Keep in mind that adding custom status messages increases the amount of work that consumers will need to do to use your DVM:
 
 
-# Protocol Flow
+| Status             | Description                                                                                                                                                                               |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `payment-required` | Service Provider requires payment before continuing                                                                                                                                       |
+| `processing`       | Service Provider is processing the job                                                                                                                                                    |
+| `error`            | Service Provider was unable to process the job                                                                                                                                            |
+| `available`        | Service Provider is responding to an open job request with availability                                                                                                              |
+| `<custom>`         | Defined as needed by the DVM. The DVM should provide documentation about their custom feedback event, including examples, and include it in the documentation tag in their `DVM announcement`. |
 
-* Customer publishes a job request (e.g. `kind:5000` speech-to-text).
-* Service Providers MAY submit `kind:7000` job-feedback events (e.g. `payment-required`, `processing`, `error`, etc.).
-* Upon completion, the service provider publishes the result of the job with a `kind:6000` job-result event.
-* At any point, if there is an `amount` pending to be paid as instructed by the service provider, the user can pay the included `bolt11` or zap the job result event the service provider has sent to the user.
 
-Job feedback (`kind:7000`) and Job Results (`kind:6000-6999`) events MAY include an `amount` tag, this can be interpreted as a suggestion to pay. Service Providers MUST use the `payment-required` feedback event to signal that a payment is required and no further actions will be performed until the payment is sent.
+**Tag Format Examples**
 
-Customers can always either pay the included `bolt11` invoice or zap the event requesting the payment and service providers should monitor for both if they choose to include a bolt11 invoice.
+```json
+// Payment required
+["status", "payment-required"]
+["price", "<amount>", "<currency>", "<period>"] // period can be used for a subscription time period
+["method", "<payment_method>", "<payment_details>", "<optional_callback>"]
 
-## Notes about the protocol flow
-The flow is deliberately ambiguous, allowing vast flexibility for the interaction between customers and service providers so that service providers can model their behavior based on their own decisions/perceptions of risk.
+// Processing
+["status", "processing"]
 
-Some service providers might choose to submit a `payment-required` as the first reaction before sending a `processing` or before delivering results, some might choose to serve partial results for the job (e.g. a sample), send a `payment-required` to deliver the rest of the results, and some service providers might choose to assess likelihood of payment based on an npub's past behavior and thus serve the job results before requesting payment for the best possible UX.
+// Error
+["status", "error", "<ERROR_CODE>", "<human readable error message>"]
 
-It's not up to this NIP to define how individual vending machines should choose to run their business.
+// Available, used when responding to an open request and not requiring payment
+["status", "available"]
+```
 
-# Cancellation
-A job request might be canceled by publishing a `kind:5` delete request event tagging the job request event.
+Note: When responding to an open job request (i.e. no `a` tag that specifies a target DVM):
+  - If your DVM is free, the default approach is to respond with a kind `21999` event with `["status", "available"]`
+  - If your DVM requires payment, the default approach is to respond with a kind `21999` event with `["status", "payment-required"]` as well as other payment related tags (see above).
 
-# Appendix 1: Job chaining
-A Customer MAY request multiple jobs to be processed as a chain, where the output of a job is the input of another job. (e.g. podcast transcription -> summarization of the transcription). This is done by specifying as input an event id of a different job with the `job` type.
+#### Standard Error Codes
 
-Service Providers MAY begin processing a subsequent job the moment they see the prior job's result, but they will likely wait for a zap to be published first. This introduces a risk that Service Provider of job #1 might delay publishing the zap event in order to have an advantage. This risk is up to Service Providers to mitigate or to decide whether the service provider of job #1 tends to have good-enough results so as to not wait for an explicit zap to assume the job was accepted.
+| Code | Meaning |
+|------|---------|
+| `BAD_REQUEST` | Malformed JSON |
+| `INVALID_PARAMETER` | A parameter value is invalid |
+| `MISSING_PARAMETER` | A required parameter is missing |
+| `RATE_LIMITED` | Too many requests |
+| `SERVICE_UNAVAILABLE` | Temporarily overloaded |
+| `UNAUTHORIZED` | Request lacks necessary authorization |
+| `PAYMENT_FAILED` | Payment processing failed |
+| `POLICY_VIOLATION` | Request violates content policy |
+| _etc._ — follow the list in PR #1929 |
 
-This gives a higher level of flexibility to service providers (which sophisticated service providers would take anyway).
+## Common Protocol Flows
 
-# Appendix 2: Service provider discoverability
-Service Providers MAY use NIP-89 announcements to advertise their support for job kinds:
+### Direct Request (Free)
+1. Customer publishes a Request (`20000-29999`) with an `a` tag that refers to a specific DVM
+2. Provider optionally publishes a `processing` Feedback event
+3. Provider publishes a Response (`20000-29999`) or a Feedback event `21999` in case of errors.
 
-```jsonc
+### Direct Request (Paid)
+1. Customer publishes a Request (`20000-29999`) with an `a` tag that refers to a specific DVM
+2. Provider publishes a `payment-required` Feedback event containing all information needed to make a payment
+3. Customer makes payment (while some examples are given below, this is largely outside the scope of this NIP)
+4. Provider optionally publishes a `processing` Feedback event once payment is confirmed
+3. Provider publishes a Response (`20000-29999`) or a Feedback event `21999` in case of errors.
+
+### Open Request (Free or Paid)
+1. Customer publishes a Request with no `a` tags
+2. Interested DVMs reply with kind `21999` (`["status", "available"]`, price and eta tags are free-form extras).
+3. The customer makes a payment(s) and republishes a new direct request for each winning DVM, using their respective `a` tags
+5. Winning Provider(s) optionally publishes a `processing` Feedback event
+6. Winning Provider publishes a Response (`20000-29999`) or a Feedback event `21999` in case of errors.
+
+### Cancellation
+A job request can be canceled by the customer publishing a `kind:5` delete request event tagging the job request event id, to let the DVM provider know they should stop work.
+
+## Payment Examples
+
+### 1. Lightning Payments
+
+```json
 {
-  "kind": 31990,
-  "pubkey": "<pubkey>",
-  "content": "{
-    \"name\": \"Translating DVM\",
-    \"about\": \"I'm a DVM specialized in translating Bitcoin content.\"
-  }",
+  "kind": 21999,
+  "pubkey": "<provider_pubkey>",
+  "created_at": 1000000000,
+  "content": "<optional message>",
   "tags": [
-    ["k", "5005"], // e.g. translation
-    ["t", "bitcoin"] // e.g. optionally advertises it specializes in bitcoin audio transcription that won't confuse "Drivechains" with "Ridechains"
-  ],
-  // other fields...
+    ["e", "<request_id>"],
+    ["status", "payment-required"],
+    ["price", "150", "sat"],
+    ["method", "lightning", "<lightning_invoice>", "<optional_callback_url>"],
+  ]
 }
 ```
 
-Customers can use NIP-89 to see what service providers their follows use.
+Verification process:
+1. Generate a unique Lightning invoice for each request
+2. Monitor the Lightning Network for payment receipt
+3. Once payment is confirmed, continue processing
+
+#### 2. Bitcoin On-chain Payments
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "<provider_pubkey>",
+  "created_at": 1000000000,
+  "content": "Payment required to process your request",
+  "tags": [
+    ["e", "<request_id>"],
+    ["status", "payment-required"],
+    ["method", "bitcoin", "<btc_address>"],
+    ["price", "0.0001", "btc"],
+  ]
+}
+```
+
+Verification process:
+1. Generate a unique Bitcoin address for each request 
+2. Monitor the address for incoming transactions
+3. Wait for sufficient confirmations (typically 1-3)
+4. Continue processing once payment is confirmed
+
+#### 3. Nostr NIP-57 Zaps
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "<provider_pubkey>",
+  "created_at": 1000000000,
+  "content": "Payment required to process your request",
+  "tags": [
+    ["e", "<request_id>"],
+    ["status", "payment-required"],
+    ["method", "zap", "<optional_lnurl_or_ln_address>"],
+    ["price", "150", "sat"],
+  ]
+}
+```
+
+Verification process:
+1. Monitor for incoming zap receipts (kind 9735)
+2. Verify the zap contains the correct request ID in the event tags
+3. Verify the amount matches the required payment
+4. Continue processing once a valid zap is received
+
+#### 4. Pre-paid Credits/Tokens
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "<provider_pubkey>",
+  "created_at": 1000000000,
+  "content": "5 credits will be deducted from your account",
+  "tags": [
+    ["e", "<request_id>"],
+    ["status", "payment-required"],
+    ["method", "credit", "<current_balance>", "<required_amount>"],
+    ["price", "5", "credits"],
+  ]
+}
+```
+
+Verification process:
+1. Maintain a database of customer balances
+2. Verify customer has sufficient balance
+3. Deduct credits and continue processing
+
+### Implementation Best Practices
+
+#### Payment Timeout Handling
+
+Send a kind 21999 error message if payment time expires:
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "<provider_pubkey>",
+  "created_at": 1000000400,
+  "content": "Payment timeout exceeded",
+  "tags": [
+    ["e", "<request_id>"],
+    ["status", "error", "PAYMENT_TIMEOUT", "Payment was not received within the required timeframe"],
+  ]
+}
+```
+
+
+#### Subscription-based Payments
+
+DVMs can support subscription models:
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "<provider_pubkey>",
+  "created_at": 1000000000,
+  "content": "Subscription required for this service",
+  "tags": [
+    ["e", "<request_id>"],
+    ["status", "payment-required"],
+    ["payment", "subscription", "<subscription_link>"],
+    ["price", "1000", "currency", "sat", "monthly"],
+  ]
+}
+```
+
+## Heartbeat Events
+
+Heartbeat events are entirely optional. They may be useful for high-availability services but are not required for basic DVM operation. DVMs can publish kind `11998` events with a short `expiration` value (recommendation of 300 seconds).
+
+```json
+{
+  "kind": 11998,
+  "pubkey": "<provider_pubkey>",
+  "content": "<status_message>",
+  "created_at": 1000000000,
+  "tags": [
+    // required
+    ["d", "<dvm-identifier>"],
+    ["status", "<status>", "<extra-info>"],
+    
+    // Expiration (recommended) (NIP-40)
+    ["expiration", "<unix-timestamp>"]
+  ]
+}
+```
+
+
+
+## Comprehensive Flow Examples
+
+This section provides complete, realistic examples for various DVM interactions to serve as reference implementations.
+
+### Event Type Examples
+
+#### Example DVM Announcement
+
+This is a complete example of how a text-to-image generation DVM might announce itself:
+
+```json
+{
+  "kind": 31999,
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1683512345,
+  "tags": [
+    ["d", "img-gen-v1"],
+    ["k", 24030],
+    ["response_kind", 24031],
+    ["name", "PixelPerfect"],
+    ["about", "AI text-to-image generation with customizable styles"],
+    ["picture", "https://example.com/pixelperfect-logo.png"],
+    ["documentation", "31808:3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d:pixelperfect-docs"]
+  ],
+  "content": {
+    "input_schema": {
+      "type": "object",
+      "required": ["prompt"],
+      "properties": {
+        "prompt": {
+          "type": "string",
+          "description": "Description of the image to generate"
+        },
+        "style": {
+          "type": "string",
+          "enum": ["photorealistic", "anime", "sketch", "pixel-art"],
+          "default": "photorealistic"
+        },
+        "aspect_ratio": {
+          "type": "string",
+          "enum": ["1:1", "16:9", "4:3"],
+          "default": "1:1"
+        },
+        "seed": {
+          "type": "integer",
+          "description": "Random seed for reproducibility"
+        }
+      }
+    },
+    "output_schema": {
+      "type": "object",
+      "required": ["image_url", "prompt_used"],
+      "properties": {
+        "image_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the generated image"
+        },
+        "prompt_used": {
+          "type": "string",
+          "description": "The actual prompt used for generation (may be modified from input)"
+        },
+        "resolution": {
+          "type": "string",
+          "description": "Image resolution in WxH format",
+          "example": "1024x1024"
+        },
+        "seed": {
+          "type": "integer",
+          "description": "Seed used for generation (for reproducibility)"
+        },
+        "generation_time": {
+          "type": "number",
+          "description": "Time taken to generate the image in seconds"
+        }
+      }
+    }
+  }
+}
+```
+
+#### Example Provider Announcement
+
+A provider operating multiple DVMs:
+
+```json
+{
+  "kind": 11999,
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1683512345,
+  "content": "We provide various AI services on Nostr, including text generation, image creation, and audio transcription.",
+  "tags": [
+    ["a", "31999:3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d:img-gen-v1"],
+    ["a", "31999:3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d:txt-gen-v2"],
+    ["a", "31999:3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d:speech-to-text"],
+    ["k", 24151], // request kind for img-gen-v1
+    ["k", 25515], // request kind for img-gen-v2
+    ["k", 27777], // request kind for speech-to-text
+    ["name", "AI Services Inc."],
+    ["about", "High-quality AI services powered by state-of-the-art models"],
+    ["picture", "https://example.com/ai-services-logo.png"],
+    ["website", "https://aiservices.example.com"],
+    ["relays", "wss://relay1.example.com", "wss://relay2.example.com"]
+  ]
+}
+```
+
+#### Example Heartbeat Event
+
+```json
+{
+  "kind": 11998,
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1683515567,
+  "content": "Ready to process image generation requests",
+  "tags": [
+    ["d", "img-gen-v1"],
+    ["status", "ready", "20 req/hr available"],
+    ["load", "0.5"],
+  ]
+}
+```
+
+### Protocol Flow Examples
+
+#### Example: Free Text Translation Service
+
+1. **DVM Announcement (Kind: 31999)**
+
+```json
+{
+  "kind": 31999,
+  "pubkey": "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245",
+  "created_at": 1683512345,
+  "tags": [
+    ["d", "translate-v1"],
+    ["k", 24010],
+    ["response_kind", 24011],
+    ["name", "NostrTranslate"],
+    ["about", "Free text translation between major languages"],
+    ["documentation", "31808:32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245:translate-docs"] // decoded naddr pointing to a wiki event (kind 31808)
+  ],
+  "content": "<JSON schema below>"
+}
+```
+
+Content field (JSON Schema):
+
+```json
+"content": {
+  "input_schema": {
+    "type": "object",
+    "required": ["text", "target_language"],
+    "properties": {
+      "text": {
+        "type": "string",
+        "description": "Text to translate"
+      },
+      "source_language": {
+        "type": "string",
+        "description": "Source language (ISO 639-1 code); will auto-detect if omitted"
+      },
+      "target_language": {
+        "type": "string",
+        "description": "Target language (ISO 639-1 code)"
+      }
+    }
+  },
+  "output_schema": {
+    "type": "object",
+    "required": ["translated_text", "target_language"],
+    "properties": {
+      "translated_text": {
+        "type": "string",
+        "description": "The translated text result"
+      },
+      "detected_language": {
+        "type": "string",
+        "description": "Auto-detected source language (ISO 639-1 code)"
+      },
+      "target_language": {
+        "type": "string",
+        "description": "Target language used for translation (ISO 639-1 code)"
+      },
+      "confidence": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Translation confidence score"
+      }
+    }
+  }
+}
+```
+
+2. **Request (Kind: 24010)**
+
+```json
+{
+  "kind": 24010,
+  "pubkey": "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e",
+  "created_at": 1683516000,
+  "content": "{\"text\":\"Hello, how are you today?\",\"target_language\":\"es\"}",
+  "tags": [
+    ["a", "31999:32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245:translate-v1"],
+    ["relays", "wss://relay.nostr.org", "wss://nos.lol"],
+  ]
+}
+```
+
+3. **Processing Status (Kind: 21999)**
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245",
+  "created_at": 1683516005,
+  "content": "",
+  "tags": [
+    ["e", "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"], // Request event ID
+    ["p", "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e"], // Customer pubkey
+    ["status", "processing", "detected_language:en"],
+  ]
+}
+```
+
+4. **Response (Kind: 24011)**
+
+```json
+{
+  "kind": 24011,
+  "pubkey": "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245",
+  "created_at": 1683516010,
+  "content": "{\"translated_text\":\"Hola, ¿cómo estás hoy?\",\"detected_language\":\"en\",\"target_language\":\"es\"}",
+  "tags": [
+    ["e", "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"], // Request event ID
+    ["p", "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e"], // Customer pubkey
+  ]
+}
+```
+
+#### Example: Free AI Text Generation Service
+
+1. **DVM Announcement (Kind: 31999)**
+
+```json
+{
+  "kind": 31999,
+  "pubkey": "8f8d2a52bfb34f6c37fb968b39b1a2a10e1b8707f96d969275e659da79b10e35",
+  "created_at": 1683512345,
+  "tags": [
+    ["d", "text-gen-v1"],
+    ["k", 24020],
+    ["response_kind", 24021],
+    ["name", "NostrGPT"],
+    ["about", "High-quality AI text generation with various models"],
+    ["picture", "https://example.com/nostrgpt-logo.png"],
+    ["documentation", "https://example.com/docs/nostr_gpt"]
+  ],
+  "content": {
+    "input_schema": {
+      "type": "object",
+      "required": ["prompt", "model"],
+      "properties": {
+        "prompt": {
+          "type": "string",
+          "description": "Prompt for text generation"
+        },
+        "model": {
+          "type": "string",
+          "enum": ["standard", "advanced", "creative"],
+          "default": "standard"
+        },
+        "max_tokens": {
+          "type": "integer",
+          "default": 500,
+          "maximum": 2000
+        }
+      }
+    },
+    "output_schema": {
+      "type": "object",
+      "required": ["text", "model_used"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The generated text content"
+        },
+        "model_used": {
+          "type": "string",
+          "description": "The specific model that was used for generation"
+        },
+        "tokens_generated": {
+          "type": "integer",
+          "description": "Number of tokens in the generated response"
+        },
+        "generation_time": {
+          "type": "number",
+          "description": "Time taken to generate the response in seconds"
+        },
+        "prompt_tokens": {
+          "type": "integer",
+          "description": "Number of tokens in the input prompt"
+        }
+      }
+    }
+  }
+}
+```
+
+2. **Request (Kind: 24020)**
+
+```json
+{
+  "kind": 24020,
+  "pubkey": "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e",
+  "created_at": 1683516000,
+  "content": "{\"prompt\":\"Write a short story about a robot discovering emotions\",\"model\":\"creative\",\"max_tokens\":1000}",
+  "tags": [
+    ["a", "31999:8f8d2a52bfb34f6c37fb968b39b1a2a10e1b8707f96d969275e659da79b10e35:text-gen-v1"],
+    ["relays", "wss://relay.nostr.org", "wss://nos.lol"],
+  ]
+}
+```
+
+3. **Payment Required (Kind: 21999)**
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "8f8d2a52bfb34f6c37fb968b39b1a2a10e1b8707f96d969275e659da79b10e35",
+  "created_at": 1683516005,
+  "content": "Payment required to generate text with the creative model",
+  "tags": [
+    ["e", "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"], // Request event ID
+    ["p", "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e"], // Customer pubkey
+    ["status", "payment-required"],
+    ["method", "lightning", "lnbc15u1p3xjtl5pp5djkudzrj93xvfu99pc7t47vk7nnl6hm6qtfhyecu5r255kp5ttsdqqcqzpgxqyz5vqsp5usyc4lk9chsfp97evfy7uy9j3acy9hn6k3pvk4sdqm3c9tukh44s9qyyssqpt3j8lcjj52mqdxlgpenm5f3xx5hzsch0vrnq2fg95w79mt2hqgc9knvqhrxz3knl7ewkhh3gyt8wpgdvpy6vfr7k42dlxr6jsvj9hcpnk4dkl"],
+    ["price", "150","sat"]
+  ]
+}
+```
+
+4. **Processing Status (Kind: 21999)**
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "8f8d2a52bfb34f6c37fb968b39b1a2a10e1b8707f96d969275e659da79b10e35",
+  "created_at": 1683516020,
+  "content": "",
+  "tags": [
+    ["e", "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"], // Request event ID
+    ["p", "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e"], // Customer pubkey
+    ["status", "processing", "estimated_completion:30s"],
+  ]
+}
+```
+
+5. **Response (Kind: 24021)**
+
+```json
+{
+  "kind": 24021,
+  "pubkey": "8f8d2a52bfb34f6c37fb968b39b1a2a10e1b8707f96d969275e659da79b10e35",
+  "created_at": 1683516050,
+  "content": "{\"text\":\"Unit-7 had never understood why humans spoke of 'feeling' things. Its neural networks processed information efficiently, but there was no processing module for emotions...\",\"model_used\":\"creative\",\"tokens_generated\":998}",
+  "tags": [
+    ["e", "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"], // Request event ID
+    ["p", "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e"], // Customer pubkey
+  ]
+}
+```
+
+#### Example: Open Request Selection Flow
+
+This is an example of submitting a competitive job request to see which DVMs respond before selecting one or more DVMs to do the work.
+
+1. **Untargeted Request (Kind: 24030)**
+
+```json
+{
+  "kind": 24030,
+  "pubkey": "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e",
+  "created_at": 1683516000,
+  "content": "{\"prompt\":\"A cyberpunk cityscape at night with neon lights\",\"style\":\"photorealistic\"}",
+  "tags": [
+    ["relays", "wss://relay.nostr.org", "wss://nos.lol"],
+  ]
+}
+```
+
+2. **Offer from DVM 1 (Kind: 21999)**
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d",
+  "created_at": 1683516005,
+  "content": "PixelPerfect can generate this image for you",
+  "tags": [
+    ["e", "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"], // Untargeted request ID
+    ["status", "available"],
+    ["d", "img-gen-v1"],
+    ["eta", "30"],
+    ["expiration", "1683516305"]
+  ]
+}
+```
+
+3. **Offer from DVM 2 (Kind: 21999)**
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "95de5f0440382a121f1225c83881e56505afead9d6f83147a351f7f9be605c63",
+  "created_at": 1683516008,
+  "content": "ImaginAI can create your image with high-definition quality",
+  "tags": [
+    ["e", "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"], // Untargeted request ID
+    ["status", "payment-required"],
+    ["method", "bolt11", "<invoice>"],
+    ["price", "150", "sat"],
+    ["resolution", "1024x1024"],
+    ["expiration", "1683516308"]
+  ]
+}
+```
+
+4. **Targeted Request to Selected DVM (Kind: 24030)**
+
+```json
+{
+  "kind": 24030,
+  "pubkey": "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e",
+  "created_at": 1683516030,
+  "content": "{\"prompt\":\"A cyberpunk cityscape at night with neon lights\",\"style\":\"photorealistic\"}",
+  "tags": [
+    ["a", "31999:95de5f0440382a121f1225c83881e56505afead9d6f83147a351f7f9be605c63:imaginai-hd"],
+    ["relays", "wss://relay.nostr.org", "wss://nos.lol"],
+  ]
+}
+```
+
+5. **Payment Required (Kind: 21999)**
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "95de5f0440382a121f1225c83881e56505afead9d6f83147a351f7f9be605c63",
+  "created_at": 1683516035,
+  "content": "Payment required to generate image",
+  "tags": [
+    ["e", "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba"], // Targeted request ID
+    ["p", "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e"], // Customer pubkey
+    ["status", "payment-required"],
+    ["method", "lightning", "lnbc15u1p3xjtl5pp5djkudzrj93xvfu99pc7t47vk7nnl6hm6qtfhyecu5r255kp5ttsdqqcqzpgxqyz5vqsp5usyc4lk9chsfp97evfy7uy9j3acy9hn6k3pvk4sdqm3c9tukh44s9qyyssqpt3j8lcjj52mqdxlgpenm5f3xx5hzsch0vrnq2fg95w79mt2hqgc9knvqhrxz3knl7ewkhh3gyt8wpgdvpy6vfr7k42dlxr6jsvj9hcpnk4dkl"],
+    ["price", "150", "sat"],
+  ]
+}
+```
+
+7. **Final Response (Kind: 24031)**
+
+```json
+{
+  "kind": 24031,
+  "pubkey": "95de5f0440382a121f1225c83881e56505afead9d6f83147a351f7f9be605c63",
+  "created_at": 1683516080,
+  "content": "{\"image_url\":\"https://example.com/image/cyberpunk123.png\",\"prompt_used\":\"A cyberpunk cityscape at night with neon lights\",\"resolution\":\"1024x1024\"}",
+  "tags": [
+    ["e", "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba"], // Targeted request ID
+    ["p", "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e"], // Customer pubkey
+  ]
+}
+```
+
+#### Example: Error Flow
+
+1. **Request (Kind: 24010)**
+
+```json
+{
+  "kind": 24010,
+  "pubkey": "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e",
+  "created_at": 1683516000,
+  "content": "{\"text\":\"Hello\",\"target_language\":\"martian\"}",
+  "tags": [
+    ["a", "31999:32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245:translate-v1"],
+  ]
+}
+```
+
+2. **Error Response (Kind: 21999)**
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245",
+  "created_at": 1683516005,
+  "content": "",
+  "tags": [
+    ["e", "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"], // Request event ID
+    ["p", "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e"], // Customer pubkey
+    ["status", "error", "INVALID_PARAMETER", "Unsupported target language: 'martian'. Please use an ISO 639-1 language code: \"en\",\"es\",\"fr\",\"de\",\"it\",\"pt\",\"ru\",\"zh\",\"ja\",\"ko\""],
+  ]
+}
+```
+
+#### Example: Complete Lightning Payment Flow
+
+1. **Request from customer**
+
+```json
+{
+  "kind": 24020,
+  "pubkey": "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e",
+  "created_at": 1683516000,
+  "content": "{\"prompt\":\"Generate a detailed business plan\",\"model\":\"business\"}",
+  "tags": [
+    ["a", "31999:8f8d2a52bfb34f6c37fb968b39b1a2a10e1b8707f96d969275e659da79b10e35:business-ai"],
+  ]
+}
+```
+
+2. **Payment required response**
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "8f8d2a52bfb34f6c37fb968b39b1a2a10e1b8707f96d969275e659da79b10e35",
+  "created_at": 1683516010,
+  "content": "Payment required to generate business plan",
+  "tags": [
+    ["e", "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"], // Request event ID
+    ["p", "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e"], // Customer pubkey
+    ["status", "payment-required"],
+    ["method", "lightning", "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdees9q5sqqqqqqqqqqqqqqqpqsq2sty8h75dcqcde4xqfdw2f8363w469yqc7p49e7kndxc8ktglgv9kgzqk4fdpecmq2pvvvhuvksrnjq4z2kjw8rglqspvlhj73", "https://callback.example.com/payment/123"],
+    ["price", "2500", "sat"],
+  ]
+}
+```
+
+3. **Payment processing status**
+
+```json
+{
+  "kind": 21999,
+  "pubkey": "8f8d2a52bfb34f6c37fb968b39b1a2a10e1b8707f96d969275e659da79b10e35",
+  "created_at": 1683516060,
+  "content": "Payment received, processing your request",
+  "tags": [
+    ["e", "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"], // Request event ID
+    ["p", "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e"], // Customer pubkey
+    ["status", "processing"],
+  ]
+}
+```
+
+4. **Response with results**
+
+```json
+{
+  "kind": 24021,
+  "pubkey": "8f8d2a52bfb34f6c37fb968b39b1a2a10e1b8707f96d969275e659da79b10e35",
+  "created_at": 1683516180,
+  "content": "{\"text\":\"# Business Plan\\n\\n## Executive Summary\\n...\",\"sections\":5,\"words\":1500}",
+  "tags": [
+    ["e", "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"], // Request event ID
+    ["p", "7e7e9c42a91bfef19fa929e5fda1b72e0ebc1a4c1141673e2794234d86addf4e"], // Customer pubkey
+  ]
+}
+```
+
+## Privacy
+
+Privacy solutions for DVMs have not yet been fully fleshed out yet; if you have suggestions, we encourage you to submit PRs for privacy. Currently there is one suggestion to increase privacy, however no guarantees are given with these approaches, please use at your own risk:
+
+1. Clients can create a temporary npub for each job request, so the user's real pubkey isn't used.
+
+**Legacy Solutions**: Legacy DVMs used a NIP-04 DM encryption scheme, which has many known issues including leaking significant metadata.
+
+**Note:** This section needs help. Privacy preserving DVM schemes are a topic for future work.
+
+## Guidance for Developers
+
+### DVM Creators
+
+1. If you are creating a new type of DVM and need a new kind number, it is recommended to:
+  - pick a request kind that is not being used in the `20000-29999` range. To find out what kinds are being used, use tools like https://stats.dvmdash.live/kind-stats, https://undocumented.nostrkinds.info/, check the NIPS repo [README.md](README.md), and query any relays you plan to use to see what kinds are being used.
+  - pick a response kind that is equal to the `request_kind + 1`, so if you pick `21343` as your request kind, then the best response_kind is `21344`. In the case when your DVM needs to output an existing Nostr event kind, like a kind 1 note, a long-form article, or a wiki page, you can instead choose the response_kind to be the existing kind number. Make sure that you a) set the response_kind in the dvm announcement and b) add an `"e"` tag in the response event that identifies the original request event.
+2. If you are creating a DVM for a job kind that already exists, please look at the DVM announcements for other DVMs and use the same request and response kinds that they are using. This makes it easier for clients to support your DVM without any additional work and increases the liklihood that users will find your DVM and be able to use it easily.  
+3. Create a `single` `kind 31999` announcement for each DVM to ensure it can be referenced directly in an `a` tag of a job request.
+4. Do not publish a `kind 31999` announcement with more than ONE `d` tag per DVM. Every DVM must correspond to a unique combination of `pubkey` and `d` tag. 
+5. Publish the `k` tag for each DVM kind supported.
+6. Publish updated DVM (`31999`) and Provider (`11999`) announcements when you make changes to how your DVMs interact with users or when adding new DVMs.
+7. Remember that for each combination of kind, pubkey, and 'd' tag, relay keeps only the last event. Publishing with same identifier updates the old announcement. If you do not follow this, you risk orphaned DVM announcements.
+8. Create documentation on how to use your DVM and include a reference to it your DVM announcement kind `31999` using the tag `documentation`. A good default way of doing this is by publishing a kind wiki `31808` event and putting the `naddr` of that event id into the documentation field. A second best option would be to host your documentation at a publicly available URL and put the url as the value of the `documentation` tag.
+9. Clearly specify input parameters and expected output formats in your documentation
+10. Handle missing or invalid parameters gracefully with helpful kind `21999` error messages by putting the error message in the `status` tag, like: `["status", "error", "INVALID_PARAMETER", "should be one of \"en\",\"es\",\"fr\",\"de\",\"it\",\"pt\",\"ru\",\"zh\",\"ja\",\"ko\""]`
+11. Make sure to pick a **response** kind number that is NOT the same as the **request** kind number. If you are unsure, a good default is the request kind + 1 (keep in mind that this would be an emphereal event and not stored on relays for long).
+12. Most reponse kinds should probably be ephemeral events. If the response should be stored long term, you can use events like Kind 1, Kind 4 long-form articles, or Kind 31808 wiki events.
+  - For example, feed curation (legacy event kind `5300`) should be an ephemeral event, but a codebase audit may be better as a long form article.
+13. When an open job request is observed from a user that does not specify an `a` tag:
+  - If your DVM is free, the default approach is to respond with a kind `21999` event with `["status", "available"]`
+  - If your DVM requires payment, the default approach is to respond with a kind `21999` event with `["status", "payment-required"]` as well as other payment related tags (see above).
+
+### Client Developers
+
+1. Keep in mind every DVM has its own flow. Use the documentation provided by a DVM to understand how to support interactions with it. 
+2. Keep in mind that the nature of every DVM job type Kind is unique.
+3. Query relays for `kind 31999` announcements to show available DVM options to your users.
+4. To support price bidding and competition, submit job requests that don't target a single DVM
+  - This is done by simply leaving out the `a` tag
+  - Free DVMs will respond with a kind `21999` and tag `"status":"available"` while paid DVMs will respond with the tag `"status":"payment-required"`.
+5. When handling payments, implement the appropriate payment flow based on the payment methods supported by the DVM.
+6. Handle payment feedback events appropriately, showing error messages or success notifications based on the DVM's response.
+7. If a request goes unanswered, simply publish a new request. You don't need to publish a kind `5` deletion request because all DVM requests are ephemeral.
+8. Store job request event IDs locally to correlate with responses, as ephemeral request events may be purged from relays.
+
+### Relay Operators
+
+1. DVM job requests and intermediate feedback events use kinds `20000-29999` and therefore will be short lived. Delete them within some reasonable time period. For DVMs that charge money, consider charging DVMs that want their responses hosted for longer periods of time.
+2. Store the Provider (`11999`) and DVM (`31999`) announcements indefinitely or until superseded.
+
+
+## Open Questions for the Broader Nostr Community
+
+These are list of questions we have for the broader nostr developer community:
+
+1. Is `response_kind` a suitable tag name in the DVM Announcement or should we use something else?
+2. Should the provider announcement have the `"k"` tags of its supported DVMs? We originally thought to include this so it could be easy to search for providers for a particular kind. If we left it out, you would have to look up providers after searching for DVM announcements for a specific kind.
+
+
+## Frequently Asked Questions
+
+> **Q:** Can I have a DVM that only publishes data, like weather data or stock market data?
+
+No, the DVM spec only covers request-driven interactions. You can make a service that publishes that kind of data, but it does not fall under the design pattern for DVMs specified here. A DVM is a service that has a request and a response.
+
+> **Q:** I want to make a service that uses RPC, websockets, or \<insert another non-nostr based event protocol here>, will this be a Data Vending machine?
+
+No. Data Vending Machines are a protocol comprising entirely of signed Nostr events broadcasted over relays. Feel free to build the service on whatever protocol you want to, but it is not considered a DVM. Feel free to design a new NIP for such services.
+
+
+

--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `2004`        | Torrent Comment                 | [35](35.md)                            |
 | `2022`        | Coinjoin Pool                   | [joinstr][joinstr]                     |
 | `4550`        | Community Post Approval         | [72](72.md)                            |
-| `5000`-`5999` | Job Request                     | [90](90.md)                            |
-| `6000`-`6999` | Job Result                      | [90](90.md)                            |
-| `7000`        | Job Feedback                    | [90](90.md)                            |
+| `5000`-`5999` | Legacy DVM Job Request          | [90](90.md)                            |
+| `6000`-`6999` | Legacy DVM Job Result           | [90](90.md)                            |
+| `7000`        | Legacy DVM Job Feedback         | [90](90.md)                            |
 | `7374`        | Reserved Cashu Wallet Tokens    | [60](60.md)                            |
 | `7375`        | Cashu Wallet Tokens             | [60](60.md)                            |
 | `7376`        | Cashu Wallet History            | [60](60.md)                            |
@@ -198,9 +198,12 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `10063`       | User server list                | [Blossom][blossom]                     |
 | `10096`       | File storage server list        | [96](96.md)                            |
 | `10166`       | Relay Monitor Announcement      | [66](66.md)                            |
+| `11998`       | DVM Heartbeat                   | [90](90.md)                            |
+| `11999`       | DVM Provider Announcement       | [90](90.md)                            |
 | `13194`       | Wallet Info                     | [47](47.md)                            |
 | `17375`       | Cashu Wallet Event              | [60](60.md)                            |
 | `21000`       | Lightning Pub RPC               | [Lightning.Pub][lnpub]                 |
+| `21999`       | DVM Feedback                    | [90](90.md)                            |
 | `22242`       | Client Authentication           | [42](42.md)                            |
 | `23194`       | Wallet Request                  | [47](47.md)                            |
 | `23195`       | Wallet Response                 | [47](47.md)                            |
@@ -247,8 +250,9 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `31924`       | Calendar                        | [52](52.md)                            |
 | `31925`       | Calendar Event RSVP             | [52](52.md)                            |
 | `31989`       | Handler recommendation          | [89](89.md)                            |
-| `31990`       | Handler information             | [89](89.md)                            |                         |
-| `32267`       | Software Application            |                                        |                        |
+| `31990`       | Handler information             | [89](89.md)                            |
+| `31999`       | DVM Announcement                | [90](90.md)                            |
+| `32267`       | Software Application            |                                        |
 | `34550`       | Community Definition            | [72](72.md)                            |
 | `38383`       | Peer-to-peer Order events       | [69](69.md)                            |
 | `39000-9`     | Group metadata events           | [29](29.md)                            |


### PR DESCRIPTION
This new DVM spec is the result of a collaborative effort from @believethehype, @gzuuus, @pippellia-btc, and others. We have reached a general consensus and believe it addresses many of the issues from this thread [https://github.com/nostr-protocol/nips/pull/1903](https://github.com/nostr-protocol/nips/pull/1903)

The major changes are:
- moving from kinds 5000-7000 to ephemeral kinds 20000-29999
- moving from NIP-89 to a new announcement scheme that includes support for providers who run multiple DVMs
- the response kind can be set by a DVM to be anything, although we give a strong recommendation that this should be an ephemeral event equal to 1 + request kind (instead of the previous 1000+request kind)
- we added guidance sections for DVM developers, Client developers, and Relay operators
- we added an introduction that compares DVMs to APIs, and providers broader context about DVMs in general
- concrete examples of all types of events
- added a FAQ

