### PR TITLE
link to AsciiDoc spec

### DIFF
--- a/54.md
+++ b/54.md
@@ -28,7 +28,7 @@ Articles are identified by lowercase, normalized ascii `d` tags.
 
 ## Content
 
-The `content` should be Asciidoc with two extra functionalities: **wikilinks** and **nostr:...** links.
+The `content` should be [https://docs.asciidoctor.org/asciidoc/latest/](Asciidoc) with two extra functionalities: **wikilinks** and **nostr:...** links.
 
 Unlike normal Asciidoc links `http://example.com[]` that link to external webpages, wikilinks `[[]]` link to other articles in the wiki. In this case, the wiki is the entirety of Nostr. Clicking on a wikilink should cause the client to ask relays for events with `d` tags equal to the target of that wikilink.
 


### PR DESCRIPTION
[AsciiDoctor](https://asciidoctor.org/) hosts the official spec of AsciiDoc

For proof of endorsement by the original AsciiDoc, please note:

https://asciidoc.org/

The "Quick Reference" button opens the links to the AsciiDoctor spec, which is the link I used.

Note the URL in the bottom-left as shown by the house hover over the Quick Reference button.

<img width="920" height="732" alt="Screenshot 2025-10-08 at 8 48 32 AM" src="https://github.com/user-attachments/assets/e60cc2b2-41b7-47f4-bcda-47e2ff218148" />
