### PR TITLE
NIP-11: fix default_limit

### DIFF
--- a/11.md
+++ b/11.md
@@ -162,7 +162,7 @@ a specific niche kind or content. Normal anti-spam heuristics, for example, do n
 
 - `created_at_upper_limit`: 'created_at' upper limit
 
-- `default_limit`: The maximum returned events if you send a filter with the limit set to 0.
+- `default_limit`: The maximum returned events if you send a filter without a `limit`.
 
 ### Event Retention
 


### PR DESCRIPTION
A limit set to 0 means the relay should not return any events according to NIP-01. This is a subtle but important mistake in NIP-11.