### PR TITLE
Add unallowpubkey and unbanpubkey

### DIFF
--- a/86.md
+++ b/86.md
@@ -34,10 +34,16 @@ This is the list of **methods** that may be supported:
 * `banpubkey`:
   - params: `["<32-byte-hex-public-key>", "<optional-reason>"]`
   - result: `true` (a boolean always set to `true`)
+* `unbanpubkey`:
+  - params: `["<32-byte-hex-public-key>", "<optional-reason>"]`
+  - result: `true` (a boolean always set to `true`)
 * `listbannedpubkeys`:
   - params: `[]`
   - result: `[{"pubkey": "<32-byte-hex>", "reason": "<optional-reason>"}, ...]`, an array of objects
 * `allowpubkey`:
+  - params: `["<32-byte-hex-public-key>", "<optional-reason>"]`
+  - result: `true` (a boolean always set to `true`)
+* `unallowpubkey`:
   - params: `["<32-byte-hex-public-key>", "<optional-reason>"]`
   - result: `true` (a boolean always set to `true`)
 * `listallowedpubkeys`:


### PR DESCRIPTION
There's currently no way to remove someone from the allowed pubkeys list without also banning them. There's also currently no way to unban a user without also adding them to the relay's member list.