### PR TITLE
NIP-99: add explicit callout for d and a tags/replaceable events

### DIFF
--- a/99.md
+++ b/99.md
@@ -6,7 +6,7 @@ Classified Listings
 
 `draft` `optional`
 
-This NIP defines `kind:30402`: an addressable event to describe classified listings that list any arbitrary product, service, or other thing for sale or offer and includes enough structured metadata to make them useful.
+This NIP defines listings that list any arbitrary product, service, or other thing for sale or offer and includes enough structured metadata to make them useful. Because these listings are addressable events as defined in [NIP-01 Kinds](https://github.com/nostr-protocol/nips/blob/master/01.md), each event MUST include exactly one `["d", "<stable unique identifier>"]` tag. The identifier SHOULD remain stable across revisions so relays and clients can fetch or replace the listing via `a`-tag lookups; implementers MAY derive it from a deterministic slug (for example, `<slugified-title>-<pubkey>`) or persist a generated random string if no natural slug exists.`
 
 The specification supports a broad range of use cases physical goods, services, work opportunities, rentals, free giveaways, personals, etc. To promote interoperability between clients implementing NIP-99 for e-commerce, you can find the extension proposal [here](https://github.com/GammaMarkets/market-spec/blob/main/spec.md) which standardizes the e-commerce use case while maintaining the specification's lightweight and flexible nature. While [NIP-15](15.md) provides a strictly structured marketplace specification, NIP-99 has emerged as a simpler and more flexible alternative.
 
@@ -41,6 +41,8 @@ The following tags, used for structured metadata, are standardized and SHOULD be
   - `"<currency>"` is the currency unit in 3-character ISO 4217 format or ISO 4217-like currency code (e.g. `"btc"`, `"eth"`).
   - `"<frequency>"` is optional and can be used to describe recurring payments. SHOULD be in noun format (hour, day, week, month, year, etc.)
 - `"status"` (optional), the status of the listing. SHOULD be either "active" or "sold".
+
+Clients that publish related events (for example, offers, inquiries, or receipts) SHOULD reference the listing with an ["a", "<kind>:<pubkey>:<d>"] tag, using the listing’s kind, pubkey, and mandatory d tag value described above. This keeps downstream lookups aligned with the [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) addressable-event convention.
 
 #### `price` examples
 


### PR DESCRIPTION
- Added an explicit requirement for the mandatory ["d", …] tag so kind:30402 listings actually behave as NIP-01 addressable events and can be fetched or replaced reliably across relays.
  - Documented how related events should reference listings via the ["a","<kind>:<pubkey>:<d>"] tag to keep cross-event linking interoperable.