### PR TITLE
Fix weird list in NIP-99

### DIFF
--- a/99.md
+++ b/99.md
@@ -40,7 +40,7 @@ The following tags, used for structured metadata, are standardized and SHOULD be
   - `"<number>"` is the amount in numeric format (but included in the tag as a string)
   - `"<currency>"` is the currency unit in 3-character ISO 4217 format or ISO 4217-like currency code (e.g. `"btc"`, `"eth"`).
   - `"<frequency>"` is optional and can be used to describe recurring payments. SHOULD be in noun format (hour, day, week, month, year, etc.)
-- - `"status"` (optional), the status of the listing. SHOULD be either "active" or "sold".
+- `"status"` (optional), the status of the listing. SHOULD be either "active" or "sold".
 
 #### `price` examples
 


### PR DESCRIPTION
This confused me for a moment. I assume "status" should not be in the "price" tag, so I removed the extra bullet point.