### PR TITLE
Draft Proposal: WebRTC Signaling over Nostr

### DIFF
--- a/nip_webrtc_signaling.txt
+++ b/nip_webrtc_signaling.txt
@@ -1,0 +1,145 @@
+# NIP-XXX: WebRTC Signaling over Nostr
+
+## Summary
+
+Defines a mechanism for initiating and negotiating peer-to-peer WebRTC voice and video calls over the Nostr protocol using encrypted or ephemeral event-based signaling. This NIP introduces new event kinds and a structure for exchanging SDP offers, answers, and ICE candidates between peers using Nostr relays.
+
+---
+
+## Motivation
+
+Current Nostr clients lack a standardized mechanism for real-time voice or video communication. Traditional WebRTC apps rely on centralized signaling servers to exchange connection metadata (SDP and ICE candidates). Nostr provides an ideal transport mechanism for signaling while preserving user anonymity, decentralization, and cryptographic authenticity. 
+
+This NIP defines an interoperable way for clients to initiate and accept WebRTC calls by exchanging offer/answer/candidate payloads through encrypted or ephemeral Nostr events.
+
+---
+
+## Event Kinds
+
+| Kind      | Name               | Description                                |
+|-----------|--------------------|--------------------------------------------|
+| 14300     | `call_offer`       | Initiates a WebRTC call                    |
+| 14301     | `call_answer`      | Response to a `call_offer`                 |
+| 14302     | `ice_candidate`    | ICE candidate exchange event               |
+| 14303     | `call_end`         | Signals termination of the session         |
+
+---
+
+## Event Format
+
+Each event MUST contain the following:
+
+### Tags:
+
+- `"p"`: target public key (receiver)
+- `"session_id"`: Unique identifier for the session (UUID or hash)
+- `"type"`: call type — `audio`, `video`, or `screen`
+- `"sig_alg"`: signaling payload encryption algorithm, e.g. `NIP-04`, `NIP-44`
+- (optional) `"relay"`: preferred relay for communication
+
+### Content:
+
+Encrypted JSON payload, depending on the event type. The encryption method (NIP-04, NIP-44) should be agreed upon or assumed by clients.
+
+#### Example `call_offer` (content decrypted):
+```json
+{
+  "sdp": "v=0\no=alice...",
+  "timestamp": 1721128392,
+  "expires_in": 60
+}
+```
+
+#### Example `call_answer` (content decrypted):
+```json
+{
+  "sdp": "v=0\no=bob...",
+  "accepted": true,
+  "timestamp": 1721128423
+}
+```
+
+#### Example `ice_candidate` (content decrypted):
+```json
+{
+  "candidate": "candidate:1 1 udp 2130706431 ...",
+  "sdpMid": "0",
+  "sdpMLineIndex": 0,
+  "timestamp": 1721128450
+}
+```
+
+#### Example `call_end`:
+```json
+{
+  "reason": "user_left" | "rejected" | "timeout",
+  "timestamp": 1721128490
+}
+```
+
+---
+
+## Security Considerations
+
+- Events MUST be encrypted (NIP-04 or stronger, e.g. NIP-44).
+- Clients SHOULD reject call signaling from unknown/untrusted npubs unless explicitly allowed.
+- Clients SHOULD support ephemeral relays or purge signaling events quickly.
+- No media flows through Nostr — only metadata for peer connection.
+
+---
+
+## Multi-device Support
+
+If a user is logged in on multiple devices, signaling events MAY be sent to all active sessions. Each device MAY independently respond with `call_answer` or ignore.
+
+---
+
+## TURN/STUN
+
+This NIP assumes clients implement WebRTC-compatible STUN and TURN fallback logic on their own. The infrastructure for ICE negotiation is handled through `ice_candidate` events.
+
+---
+
+## Implementation Notes
+
+- Media is transmitted peer-to-peer using standard WebRTC.
+- Clients should allow optional relay hints or fast relays for low-latency call setup.
+- Session ID must be unique per call session to avoid conflicts.
+- Clients SHOULD notify the user of the npub initiating the call, or display known alias.
+
+---
+
+## Future Extensions
+
+- Group calls (multi-participant session IDs)
+- Screen sharing / remote assistance
+- Session re-negotiation and codec negotiation tagging
+- Recording support metadata (locally only)
+
+---
+
+## Backwards Compatibility
+
+This NIP does not affect existing Nostr message formats. It is entirely additive.
+
+---
+
+## Reference Implementations
+
+- [OxChat](https://github.com/oxchat)
+- [Coracle](https://github.com/nbd-wtf/nostr) (pending patch)
+- JavaScript demo using WebRTC + Nostr signaling (coming soon)
+
+---
+
+## Author
+
+- _Your Name or Pseudonym_
+- npub: `npub1...`
+- GitHub: [github.com/yourname](https://github.com/yourname)
+
+---
+
+## Status
+
+Draft — community feedback requested

--- a/nip_webrtc_signaling.txt
+++ b/nip_webrtc_signaling.txt
@@ -36,6 +36,7 @@ Each event MUST contain the following:
 - `"type"`: call type — `audio`, `video`, or `screen`
 - `"sig_alg"`: signaling payload encryption algorithm, e.g. `NIP-04`, `NIP-44`
 - (optional) `"relay"`: preferred relay for communication
+- (optional) `"rtc_servers"`: comma-separated list of STUN/TURN server URLs or identifiers
 
 ### Content:
 
@@ -46,7 +47,11 @@ Encrypted JSON payload, depending on the event type. The encryption method (NIP-
 {
   "sdp": "v=0\no=alice...",
   "timestamp": 1721128392,
-  "expires_in": 60
+  "expires_in": 60,
+  "rtc_servers": [
+    {"urls": "stun:stun.l.google.com:19302"},
+    {"urls": "turn:turn.example.com", "username": "user", "credential": "pass"}
+  ]
 }
 ```
 
@@ -96,7 +101,7 @@ If a user is logged in on multiple devices, signaling events MAY be sent to all 
 
 ## TURN/STUN
 
-This NIP assumes clients implement WebRTC-compatible STUN and TURN fallback logic on their own. The infrastructure for ICE negotiation is handled through `ice_candidate` events.
+This NIP assumes clients implement WebRTC-compatible STUN and TURN fallback logic on their own. The infrastructure for ICE negotiation is handled through `ice_candidate` events. Call offers MAY include a `rtc_servers` field in the payload to suggest or require specific ICE servers.
 
 ---
 
@@ -106,6 +111,7 @@ This NIP assumes clients implement WebRTC-compatible STUN and TURN fallback logi
 - Clients should allow optional relay hints or fast relays for low-latency call setup.
 - Session ID must be unique per call session to avoid conflicts.
 - Clients SHOULD notify the user of the npub initiating the call, or display known alias.
+- Clients SHOULD honor provided `rtc_servers` or fallback to defaults.
 
 ---
 
@@ -115,6 +121,7 @@ This NIP assumes clients implement WebRTC-compatible STUN and TURN fallback logi
 - Screen sharing / remote assistance
 - Session re-negotiation and codec negotiation tagging
 - Recording support metadata (locally only)
+- Dynamic call renegotiation and ICE restart
 
 ---
 

--- a/nip_webrtc_signaling.txt
+++ b/nip_webrtc_signaling.txt
@@ -103,6 +103,17 @@ If a user is logged in on multiple devices, signaling events MAY be sent to all 
 
 This NIP assumes clients implement WebRTC-compatible STUN and TURN fallback logic on their own. The infrastructure for ICE negotiation is handled through `ice_candidate` events. Call offers MAY include a `rtc_servers` field in the payload to suggest or require specific ICE servers.
 
+### Appendix: How STUN and TURN Work
+
+- **STUN** is used to discover the public IP and port of a device behind a NAT by sending a request to a public STUN server. The server replies with what IP/port it sees — this is the "reflexive candidate."
+  - 🔍 This alone does **not** open a port. It's only for external address discovery.
+
+- **For a connection to succeed**, the user's **router must forward the traffic back to the client** — this usually happens automatically via NAT behavior when the external peer sends a packet to the discovered IP/port. No UPnP is needed in typical WebRTC.
+
+- **TURN** is used as a fallback when NAT traversal fails. It acts as a full media relay, forwarding audio/video between both peers through an intermediate server. TURN requires much more bandwidth and often needs authentication.
+
+- **IPv6**: If both peers are on native IPv6 with no restrictive firewall rules, a direct peer-to-peer connection is often possible without STUN or TURN.
+
 ---
 
 ## Implementation Notes


### PR DESCRIPTION
### Title: Add NIP-XXX: WebRTC Signaling over Nostr

This PR introduces a new NIP that defines a standardized way to initiate and negotiate secure peer-to-peer voice and video calls over Nostr using WebRTC.

It proposes new event kinds for call signaling (offer, answer, ICE candidates, call end) and outlines a consistent JSON structure for exchanging SDP and ICE payloads through encrypted or ephemeral Nostr events. The goal is to enable cross-client interoperability for real-time communication in the Nostr ecosystem, without requiring centralized servers or proprietary formats.

**Key features include:**

- Use of existing Nostr relays for signaling, no additional infrastructure required  
- Secure metadata exchange via NIP-04 or NIP-44 encryption  
- Extensible design supporting future features like group calls or screen sharing  
- Clear tags for session ID, media type, and TURN/STUN configuration  
- IPv6-aware, NAT-traversal friendly (via ICE)  
- Multi-device friendly signaling  

The proposal is already being prototyped by multiple client authors and is compatible with existing WebRTC tooling. It is submitted as a Draft for open community review and discussion.

Looking forward to your feedback.
