### PR TITLE
`NIP-47: Add support for Arkade and non-BOLT11 addresses`

### DIFF
--- a/47.md
+++ b/47.md
@@ -538,6 +538,67 @@ Notification:
     }
 }
 ```
+```markdown
+## Extended Parameters for Non-BOLT11 Addresses
+
+For payment addresses that don't encode amounts (such as Arkade addresses starting with `ark1`),
+the `amount` parameter MUST be included with `pay_invoice`.
+
+### pay_invoice with amount parameter
+
+Request:
+```json
+{
+  "method": "pay_invoice",
+  "params": {
+    "invoice": "ark1qq4hfssprtcg...",
+    "amount": 50000  // millisatoshis, REQUIRED for non-BOLT11
+  }
+}
+```
+
+Response unchanged. For Arkade, wallets MAY return `txid` instead of `preimage`:
+```json
+{
+  "result_type": "pay_invoice",
+  "result": {
+    "txid": "9934a446314e..."  // VTXO transaction ID
+  }
+}
+```
+
+### Address Type Detection
+
+| Prefix | Type | Amount Parameter |
+|--------|------|------------------|
+| `lnbc`, `lntb`, `lnbcrt` | BOLT11 | Optional (ignored) |
+| `ark1` | Arkade | Required |
+
+Wallets MUST return error code `AMOUNT_REQUIRED` if amount is missing for non-BOLT11 addresses.
+
+## Arkade Zap Receipts
+
+For Arkade zaps, the kind 9735 event SHOULD include these tags:
+
+- `["arkade", "<vtxo-txid>"]` - Payment proof (VTXO transaction ID)
+- `["amount", "<millisats>"]` - Payment amount
+- `["description", "<json>"]` - kind 9734 zap request
+
+Example:
+```json
+{
+  "kind": 9735,
+  "tags": [
+    ["p", "recipient-pubkey"],
+    ["arkade", "9934a446314e..."],
+    ["amount", "50000"],
+    ["description", "{...}"]
+  ]
+}
+```
+```
+
+
 
 ## Example pay invoice flow
 


### PR DESCRIPTION

This PR extends NIP-47 to support payment protocols that use addresses
which don't encode amounts (like Arkade).

## Changes
- Add optional `amount` parameter to `pay_invoice` method
- Required for non-BOLT11 addresses (Arkade: `ark1...`)
- Define Arkade zap receipt format (kind 9735)
- Address type detection guidelines

## Motivation
Arkade is a Bitcoin payment protocol using static addresses (similar
to Lightning addresses) where the amount must be specified separately.

## Backwards Compatibility
✅ Fully compatible - existing wallets ignore `amount` for BOLT11

## Testing
Successfully tested with:
- Arkadeos wallet (NWC-enabled)
- Nostrudel client
- 50 sats transferred via Arkade zap

## Reference Implementation
- Client: Nostrudel (PR pending)
- Wallet: Arkadeos PWA