### PR TITLE
NIP-51: Updates lists to NIP-44, deprecates NIP-04

### DIFF
--- a/51.md
+++ b/51.md
@@ -8,7 +8,7 @@ Lists
 
 This NIP defines lists of things that users can create. Lists can contain references to anything, and these references can be **public** or **private**.
 
-Public items in a list are specified in the event `tags` array, while private items are specified in a JSON array that mimics the structure of the event `tags` array, but stringified and encrypted using the same scheme from [NIP-04](04.md) (the shared key is computed using the author's public and private key) and stored in the `.content`.
+Public items in a list are specified in the event `tags` array, while private items are specified in a JSON array that mimics the structure of the event `tags` array, but stringified and encrypted using the same scheme from [NIP-44](44.md) (the shared key is computed using the author's public and private key) and stored in the `.content`. An earlier version of this specification used [NIP-04](04.md) for encryptions. Those are now deprecated. For backward compatibility, Clients can automatically discover if the encryption is NIP-04 or NIP-44 by searching for "iv" in the ciphertext and decrypting accordingly.
 
 When new items are added to an existing list, clients SHOULD append them to the end of the list, so they are stored in chronological order.
 
@@ -165,6 +165,6 @@ val private_items = [
   ["p", "07caba282f76441955b695551c3c5c742e5b9202a3784780f8086fdcdc1da3a9"],
   ["a", "a55c15f5e41d5aebd236eca5e0142789c5385703f1a7485aa4b38d94fd18dcc4"],
 ]
-val base64blob = nip04.encrypt(json.encode_to_string(private_items))
+val base64blob = nip44.encrypt(json.encode_to_string(private_items))
 event.content = base64blob
 ```


### PR DESCRIPTION
It's about time. And some of these lists are already nip-44, so we'd better update this spec. 