### PR TITLE
NIP-72: use kind 1111 events for text notes

### DIFF
--- a/72.md
+++ b/72.md
@@ -41,18 +41,54 @@ The goal of this NIP is to enable public communities. It defines the replaceable
 
 # Posting to a community
 
-Any Nostr event can be posted to a community. Clients MUST add one or more community `a` tags, each with a recommended relay.
+[NIP-22](NIP-22) kind 1111 events SHOULD be used for text notes posted to a community, with the `A` tag always scoped to the community definition.
+
+## Top-level posts
+
+For top-level posts, the uppercase and lowercase NIP-22 tags should both refer to the community definition itself.
 
 ```jsonc
 {
-  "kind": 1,
+  "kind": 1111,
   "tags": [
-    ["a", "34550:<community event author pubkey>:<community-d-identifier>", "<optional-relay-url>"],
+    ["A", "34550:<community-author-pubkey>:<community-d-identifier>", "<optional-relay-url>"],
+    ["a", "34550:<community-author-pubkey>:<community-d-identifier>", "<optional-relay-url>"],
+    ["P", "<community-author-pubkey>", "<optional-relay-url>"],
+    ["p", "<community-author-pubkey>", "<optional-relay-url>"],
+    ["K", "34550"],
+    ["k", "34550"],
   ],
-  "content": "hello world",
+  "content": "Hi everyone. It's great to be here!",
   // other fields...
 }
 ```
+
+## Nested replies
+
+For nested replies, the uppercase tags should still refer to the community definition, while the lowercase tags should refer to the parent post or reply.
+
+```jsonc
+{
+  "kind": 1111,
+  "tags": [
+    // community definition itself
+    ["A", "34550:<community-author-pubkey>:<community-d-identifier>", "<optional-relay-url>"],
+    ["P", "<community-author-pubkey>", "<optional-relay-url>"],
+    ["K", "34550"],
+
+    // parent post or reply
+    ["e", "<parent-event-id>", "<optional-relay-url>"],
+    ["p", "<parent-event-author-pubkey>", "<optional-relay-url>"],
+    ["k", "<parent-event-kind>"] // most likely "1111"
+  ],
+  "content": "Agreed! Welcome everyone!",
+  // other fields...
+}
+```
+
+## Backwards compatibility note
+
+Previously kind 1 events were used for posts in communities, with an "a" tag pointing to the community. For backwards compatibility, clients MAY still query for kind 1 events, but SHOULD NOT use them for new posts. Instead, clients SHOULD use kind 1111 events with the `A` and `a` tags as described above.
 
 # Moderation
 


### PR DESCRIPTION
Another shot at https://github.com/nostr-protocol/nips/pull/1932. I now believe this is the right way.

I have https://nostrhub.io/community set up like this.

Currently working on migrating chorus.community to use it.