### PR TITLE
nip22: Make the root `SHOULD` instead of `MUST`

### DIFF
--- a/22.md
+++ b/22.md
@@ -10,10 +10,10 @@ A comment is a threading note always scoped to a root event or an [`I`-tag](73.m
 
 It uses `kind:1111` with plaintext `.content` (no HTML, Markdown, or other formatting).
 
-Comments MUST point to the root scope using uppercase tag names (e.g. `K`, `E`, `A` or `I`)
+Comments SHOULD point to the root scope using uppercase tag names (e.g. `K`, `E`, `A` or `I`)
 and MUST point to the parent item with lowercase ones (e.g. `k`, `e`, `a` or `i`).
 
-Comments MUST point to the authors when one is available (i.e. tagging a nostr event). `P` for the root scope
+Comments SHOULD point to the authors (i.e. tagging a nostr event). `P` for the root scope
 and `p` for the author of the parent item.
 
 ```jsonc


### PR DESCRIPTION
Because clients can't always get the root, so if it's there add it, otherwise it's fine.

Note:

I didn't change anything in the `P/p` tag, I just reworded it.

---

@dluvian wrote:
> I conceded and added the root tag in my app because it was trivial but that is not always the case. It's not always possible to determine the correct root tag **and I think having no root tag is better than setting a wrong one**.
> And in addition to that it's expensive fetching an event just to be able to create a comment.