### PR TITLE
Clarifications to NIP-61

### DIFF
--- a/61.md
+++ b/61.md
@@ -29,7 +29,7 @@ Alice wants to nutzap 1 sat to Bob because of an event `event-id-1` she liked.
         [ "relay", "wss://relay2" ],
         [ "mint", "https://mint1", "usd", "sat" ],
         [ "mint", "https://mint2", "sat" ],
-        [ "pubkey", "<p2pk-pubkey>" ]
+        [ "pubkey", "<hex-pubkey>" ]
     ]
 }
 ```
@@ -37,12 +37,14 @@ Alice wants to nutzap 1 sat to Bob because of an event `event-id-1` she liked.
 * `kind:10019` is an event that is useful for others to know how to send money to the user.
 * `relay`: relays where the user will be reading token events from. If a user wants to send money to the user, they should write to these relays.
 * `mint`: mints the user is explicitly agreeing to use to receive funds on. Clients SHOULD not send money on mints not listed here or risk burning their money. Additional markers can be used to list the supported base units of the mint.
-* `pubkey`: Public key that MUST be used to P2PK-lock receiving nutzaps -- implementations MUST NOT use the target user's main Nostr public key. This public key corresponds to the `privkey` field encrypted in a user's [nip-60](60.md) _wallet event_.
+* `pubkey`: Nostr public key that MUST be used to P2PK-lock receiving nutzaps -- implementations MUST NOT use the target user's main Nostr public key. This public key corresponds to the `privkey` field encrypted in a user's [nip-60](60.md) _wallet event_.
 
-### Nutzap event
-Event `kind:9321` is a nutzap event published by the sender, p-tagging the recipient. The outputs are P2PK-locked to the public key the recipient indicated in their `kind:10019` event.
+## Nutzap event
+Event `kind:9321` is a nutzap event published by the sender, p-tagging the recipient. The outputs are P2PK-locked to the `pubkey` the recipient indicated in their `kind:10019` event.
 
-Clients MUST prefix the public key they P2PK-lock with `"02"` (for nostr<>cashu compatibility).
+> [!NOTE]
+> Cashu P2PK-locks use 33-byte compressed hex-format public keys (x-coordinate with y-coordinate 02/03 prefix).<br>
+> Clients MUST prefix the Nostr hex `pubkey` they P2PK-lock with `"02"` (for nostr<>cashu compatibility).
 
 ```jsonc
 {
@@ -50,7 +52,8 @@ Clients MUST prefix the public key they P2PK-lock with `"02"` (for nostr<>cashu 
     "content": "Thanks for this great idea.",
     "pubkey": "<sender-pubkey>",
     "tags": [
-        [ "proof", "{\"amount\":1,\"C\":\"02277c66191736eb72fce9d975d08e3191f8f96afb73ab1eec37e4465683066d3f\",\"id\":\"000a93d6f8a1d2c4\",\"secret\":\"[\\\"P2PK\\\",{\\\"nonce\\\":\\\"b00bdd0467b0090a25bdf2d2f0d45ac4e355c482c1418350f273a04fedaaee83\\\",\\\"data\\\":\\\"02eaee8939e3565e48cc62967e2fde9d8e2a4b3ec0081f29eceff5c64ef10ac1ed\\\"}]\"}" ],
+        [ "proof", "{\"amount\":1,\"C\":\"02277c66191736eb72fce9d975d08e3191f8f96afb73ab1eec37e4465683066d3f\",\"id\":\"000a93d6f8a1d2c4\",\"secret\":\"[\\\"P2PK\\\",{\\\"nonce\\\":\\\"b00bdd0467b0090a25bdf2d2f0d45ac4e355c482c1418350f273a04fedaaee83\\\",\\\"data\\\":\\\"02e9fbced3a42dcf551486650cc752ab354347dd413b307484e4fd1818ab53f991\\\"}]\"}" ],
+        [ "proof", "{\"amount\":4,\"C\":\"02b5e00eb00907f3dde6609276cdfd457093639fe68294f0adb3506f9215ffe3f3\",\"id\":\"001b6c716bf42c7e\",\"secret\":\"[\\\"P2PK\\\",{\\\"nonce\\\":\\\"cfdc655e8d96678b4e34816297bb27dfd3bcfeb49bad98747080ad1c9a63c045\\\",\\\"data\\\":\\\"02e9fbced3a42dcf551486650cc752ab354347dd413b307484e4fd1818ab53f991\\\"}]\"}" ],
         [ "unit", "sat" ],
         [ "u", "https://stablenut.umint.cash" ],
         [ "e", "<nutzapped-event-id>", "<relay-hint>" ],
@@ -62,11 +65,13 @@ Clients MUST prefix the public key they P2PK-lock with `"02"` (for nostr<>cashu 
 
 * `.content` is an optional comment for the nutzap
 * `.tags`:
-  * `proof` is one or more proofs P2PK-locked to the public key the recipient specified in their `kind:10019` event and including a DLEQ proof.
+  * `proof` A proof, P2PK-locked to the public key the recipient specified in their `kind:10019` event and including a DLEQ proof. Multiple `proof` tags may be added - one proof per tag.
   * `unit` the base unit the proofs are denominated in (eg: `sat`, `usd`, `eur`). Default: `sat` if omitted.
   * `u` is the mint the URL of the mint EXACTLY as specified by the recipient's `kind:10019`.
   * `p` is the Nostr identity public key of nutzap recipient.
   * `e` is the event that is being nutzapped, if any.
+
+Notice the `p` tag contains the Nostr public key of the Nutzap recipient, and the P2PK Secret `data` contains the recipient's public key with the `"02"` prefix.
 
 ## Sending a nutzap
 


### PR DESCRIPTION
This PR tightens some of the language used in NIP-61, specifically:

- `pubkey` is a Nostr hex pubkey
- The interop requirement between Nostr and Cashu pubkeys
- Proof tag is one proof per tag, not multiple.
- Fixes the example proof `Secret.data` tag