### PR TITLE
NIP-71: Add addressable video events (kinds 32221, 32222)

### DIFF
--- a/29.md
+++ b/29.md
@@ -20,7 +20,7 @@ Relays are supposed to generate the events that describe group metadata and grou
 
 ## Group identifier
 
-A group may be identified by a string in the format `<host>'<group-id>`. For example, a group with _id_ `abcdef` hosted at the relay `wss://groups.nostr.com` would be identified by the string `groups.nostr.com'abcdef`.
+A group must be identified by a string in the format `<host>'<group-id>`. For example, a group with _id_ `abcdef` hosted at the relay `wss://groups.nostr.com` would be identified by the string `groups.nostr.com'abcdef`.
 
 Group identifiers must be strings restricted to the characters `a-z0-9-_`, and SHOULD be random in order to avoid name collisions.
 
@@ -29,6 +29,10 @@ When encountering just the `<host>` without the `'<group-id>`, clients MAY infer
 ## The `h` tag
 
 Events sent by users to groups (chat messages, text notes, moderation events etc) MUST have an `h` tag with the value set to the group _id_.
+
+## Protected events
+
+Events sent to a group MAY include the [NIP-70](70.md) `-` tag to mark them as protected events. This ensures that group messages can only be published to the intended relay by their original authors, preventing unauthorized republishing to other relays and maintaining the integrity of group discussions within their designated relay. This provides an alternative or additional method to timeline references for keeping group messages from being taken out of context.
 
 ## Timeline references
 
@@ -154,13 +158,14 @@ When this event is not found, clients may still connect to the group, but treat 
     ["picture", "https://pizza.com/pizza.png"],
     ["about", "a group for people who love pizza"],
     ["public"], // or ["private"]
-    ["open"] // or ["closed"]
+    ["open"], // or ["closed"]
+    ["original_relay", "wss://original.relay.com"] // optional: original relay where group was created
   ]
   // other fields...
 }
 ```
 
-`name`, `picture` and `about` are basic metadata for the group for display purposes. `public` signals the group can be _read_ by anyone, while `private` signals that only AUTHed users can read. `open` signals that anyone can request to join and the request will be automatically granted, while `closed` signals that members must be pre-approved or that requests to join will be manually handled.
+`name`, `picture` and `about` are basic metadata for the group for display purposes. `public` signals the group can be _read_ by anyone, while `private` signals that only AUTHed users can read. `open` signals that anyone can request to join and the request will be automatically granted, while `closed` signals that members must be pre-approved or that requests to join will be manually handled. `original_relay` (optional) indicates the relay where the group was originally created, allowing clients to track the group's origin even when it has been forked to other relays.
 
 - *group admins* (`kind:39001`) (optional)
 

--- a/71.md
+++ b/71.md
@@ -24,8 +24,8 @@ The format uses a _regular event_ kind `21` for _normal_ videos and `22` for _sh
 
 For content that may need updates after publication (such as correcting metadata, descriptions, or handling URL migrations), addressable versions are available:
 
-- Kind `32221` for _addressable normal videos_
-- Kind `32222` for _addressable short videos_
+- Kind `34235` for _addressable normal videos_
+- Kind `34236` for _addressable short videos_
 
 These addressable events follow the same format as their regular counterparts but include a `d` tag as a unique identifier and can be updated while maintaining the same addressable reference. This is particularly useful for:
 
@@ -86,7 +86,7 @@ The `image` tag contains a preview image (at the same resolution). Multiple `ima
 Additionally `service nip96` may be included to allow clients to search the authors NIP-96 server list to find the file using the hash.
 
 ### Required tags for addressable events:
-* `d` - Unique identifier for this video (user-chosen string, required for kinds 32221, 32222)
+* `d` - Unique identifier for this video (user-chosen string, required for kinds 34235, 34236)
 
 ### Other tags:
 * `title` (required) title of the video
@@ -155,7 +155,7 @@ Additionally `service nip96` may be included to allow clients to search the auth
   "id": <32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>,
   "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>,
   "created_at": <Unix timestamp in seconds>,
