### PR TITLE
Deprecates NIP-31 alts

### DIFF
--- a/31.md
+++ b/31.md
@@ -1,3 +1,5 @@
+> __Warning__  `unrecommended`: this NIP did not achieve the goal it was designed for
+
 NIP-31
 ======
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-28: Public Chat](28.md)
 - [NIP-29: Relay-based Groups](29.md)
 - [NIP-30: Custom Emoji](30.md)
-- [NIP-31: Dealing with Unknown Events](31.md)
+- [NIP-31: Dealing with Unknown Events](31.md) --- **unrecommended**: adds verbosity for little gain
 - [NIP-32: Labeling](32.md)
 - [NIP-34: `git` stuff](34.md)
 - [NIP-35: Torrents](35.md)
@@ -343,7 +343,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `y`               | platform                             | --                              | [69](69.md)                                        |
 | `z`               | order number                         | --                              | [69](69.md)                                        |
 | `-`               | --                                   | --                              | [70](70.md)                                        |
-| `alt`             | summary                              | --                              | [31](31.md)                                        |
+| `alt`             | summary                              | --                              | [31](31.md) (deprecated)                           |
 | `amount`          | millisatoshis, stringified           | --                              | [57](57.md)                                        |
 | `bolt11`          | `bolt11` invoice                     | --                              | [57](57.md)                                        |
 | `challenge`       | challenge string                     | --                              | [42](42.md)                                        |


### PR DESCRIPTION
Main reason: 
- Relying on the writing client to create a text that will look good in all types of receiving clients is the wrong solution. It's impossible to do a good job given the variety of clients today.

Other Reasons: 
1. Nobody is displaying this 
2. Current alts are generally not descriptive enough and don't really help the user.
3. Clients still need to allow users to easily open the event in a separate client (or njump) to see what it is about.
4. Alts have exposed private information (mostly metadata) before
5. It leads devs towards unsatisfactory levels of interoperability