### PR TITLE
Add Live Event Consent (kind:30316) to NIP-53

### DIFF
--- a/53.md
+++ b/53.md
@@ -61,6 +61,26 @@ Clients MAY only display participants if the proof is available or MAY display p
 
 This feature is important to avoid malicious event owners adding large account holders to the event, without their knowledge, to lure their followers into the malicious owner's trap.
 
+#### Live Event Consent
+
+Event `kind:30316` "Live Event Consent" provides a standardized mechanism for participants to publish their agreement to join a Live Event. Participants publish consent events containing the same cryptographic proof used in the `p` tag.
+
+```jsonc
+{
+  "kind": 30316,
+  "tags": [
+    ["d", "<live-event-d-tag>"],
+    ["a", "30311:<organizer_pubkey>:<event_d_tag>", "<optional-relay-hint>"],
+    ["proof", "<hex-encoded-signature>"],
+    ["p", "<organizer_pubkey>"]
+  ],
+  "content": "<optional consent message>",
+  // other fields...
+}
+```
+
+Event owners can discover consent events by querying for `kind:30316` events with an `a` tag matching their Live Event. The proof from the consent event can then be included in the Live Event's `p` tag.
+
 ### Live Chat Message
 
 Event `kind:1311` is live chat's channel message. Clients MUST include the `a` tag of the activity. An `e` tag denotes the direct parent message this post is replying to. 


### PR DESCRIPTION
## Summary
Adds `kind:30316` Live Event Consent to provide a standardized, discoverable mechanism for participants to publish their agreement to join Live Events.

## Problem
Currently, NIP-53 defines a proof mechanism where event organizers can include cryptographic proofs in `p` tags to show participant consent. However, there's no standardized way for:
- Participants to publish their consent proactively
- Event organizers to discover consent events

This requires out-of-band coordination between organizers and participants.

## Solution
This PR introduces `kind:30316` Live Event Consent events that:
- Allow participants to publish their consent to Nostr relays
- Are discoverable by event organizers via `a` tag queries
- Use the same cryptographic proof as the existing `p` tag mechanism

## Implementation Notes
- Fully backward compatible - existing proof mechanism still works
- Event organizers can discover consents by querying: `{"kinds": [30316], "tags": {"a": ["30311:organizer_pubkey:event_d_tag"]}}`
- The proof field uses the same signed SHA256 format already defined in NIP-53