### PR TITLE
NIP-17: Mark as Received event

### DIFF
--- a/17.md
+++ b/17.md
@@ -149,7 +149,7 @@ Clients SHOULD publish kind `14` events to the `10050`-listed relays. If that is
 
 ## Received Event
 
-A public (not gift-wrapped) event of type `10017` SHOULD be updated every time a Client decrypts a new message. This update will mark all messages up to this point as "received" to peers and confirm the user's ability to receive and view messages.
+A public (not gift-wrapped) event of type `10017` SHOULD be updated every time a Client decrypts a new batch of messages. This update will mark all messages up to this point as "received" to peers and confirm the user's ability to receive and view messages.
 
 ```jsonc
 {


### PR DESCRIPTION
Adds the simplistic idea to give users some feedback for sent DMs as discussed in https://github.com/nostr-protocol/nips/pull/1994 

This also serves as a heartbeat event to check if users are still using their NIP-17 clients, regardless of their DM relay configurations. 