### PR TITLE
Add encryption support to NIPs 92 and 94

### DIFF
--- a/17.md
+++ b/17.md
@@ -69,8 +69,8 @@ Kind `15` is used for sending encrypted file event messages:
 
 - `file-type`: Specifies the MIME type of the attached file (e.g., `image/jpeg`, `audio/mpeg`, etc.) before encryption.
 - `encryption-algorithm`: Indicates the encryption algorithm used for encrypting the file. Supported algorithms: `aes-gcm`.
-- `decryption-key`: The decryption key that will be used by the recipient to decrypt the file.
-- `decryption-nonce`: The decryption nonce that will be used by the recipient to decrypt the file.
+- `decryption-key`: The hex-encoded decryption key that will be used by the recipient to decrypt the file.
+- `decryption-nonce`: The hex-encoded decryption nonce that will be used by the recipient to decrypt the file.
 - `content`: The URL of the file (`<file-url>`).
 - `x` containing the SHA-256 hexencoded string of the encrypted file.
 - `ox` containing the SHA-256 hexencoded string of the file before encryption.

--- a/92.md
+++ b/92.md
@@ -34,6 +34,16 @@ any field specified by [NIP 94](./94.md). There SHOULD be only one `imeta` tag p
 }
 ```
 
+## Encrypted files
+
+Clients MAY encrypt files, in which case the file name and mimetype should reflect the decrypted file's content type. The following tags are also required:
+
+- `encryption-algorithm` - the algorithm used to encrypt the file contents. MUST be `aes-gcm`.
+- `decryption-key`: a hex-encoded key that will can used to decrypt the file
+- `decryption-nonce`: a hex-encoded nonce that can be used to decrypt the file
+
+Clients SHOULD NOT use encrypted files if the event is not protected by some form of access control (encryption, relay AUTH, etc).
+
 ## Recommended client behavior
 
 When uploading files during a new post, clients MAY include this metadata

--- a/94.md
+++ b/94.md
@@ -28,11 +28,11 @@ This NIP specifies the use of the `1063` event kind, having in `content` a descr
 * `fallback` (optional) zero or more fallback file sources in case `url` fails
 * `service` (optional) service type which is serving the file (eg. [NIP-96](96.md))
 
-```jsonc
+```yaml
 {
   "kind": 1063,
   "tags": [
-    ["url",<string with URI of file>],
+    ["url", <string with URI of file>],
     ["m", <MIME type>],
     ["x", <Hash SHA-256>],
     ["ox", <Hash SHA-256>],


### PR DESCRIPTION
This adds file encryption support to normal imeta tags and kind 1063 events. Use cases I have in mind:

- Attaching encrypted files to NIP 17 DMs (rather than sending a separate event for a file)
- Attaching encrypted files to events sent to access-controlled communities (e.g. closed NIP 29 groups)