### PR TITLE
Clarify closed/private, add hidden to nip 29

### DIFF
--- a/29.md
+++ b/29.md
@@ -83,7 +83,7 @@ Any user can send a kind `9021` event to the relay in order to request admission
 }
 ```
 
-The optional `code` tag may be used by the relay to preauthorize acceptances in `closed` groups, together with the `kind:9009` `create-invite` moderation event.
+The optional `code` tag may be used by the relay to preauthorize acceptance, together with the `kind:9009` `create-invite` moderation event.
 
 - *leave request* (`kind:9022`)
 
@@ -235,7 +235,7 @@ The latest of either `kind:9000` or `kind:9001` events present in a group should
 
 ### Adding yourself to a group
 
-When a group is `open`, anyone can send a `kind:9021` event to it in order to be added, then expect a `kind:9000` event to be emitted confirming that the user was added. The same happens with `closed` groups, except in that case a user may only send a `kind:9021` if it has an invite code.
+Anyone can send a `kind:9021` join request to a group. The relay may then generate a `kind:9000` event immediately, or defer that decision to an administator. If a group is `closed`, join requests are not honored unless they include an invite code.
 
 ### Storing your list of groups
 


### PR DESCRIPTION
This PR:

- Redefines `closed` to mean "unable to write". This is not backwards compatible, but IMO the old behavior doesn't make any sense and supports no use cases, while read-only groups is a real use case. I have the feeling that this was intended all along, but correct me if I'm wrong and I can add a new tag instead.
- Adds `hidden` groups. Relays should not serve metadata or members events to non-members.

@fiatjaf @verbiricha 