### PR TITLE
Add NIP-XX: Nostr Internet Radio

### DIFF
--- a/XX.md
+++ b/XX.md
@@ -48,8 +48,7 @@ Radio stations are published as addressable events of `kind:31237`. These events
     ["countryCode", "<ISO-3166-2-code>"],
     ["location", "<human-readable-location>"],
     ["thumbnail", "<image-url>"],
-    ["website", "<station-website>"],
-    ["client", "<client-name>", "<handler-address>", "<relay-hint>"]
+    ["website", "<station-website>"]
   ]
 }
 ```
@@ -108,7 +107,6 @@ Each stream object MUST include:
 - `location`: Human-readable location string
 - `thumbnail`: Station logo/image URL
 - `website`: Station's official website
-- `client`: Client that published the event (format: `["client", "ClientName", "HandlerId", "RelayURL"]`)
 
 ### Example
 
@@ -128,13 +126,7 @@ Each stream object MUST include:
     ["countryCode", "FR"],
     ["location", "Paris, France"],
     ["thumbnail", "https://example.com/fip-logo.png"],
-    ["website", "https://www.radiofrance.fr/fip"],
-    [
-      "client",
-      "NostrRadio",
-      "31990:pubkey:handler123",
-      "wss://relay.example.com"
-    ]
+    ["website", "https://www.radiofrance.fr/fip"]
   ]
 }
 ```
@@ -173,7 +165,6 @@ Persistent discussion threads use existing comment protocols such as [NIP-25](25
 
 ### Privacy Considerations
 
-- The `client` tag has privacy implications - clients SHOULD allow opt-out
 - Station owners can moderate chat/comments by maintaining block lists
 - Consider rate limiting for chat messages to prevent spam
 

--- a/XX.md
+++ b/XX.md
@@ -141,7 +141,7 @@ Real-time chat during radio streaming uses existing live chat protocols such as 
 
 ### Station Comments
 
-Persistent discussion threads use existing comment protocols such as [NIP-25](25.md). Comments should reference the radio station event to create threaded discussions about stations.
+Persistent discussion threads use existing comment protocols such as [NIP-22](22.md). Comments should reference the radio station event to create threaded discussions about stations.
 
 ## Implementation Notes
 

--- a/XX.md
+++ b/XX.md
@@ -6,30 +6,6 @@
 
 This NIP defines a standard for publishing and discovering internet radio stations on Nostr, enabling decentralized radio station directories, streaming metadata, social features, and interoperability between radio applications.
 
-## Rationale
-
-Traditional internet radio directories are centralized services controlled by single entities, making them vulnerable to censorship, takedowns, and service discontinuation. Radio stations and listeners lack data portability between different platforms and applications.
-
-This specification leverages Nostr's decentralized infrastructure to create an open, censorship-resistant radio ecosystem where:
-
-- Radio stations can publish their metadata and streaming information directly
-- Users maintain portable favorites lists across applications
-- Developers can build interoperable radio clients without vendor lock-in
-- Communities can engage around stations through comments and live chat
-- Discovery happens through the network rather than centralized algorithms
-- Organic, decentralized maintenance of station entries helps keep quality high and mitigate broken links
-- Direct listener-to-station monetization becomes possible through Nostr's native micropayment capabilities
-
-## Overview
-
-This specification defines radio station events and describes how existing Nostr protocols can be used to create a complete radio ecosystem:
-
-- **Radio Station Events** (`kind:31237`) - Station metadata and streaming information (defined in this NIP)
-- **Live Chat Messages** - Real-time chat during streaming using existing live chat protocols
-- **Station Comments** - Persistent discussion threads using existing comment protocols
-- **Favorites Management** - Personal and curated station collections using [NIP-78](78.md)
-- **Application Discovery** - Handler registration using [NIP-89](89.md)
-
 ## Radio Station Events
 
 Radio stations are published as addressable events of `kind:31237`. These events contain streaming URLs, metadata, and technical specifications needed for playback.

--- a/XX.md
+++ b/XX.md
@@ -44,7 +44,7 @@ Radio stations are published as addressable events of `kind:31237`. These events
     ["d", "<station-identifier>"],
     ["name", "<station-name>"],
     ["t", "<genre>"],
-    ["language", "<ISO-639-1-code>"],
+    ["l", "<ISO-639-1-code>"],
     ["countryCode", "<ISO-3166-2-code>"],
     ["location", "<human-readable-location>"],
     ["thumbnail", "<image-url>"],
@@ -102,7 +102,7 @@ Each stream object MUST include:
 ### Recommended Tags
 
 - `t`: Genre/category tags (multiple allowed)
-- `language`: ISO 639-1 language codes (multiple allowed)
+- `l`: ISO 639-1 language codes (multiple allowed)
 - `countryCode`: ISO 3166-2 country code
 - `location`: Human-readable location string
 - `thumbnail`: Station logo/image URL
@@ -122,7 +122,7 @@ Each stream object MUST include:
     ["t", "jazz"],
     ["t", "world"],
     ["t", "electronic"],
-    ["language", "fr"],
+    ["l", "fr"],
     ["countryCode", "FR"],
     ["location", "Paris, France"],
     ["thumbnail", "https://example.com/fip-logo.png"],
@@ -160,7 +160,7 @@ Persistent discussion threads use existing comment protocols such as [NIP-22](22
 ### Content Indexing
 
 - Use `t` tags for genre/category filtering
-- Include `language` tags for internationalization
+- Include `l` tags for internationalization
 - Add `location` for geographical discovery
 
 ## Reference Implementation

--- a/XX.md
+++ b/XX.md
@@ -23,6 +23,7 @@ Radio stations are published as addressable events of `kind:31237`. These events
     ["l", "<ISO-639-1-code>"],
     ["countryCode", "<ISO-3166-2-code>"],
     ["location", "<human-readable-location>"],
+    ["g", "<geohash>"],
     ["thumbnail", "<image-url>"],
     ["website", "<station-website>"]
   ]
@@ -81,6 +82,7 @@ Each stream object MUST include:
 - `l`: ISO 639-1 language codes (multiple allowed)
 - `countryCode`: ISO 3166-2 country code
 - `location`: Human-readable location string
+- `g`: Geohash for precise geographical coordinates
 - `thumbnail`: Station logo/image URL
 - `website`: Station's official website
 
@@ -101,6 +103,7 @@ Each stream object MUST include:
     ["l", "fr"],
     ["countryCode", "FR"],
     ["location", "Paris, France"],
+    ["g", "u09tvw0"],
     ["thumbnail", "https://example.com/fip-logo.png"],
     ["website", "https://www.radiofrance.fr/fip"]
   ]
