### PR TITLE
nip22: fix example type for external URL

### DIFF
--- a/22.md
+++ b/22.md
@@ -143,13 +143,13 @@ A comment on a website's url looks like this:
   "tags": [
     // referencing the root url
     ["I", "https://abc.com/articles/1"],
-    // the root "kind": for an url, the kind is its domain
-    ["K", "https://abc.com"],
+    // the root "kind": for an url
+    ["K", "web"],
 
     // the parent reference (same as root for top-level comments)
     ["i", "https://abc.com/articles/1"],
-    // the parent "kind": for an url, the kind is its domain
-    ["k", "https://abc.com"]
+    // the parent "kind": for an url
+    ["k", "web"]
   ]
   // other fields
 }


### PR DESCRIPTION
The kind of an external URL changed from its domain to "web" here bf699c9bc15e16d78a2bd805626e8813446e5d31