### PR TITLE
nip34: change 'defaults' to 'is' in patch revision status description

### DIFF
--- a/34.md
+++ b/34.md
@@ -163,7 +163,7 @@ Root Patches and Issues have a Status that defaults to 'Open' and can be set by 
 
 The most recent Status event (by `created_at` date) from either the issue/patch author or a maintainer is considered valid.
 
-The Status of a patch-revision defaults to either that of the root-patch, or `1632` (_Closed_) if the root-patch's Status is `1631` (_Applied/Merged_) and the patch-revision isn't tagged in the `1631` (_Applied/Merged_) event.
+The Status of a patch-revision is to either that of the root-patch, or `1632` (_Closed_) if the root-patch's Status is `1631` (_Applied/Merged_) and the patch-revision isn't tagged in the `1631` (_Applied/Merged_) event.
 
 
 ## Possible things to be added later


### PR DESCRIPTION
The current wording incorrectly uses "defaults" which implies a patch revision could inherit a default status when none is set. In reality, status events cannot be issued directly for patch revisions, only the original root patch can receive a status event where the revision must be specifically referenced. This change replaces "defaults" with "is" to accurately describe the actual status behavior where only explicit status assignments apply.