### PR TITLE
NIP-17: Clarify client event publishing instructions

### DIFF
--- a/17.md
+++ b/17.md
@@ -145,7 +145,7 @@ Kind `10050` indicates the user's preferred relays to receive DMs. The event MUS
 }
 ```
 
-Clients SHOULD publish kind `14` events to the `10050`-listed relays. If that is not found that indicates the user is not ready to receive messages under this NIP and clients shouldn't try.
+Clients SHOULD publish the gift-wrapped kind 1059 events that contain the sealed kind 14 (text) or kind 15 (file) rumors to the relays listed in the recipient’s kind 10050 event. If that is not found that indicates the user is not ready to receive messages under this NIP and clients shouldn't try.
 
 ## Relays
 


### PR DESCRIPTION
 Clarify that clients must relay DM traffic by sending **gift-wrapped** kind 1059 events (covering both text and file rumors) to the recipient’s kind 10050 relays.

Priot text could be misinterpreted to read as encouraging publishing of raw kind 14 notes.