### PR TITLE
NIP-34: Multi-maintainer semantics + NIP-32 guidance for assignees/reviewers

### DIFF
--- a/34.md
+++ b/34.md
@@ -92,14 +92,11 @@ If maintainers disagree on the `"euc"` commit (`r` with `"euc"` marker), clients
 When `30617` fields differ (e.g., `web`, `clone`, `relays`, `description`):
 
 * Clients MAY show a **union** of values and highlight conflicts, or
-* Prefer values from a **primary** maintainer chosen by the user, or
 * Prefer values from the **most recent** `30617` among recognized maintainers.
 
 For `30618` conflicts:
 
 * If a ref advances in multiple `30618`s, clients MAY adopt **last-write-wins** (latest `created_at`) or show a **contested** badge until the user selects a maintainer.
-
-**Recommendation:** Maintainers SHOULD list themselves in `maintainers` and keep that list synchronized across their `30617`s to minimize ambiguity.
 
 ## Patches
 
@@ -235,7 +232,6 @@ Multiple `p` tags MAY be present; each applies to the role indicated by accompan
 
 * the issue/patch author, or
 * any recognized maintainer (per any valid `30617` for the same `(d,euc)`), or
-* a user granted such rights by project policy.
 
 **Conflict handling:** When multiple `1985` events modify the same role/label on the same target:
 
@@ -248,8 +244,6 @@ Multiple `p` tags MAY be present; each applies to the role indicated by accompan
 
 * chips for `priority/*`, `area/*`, etc.
 * “Assignees” and “Reviewers” lists derived from `("role", assignee|reviewer) + p`.
-
-**Persistence:** Because NIP-32 labels are independent events, assignments and tags survive edits to the underlying `1621`/`1617` content and are easily auditable.
 
 ## Possible things to be added later
 


### PR DESCRIPTION
## Summary

This PR updates NIP-34 in two focused ways:

1. **Multi-maintainer repositories:**
   Clarifies that each maintainer publishes their own `30617` (repository announcement) **and** `30618` (state) events. Specifies that clients should:

   * De-duplicate by `(d, euc)` (same repo id + earliest unique commit).
   * Surface per-maintainer metadata when fields conflict (no single canonical source is mandated by the spec).
   * Treat multiple maintainers as parallel, valid views of the same repo identity.

2. **NIP-32 integration (labels) for workflow metadata:**
   Adds concise guidance for using **NIP-32** labels (`kind:1985`) to model:

   * **Assignees** on issues (`kind:1621`)
   * **Reviewers** on patches (`kind:1617`)
     without introducing new kinds. Includes example tags and recommended label namespaces.

## Motivation

* Multi-maintainer repos are already common; clients needed a minimal, interoperable rule-set to reconcile multiple `30617/30618` streams.
* Assigning people and designating reviewers is widely requested; NIP-32 labels provide a simple, backwards-compatible mechanism.

## What changed (spec-only)

* Added a short subsection defining per-maintainer `30617/30618` expectations and client behavior for conflicts.
* Added a short subsection showing how to apply NIP-32 labels for **assignees** and **reviewers** (example tag patterns and suggested label namespacing).

## Backwards compatibility

* **No breaking changes.** These are clarifications and optional usage guidance aligning with existing practices.
