### PR TITLE
Public Messages

### DIFF
--- a/A4.md
+++ b/A4.md
@@ -21,12 +21,12 @@ The `.content` contains the message. `p` tags identify one or more receivers.
 }
 ```
 
-Kind 24 are designed to be shown and replied from notification screens. The goal is to allow clients to 
+Kind 24 is designed to be shown and replied to from notification screens. The goal is to allow clients to 
 support this feature without having to worry about chat history. There are no message chains. The concept of a 
 "thread", a "thread root", or a "chatroom" does not exist in this system, as messages can start and continue 
-without any synthatic connection to each other.  
+without any syntactic connection to each other.  
 
-This kind is not designed to be shown on feeds, but anyone can see and reply to messages that may not be for them.
+This kind is not designed to be displayed on feeds, but anyone can see and reply to messages that may not be for them.
 
 ## Advanced Support
 
@@ -44,3 +44,8 @@ This kind is not designed to be shown on feeds, but anyone can see and reply to 
 
 [NIP-92](92.md) `imeta` tags are recommended for image and video links.
 
+## Warnings
+
+There should be no expectation of privacy in this kind. It is just a public reply, but without a root note.
+
+Avoid confusing this kind with Kind `14` rumors in [NIP-17](17.md) DMs. This kind is signed and designed for public consumption.

--- a/A4.md
+++ b/A4.md
@@ -1,0 +1,46 @@
+NIP-A4
+======
+
+Public Messages
+---------------
+
+`draft` `optional`
+
+This NIP defines the `kind:24` as a simple plaintext message to one or more Nostr users. 
+
+The `.content` contains the message. `p` tags identify one or more receivers.
+
+```jsonc
+{
+  "pubkey": "<sender-pubkey>",
+  "kind": 24,
+  "tags": [
+    ["p", "<receiver>", "<relay-url>"],
+  ],
+  "content": "<message-in-plain-text>",
+}
+```
+
+Kind 24 are designed to be shown and replied from notification screens. The goal is to allow clients to 
+support this feature without having to worry about chat history. There are no message chains. The concept of a 
+"thread", a "thread root", or a "chatroom" does not exist in this system, as messages can start and continue 
+without any synthatic connection to each other.  
+
+This kind is not designed to be shown on feeds, but anyone can see and reply to messages that may not be for them.
+
+## Advanced Support
+
+`q` tags MAY be used when citing events in the `.content` with [NIP-21](21.md).
+
+```json
+["q", "<event-id> or <event-address>", "<relay-url>", "<pubkey-if-a-regular-event>"]
+```
+
+[NIP-25](25.md) reactions MUST add a `k` tag to `24`. 
+
+[NIP-57](57.md) zaps MUST include the `k` tag to `24`
+
+[NIP-21](21.md) links that use [NIP-19](19.md)'s `nevent1` must include a `kind` of `24`. Links that are not `kind:24` are not expected to be rendered natively by the client.
+
+[NIP-92](92.md) `imeta` tags are recommended for image and video links.
+


### PR DESCRIPTION
A public message kind designed to be shown and replied to from notification screens. 

The goal is broad support in all clients. And because of that, this kind has no concept of a "chat history". There are no message chains. The concept of a "thread", a "thread root", or a "chatroom" does not exist in this system, as messages can start and continue without any syntactic connection to each other.  