### PR TITLE
Fix fundamentally incorrect assertions in NIP-66

### DIFF
--- a/66.md
+++ b/66.md
@@ -28,10 +28,8 @@ Other tags include:
 - `N` - NIPs supported by the relay
 - `R` - Keys corresponding to requirements per [NIP 11](https://github.com/nostr-protocol/nips/blob/master/11.md)'s `limitations` array, including `auth`, `writes`, `pow`, and `payment`. False values should be specified using a `!` prefix, for example `!auth`.
 - `t` - A topic associated with this relay
-- `k` - An event kind accepted by the relay
-- `!k` - An event kind not accepted by the relay
+- `k` - Accepted and unaccepted kinds (false values prepended by `!`) 
 - `g` - A [NIP-52](https://github.com/nostr-protocol/nips/blob/master/52.md) geohash
-- `l` - A language tag
 
 Tags with more than one value should be repeated, rather than putting all values in a single tag, for example `[["t", "cats"], ["t", "dogs"]]`, rather than `[["t", "cats", "dogs"]]`.
 


### PR DESCRIPTION
During the edit of NIP-66 by @staab, there were a number of particularly broken changes that were introduced. It was titled "Fix NIP-66" but it actually broke it. 

I brought this up, but was ignored (#1415). In the PR **not only I am the only person in the conversation who has implemented NIP-66, from every possibly angle, I am also the original author**. 

1. The modification `!k` as unaccepted kinds. This is incorrect and makes the key unindexable. The correct usage would be `['k', '!12345']`
2. The `l` tag is not part of NIP-66

The PR was merged without any rationale or considering any feedback. It was merged without consensus or approval by anyone who has implemented NIP-66.

There were other things removed that probably should not have been, namely methodology, but is less important. 