### PR TITLE
NIP-34: send patches and issues to repos not yet on Nostr

### DIFF
--- a/34.md
+++ b/34.md
@@ -19,13 +19,16 @@ Git repositories are hosted in Git-enabled servers, but their existence can be a
   "tags": [
     ["d", "<repo-id>"], // usually kebab-case short name
     ["name", "<human-readable project name>"],
-    ["description", "brief human-readable project description>"],
-    ["web", "<url for browsing>", ...], // a webpage url, if the git server being used provides such a thing
     ["clone", "<url for git-cloning>", ...], // a url to be given to `git clone` so anyone can clone it
     ["relays", "<relay-url>", ...], // relays that this repository will monitor for patches and issues
+
+    // optional
+    ["description", "brief human-readable project description>"],
+    ["web", "<url for browsing>", ...], // a webpage url, if the git server being used provides such a thing
     ["r", "<earliest-unique-commit-id>", "euc"],
     ["maintainers", "<other-recognized-maintainer>", ...],
     ["t", "<arbitrary string>"], // hashtags labelling the repository
+    ["retired-clone", "<url for git-cloning>", ...] // to continue the association with patches and issues sent to this repository via the `i` tag before this repo maintainer's moved it to nostr
   ]
 }
 ```
@@ -80,6 +83,8 @@ The first patch revision in a patch revision SHOULD include a [NIP-10](10.md) `e
   "content": "<patch>", // contents of <git format-patch>
   "tags": [
     ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"],
+    // alternatively, if repository state announcement doesnt exist yet use:
+    ["i", "https://github.com/bitoin/bitcoin.git"], // repository git clone url SHOULD use https formation with .git suffix but no trailing slash
     ["r", "<earliest-unique-commit-id-of-repo>"] // so clients can subscribe to all patches sent to a local git repo
     ["p", "<repository-owner>"],
     ["p", "<other-user>"], // optionally send the patch to another user to bring it to their attention
@@ -115,6 +120,8 @@ Issues may have a `subject` tag, which clients can utilize to display a header. 
   "content": "<markdown text>",
   "tags": [
     ["a", "30617:<base-repo-owner-pubkey>:<base-repo-id>"],
+    // alternatively, if repository isn't yey on nostr:
+    ["i", "https://github.com/bitoin/bitcoin.git"], // repository git clone url SHOULD use https formation with .git suffix but no trailing slash
     ["p", "<repository-owner>"]
     ["subject", "<issue-subject>"]
     ["t", "<issue-label>"]


### PR DESCRIPTION
Allow contributors to share patches and issues without requiring maintainers to first create a Nostr repository announcement.

Motivation:

- Aligns with the permissionless philosophy of Nostr.
- Provides a way to contribute when the author doesn't have — or can't create — an account on the centralized git platform chosen by maintainers.
- Allows contributors who want a repository moved to Nostr to:
  1. Demo it to maintainers using their own data and community.
  2. Build community support by encouraging other community members to comment on, review, and interact with the issues/patches and to create their own issues/patches.

Once this community support is achieved and demonstrated and the repo moves to Nostr, the first issues / patches shouldn't be disconnected or unavailable. The `retired-clone` tag is intended to make it easier for clients to find and display this content.