### PR TITLE
NIP-89: Fix heading levels

### DIFF
--- a/89.md
+++ b/89.md
@@ -47,7 +47,7 @@ Multiple `a` tags can appear on the same `kind:31989`.
 The second value of the tag SHOULD be a relay hint.
 The third value of the tag SHOULD be the platform where this recommendation might apply.
 
-## Handler information
+### Handler information
 ```jsonc
 {
   "kind": 31990,
@@ -76,7 +76,7 @@ Multiple tags might be registered by the app, following NIP-19 nomenclature as t
 
 A tag without a second value in the array SHOULD be considered a generic handler for any NIP-19 entity that is not handled by a different tag.
 
-# Client tag
+## Client tag
 When publishing events, clients MAY include a `client` tag. Identifying the client that published the note. This tag is a tuple of `name`, `address` identifying a handler event and, a relay `hint` for finding the handler event. This has privacy implications for users, so clients SHOULD allow users to opt-out of using this tag.
 
 ```jsonc


### PR DESCRIPTION
Before:

* (h1) NIP-89
  * (h2) Recommended Application Handlers
  * (h2) Rationale
    * (h3) Parties involved
  * (h2) Events
    * (h3) Recommendation event
  * (h2) Handler information
* (h1) Client tag
  * (h2) User flow
  * (h2) Example
    * (h3) User A recommends a `kind:31337`-handler
    * (h3) User B interacts with a `kind:31337`-handler
    * (h3) Alternative query bypassing `kind:31989`

After:

* (h1) NIP-89
  * (h2) Recommended Application Handlers
  * (h2) Rationale
    * (h3) Parties involved
  * (h2) Events
    * (h3) Recommendation event
    * (h3) Handler information
  * (h2) Client tag
  * (h2) User flow
  * (h2) Example
    * (h3) User A recommends a `kind:31337`-handler
    * (h3) User B interacts with a `kind:31337`-handler
    * (h3) Alternative query bypassing `kind:31989`
