### PR TITLE
NIP-61: optional k tag in kind:10019 events for reverse lookups

### DIFF
--- a/61.md
+++ b/61.md
@@ -29,7 +29,8 @@ Alice wants to nutzap 1 sat to Bob because of an event `event-id-1` she liked.
         [ "relay", "wss://relay2" ],
         [ "mint", "https://mint1", "usd", "sat" ],
         [ "mint", "https://mint2", "sat" ],
-        [ "pubkey", "<p2pk-pubkey>" ]
+        [ "pubkey", "<hex-pubkey>" ],
+        [ "k", "<hex-pubkey>" ]
     ]
 }
 ```
@@ -37,7 +38,11 @@ Alice wants to nutzap 1 sat to Bob because of an event `event-id-1` she liked.
 * `kind:10019` is an event that is useful for others to know how to send money to the user.
 * `relay`: relays where the user will be reading token events from. If a user wants to send money to the user, they should write to these relays.
 * `mint`: mints the user is explicitly agreeing to use to receive funds on. Clients SHOULD not send money on mints not listed here or risk burning their money. Additional markers can be used to list the supported base units of the mint.
-* `pubkey`: Public key that MUST be used to P2PK-lock receiving nutzaps -- implementations MUST NOT use the target user's main Nostr public key. This public key corresponds to the `privkey` field encrypted in a user's [nip-60](60.md) _wallet event_.
+* `pubkey`: Nostr public key that MUST be used to P2PK-lock receiving nutzaps -- implementations MUST NOT use the target user's main Nostr public key. This public key corresponds to the `privkey` field encrypted in a user's [nip-60](60.md) _wallet event_.
+* `k`: Optional. If the user wishes to allow easy reverse lookup of their Nostr identity using their P2PK-lock `pubkey`, they can add it again here. Clients can then REQ, filtering with `#k` to find the owner of a P2PK pubkey.
+
+> [!NOTE]
+> The `pubkey` and `k` tags are Nostr hex-format public keys (32-byte, x-coordinate only).
 
 ## Nutzap event
 Event `kind:9321` is a nutzap event published by the sender, p-tagging the recipient. The outputs are P2PK-locked to the public key the recipient indicated in their `kind:10019` event.


### PR DESCRIPTION
NIP-61 specifies that Cashu tokens should be locked to the NIP-61 pubkey by preference.

If a Nostr user wishes to allow easy reverse lookup of their Nostr identity using their NIP-61 P2PK-lock `pubkey`, they can add it again here. Clients can then REQ, filtering with `#k` to find the owner of a P2PK pubkey.

Implementations using the NIP-61 kind:10019 "`k`" filter tag:

- [x] **[Cashu Witness](https://www.nostrly.com/cashu-witness/)** - to  reverse lookup Nostr Identity given NIP-61 pubkey
- [x] **[Cashu Redeem](https://www.nostrly.com/cashu-redeem/)**  - to  reverse lookup Nostr Identity given NIP-61 pubkey
- [x] **[Cashu NutLock](https://www.nostrly.com/cashu-nutlock/)**  - to  reverse lookup Nostr Identity given NIP-61 pubkey
- [x] **[Cashu Cache](https://www.nostrly.com/cashu-cache/)**  - when creating the NutZap kind:10019 event
