### PR TITLE
NIP-C4: Moderation Services

### DIFF
--- a/C4.md
+++ b/C4.md
@@ -1,73 +1,75 @@
 NIP-C4
 ======
 
-Relay-based Moderation
-----------------------
+Moderation Services
+-------------------
 
 `draft` `optional`
 
 ## Abstract
 
-This NIP defines a way for relays to expose a moderation service, and for clients to be able to request moderation from relays.
+This NIP defines a way for moderation services to be implemented on Nostr.
 
-## Negotiation
+## Moderation Service
 
-Before the client starts requesting moderation, the client should wait for a `MOD-INFO` message from the relay. This message is formatted as follows:
+A service should publish a kind `11984` event to define what moderation fields it provides:
 
 ```jsonc
-["MOD-INFO", {
-  "spam": {
-    "recommend": [{"action": "blur-media"}],
-    "type": "binary",
-    "name": "Spam"
-  },
+{
+  "kind": 11984,
+  "tags": [
+    ["filter", "nsfw", "NSFW media scanner", "binary"],
+    ["filter", "spam", "Spam detector", "score"],
+    ["option", "spam", "0.3", "hide"],
+    ["filter", "nsfw", "true", "blur-media"]
+  ],
+  "content": "",
   ...
-}, false]
+}
 ```
 
-The first object contains *classification types*, where the key represents the ID, and the value contains several properties:
-- `recommend`: This is a recommended configuration. Only one may exist in the `binary` type. Each entry must contain the following properties:
-    - `action`: This is the action to recommend. These can be *any action*, and clients may change this to be more suitable to their moderation model, but the following are standardized:
-        - `blur-media`: Blurs the media on this note.
-        - `collapse`: Collapses, hides or otherwise marks this note as being flagged.
-        - `hide`: Hides this note in a possibly spam section.
-    - `threshold` (score only): The threshold to trigger this action.
-- `type`: The type of rating. Clients MUST NOT process rating types they do not understand. This can be:
-    - `binary`: This is a simple yes/no.
-    - `score`: This is a score between 0 (not flagged) and 1 (flagged). This allows the user to set their own thresholds.
-- `name`: A human readable name to show to the user.
+`filter` tags describe a certain filter that is available, where:
+- The first value indicates the *ID* of the filter
+- The second value is a human-readable name for the filter
+- The third value indicates the value of the filter. Clients SHOULD not attempt to handle filters of unknown types.
 
-Relays MAY define any number of custom moderation types, and clients SHOULD allow users to set per-relay moderation configurations, as each relay may have its own algorithm.
+Currently, only the `binary` and `score` types are defined, for boolean and floating values between 0-1 respectively, where a high result indicates flagging.
 
-The second boolean indicates if AUTH is required. Relays MAY NOT send certain moderation options until AUTH is provided.
+`option` tags define recommended defaults users can use, where:
+- The first value indicates the filter ID
+- The second value indicates the threshold (for a score) or `true` for binary.
+- The third value includes the recommended action. The defined types are:
+  - `hide`: The message is hidden unless the user explicitly wants to show spam replies (in a dedicated section)
+  - `collapse`: The message is collapsed as "potentially spam".
+  - `blur-media`: Media is blurred.
 
-## Request/Response
+A fully-empty kind 11984 event should be treated the same as there being none at all.
 
-The client should send a request in the following format:
+## Moderation Result
 
+A moderation service publishes a moderation result for each event with kind `31984` in the following format:
 ```jsonc
-["MOD-REQ", <event ID>]
+{
+  "kind": 31984,
+  "tags": [
+    ["d", "14f34e7e9b21da4a2f4d8299010a2febb76e9fc275033ce9e6d0ddf0d5d333fa"]
+    ["filter", "spam", "0.5"]
+  ],
+  "content": "",
+  ...
+}
 ```
 
-The relay is responsible for retrieving the event ID.
+The `d` tag indicates the ID of the event being moderated. One or more `filter` tags are provided, where the first element indicates the filter ID, and the second indicates the value provided by the filter.
 
-The response is *streamed* from the client to the server. Certain filters, like media scanning, may take a few seconds to process. This allows clients to receive certain moderation results immediately and wait for others.
+Clients SHOULD assume a non-existent event as there being no flags.
 
-The full exchange looks like this:
-```jsonc
-["MOD-REQ", <event ID>]
-["MOD-RES", <event ID>, {"spam": false}]
-... 1 second later ...
-["MOD-RES", <event ID>, {"nsfw": 0.2}]
-["MOD-END", <event ID>, true, ""]
-```
+If an event exists but is missing certain filters, the filter should be considered *in progress* and the client should wait for a given period or the filter value to be available in a new event (by keeping open the subscription) before taking action.
 
-`MOD-RES` events include newly available moderation information for that event ID. Clients should treat this as incremental updates, and apply this *on top* of existing moderation.
+## Relay-based Services
 
-Relays MUST NOT send the same moderation status twice, like so:
-```jsonc
-["MOD-RES", <event ID>, {"spam": false}]
-["MOD-RES", <event ID>, {"spam": true}]
-```
-
-The `MOD-END` message indicates that the moderation request is complete. The boolean indicates if the moderation request succeeded, and the string includes a status message similar to `OK` and `CLOSED`.
+To allow for relays implementing moderation functionality on-demand, clients SHOULD format their filters for moderation events in the following way:
+- The `kinds` filter is set to `[31984]`
+- One or more `authors` are used to filter the REQ
+- One or more `#d` are used to filter the REQ
+- No other restrictions exist including `limit`


### PR DESCRIPTION
This NIP defines a way for moderation services to publish event moderation information.

I have not defined a way to request moderation events yet, but this could be implemented with a kind `21984` event if there is interest.

A whitelisted moderation service can use a relay that supports read filtering, while adding a `-` tag to prevent rebroadcasts.

cc @staab and @jb55 as a follow up from the previous PR