### PR TITLE
[NIP 55] -  Instructions on how to use the get_public_key method with content resolver

### DIFF
--- a/55.md
+++ b/55.md
@@ -295,6 +295,8 @@ For the other types Signer Application returns the column "result"
 
 If the user chose to always reject the event, signer application will return the column "rejected" and you should not open signer application
 
+Clients SHOULD save the user pubkey locally and avoid calling the `get_public_key` after the user is logged in to the Client
+
 #### Methods
 
 - **get_public_key**
@@ -303,7 +305,7 @@ If the user chose to always reject the event, signer application will return the
     ```kotlin
     val result = context.contentResolver.query(
         Uri.parse("content://com.example.signer.GET_PUBLIC_KEY"),
-        listOf("login"),
+        listOf(hex_pub_key),
         null,
         null,
         null


### PR DESCRIPTION
Added this instruction to fix a issue signer may have when the user has multiple keys logged into the same client

See https://github.com/coracle-social/flotilla/issues/205

cc @staab 