### PR TITLE
NIP-C4: Relay-based Moderation

### DIFF
--- a/C4.md
+++ b/C4.md
@@ -1,0 +1,73 @@
+NIP-C4
+======
+
+Relay-based Moderation
+----------------------
+
+`draft` `optional`
+
+## Abstract
+
+This NIP defines a way for relays to expose a moderation service, and for clients to be able to request moderation from relays.
+
+## Negotiation
+
+Before the client starts requesting moderation, the client should wait for a `MOD-INFO` message from the relay. This message is formatted as follows:
+
+```jsonc
+["MOD-INFO", {
+  "spam": {
+    "recommend": [{"action": "blur-media"}],
+    "type": "binary",
+    "name": "Spam"
+  },
+  ...
+}, false]
+```
+
+The first object contains *classification types*, where the key represents the ID, and the value contains several properties:
+- `recommend`: This is a recommended configuration. Only one may exist in the `binary` type. Each entry must contain the following properties:
+    - `action`: This is the action to recommend. These can be *any action*, and clients may change this to be more suitable to their moderation model, but the following are standardized:
+        - `blur-media`: Blurs the media on this note.
+        - `collapse`: Collapses, hides or otherwise marks this note as being flagged.
+        - `hide`: Hides this note in a possibly spam section.
+    - `threshold` (score only): The threshold to trigger this action.
+- `type`: The type of rating. Clients MUST NOT process rating types they do not understand. This can be:
+    - `binary`: This is a simple yes/no.
+    - `score`: This is a score between 0 (not flagged) and 1 (flagged). This allows the user to set their own thresholds.
+- `name`: A human readable name to show to the user.
+
+Relays MAY define any number of custom moderation types, and clients SHOULD allow users to set per-relay moderation configurations, as each relay may have its own algorithm.
+
+The second boolean indicates if AUTH is required. Relays MAY NOT send certain moderation options until AUTH is provided.
+
+## Request/Response
+
+The client should send a request in the following format:
+
+```jsonc
+["MOD-REQ", <event ID>]
+```
+
+The relay is responsible for retrieving the event ID.
+
+The response is *streamed* from the client to the server. Certain filters, like media scanning, may take a few seconds to process. This allows clients to receive certain moderation results immediately and wait for others.
+
+The full exchange looks like this:
+```jsonc
+["MOD-REQ", <event ID>]
+["MOD-RES", <event ID>, {"spam": false}]
+... 1 second later ...
+["MOD-RES", <event ID>, {"nsfw": 0.2}]
+["MOD-END", <event ID>, true, ""]
+```
+
+`MOD-RES` events include newly available moderation information for that event ID. Clients should treat this as incremental updates, and apply this *on top* of existing moderation.
+
+Relays MUST NOT send the same moderation status twice, like so:
+```jsonc
+["MOD-RES", <event ID>, {"spam": false}]
+["MOD-RES", <event ID>, {"spam": true}]
+```
+
+The `MOD-END` message indicates that the moderation request is complete. The boolean indicates if the moderation request succeeded, and the string includes a status message similar to `OK` and `CLOSED`.


### PR DESCRIPTION
This NIP defines a way for relays to provide moderation services with low-latency, while allowing different types of moderation.

cc @vitorpamplona @jb55 