### PR TITLE
NIP-34: `mention` marker ~> `q` tag NIP-10 update

### DIFF
--- a/34.md
+++ b/34.md
@@ -150,7 +150,7 @@ Root Patches and Issues have a Status that defaults to 'Open' and can be set by 
     ["r", "<earliest-unique-commit-id-of-repo>"]
 
     // optional for `1631` status
-    ["e", "<applied-or-merged-patch-event-id>", "", "mention"], // for each
+    ["q", "<applied-or-merged-patch-event-id>", "<relay-url>", "<pubkey>"], // for each
     // when merged
     ["merge-commit", "<merge-commit-id>"]
     ["r", "<merge-commit-id>"]


### PR DESCRIPTION
comply with changes to NIP-10 made in https://github.com/nostr-protocol/nips/pull/1750