### PR TITLE
NIP-47: mark "state" field as optional in make_invoice response for backward compatibility

### DIFF
--- a/47.md
+++ b/47.md
@@ -369,7 +369,7 @@ Response:
     "result_type": "lookup_invoice",
     "result": {
         "type": "incoming", // "incoming" for invoices, "outgoing" for payments
-        "state": "pending", // can be "pending", "settled", "expired" (for invoices) or "failed" (for payments)
+        "state": "pending", // can be "pending", "settled", "expired" (for invoices) or "failed" (for payments), optional
         "invoice": "string", // encoded invoice, optional
         "description": "string", // invoice's description, optional
         "description_hash": "string", // invoice's description hash, optional
@@ -418,7 +418,7 @@ Response:
         "transactions": [
             {
                "type": "incoming", // "incoming" for invoices, "outgoing" for payments
-               "state": "pending", // can be "pending", "settled", "expired" (for invoices) or "failed" (for payments)
+               "state": "pending", // can be "pending", "settled", "expired" (for invoices) or "failed" (for payments), optional
                "invoice": "string", // encoded invoice, optional
                "description": "string", // invoice's description, optional
                "description_hash": "string", // invoice's description hash, optional
@@ -495,7 +495,7 @@ Notification:
     "notification_type": "payment_received",
     "notification": {
         "type": "incoming",
-        "state": "settled",
+        "state": "settled", // optional
         "invoice": "string", // encoded invoice
         "description": "string", // invoice's description, optional
         "description_hash": "string", // invoice's description hash, optional
@@ -521,7 +521,7 @@ Notification:
     "notification_type": "payment_sent",
     "notification": {
         "type": "outgoing",
-        "state": "settled",
+        "state": "settled", // optional
         "invoice": "string", // encoded invoice
         "description": "string", // invoice's description, optional
         "description_hash": "string", // invoice's description hash, optional

--- a/47.md
+++ b/47.md
@@ -335,7 +335,7 @@ Response:
     "result_type": "make_invoice",
     "result": {
         "type": "incoming", // "incoming" for invoices, "outgoing" for payments
-        "state": "pending",
+        "state": "pending", // optional
         "invoice": "string", // encoded invoice, optional
         "description": "string", // invoice's description, optional
         "description_hash": "string", // invoice's description hash, optional


### PR DESCRIPTION
Libraries that implement the spec strictly and validate fields after https://github.com/nostr-protocol/nips/pull/1933 will lose backward compatibility, since the new field is not marked as `optional`.

This is contrary to the stated intention of making it backward compatibility in the PR:

> This change is backward-compatible and aims to improve UX for clients fetching payments.

This has already happened in https://github.com/rust-nostr/nostr/pull/1021 .

This PR simply adds `// optional` to the field so that libraries developers know they should not strictly require its presence.