### PR TITLE
scrobbling

### DIFF
--- a/F3.md
+++ b/F3.md
@@ -1,0 +1,21 @@
+NIP-F3
+======
+
+Scrobbling
+----------
+
+`draft` `optional`
+
+This NIP defines `kind:1073` as a _scrobble_ event. It has the following format:
+
+```yaml
+{
+  "kind": 1073,
+  "tags": [
+    ["title", "<song title>"],
+    ["album", "<song album>", "<optional variant>"],
+    ["artist", "<musician or band>", "<optional variant>"]
+  ]
+  // other fields...
+}
+```


### PR DESCRIPTION
this is for publishing music you heard to, like https://last.fm/ and other social networks do.

this is a placeholder and the NIP text is incomplete.