### PR TITLE
Add NIP 51 list for tracking relays the user trusts to validate and strip signatures

### DIFF
--- a/51.md
+++ b/51.md
@@ -37,6 +37,7 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | Media follows     | 10020 | multimedia (photos, short video) follow list                | `"p"` (pubkeys -- with optional relay hint and petname)                                             |
 | Emojis            | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                                    |
 | DM relays         | 10050 | Where to receive [NIP-17](17.md) direct messages            | `"relay"` (see [NIP-17](17.md))                                                                     |
+| Trusted relays    | 10052 | Relays that the user trusts to validate event signatures. These relays MAY set event signatures to an empty string.    | `"relay"` (relay URLs)                                                                     |
 | Good wiki authors | 10101 | [NIP-54](54.md) user recommended wiki authors               | `"p"` (pubkeys)                                                                                     |
 | Good wiki relays  | 10102 | [NIP-54](54.md) relays deemed to only host useful articles  | `"relay"` (relay URLs)                                                                              |
 


### PR DESCRIPTION
The use case here is to provide members of [relays as groups](https://habla.news/u/hodlbod@coracle.social/1741286140797) with deniability, so if a mole exfiltrates group data it will at best be public, but unsigned (and therefore rejected by well-behaved relays). This isn't exactly private or secure, but can help reduce the blast radius for events leaked either accidentally or maliciously.

In terms of UX, I am adding middleware to flotilla which detects events missing a signature, buffers them, and notifies the user if the relay is "misbehaving" in this way, with the option to add the relay to their trusted relay list. If a relay is trusted, signature validation is bypassed and events are processed as usual.