### PR TITLE
New spec in NIP 73 for referencing arbitrary NIP specifications

### DIFF
--- a/73.md
+++ b/73.md
@@ -46,14 +46,21 @@ For the webpage "https://myblog.example.com/post/2012-03-27/hello-world" the "i"
 
 ### Nostr NIPS
 
-Allow 'all of nostr' to reference, comment, and react on any published NIP spec in a standardized manner, regardless of which repo or nostr event kind they are posted to. The `i` tag value SHOULD be in a standard format matching `a` tags, as specified in NIP-01. 
+Allow 'all of nostr' to reference, comment, and react on any published NIP spec in a standardized manner, regardless of which repo or nostr event kind they are posted to. The first argument of the `i` tag SHOULD be in a standard format matching `a` tags, as specified in NIP-01. Other arguments are optional.
+
+#### First argument
 
 - If referencing a published Nostr event that contains a NIP proposal, the format SHOULD be`<kind integer>:<32-bytes lowercase hex of a pubkey>:<d tag value>`.
 - If referencing a NIP proposal file in an online repository, the format SHOULD be `<repo-domain>:<repo-owner>/<repo-name>:<NIP-identifier>`, using the following standards :
   - [URI hostname](https://en.wikipedia.org/wiki/Hostname#Syntax) syntax for `<repo-domain>`
   - [URI encoded](https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_in_a_URI) syntax for `<repo-owner>` and `<repo-name>`
   - [URL slug](https://en.wikipedia.org/wiki/Clean_URL#Slug) syntax for `<NIP-identifier>`
-- The `i` tag value MAY be a single finalized NIP number, but this use is deprecated. A URL hint MAY be added at end of the `i` tag, to suggest a web page without hard linking the reference to a specific repo or nostr client. 
+- The value MAY be a single finalized NIP number, but this use is deprecated.
+
+#### Other arguments
+
+- A URL hint MAY be added as the second argumant of the `i` tag, to suggest a web page without hard linking the reference to a specific repo or nostr client.
+- A `rel` string MAY be added as the third argument of the `i` tag, to designate this referenced NIP as being `upstream`, `preferred`, `alternate`, `deprecated`, `suggested`, `related`, or having some other relationship to the current event. (usefull when forking or commenting about NIP events) 
 
 
 A reference to a NIP published in the GitHub "primary" NIPs repo SHOULD look like this:
@@ -62,12 +69,12 @@ A reference to a NIP published in the GitHub "primary" NIPs repo SHOULD look lik
 // preferred format matches `a` tag
 // <repo-domain>:<repo-owner>/<repo-name>:<NIP-identifier>
 [
-  ["i", "github.com:nostr-protocol/nips:25", "https://github.com/nostr-protocol/nips/blob/master/25.md"],
+  ["i", "github.com:nostr-protocol/nips:73", "https://github.com/nostr-protocol/nips/blob/master/73.md", "upstream"],
   ["k", "nip"]
 ]
 // deprecated format matches arbitrary NIP number
 [
-  ["i", "25", "https://github.com/nostr-protocol/nips/blob/master/25.md"],
+  ["i", "73", "https://github.com/nostr-protocol/nips/blob/master/73.md"],
   ["k", "nip"]
 ]
 ```
@@ -78,7 +85,7 @@ A reference to a NIP published as kind `30817` to NostrHub SHOULD look like this
 // format matches `a` tag
 // <kind integer>:<32-bytes lowercase hex of a pubkey>:<d tag value>
 [
-  ["i", "30817:0461fcbecc4c3374439932d6b8f11269ccdb7cc973ad7a50ae362db135a474dd:nips-on-nostr", "https://nostrhub.io/naddr1qvzqqqrcvypzqprpljlvcnpnw3pejvkkhrc3y6wvmd7vjuad0fg2ud3dky66gaxaqqxku6tswvkk7m3ddehhxarjqk4nmy"],
+  ["i", "30817:0461fcbecc4c3374439932d6b8f11269ccdb7cc973ad7a50ae362db135a474dd:nips-on-nostr", "https://nostrhub.io/naddr1qvzqqqrcvypzqprpljlvcnpnw3pejvkkhrc3y6wvmd7vjuad0fg2ud3dky66gaxaqqxku6tswvkk7m3ddehhxarjqk4nmy", "related"],
   ["k", "nip"]
 ]
 ```
@@ -178,3 +185,12 @@ Each `i` tag MAY have a url hint as the second argument to redirect people to a 
 `["i", "podcast:item:guid:d98d189b-dc7b-45b1-8720-d4b98690f31f", https://fountain.fm/episode/z1y9TMQRuqXl2awyrQxg]`
 
 `["i", "isan:0000-0000-401A-0000-7", https://www.imdb.com/title/tt0120737]`
+
+
+
+--- 
+
+### Optional `rel` string
+
+Each `i` tag MAY have a `rel` string added as the third argument (or second argument for Webpage tags) to suggest a [relationship](https://www.w3schools.com/TAGS/att_a_rel.asp) between the current event and the external content. This may be any string in [URL slug](https://en.wikipedia.org/wiki/Clean_URL#Slug) syntax.
+


### PR DESCRIPTION
Allows 'all of nostr' to reference, comment, and react on any published NIP spec in a standardized manner, regardless of which repo or nostr event kind they are posted to.