### PR TITLE
NIP-25: Add External Content Reactions

### DIFF
--- a/25.md
+++ b/25.md
@@ -45,10 +45,24 @@ func make_like_event(pubkey: String, privkey: String, liked: NostrEvent, hint: S
 }
 ```
 
-Reactions to a website
+External Content Reactions
 ---------------------
 
-If the target of the reaction is a website, the reaction MUST be a `kind 17` event and MUST include an `r` tag with the website's URL.
+If the target of a reaction is not a native nostr event, the reaction MUST be a `kind 17` event and MUST include either:
+
+- [NIP-73](73.md) external content `k` + `i` tags (preferred)
+- for websites, an `r` tag with the website's URL
+
+```jsonc
+{
+  "kind": 17,
+  "content": "+",
+  "tags": [
+    ["k", "podcast:guid"],
+    ["i", "podcast:guid:c1795fb3-33f9-5492-8987-19e3e377dd52", "https://fountain.fm/show/YQaBnDSYWpg8fTVRqmev"]
+  ],
+}
+```
 
 ```jsonc
 {
@@ -57,11 +71,10 @@ If the target of the reaction is a website, the reaction MUST be a `kind 17` eve
   "tags": [
     ["r", "https://example.com/"]
   ],
-  // other fields...
 }
 ```
 
-URLs SHOULD be [normalized](https://datatracker.ietf.org/doc/html/rfc3986#section-6), so that reactions to the same website are not omitted from queries.
+Website URLs SHOULD be [normalized](https://datatracker.ietf.org/doc/html/rfc3986#section-6), so that reactions to the same website are not omitted from queries.
 A fragment MAY be attached to the URL, to react to a section of the page.
 It should be noted that a URL with a fragment is not considered to be the same URL as the original.
 

--- a/25.md
+++ b/25.md
@@ -69,7 +69,9 @@ _Reacting to a podcast episode:_
   "content": "+",
   "tags": [
     ["k", "podcast:guid"],
-    ["i", "podcast:guid:c1795fb3-33f9-5492-8987-19e3e377dd52", "https://fountain.fm/show/YQaBnDSYWpg8fTVRqmev"]
+    ["i", "podcast:guid:917393e3-1b1e-5cef-ace4-edaa54e1f810", "https://fountain.fm/show/QRT0l2EfrKXNGDlRrmjL"],
+    ["k", "podcast:item:guid"],
+    ["i", "podcast:item:guid:PC20-229", "https://fountain.fm/show/DQqBg5sD3qFGMCZoSuLF"]
   ],
 }
 ```

--- a/25.md
+++ b/25.md
@@ -71,7 +71,7 @@ _Reacting to a podcast episode:_
     ["k", "podcast:guid"],
     ["i", "podcast:guid:917393e3-1b1e-5cef-ace4-edaa54e1f810", "https://fountain.fm/show/QRT0l2EfrKXNGDlRrmjL"],
     ["k", "podcast:item:guid"],
-    ["i", "podcast:item:guid:PC20-229", "https://fountain.fm/show/DQqBg5sD3qFGMCZoSuLF"]
+    ["i", "podcast:item:guid:PC20-229", "https://fountain.fm/episode/DQqBg5sD3qFGMCZoSuLF"]
   ],
 }
 ```

--- a/25.md
+++ b/25.md
@@ -48,11 +48,21 @@ func make_like_event(pubkey: String, privkey: String, liked: NostrEvent, hint: S
 External Content Reactions
 ---------------------
 
-If the target of a reaction is not a native nostr event, the reaction MUST be a `kind 17` event and MUST include either:
+If the target of a reaction is not a native nostr event, the reaction MUST be a `kind 17` event and MUST include [NIP-73](73.md) external content `k` + `i` tags to properly reference the content.
 
-- [NIP-73](73.md) external content `k` + `i` tags (preferred)
-- for websites, an `r` tag with the website's URL
+_Reacting to a website:_
+```jsonc
+{
+  "kind": 17,
+  "content": "⭐",
+  "tags": [
+    ["k", "web"],
+    ["i", "https://example.com"]
+  ],
+}
+```
 
+_Reacting to a podcast episode:_
 ```jsonc
 {
   "kind": 17,
@@ -64,19 +74,8 @@ If the target of a reaction is not a native nostr event, the reaction MUST be a 
 }
 ```
 
-```jsonc
-{
-  "kind": 17,
-  "content": "⭐",
-  "tags": [
-    ["r", "https://example.com/"]
-  ],
-}
-```
 
-Website URLs SHOULD be [normalized](https://datatracker.ietf.org/doc/html/rfc3986#section-6), so that reactions to the same website are not omitted from queries.
-A fragment MAY be attached to the URL, to react to a section of the page.
-It should be noted that a URL with a fragment is not considered to be the same URL as the original.
+
 
 Custom Emoji Reaction
 ---------------------


### PR DESCRIPTION
[NIP-25 Reactions](https://github.com/nostr-protocol/nips/blob/master/25.md) has long had a provision for reacting to websites by using a kind `17` event with an `r` tag to link to the website being reacted to.

This is great as it helps nostr bridge into the existing internet - providing a universal social layer with a social graph you can take to any website.

Since the original NIP-25 we have seen the introduction of [NIP-73](https://github.com/nostr-protocol/nips/blob/master/73.md) which outlines a more extensible method for tagging any external content such as podcasts, books, movies, geohashes, papers, and also urls.

This PR replaces the old `r` tags with NIP-73  `k` and `i` tags as a way of reacting to any external content.

Fountain recently added podcast episode likes using this approach - https://blog.fountain.fm/p/1-3