### PR TITLE
NIP-17: Expiration preferences

### DIFF
--- a/17.md
+++ b/17.md
@@ -139,6 +139,7 @@ Kind `10050` indicates the user's preferred relays to receive DMs. The event MUS
   "tags": [
     ["relay", "wss://inbox.nostr.wine"],
     ["relay", "wss://myrelay.nostr1.com"],
+    ["expiration_preference", "<seconds>"], // optional
   ],
   "content": "",
   // other fields...
@@ -146,6 +147,8 @@ Kind `10050` indicates the user's preferred relays to receive DMs. The event MUS
 ```
 
 Clients SHOULD publish kind `14` events to the `10050`-listed relays. If that is not found that indicates the user is not ready to receive messages under this NIP and clients shouldn't try.
+
+The tag `expiration_preference` indicates the user's preferred expiration delta in seconds. If present, gift wraps to each user MUST contain an `expiration` tag for their `<seconds>` in the future. 
 
 ## Relays
 


### PR DESCRIPTION
Trying to see if there is an appetite for formal disappearing messages in NIP-17. 

By adding a setting to the relay list event, each user can make their own chat disappear at a fixed schedule. If enough people implement this feature, it would delete sent and received messages together, avoiding the weird UX of my messages disappearing while other users' messages stay.

Each user can then have their own choice.

