### PR TITLE
[WIP] NIP-29: Add optional protected events and original relay tracking

### DIFF
--- a/29.md
+++ b/29.md
@@ -20,7 +20,7 @@ Relays are supposed to generate the events that describe group metadata and grou
 
 ## Group identifier
 
-A group may be identified by a string in the format `<host>'<group-id>`. For example, a group with _id_ `abcdef` hosted at the relay `wss://groups.nostr.com` would be identified by the string `groups.nostr.com'abcdef`.
+A group must be identified by a string in the format `<host>'<group-id>`. For example, a group with _id_ `abcdef` hosted at the relay `wss://groups.nostr.com` would be identified by the string `groups.nostr.com'abcdef`.
 
 Group identifiers must be strings restricted to the characters `a-z0-9-_`, and SHOULD be random in order to avoid name collisions.
 
@@ -29,6 +29,10 @@ When encountering just the `<host>` without the `'<group-id>`, clients MAY infer
 ## The `h` tag
 
 Events sent by users to groups (chat messages, text notes, moderation events etc) MUST have an `h` tag with the value set to the group _id_.
+
+## Protected events
+
+Events sent to a group MAY include the [NIP-70](70.md) `-` tag to mark them as protected events. This ensures that group messages can only be published to the intended relay by their original authors, preventing unauthorized republishing to other relays and maintaining the integrity of group discussions within their designated relay. This provides an alternative or additional method to timeline references for keeping group messages from being taken out of context.
 
 ## Timeline references
 
@@ -154,13 +158,14 @@ When this event is not found, clients may still connect to the group, but treat 
     ["picture", "https://pizza.com/pizza.png"],
     ["about", "a group for people who love pizza"],
     ["public"], // or ["private"]
-    ["open"] // or ["closed"]
+    ["open"], // or ["closed"]
+    ["original_relay", "wss://original.relay.com"] // optional: original relay where group was created
   ]
   // other fields...
 }
 ```
 
-`name`, `picture` and `about` are basic metadata for the group for display purposes. `public` signals the group can be _read_ by anyone, while `private` signals that only AUTHed users can read. `open` signals that anyone can request to join and the request will be automatically granted, while `closed` signals that members must be pre-approved or that requests to join will be manually handled.
+`name`, `picture` and `about` are basic metadata for the group for display purposes. `public` signals the group can be _read_ by anyone, while `private` signals that only AUTHed users can read. `open` signals that anyone can request to join and the request will be automatically granted, while `closed` signals that members must be pre-approved or that requests to join will be manually handled. `original_relay` (optional) indicates the relay where the group was originally created, allowing clients to track the group's origin even when it has been forked to other relays.
 
 - *group admins* (`kind:39001`) (optional)
 


### PR DESCRIPTION
## Summary
- Changes group identifier format from "may" to "must" for consistency
- Adds optional NIP-70 protected events tag as an alternative to timeline references
- Adds optional "original_relay" tag to group metadata to track where group was first created

## Changes

1. **Group identifier requirement**: Changed "A group may be identified" to "A group must be identified" to make the group identifier format mandatory rather than optional.

2. **Protected events section**: Added a new section explaining that events MAY include the NIP-70 `-` tag to mark them as protected events. This provides an alternative or additional method to timeline references for preventing events from being taken out of context.

3. **Original relay tracking**: Added an optional `original_relay` tag to the kind:39000 group metadata event. This allows clients to track where a group was originally created, even when it has been forked to other relays.

## Rationale

These changes improve group relay specifications by:
- Providing clearer requirements for group identifiers
- Offering multiple methods to maintain group integrity (timeline references and/or protected events)
- Enabling better tracking of group origins across relay forks

🤖 Generated with [Claude Code](https://claude.ai/code)