### PR TITLE
NIP-52: Add collaborative calendar event request

### DIFF
--- a/52.md
+++ b/52.md
@@ -25,12 +25,19 @@ These tags are common to both types of calendar events:
 * `p` (optional, repeated) 32-bytes hex pubkey of a participant, optional recommended relay URL, and participant's role in the meeting
 * `t` (optional, repeated) hashtag to categorize calendar event
 * `r` (optional, repeated) references / links to web pages, documents, video calls, recorded videos, etc.
+* `a` (repeated) reference tag to kind `31924` calendar event requesting to be included in Calendar
 
 The following tags are deprecated:
 
 * `name` name of the calendar event. Use only if `title` is not available.
 
 Calendar events are _not_ required to be part of a [calendar](#calendar).
+
+## Collaborative Calendar Event Requests
+
+Calendar events can include an `a` tag referencing a calendar (kind 31924) to request addition to that calendar. When a calendar event includes such a reference, clients should interpret this as a request to add the event to the referenced calendar by referencing it with an `a` tag.
+
+This enables collaborative calendar management where multiple users can contribute events to calendars they do not own, subject to the calendar owner's approval.
 
 ### Date-Based Calendar Event
 
@@ -124,6 +131,8 @@ Aside from the common tags, this also takes the following tags:
 ## Calendar
 
 A calendar is a collection of calendar events, represented as a custom _addressable list_ event using kind `31924`. A user can have multiple calendars. One may create a calendar to segment calendar events for specific purposes. e.g., personal, work, travel, meetups, and conferences.
+
+Calendars can accept event requests from other users. When calendar events reference a calendar via an `a` tag, this represents a request for inclusion.
 
 The `.content` of these events should be a detailed description of the calendar. It is required but can be an empty string.
 


### PR DESCRIPTION
This PR enhances NIP-52 to enable collaborative calendar management by introducing an approval workflow for calendar event requests. This addresses the limitation where only calendar owners can add events to their calendars.

## Problem Statement

Currently, NIP-52 only supports calendar owners adding events to their calendars. This prevents collaborative scenarios such as:
- Community event calendars where multiple organizers contribute
- Team calendars with distributed event management
- Conference schedules with multiple speakers/organizers
- Group coordination calendars

## Solution

The enhancement interprets existing `a` tags on calendar events as **requests** rather than confirmations when they reference calendars owned by others. This creates a natural approval workflow:

1. Users create events with `a` tags referencing target calendars
2. Calendar owners review and approve/reject requests
3. Approved events are added to the calendar's `a` tag list
4. Clients can implement flexible display options