### PR TITLE
NIP-37: Improving Draft events

### DIFF
--- a/37.md
+++ b/37.md
@@ -1,50 +1,57 @@
 NIP-37
 ======
 
-Draft Events 
-------------
+Draft Wraps
+-----------
 
 `draft` `optional`
 
-This NIP defines kind `31234` as a private wrap for drafts of any other event kind. 
+This NIP defines kind `31234` as an encrypted storage for unsigned draft events of any other kind. 
 
-The draft event is JSON-stringified, [NIP44-encrypted](44.md) to the signer's public key and placed inside the `.content` of the event.
+The draft is JSON-stringified, [NIP44-encrypted](44.md) to the signer's public key and placed inside the `.content`.
 
-An additional `k` tag identifies the kind of the draft event. 
+`k` tags identify the kind of the draft. 
 
 ```js
 {
   "kind": 31234,
   "tags": [
     ["d", "<identifier>"],
-    ["k", "<kind of the draft event>"],
-    ["e", "<anchor event event id>", "<relay-url>"],
-    ["a", "<anchor event address>", "<relay-url>"],
+    ["k", "<kind of the draft event>"], // required
+    ["expiration", "now + 90 days"] // recommended
   ],
   "content": nip44Encrypt(JSON.stringify(draft_event)),
   // other fields
 }
 ```
 
-A blanked `.content` means this draft has been deleted by a client but relays still have the event. 
+A blanked `.content` field signals that the draft has been deleted. 
 
-Tags `e` and `a` identify one or more anchor events, such as parent events on replies.   
+[NIP-40](40.md) `expiration` tags are recommended. 
+
+Clients SHOULD publish kind `31234` events to relays listed on kind `10013` below.
 
 ## Relay List for Private Content
 
-Kind `10013` indicates the user's preferred relays to store private events like Drafts. The event MUST include a list of `relay` URLs in private tags. Private tags are JSON Stringified, NIP-44-encrypted to the signer's keys and placed inside the .content of the event.
+Kind `10013` indicates the user's preferred relays to store private events like Draft Wraps. 
+
+The event MUST include a list of `relay` URLs in private tags. Private tags are JSON Stringified, [NIP44-encrypted](44.md) to the signer's keys and placed inside the .content of the event.
 
 ```js
 {
   "kind": 10013,
   "tags": [],
-  "content": nip44Encrypt(JSON.stringify([
-    ["relay", "wss://myrelay.mydomain.com"]
-  ]))
+  "content": nip44Encrypt(
+    JSON.stringify(
+      [
+        ["relay", "wss://myrelay.mydomain.com"]
+      ]
+    )
+  )
   //...other fields
 }
 ```
 
-Relays listed in this event SHOULD be authed and only allow downloads to events signed by the authed user.
+It's recommended that Private Storage relays SHOULD be [NIP-42](42.md)-authed and only allow downloads of events signed by the authed user.
 
-Clients SHOULD publish kind `10013` events to the author's [NIP-65](65.md) `write` relays. 
+Clients MUST publish kind `10013` events to the author's [NIP-65](65.md) `write` relays. 


### PR DESCRIPTION
This improves the NIP in 4 ways: 

1. Drops support for anchor tags. It's too complicated to have drafts with whatever tags each other NIP uses to anchor things. It's also a massive privacy issue, and it doesn't really add much since they were optional in the past. Clients can just decrypt first and then anchor the draft from the tags found in the draft itself. 

2. There was confusion about which event should be called "Draft Event", the inner or the outer. I changed the text to call the outer event a Wrap and the inner the draft itself. 

3. Added guidance for where the wrap should be sent to and to add expiration tags. 

4. Other minor text improvements.