@@ -137,6 +140,7 @@ Persistent discussion threads use existing comment protocols such as [NIP-22](22
 
 - Use `t` tags for genre/category filtering
 - Include `l` tags for internationalization
+- Add `g` tags with geohash for precise geographical discovery
 
 ## Reference Implementation
 

--- a/XX.md
+++ b/XX.md
@@ -1,0 +1,197 @@
+# NIP-XX
+
+## Internet Radio
+
+`draft` `optional`
+
+This NIP defines a standard for publishing and discovering internet radio stations on Nostr, enabling decentralized radio station directories, streaming metadata, social features, and interoperability between radio applications.
+
+## Rationale
+
+Traditional internet radio directories are centralized services controlled by single entities, making them vulnerable to censorship, takedowns, and service discontinuation. Radio stations and listeners lack data portability between different platforms and applications.
+
+This specification leverages Nostr's decentralized infrastructure to create an open, censorship-resistant radio ecosystem where:
+
+- Radio stations can publish their metadata and streaming information directly
+- Users maintain portable favorites lists across applications
+- Developers can build interoperable radio clients without vendor lock-in
+- Communities can engage around stations through comments and live chat
+- Discovery happens through the network rather than centralized algorithms
+- Organic, decentralized maintenance of station entries helps keep quality high and mitigate broken links
+- Direct listener-to-station monetization becomes possible through Nostr's native micropayment capabilities
+
+## Overview
+
+This specification defines radio station events and describes how existing Nostr protocols can be used to create a complete radio ecosystem:
+
+- **Radio Station Events** (`kind:31237`) - Station metadata and streaming information (defined in this NIP)
+- **Live Chat Messages** - Real-time chat during streaming using existing live chat protocols
+- **Station Comments** - Persistent discussion threads using existing comment protocols
+- **Favorites Management** - Personal and curated station collections using [NIP-78](78.md)
+- **Application Discovery** - Handler registration using [NIP-89](89.md)
+
+## Radio Station Events
+
+Radio stations are published as addressable events of `kind:31237`. These events contain streaming URLs, metadata, and technical specifications needed for playback.
+
+### Event Structure
+
+```json
+{
+  "kind": 31237,
+  "content": "<JSON metadata>",
+  "tags": [
+    ["d", "<station-identifier>"],
+    ["name", "<station-name>"],
+    ["t", "<genre>"],
+    ["language", "<ISO-639-1-code>"],
+    ["countryCode", "<ISO-3166-2-code>"],
+    ["location", "<human-readable-location>"],
+    ["thumbnail", "<image-url>"],
+    ["website", "<station-website>"],
+    ["client", "<client-name>", "<handler-address>", "<relay-hint>"]
+  ]
+}
+```
+
+### Content Format
+
+The `content` field MUST contain a JSON string with the following structure:
+
+```json
+{
+  "description": "Station description with **markdown** support",
+  "streams": [
+    {
+      "url": "https://stream.example.com/radio.mp3",
+      "format": "audio/mpeg",
+      "quality": {
+        "bitrate": 128000,
+        "codec": "mp3",
+        "sampleRate": 44100
+      },
+      "primary": true
+    }
+  ],
+  "streamingServerUrl": "https://server.example.com"
+}
+```
+
+#### Required Fields
+
+- `description`: Human-readable description (markdown supported)
+- `streams`: Array of stream objects (minimum one required)
+
+#### Optional Fields
+
+- `streamingServerUrl`: Base URL of the streaming server (needed for metadata endpoints when using typical streaming servers like Icecast that provide `/status-json.xsl`, `/admin/stats`, or similar metadata APIs)
+
+#### Stream Object
+
+Each stream object MUST include:
+
+- `url`: Direct URL to the audio stream
+- `format`: MIME type (e.g., "audio/mpeg", "audio/aac")
+- `quality`: Object with `bitrate`, `codec`, and `sampleRate`
+- `primary`: Boolean indicating the default stream (optional)
+
+### Required Tags
+
+- `d`: Unique identifier for the station (used for addressability)
+- `name`: Human-readable station name
+
+### Recommended Tags
+
+- `t`: Genre/category tags (multiple allowed)
+- `language`: ISO 639-1 language codes (multiple allowed)
+- `countryCode`: ISO 3166-2 country code
+- `location`: Human-readable location string
+- `thumbnail`: Station logo/image URL
+- `website`: Station's official website
+- `client`: Client that published the event (format: `["client", "ClientName", "HandlerId", "RelayURL"]`)
+
+### Example
+
+```json
+{
+  "kind": 31237,
+  "pubkey": "a1b2c3d4...",
+  "created_at": 1690000000,
+  "content": "{\"description\":\"Eclectic mix of jazz, world music, and electronic sounds from France.\",\"streams\":[{\"url\":\"https://icecast.radiofrance.fr/fiprock-hifi.aac\",\"format\":\"audio/aac\",\"quality\":{\"bitrate\":128000,\"codec\":\"aac\",\"sampleRate\":44100},\"primary\":true}]}",
+  "tags": [
+    ["d", "fip-radio-paris"],
+    ["name", "FIP Radio"],
+    ["t", "jazz"],
+    ["t", "world"],
+    ["t", "electronic"],
+    ["language", "fr"],
+    ["countryCode", "FR"],
+    ["location", "Paris, France"],
+    ["thumbnail", "https://example.com/fip-logo.png"],
+    ["website", "https://www.radiofrance.fr/fip"],
+    [
+      "client",
+      "NostrRadio",
+      "31990:pubkey:handler123",
+      "wss://relay.example.com"
+    ]
+  ]
+}
+```
+
+## Social Features
+
+Radio stations can leverage existing Nostr social protocols:
+
+### Live Chat Messages
+
+Real-time chat during radio streaming uses existing live chat protocols such as [NIP-53](53.md). Messages should reference the radio station via `a` tag to associate chat with the specific station.
+
+### Station Comments
+
+Persistent discussion threads use existing comment protocols such as [NIP-25](25.md). Comments should reference the radio station event to create threaded discussions about stations.
+
+## Implementation Notes
+
+### Station Identification
+
+- The `d` tag value SHOULD be descriptive and stable for the station
+- Multiple stations can be published by the same pubkey using different `d` tags
+- Clients SHOULD use the station name as a fallback identifier
+
+### Streaming Compatibility
+
+- Support multiple stream formats for broader client compatibility
+- Include quality metadata to enable adaptive streaming
+- Mark one stream as `primary` for default selection
+
+### Content Indexing
+
+- Use `t` tags for genre/category filtering
+- Include `language` tags for internationalization
+- Add `location` for geographical discovery
+
+### Privacy Considerations
+
+- The `client` tag has privacy implications - clients SHOULD allow opt-out
+- Station owners can moderate chat/comments by maintaining block lists
+- Consider rate limiting for chat messages to prevent spam
+
+## Security Considerations
+
+- Validate stream URLs before playback to prevent malicious redirects
+- Sanitize station descriptions when rendering markdown content
+- Implement reasonable limits on metadata size to prevent DoS attacks
+- Verify signatures on all events before processing
+
+## Backwards Compatibility
+
+This specification introduces new event kinds that do not conflict with existing NIPs. Clients that don't understand `kind:31237` can safely ignore these events without affecting other functionality.
+
+## Reference Implementation
+
+A reference implementation is available at [WaveFunc](https://github.com/zeSchlausKwab/wavefunc), demonstrating station publishing, favorites management, and social features.
+
+## Conclusion
+
+This specification enables a decentralized internet radio ecosystem built on Nostr's foundation of censorship resistance and data portability. By standardizing station metadata, social features, and application discovery, it creates interoperability between radio clients while preserving user autonomy and freedom of choice.

--- a/XX.md
+++ b/XX.md
@@ -137,7 +137,6 @@ Persistent discussion threads use existing comment protocols such as [NIP-22](22
 
 - Use `t` tags for genre/category filtering
 - Include `l` tags for internationalization
-- Add `location` for geographical discovery
 
 ## Reference Implementation
 

--- a/XX.md
+++ b/XX.md
@@ -163,26 +163,6 @@ Persistent discussion threads use existing comment protocols such as [NIP-25](25
 - Include `language` tags for internationalization
 - Add `location` for geographical discovery
 
-### Privacy Considerations
-
-- Station owners can moderate chat/comments by maintaining block lists
-- Consider rate limiting for chat messages to prevent spam
-
-## Security Considerations
-
-- Validate stream URLs before playback to prevent malicious redirects
-- Sanitize station descriptions when rendering markdown content
-- Implement reasonable limits on metadata size to prevent DoS attacks
-- Verify signatures on all events before processing
-
-## Backwards Compatibility
-
-This specification introduces new event kinds that do not conflict with existing NIPs. Clients that don't understand `kind:31237` can safely ignore these events without affecting other functionality.
-
 ## Reference Implementation
 
 A reference implementation is available at [WaveFunc](https://github.com/zeSchlausKwab/wavefunc), demonstrating station publishing, favorites management, and social features.
-
-## Conclusion
-
-This specification enables a decentralized internet radio ecosystem built on Nostr's foundation of censorship resistance and data portability. By standardizing station metadata, social features, and application discovery, it creates interoperability between radio clients while preserving user autonomy and freedom of choice.

--- a/XX.md
+++ b/XX.md
@@ -117,7 +117,7 @@ Each stream object MUST include:
   "created_at": 1690000000,
   "content": "{\"description\":\"Eclectic mix of jazz, world music, and electronic sounds from France.\",\"streams\":[{\"url\":\"https://icecast.radiofrance.fr/fiprock-hifi.aac\",\"format\":\"audio/aac\",\"quality\":{\"bitrate\":128000,\"codec\":\"aac\",\"sampleRate\":44100},\"primary\":true}]}",
   "tags": [
-    ["d", "fip-radio-paris"],
+    ["d", "a7f9d2e1b8c3"],
     ["name", "FIP Radio"],
     ["t", "jazz"],
     ["t", "world"],
@@ -147,9 +147,9 @@ Persistent discussion threads use existing comment protocols such as [NIP-25](25
 
 ### Station Identification
 
-- The `d` tag value SHOULD be descriptive and stable for the station
+- The `d` tag value SHOULD be a random identifier to ensure stability over time
+- If no `d` tag is present, it defaults to an empty string
 - Multiple stations can be published by the same pubkey using different `d` tags
-- Clients SHOULD use the station name as a fallback identifier
 
 ### Streaming Compatibility
 

--- a/XX.md
+++ b/XX.md
@@ -19,7 +19,7 @@ Radio stations are published as addressable events of `kind:31237`. These events
   "tags": [
     ["d", "<station-identifier>"],
     ["name", "<station-name>"],
-    ["t", "<genre>"],
+    ["c", "<category>", "<facet>"],
     ["l", "<ISO-639-1-code>"],
     ["countryCode", "<ISO-3166-2-code>"],
     ["location", "<human-readable-location>"],
@@ -78,7 +78,7 @@ Each stream object MUST include:
 
 ### Recommended Tags
 
-- `t`: Genre/category tags (multiple allowed)
+- `c`: Category tags (multiple allowed). The third value indicates the facet, e.g. `["c", "jazz", "genre"]`.
 - `l`: ISO 639-1 language codes (multiple allowed)
 - `countryCode`: ISO 3166-2 country code
 - `location`: Human-readable location string
@@ -97,15 +97,15 @@ Each stream object MUST include:
   "tags": [
     ["d", "a7f9d2e1b8c3"],
     ["name", "FIP Radio"],
-    ["t", "jazz"],
-    ["t", "world"],
-    ["t", "electronic"],
+    ["c", "jazz", "genre"],
+    ["c", "world", "genre"],
+    ["c", "electronic", "genre"],
     ["l", "fr"],
     ["countryCode", "FR"],
     ["location", "Paris, France"],
     ["g", "u09tvw0"],
     ["thumbnail", "https://example.com/fip-logo.png"],
-    ["website", "https://www.radiofrance.fr/fip"]
+    ["website", "https://www.radio.net/s/fip"]
   ]
 }
 ```
@@ -138,7 +138,7 @@ Persistent discussion threads use existing comment protocols such as [NIP-22](22
 
 ### Content Indexing
 
-- Use `t` tags for genre/category filtering
+- Use `c` tags for category filtering (e.g. `["c", "jazz", "genre"]`)
 - Include `l` tags for internationalization
 - Add `g` tags with geohash for precise geographical discovery
 


### PR DESCRIPTION
## What this adds

A standard for publishing internet radio stations on Nostr as `kind:31237` events, enabling decentralized radio directories and cross-app compatibility. Current open solutions use awkward semi-community driven flows to maintain quality of their registries leading to broken streams and outdated metadata. The direct monetization could incentivize station runners and listeners to maintain station entries ensuring a cleaner registry.

## Why we need this

Current radio directories are centralized platforms that control discovery and can deplatform stations. Users lose their favorites when services shut down, and there's no interoperability between radio apps.

## How it works

- **Radio stations** publish their streaming URLs and metadata directly to Nostr
- **Users** maintain portable favorites across any compatible app  
- **Developers** can build interoperable radio clients using the standard
- **Social features** use existing NIPs (comments, live chat) rather than reinventing them

## Key benefits

- Censorship-resistant station publishing
- Portable user data (no vendor lock-in)
- Direct listener-to-station micropayments
- Community-driven quality maintenance
- Works with existing Nostr social features

## Implementation

Builds on proven Nostr patterns:
- Uses NIP-78 for favorites (not redefined here)
- References NIP-25/NIP-53 for social features  
- Integrates with NIP-89 for app discovery
- Focuses only on radio-specific functionality

Working reference implementation: [WaveFunc](https://github.com/zeSchlausKwab/wavefunc)

## Request for feedback

This introduces `kind:31237` without conflicting with existing NIPs. Looking for community input on the event structure and integration approach. 