### PR TITLE
docs: clarify NIP-47 zap request metadata

### DIFF
--- a/47.md
+++ b/47.md
@@ -635,9 +635,9 @@ Here are some properties that are recognized by some NWC clients:
   "nostr": {
     "pubkey": "string",
     "tags": [],
-    // ... 
-  }, // NIP-57 (Nostr Zaps)
-  "tlv_records": [ // tlv records, optional
+    // ... rest of zap request event
+  }, // NIP-57 Zap Request event (kind 9734)
+  "tlv_records": [
     {
       "type": 5482373484, // tlv type
       "value": "0123456789abcdef" // hex encoded tlv value


### PR DESCRIPTION
In https://github.com/nostr-protocol/nips/pull/2063 it was not 100% clear how the zap metadata should look - that it should be the full zap request.