-  "kind": 32221 | 32222,
+  "kind": 34235 | 34236,
   "content": "<summary / description of video>",
   "tags": [
     ["d", "<unique-identifier>"],
@@ -197,6 +197,6 @@ Additionally `service nip96` may be included to allow clients to search the auth
 To reference an addressable video:
 
 ```
-["a", "32221:<pubkey>:<d-tag-value>", "<relay-url>"]  // for normal videos
-["a", "32222:<pubkey>:<d-tag-value>", "<relay-url>"]  // for short videos
+["a", "34235:<pubkey>:<d-tag-value>", "<relay-url>"]  // for normal videos
+["a", "34236:<pubkey>:<d-tag-value>", "<relay-url>"]  // for short videos
 ```

--- a/71.md
+++ b/71.md
@@ -20,6 +20,20 @@ Nothing except cavaliership and common sense prevents a _short_ video from being
 
 The format uses a _regular event_ kind `21` for _normal_ videos and `22` for _short_ videos.
 
+## Addressable Video Events
+
+For content that may need updates after publication (such as correcting metadata, descriptions, or handling URL migrations), addressable versions are available:
+
+- Kind `32221` for _addressable normal videos_
+- Kind `32222` for _addressable short videos_
+
+These addressable events follow the same format as their regular counterparts but include a `d` tag as a unique identifier and can be updated while maintaining the same addressable reference. This is particularly useful for:
+
+- Metadata corrections (descriptions, titles, tags) without republishing
+- Preservation of imported content IDs from legacy platforms
+- URL migration when hosting changes
+- Platform migration tracking
+
 The `.content` of these events is a summary or description on the video content.
 
 The primary source of video information is the `imeta` tags which is defined in [NIP-92](92.md)
@@ -71,6 +85,9 @@ The `image` tag contains a preview image (at the same resolution). Multiple `ima
 
 Additionally `service nip96` may be included to allow clients to search the authors NIP-96 server list to find the file using the hash.
 
+### Required tags for addressable events:
+* `d` - Unique identifier for this video (user-chosen string, required for kinds 32221, 32222)
+
 ### Other tags:
 * `title` (required) title of the video
 * `published_at`, for the timestamp in unix seconds (stringified) of the first time the video was published
@@ -82,6 +99,9 @@ Additionally `service nip96` may be included to allow clients to search the auth
 * `t` (optional, repeated) hashtag to categorize video
 * `p` (optional, repeated) 32-bytes hex pubkey of a participant in the video, optional recommended relay URL
 * `r` (optional, repeated) references / links to web pages
+
+### Optional tags for imported content:
+* `origin` - Track original platform and ID: `["origin", "<platform>", "<external-id>", "<original-url>", "<optional-metadata>"]`
 
 ```jsonc
 {
@@ -126,4 +146,57 @@ Additionally `service nip96` may be included to allow clients to search the auth
     ["r", "<url>"]
   ]
 }
+```
+
+## Addressable Event Example
+
+```jsonc
+{
+  "id": <32-bytes lowercase hex-encoded SHA-256 of the the serialized event data>,
+  "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>,
+  "created_at": <Unix timestamp in seconds>,
+  "kind": 32221 | 32222,
+  "content": "<summary / description of video>",
+  "tags": [
+    ["d", "<unique-identifier>"],
+    ["title", "<title of video>"],
+    ["published_at", "<unix timestamp>"],
+    ["alt", "<description for accessibility>"],
+
+    // video data
+    ["imeta",
+      "url https://example.com/media.mp4",
+      "m video/mp4",
+      "dim 480x480",
+      "blurhash eVF$^OI:${M{%LRjWBoLoLaeR*",
+      "image https://example.com/thumb.jpg",
+      "x 3093509d1e0bc604ff60cb9286f4cd7c781553bc8991937befaacfdc28ec5cdc"
+    ],
+
+    ["duration", <duration in seconds>],
+    ["content-warning", "<reason>"],
+
+    // origin tracking for imported content
+    ["origin", "<platform>", "<external-id>", "<original-url>", "<optional-metadata>"],
+
+    // participants
+    ["p", "<32-bytes hex of a pubkey>", "<optional recommended relay URL>"],
+
+    // hashtags
+    ["t", "<tag>"],
+    ["t", "<tag>"],
+
+    // reference links
+    ["r", "<url>"]
+  ]
+}
+```
+
+## Referencing Addressable Events
+
+To reference an addressable video:
+
+```
+["a", "32221:<pubkey>:<d-tag-value>", "<relay-url>"]  // for normal videos
+["a", "32222:<pubkey>:<d-tag-value>", "<relay-url>"]  // for short videos
 ```

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `31925`       | Calendar Event RSVP             | [52](52.md)                            |
 | `31989`       | Handler recommendation          | [89](89.md)                            |
 | `31990`       | Handler information             | [89](89.md)                            |                         |
+| `32221`       | Addressable Video Event         | [71](71.md)                            |
+| `32222`       | Addressable Short Video Event   | [71](71.md)                            |
 | `32267`       | Software Application            |                                        |                        |
 | `34550`       | Community Definition            | [72](72.md)                            |
 | `38383`       | Peer-to-peer Order events       | [69](69.md)                            |

--- a/README.md
+++ b/README.md
@@ -248,9 +248,9 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `31925`       | Calendar Event RSVP             | [52](52.md)                            |
 | `31989`       | Handler recommendation          | [89](89.md)                            |
 | `31990`       | Handler information             | [89](89.md)                            |                         |
-| `32221`       | Addressable Video Event         | [71](71.md)                            |
-| `32222`       | Addressable Short Video Event   | [71](71.md)                            |
 | `32267`       | Software Application            |                                        |                        |
+| `34235`       | Addressable Video Event         | [71](71.md)                            |
+| `34236`       | Addressable Short Video Event   | [71](71.md)                            |
 | `34550`       | Community Definition            | [72](72.md)                            |
 | `38383`       | Peer-to-peer Order events       | [69](69.md)                            |
 | `39000-9`     | Group metadata events           | [29](29.md)                            |


### PR DESCRIPTION
## Summary
- Extends NIP-71 to support addressable video events for content that may need updates after publication
- Adds kinds 34235 (normal videos) and 34236 (short videos) 
- Enables metadata corrections, URL migration, and preservation of imported content IDs from legacy platforms

## Rough Consensus & Running Code.

These nostr kinds are used in the new short form video app: 
 - https://github.com/rabble/nostrvine
 - https://github.com/rabble/divine_media_server
 - https://github.com/rabble/divine-web

## Test plan
- [x] Updated NIP-71 with new addressable event kinds and format
- [x] Added required 'd' tag documentation for unique identification
- [x] Added optional 'origin' tag for tracking imported content
- [x] Updated README with new event kinds
- [x] Validated JSON examples and referencing format