### PR TITLE
relay tags in nip-60 on 17375 instead of 10019

### DIFF
--- a/51.md
+++ b/51.md
@@ -32,6 +32,7 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | Blocked relays    | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                                              |
 | Search relays     | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                                              |
 | Simple groups     | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group id + relay URL + optional group name), `"r"` for each relay in use |
+| Wallet relays     | 17375 | relays for [NIP-60](60.md) wallet operations                | `"relay"` (relay URLs) - stored in the wallet event itself, see [NIP-60](60.md)                     |
 | Relay feeds       | 10012 | user favorite browsable relays (and relay sets)             | `"relay"` (relay URLs) and `"a"` (kind:30002 relay set)                                             |
 | Interests         | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a"` (kind:30015 interest set)                                                |
 | Media follows     | 10020 | multimedia (photos, short video) follow list                | `"p"` (pubkeys -- with optional relay hint and petname)                                             |

--- a/60.md
+++ b/60.md
@@ -30,7 +30,10 @@ This NIP doesn't deal with users' *receiving* money from someone else, it's just
         [ "mint", "https://mint1" ],
         [ "mint", "https://mint2" ]
     ]),
-    "tags": []
+    "tags": [
+        [ "relay", "wss://relay1.example.com" ],
+        [ "relay", "wss://relay2.example.com" ]
+    ]
 }
 ```
 
@@ -39,6 +42,7 @@ The wallet event is an replaceable event `kind:17375`.
 Tags:
 * `mint` - Mint(s) this wallet uses -- there MUST be one or more mint tags.
 * `privkey` - Private key used to unlock P2PK ecash. MUST be stored encrypted in the `.content` field. **This is a different private key exclusively used for the wallet, not associated in any way to the user's Nostr private key** -- This is only used for receiving [NIP-61](61.md) nutzaps.
+* `relay` - Relay(s) where the wallet's events (`kind:7374`, `kind:7375`, `kind:7376`) are published to and queried from. Clients MUST use these relays for all wallet operations. If no `relay` tags are present, clients SHOULD fall back to the user's [NIP-65](65.md) relay list.
 
 ### Token Event
 Token events are used to record unspent proofs.
@@ -104,10 +108,14 @@ All tags can be [NIP-44](44.md) encrypted. Clients SHOULD leave `e` tags with a 
 Multiple `e` tags can be added, and should be encrypted, except for tags with the `redeemed` marker.
 
 ## Flow
-A client that wants to check for user's wallets information starts by fetching `kind:10019` events from the user's relays, if no event is found, it should fall back to using the user's [NIP-65](65.md) relays.
+A client that wants to check for user's wallet information:
+
+1. Fetches the user's `kind:17375` wallet event from the user's [NIP-65](65.md) relays (or any known relays)
+2. Reads the `relay` tags from the wallet event to determine which relays to use for wallet operations
+3. If no `relay` tags are present, falls back to using the user's [NIP-65](65.md) relay list
 
 ### Fetch wallet and token list
-From those relays, the client should fetch wallet and token events.
+Using the relays from the wallet event's `relay` tags (or NIP-65 relays if not specified), the client should fetch wallet and token events:
 
 `"kinds": [17375, 7375], "authors": ["<my-pubkey>"]`
 


### PR DESCRIPTION
Moving the authoritative `relay` were wallet events (`kind:737{4,5,6}`) are to be found.

Recently we had changed this to be in 10019 but on closer inspection this doesn't make much sense, relays in 10019 is essentially like the nutzaps inbox whereas relays in `kind:17375` are for the user's own sake. For example, a user might use ws://localhost:8888 to store their tokens events.