### PR TITLE
Enhance metadata/timestamp protection guidance in NIP-59

### DIFF
--- a/59.md
+++ b/59.md
@@ -97,6 +97,9 @@ To protect recipient metadata, relays SHOULD only serve `kind 1059` events inten
 When possible, clients should only send wrapped events to `read` relays for the recipient that implement
 AUTH, and refuse to serve wrapped events to non-recipients.
 
+When adding expiration tags to both `seal` and `gift wrap` layers, implementations SHOULD use independent random timestamps for each layer. Using different `created_at` values increases timing variance and helps protect against metadata correlation attacks.
+
+
 ## An Example
 
 Let's send a wrapped `kind 1` message between two parties asking "Are you going to the party tonight?"


### PR DESCRIPTION
Per discussion with @vitorpamplona , added guidance on using independent random timestamps for expiration tags to enhance metadata protection. 