### PR TITLE
Update audio format and waveform recommendation for NIP-A0: Voice Messages

### DIFF
--- a/A0.md
+++ b/A0.md
@@ -34,7 +34,7 @@ The `kind: 1222` event is defined as follows:
 
 The following imeta (NIP-92) tags MAY be included so clients can render a visual preview without having to download the audio file first:
 
-- `waveform`: amplitude values over time, space separated, less than 100 values should be enough to render a nice visual
+- `waveform`: amplitude values over time, space separated full integers, less than 100 values should be enough to render a nice visual
 - `duration`: audio length in seconds
 
 ## Examples
@@ -53,7 +53,7 @@ The following imeta (NIP-92) tags MAY be included so clients can render a visual
     [
       "imeta",
       "url https://blossom.primal.net/5fe7df0e46ee6b14b5a8b8b92939e84e3ca5e3950eb630299742325d5ed9891b.mp4",
-      "waveform 0 0.05 0.27 0.08 0.01 0.01 0.01 0.03 0.38 1.5 0.49 0.02 0.28 0.04 0.01 0 0 0.39 0.22 0.16 0.05 0.06 0.55 0.01 0.06 0.01 0 0 0.02 0.61 0.02 0.07 0.01 0.21 0.09 0.12 0.63 0.01 0.02 0.02 0.42 0.02 0.68 0.05 0.02 0.05 0.02 0 0 0 0",
+      "waveform 0 7 35 8 100 100 49 8 4 16 8 10 7 2 20 10 100 100 100 100 100 100 15 100 100 100 25 60 5 4 3 1 0 100 100 15 100 29 88 0 33 11 39 100 100 19 4 100 42 35 5 0 1 5 0 0 11 38 100 94 17 11 44 58 5 100 100 100 55 14 72 100 100 57 6 1 14 2 16 100 100 40 16 100 100 6 32 14 13 41 36 16 14 6 3 0 1 2 1 6 0",
       "duration 8"
     ]
   ]


### PR DESCRIPTION
- Recommend `audio/mp4` (.m4a) format using AAC or Opus encoding
- Recommend waveform data to use full integers