### PR TITLE
Add NIP-RP: Reservation Protocol. NIP numbering TBD.

### DIFF
--- a/rp.md
+++ b/rp.md
@@ -1,0 +1,592 @@
+NIP-RP
+======
+
+Reservation Protocol v1.0
+-------------------------
+
+`draft` `optional`
+
+This NIP defines a protocol to manage reservations via Nostr. The term "reservations" is used as a broad term and could be applied to restaurants, hotels, or any other business offering appointments. This NIP also defines a business transaction attestation event associated with a succesfully completed reservation so that customers can issue a **verified business review**.
+
+The reservation process uses 4 different messages, each with its own kind, that are sent unsigned, sealed, and gift wrapped between the parties to maintain the privacy of the customer. Only the customer and the business are aware of the reservation.
+
+## Overview
+
+The Reservation Protocol uses four event kinds to support a complete negotiation flow:
+
+- `reservation.request` - `kind:9901`: Initial message sent  by the customer to make a reservation request
+- `reservation.response` - `kind:9902`: Message sent by the business or the customer to finalize the exchange of messages with status `confirmed`, `declined`, or `cancelled`
+- `reservation.modification.request` - `kind:9903`: Message sent to modify a firm reservation or a reservation under negotiation
+- `reservation.modification.response` - `kind:9904`: Message sent in response to a `reservation.modification.request`
+
+Additionally, the Reservation Protocol also defines a transaction attestation event to enable verified business reviews. 
+- `transaction.attestation` - `kind:9905`: Message sent by the business to attest that a specific customer transacted with the business.
+
+
+Clients must support `kind:9901` and `kind:9902` messages. Support for `kind:9903`, `kind:9904` and `kind:9905` is optional but strongly recommended.
+
+## Kind Definitions
+
+### Reservation Request - Kind:9901
+
+**Rumor Event Structure:**
+```yaml
+{
+  "id": "<32-byte hex of unsigned event hash>",
+  "pubkey": "<senderPublicKey>",
+  "created_at": <unix timestamp in seconds>,
+  "kind": 9901,
+  "tags": [
+    ["p", "<businessPublicKey>", "<relayUrl>"]
+    // Additional tags MAY be included
+  ],
+  "content": "<content-in-plain-text>"
+  // Note: No signature field - this is an unsigned rumor
+}
+```
+
+**Content Structure:**
+```yaml
+{
+  "party_size": <integer between 1 and 20>,
+  "iso_time": "<ISO8601 datetime with timezone>",
+  "notes": "<optional string, max 2000 chars>",
+  "contact": {
+    "name": "<optional string, max 200 chars>",
+    "phone": "<optional string, max 64 chars>",
+    "email": "<optional email>"
+  },
+  "constraints": {
+    "earliest_iso_time": "<optional ISO8601 datetime>",
+    "latest_iso_time": "<optional ISO8601 datetime>",
+  }
+}
+```
+
+**Required Fields:**
+- `party_size`: Integer between 1 and 20
+- `iso_time`: ISO8601 datetime string with timezone offset
+
+**Optional Fields:**
+- `notes`: Additional notes or special requests (max 2000 characters)
+- `contact`: Contact information object
+- `constraints`: Preferences for negotiation
+
+---
+
+### Reservation Response - Kind:9902
+
+**Rumor Event Structure:**
+```yaml
+{
+  "id": "<32-byte hex of unsigned event hash>",
+  "pubkey": "<senderPublicKey>",
+  "created_at": <unix timestamp in seconds>,
+  "kind": 9902,
+  "tags": [
+    ["p", "<recipientPublicKey>", "<relay-url>"],
+    ["e", "<unsigned-9901-rumor-id>", "", "root"]
+    // Additional tags MAY be included
+  ],
+  "content": "<content-in-plain-text>"
+  // Note: No signature field - this is an unsigned rumor
+}
+```
+
+**Content Structure:**
+```yaml
+{
+  "status": "<confirmed|declined|cancelled>",
+  "iso_time": "<ISO8601 datetime with timezone> | null",
+  "message": "<optional string, max 2000 chars>",
+  "table": "<optional string | null>",
+}
+```
+
+**Required Fields:**
+- `status`: One of `"confirmed"`, `"declined"`, or `"cancelled"`
+- `iso_time`: ISO8601 datetime string with timezone offset
+
+**Optional Fields:**
+- `message`: Human-readable message to the customer
+- `table`: Table identifier (e.g., "A5", "12", "Patio 3")
+
+**Threading:**
+- MUST include an `e` tag with `["e", "<unsigned-9901-rumor-id>", "", "root"]` referencing the unsigned rumor ID of the original request (kind:9901).
+
+---
+
+### Reservation Modification Request - Kind:9903
+
+**Rumor Event Structure:**
+```yaml
+{
+  "id": "<32-byte hex of unsigned event hash>",
+  "pubkey": "<senderPubKey>",
+  "created_at": <unix timestamp in seconds>,
+  "kind": 9903,
+  "tags": [
+    ["p", "<recipientPublicKey>", "<relay-url>"],
+    ["e", "<unsigned-9901-rumor-id>", "", "root"],
+    // Additional tags MAY be included
+  ],
+  "content": "<content-in-plain-text>"
+  // Note: No signature field - this is an unsigned rumor
+}
+```
+
+**Content Structure:**
+```yaml
+{
+  "party_size": <integer between 1 and 20>,
+  "iso_time": "<ISO8601 datetime with timezone>",
+  "notes": "<optional string, max 2000 chars>",
+  "contact": {
+    "name": "<optional string, max 200 chars>",
+    "phone": "<optional string, max 64 chars>",
+    "email": "<optional email>"
+  },
+  "constraints": {
+    "earliest_iso_time": "<optional ISO8601 datetime>",
+    "latest_iso_time": "<optional ISO8601 datetime>",
+  }
+}
+```
+
+**Required Fields:**
+- `party_size`: Integer between 1 and 20
+- `iso_time`: ISO8601 datetime string with timezone offset
+
+**Optional Fields:**
+- `notes`: Additional notes or special requests (max 2000 characters)
+- `contact`: Contact information object
+- `constraints`: Preferences for negotiation
+
+**Threading:**
+- MUST include an `e` tags with `["e", "<unsigned-9901-rumor-id>", "", "root"]` referencing the unsigned rumor ID of the original request.
+
+---
+
+### Reservation Modification Response - Kind:9904
+
+**Rumor Event Structure:**
+```yaml
+{
+  "id": "<32-byte hex of unsigned event hash>",
+  "pubkey": "<senderPublicKey>",
+  "created_at": <unix timestamp in seconds>,
+  "kind": 9904,
+  "tags": [
+    ["p", "<recipientPublicKey>", "<relay-url>"],
+    ["e", "<unsigned-9901-rumor-id>", "", "root"],
+    // Additional tags MAY be included
+  ],
+  "content": "<content-in-plain-text>"
+  // Note: No signature field - this is an unsigned rumor
+}
+```
+
+**Content Structure:**
+```yaml
+{
+  "status": "<confirmed|declined>",
+  "iso_time": "<ISO8601 datetime with timezone> | null",
+  "message": "<optional string, max 2000 chars>",
+}
+```
+
+**Required Fields:**
+- `status`: One of `"confirmed"` or `"declined"`
+- `iso_time`: ISO8601 datetime string with timezone offset
+
+**Optional Fields:**
+- `message`: Human-readable message to the customer
+
+
+**Threading:**
+- MUST include an `e` tags with `["e", "<unsigned-9901-rumor-id>", "", "root"]` referencing the unsigned rumor ID of the original request.
+
+
+## Encryption, Wrapping, and Threading
+
+All reservation messages MUST follow the [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md) Gift Wrap protocol:
+
+1. **Create Rumor**: Build an unsigned event of the appropriate kind (9901, 9902, 9903, or 9904) with plain text content
+2. **Create Seal**: Wrap the rumor in a `kind:13` seal event, encrypted with [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md)
+3. **Create Gift Wrap**: Wrap the seal in a `kind:1059` gift wrap event, addressed to the recipient via `p` tag
+
+### Encryption and Wrapping Details
+
+- **Content Encryption**: The JSON payload MUST be encrypted using [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) version 2 encryption
+- **Seal Encryption**: The serialized rumor JSON MUST be encrypted using [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) version 2 encryption with a conversation key derived from the sender's private key and recipient's public key
+- **Gift Wrap Encryption**: The serialized seal JSON MUST be encrypted using [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) version 2 encryption with a conversation key derived from a random ephemeral private key and recipient's public key
+
+Per [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md), `created_at` timestamps SHOULD be randomized up to 2 days in the past for both seal and gift wrap events to prevent metadata correlation attacks.
+
+### Sample Gift Wrap
+
+**Gift Wrap**
+```yaml
+{
+  "id": "<usual hash>",
+  "pubkey": randomPublicKey,
+  "created_at": randomTimeUpTo2DaysInThePast(),
+  "kind": 1059, // gift wrap
+  "tags": [
+    ["p", receiverPublicKey, "<relay-url>"] // receiver
+  ],
+  "content": nip44Encrypt(
+    {
+      "id": "<usual hash>",
+      "pubkey": senderPublicKey,
+      "created_at": randomTimeUpTo2DaysInThePast(),
+      "kind": 13, // seal
+      "tags": [], // no tags
+      "content": nip44Encrypt(unsignedKind990x, senderPrivateKey, receiverPublicKey),
+      "sig": "<signed by senderPrivateKey>"
+    },
+    randomPrivateKey, receiverPublicKey
+  ),
+  "sig": "<signed by randomPrivateKey>"
+}
+```
+
+---
+
+### Threading
+
+Following [NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md) and [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md), senders SHOULD publish gift wraps to both the recipient AND themselves (self-addressed). This ensures:
+- Senders can retrieve their own messages across devices
+- Full conversation history is recoverable with the sender's private key
+- Each recipient gets a separately encrypted gift wrap
+
+All messages in a reservation conversation after the original `reservation.request` `kind:9901` message MUST be threaded using the **unsigned rumor ID** of the original request as the root.
+---
+
+## Protocol Flow
+
+### Simple Reservation Request 
+1. Customer sends `reservation.request` `kind:9901` message to the business
+2. Business responds with `reservation.response` `kind:9902` message to the customer with `"status":"confirmed"` or `"status":"declined"`
+3. Message exchange ends
+
+### Reservation Request With Business Suggesting Alternative Time
+1. Customer sends `reservation.request` `kind:9901` message to the business
+2. Business responds with `reservation.modification.request` `kind:9903` message to the customer with proposed new time
+3. Customer responds with `reservation.modification.response` `kind:9904` message to the business with `"status":"confirmed"` or `"status":"declined"`
+4. Business responds with `reservation.response` `kind:9902` message to the customer with matching status `confirmed` or `declined`
+5. Message exchange ends
+
+### Succesful Reservation Modification by Customer
+1. Customer sends `reservation.modification.request` `kind:9903` message to the business with proposed new time
+2. Business sends `reservation.modification.response` `kind:9904` message to the customer with `"status":"confirmed"` to indicate availability for the new time
+3. Customer sends `reservation.response` `kind:9902` message to the business with status `confirmed`
+4. Message exchange ends
+
+Note: *This flow assumes that there is an existing confirmed reservation initiated by a `reservation.request` `kind:9901` message sent by the customer to the business. All messages should include the `"e"` tag with the rumor ID of the original `reservation.request` message to match the modification to the original reservation.*
+
+### Unsuccesful Reservation Modification by Customer
+1. Customer sends `reservation.modification.request` `kind:9903` message to the business with proposed new time
+2. Business sends `reservation.modification.response` `kind:9904` message to the customer with `"status":"declined"` to indicate lack of availability for the new time
+3. Customer sends `reservation.response` `kind:9902` message to the business with original time and status `"status":"confirmed"` to maintain original reservation or `"status":"cancelled"` to cancel the original reservation
+4. Message exchange ends
+
+Note: *This flow assumes that there is an existing confirmed reservation initiated by a `reservation.request` `kind:9901` message sent by the customer to the business. All messages should include the `"e"` tag with the rumor ID of the original `reservation.request` message to match the modification to the original reservation.*
+
+### Reservation Cancellation Initated by the Business
+1. Business sends `reservation.response` `kind:9902` message to the customer with `"status":"cancelled"`. Including a note in the `content.message` field is highly encouraged. 
+2. Message exchange ends
+
+No further action is expected from the customer. 
+
+Note: *This flow assumes that there is an existing confirmed reservation initiated by a `reservation.request` `kind:9901` message sent by the customer to the business. All messages should include the `"e"` tag with the rumor ID of the original `reservation.request` message to match the modification to the original reservation.*
+
+### Reservation Cancellation Initated by the Customer
+1. Customer sends `reservation.response` `kind:9902` message to the business with `"status":"cancelled"`. Including a note in the `content.message` field is highly encouraged. 
+2. Message exchange ends
+
+No further action is expected from the business.
+
+Note: *This flow assumes that there is an existing confirmed reservation initiated by a `reservation.request` `kind:9901` message sent by the customer to the business. All messages should include the `"e"` tag with the rumor ID of the original `reservation.request` message to match the modification to the original reservation.*
+
+## JSON Schema Validation
+
+Clients MUST validate payloads against JSON schemas before processing:
+
+- Kind 9901: Validate against `nostrability/schemata/nips/nip-rp/kind-9901/schema.yaml`
+- Kind 9902: Validate against `nostrability/schemata/nips/nip-rp/kind-9902/schema.yaml`
+- Kind 9903: Validate against `nostrability/schemata/nips/nip-rp/kind-9903/schema.yaml`
+- Kind 9904: Validate against `nostrability/schemata/nips/nip-rp/kind-9904/schema.yaml`
+
+
+Invalid payloads MUST be rejected and not processed further.
+
+## Business Discovery 
+
+Businesses MUST advertise their capability to handle reservation messages using [NIP-89](https://github.com/nostr-protocol/nips/blob/master/89.md) Application Handlers.
+
+### Handler Information Event (kind:31990)
+
+Businesses MUST publish a `kind:31990` handler information event that declares support for all reservation message kinds:
+
+```yaml
+{
+  "kind": 31990,
+  "pubkey": "<businessPublicKey>",
+  "tags": [
+    ["d", "reservations-v1.0"],
+    ["k", "9901"],
+    ["k", "9902"],
+    ["k", "9903"],
+    ["k", "9904"]
+  ],
+  "content": ""
+}
+```
+
+- The `d` tag MUST use the identifier `"reservations-v1.0"`
+- The `k` tags MUST include all four supported kinds: `9901`, `9902`, `9903`, and `9904`
+- The `content` field MAY be empty (clients will use the business' `kind:0` profile for display)
+
+### Handler Recommendation Events (kind:31989)
+
+Businesses MUST publish four `kind:31989` handler recommendation events, one for each supported event kind:
+
+**For kind:9901 (reservation.request):**
+```yaml
+{
+  "kind": 31989,
+  "pubkey": "<businessPublicKey>",
+  "tags": [
+    ["d", "9901"],
+    ["a", "31990:<businessPublicKey>:reservations-v1.0", "<relayUrl>", "all"]
+  ],
+  "content": ""
+}
+```
+
+**For kind:9902 (reservation.response):**
+```yaml
+{
+  "kind": 31989,
+  "pubkey": "<businessPublicKey>",
+  "tags": [
+    ["d", "9902"],
+    ["a", "31990:<businessPublicKey>:reservations-v1.0", "<relayUrl>", "all"]
+  ],
+  "content": ""
+}
+```
+
+**For kind:9903 (reservation.modification.request):**
+```yaml
+{
+  "kind": 31989,
+  "pubkey": "<businessPublicKey>",
+  "tags": [
+    ["d", "9903"],
+    ["a", "31990:<businessPublicKey>:reservations-v1.0", "<relayUrl>", "all"]
+  ],
+  "content": ""
+}
+```
+
+**For kind:9904 (reservation.modification.response):**
+```yaml
+{
+  "kind": 31989,
+  "pubkey": "<businessPublicKey>",
+  "tags": [
+    ["d", "9904"],
+    ["a", "31990:<businessPublicKey>:reservations-v1.0", "<relayUrl>", "all"]
+  ],
+  "content": ""
+}
+```
+
+- Each `kind:31989` event MUST have a `d` tag with the event kind it recommends (`"9901"`, `"9902"`, `"9903"`, or `"9904"`)
+- Each `kind:31989` event MUST include an `a` tag referencing the business' `kind:31990` handler information event
+- The `a` tag format MUST be: `"31990:<businessPublicKey>:reservations-v1.0"`
+- The second value of the `a` tag SHOULD be a relay URL hint for finding the handler
+- The third value of the `a` tag SHOULD be `"all"` to indicate the recommendation applies to all platforms
+
+---
+
+### Publishing Requirements
+
+- Businesses MUST publish the `kind:31990` handler information event when first setting up their reservation system
+- Businesses MUST publish all four `kind:31989` recommendation events when first setting up their reservation system
+- Businesses SHOULD republish these events whenever their handler configuration changes or when updating their business profile
+- All handler events MUST be published to the same relays where reservation messages are expected to be received
+
+---
+
+### Client Discovery
+
+Customer clients discovering businesses that support reservations SHOULD:
+
+1. Query for `kind:31989` events with `#d` filters for `["9901"]`, `["9902"]`, `["9903"]`, and `["9904"]`
+2. Extract the `a` tag values from recommendation events to find handler information events
+3. Query for the corresponding `kind:31990` handler information events using the `a` tag coordinates
+4. Verify that the handler information event includes all four `k` tags (`9901`, `9902`, `9903`, `9904`) before considering the business as fully supporting the protocol
+
+
+## Verified Business Reviews
+Customers who succesfully complete a business transaction after creating a reservation using the Reservation Protocol may issue a verified business review. Verified business reviews are reviews from real customers and should be considered more relevant than unverified reviews from users for whom it is not possible to determine if they have transacted with the business. 
+
+The Reservation Protocol supports verified business reviews by expanding upon reviews as specified by the [market specification](https://github.com/GammaMarkets/market-spec/blob/main/spec.md) addendum to [NIP-99](https://github.com/nostr-protocol/nips/blob/master/99.md).
+
+Once a reservation is fulfilled, for example when the restaurant check is closed, the business privately issues a token to the customer to attest the business transaction. This token is independent of the review itself and only attests for the fact that the customer and the business executed a transaction:
+- It's created before the review is written
+- Does not endorse the content of the review
+
+
+The verified business review follows the [QTS guidelines](https://habla.news/u/arkinox@arkinox.tech/DLAfzJJpQDS4vj3wSleum) with labels specified by the business to ensure review uniformity regardless of the application used by the customer to issue the review. 
+
+---
+
+### Business Transaction Attestation – Kind:9905
+
+`kind:9905` is a **signed** nostr event created by the business to attest that a business transaction occurred under a given reservation. The event is created by the business when a reservation is fulfilled and sent privately to the customer using an encrypted direct message (`kind:14`). The `kind:9905` event is **never** published to public relays to maintain the business transaction private until the customer decides to publish a review.
+
+The event is intended as a business transaction attestation token that the customer MAY later embed in a public review. If the customer does not publish a review, then the reservation and business transaction will remain private. 
+
+**Event Structure:**
+```yaml
+{
+  "id": "<32-byte hex of event hash>",
+  "pubkey": "<businessPublicKey>",
+  "created_at": <unix timestamp in seconds>,
+  "kind": 9905,
+  "tags": [
+    ["e", "<unsigned-9901-rumor-id>"],  # Reservation thread id 
+    ["p", "<customerPublicKey>"]
+  ],
+  "content": "<content-in-plain-text>",
+  "sig": "<signed by businessPrivateKey>"
+}
+```
+
+**Content Structure:**
+```yaml
+{
+  "iso_time": "<ISO8601 datetime with timezone>",
+  "qts_labels": [
+    "label1",
+    "label2",
+    "label3"
+    # Add more labels as needed
+  ]
+}
+```
+
+**Required Tags:**
+- `["e", "<unsigned-9901-rumor-id>"]`: MUST reference the unsigned rumor ID of the original reservation.request `kind:9901` message. This value is the reservation thread id.
+- `["p", "<customerPublicKey>"]`: MUST reference the customer associated with the transaction.
+- `iso_time`: reservation ISO8601 datetime string with timezone offset
+- `qts_labels`: the array of labels to be used for the QTS review
+---
+
+The `transaction.attestation` `kind:9905` message is sent from the business to the customer as the content of a direct message `kind:14` with the same `<unsigned-9901-rumor-id>` thread ID to connect it to the reservation in question. 
+
+```yaml
+{
+  "kind": 14,
+  "pubkey": "<businessPublicKey>",
+  "created_at": <unix timestamp in seconds>,
+  "tags": [
+    ["p", "<customerPublicKey>"],
+    ["e", "<unsigned-9901-rumor-id>", "", "root"]
+  ],
+  "content": "<plain-text serialized and signed kind-9905 event>"
+  // no sig field – this is a rumor, encrypted and transported via NIP-59
+}
+```
+---
+
+### Verified Business Review - Kind 31555
+
+The verified business review is issued as a `kind:31555` nostr event following the NIP-99 market specification addendum with additional tags included for the verification process:
+- `verified` tag with the base64 encoding of the full serialized `transaction.attestation` `kind:9905` event
+- `e` tag with the original reservation thread id
+
+When in conflict, the NIP-99 market specification addendum takes precedence over this NIP.
+
+**Event Structure:**
+```yaml
+{
+  "id": "<32-byte hex of event hash>",
+  "pubkey": "<customerPublicKey>",
+  "created_at": <unix timestamp in seconds>,
+  "kind": 31555,
+  "tags": [
+    ["d", "p:<businessPublicKey>"],
+    ["rating", "<0 or 1>", "thumb"],  # Primary rating, 0 for thumbs down and 1 for thumbs up
+    // Optional rating categories
+    ["rating", "0.8", <label1-from-qts-labels-field-in-transaction-attestation-event], # rating between 0 and 1 with one decimal point.
+    ["rating", "1.0", <label1-from-qts-labels-field-in-transaction-attestation-event], # rating between 0 and 1 with one decimal point
+    ["rating", "0.6", <label1-from-qts-labels-field-in-transaction-attestation-event], # rating between 0 and 1 with one decimal point
+    # Add more labels as specified by the kind:9905 event.
+    ["e", "<unsigned-9901-rumor-id>"], # Reservation thread id 
+    ["verified", "<base64-encoded-transaction-attestation-event-kind-9905>"] 
+    # Additional tags MAY be included
+  ],
+  "content": "<free-form review text>",
+  "sig": "<signed by customerPrivateKey>"
+}
+```
+
+**Required Tags**:
+	- `["d", "p:<businessPublicKey>"]`: MUST specify the business being reviewed.
+	- `["e", "<unsigned-9901-rumor-id>"]`: MUST reference the same reservation thread id used during the reservation flow.
+  - `["verified", "<base64-encoded-transaction-attestation-event-kind-9905>"]`: The value MUST be a base64 encoding of the full serialized kind:9905 transaction attestation event.
+	- `["rating", "<0 or 1>", "thumb"]`: Primary rating, 0 for thumbs down and 1 for thumbs up.
+	-	`["rating", "<empty> | <0 to 1>", <labelN-from-qts-labels-field-in-transaction-attestation-event]`: additional rating between 0 and 1 with one decimal point. All labels listed in the `kind:9905` event should be included. Value may be empty if user did not provide a rating for an specific label. 
+
+A client MAY treat a `kind:31555` event as a **verified business review** if all of the following conditions are met:
+1.	The event has a `["verified", "<payload>"]` tag. 
+2.	Decoding `<payload>` from base64 yields a valid nostr `transaction.attestation` `kind:9905` event with the following properties:
+  - The `pubkey` field matches the business public key indicated by the `kind:31555` `["d", "p:<businessPublicKey>"]` tag
+  - The customer public key of the `["p", "<customerPublicKey>"]` tag matches the public key signing the `kind:31555` review event
+  - There is a `["e", "<unsigned-9901-rumor-id>"]` tag matching the `["e", "<unsigned-9901-rumor-id>"]` tag of the  `kind:31555` review event
+  - The `transaction.attestation` `kind:9905` event has a valid signature computed according to NIP-01.
+
+If verification succeeds, clients MAY consider the review as a **verified business review**. If verification fails, clients SHOULD NOT display the review. 
+
+---
+
+### Verified Business Review Flow
+
+#### Business Transaction Attestation Issued By The Business
+1. After the transaction is considered fulfilled, the business sends a `transaction.attestation` `kind:9905` message to the customer via a `kind:14` direct message. The `transaction.attestation` `kind:9905` message is **never** published to a relay.
+2. Message exchange ends
+
+No further action is expected from the business or the customer. 
+
+#### Customer Elects to Not Publish a Review
+1. Customer receives the `transaction.attestation` `kind:9905` message from the business.
+2. Customer chooses to not issue a review
+3. Message exchange ends
+
+The fact that the customer transacted with the business remains a private fact known only to the customer and the business. 
+
+#### Customer Elects to Publish a Review
+1. Customer receives the `transaction.attestation` `kind:9905` message from the business.
+2. Customer writes a review and publishes it as a `kind:31555` event that includes the `["verified", "<base64-encoded-transaction-attestation-event-kind-9905>"]` tag 
+3. Message exchange ends
+
+The fact that the customer transacted with the business becomes a public fact. 
+
+### JSON Schema Validation
+- Kind 9905: Validate against `nostrability/schemata/nips/nip-rp/kind-9905/schema.yaml`
+
+---
+
+### Verified Reviews Discovery
+
+A client searching for verified reviews for a given business with `businessPublicKey` SHOULD:
+  1. Query for `kind:31555` events with:
+	  •	`["d", "p:<businessPublicKey>"]` to select reviews for this business
+	  •	For each review, check for a `["verified", "<payload>"]` tag and, if present, perform the verification steps defined in section [Verified Business Review - Kind:31555](#verified-business-review–kind:31555).
+
+If verification succeeds, the review MAY be treated as a **Verified Business Review**. 

--- a/rp.md
+++ b/rp.md
@@ -35,6 +35,7 @@ The following tags are used across the different kinds defined by this NIP:
 - `party_size`: number of people in the reservation.
 - `time`: inclusive reservation start Unix timestamp in seconds.
 - `tzid`: time zone of the reservation `time`, `earliest_time`, and `latest_time` Unix timestamps, as defined by the IANA Time Zone Database. e.g., `America/Costa_Rica`.
+- `duration`: duration of the reservation in seconds.
 - `name`: name of the requestor for the reservation.
 - `phone`: phone number of the requestor for the reservation.
 - `email`: email of the requestor for the reservation.
@@ -56,6 +57,7 @@ The following tags are used across the different kinds defined by this NIP:
     ["party_size", "<integer between 1 and 20>"],
     ["time", "<unix timestamp in seconds>"],
     ["tzid", "<IANA Time Zone Database identifier>"],
+    ["duration", <optional duration of reservation in seconds>"],
     ["name", "<optional string, max 200 chars>"],
     ["phone", "<optional string, max 64 chars>"],
     ["email", "<optional email>"],
@@ -63,7 +65,7 @@ The following tags are used across the different kinds defined by this NIP:
     ["latest_time", "<optional unix timestamp in seconds>"]
   ],
   "content": "<reservation request message in plain text>"
-  // Note: No signature field - this is an unsigned rumor
+  # Note: No signature field - this is an unsigned rumor
 }
 ```
 
@@ -84,10 +86,11 @@ The following tags are used across the different kinds defined by this NIP:
     ["status", "<confirmed|declined|cancelled>"],
     ["time", "<unix timestamp in seconds>"],
     ["tzid", "<IANA Time Zone Database identifier>"],
-    // Additional tags MAY be included
+    ["duration", <optional duration of reservation in seconds>"]
+    # Additional tags MAY be included
   ],
   "content": "<reservation response message in plain text>"
-  // Note: No signature field - this is an unsigned rumor
+  # Note: No signature field - this is an unsigned rumor
 }
 ```
 
@@ -108,12 +111,13 @@ The following tags are used across the different kinds defined by this NIP:
     ["party_size", "<integer between 1 and 20>"],
     ["time", "<unix timestamp in seconds>"],
     ["tzid", "<IANA Time Zone Database identifier>"],
+    ["duration", <optional duration of reservation in seconds>"],
     ["name", "<optional string, max 200 chars>"],
     ["phone", "<optional string, max 64 chars>"],
     ["email", "<optional email>"],
     ["earliest_time", "<optional unix timestamp in seconds>"],
     ["latest_time", "<optional unix timestamp in seconds>"]
-    // Additional tags MAY be included
+    # Additional tags MAY be included
   ],
   "content": "<reservation modification request message in plain text>"
   // Note: No signature field - this is an unsigned rumor
@@ -137,10 +141,11 @@ The following tags are used across the different kinds defined by this NIP:
     ["status", "<confirmed|declined|cancelled>"],
     ["time", "<unix timestamp in seconds>"],
     ["tzid", "<IANA Time Zone Database identifier>"],
-    // Additional tags MAY be included
+    ["duration", <optional duration of reservation in seconds>"],
+    # Additional tags MAY be included
   ],
   "content": "<creservation modification response message in plain text>"
-  // Note: No signature field - this is an unsigned rumor
+  # Note: No signature field - this is an unsigned rumor
 }
 ```
 ## Protocol Flow
@@ -224,7 +229,7 @@ The event is intended as a business transaction attestation token that the custo
     ["e", "<unsigned-9901-rumor.id>", "", "root"], # connects message to reservation thread
     ["time", "<unix timestamp in seconds>"],
     ["tzid", "<IANA Time Zone Database identifier>"],
-    ["qts_labels", "label1, label2, label3, ..., labelN"] # comma separated list of labels
+    ["qts_labels", "label1, label2, ..., labelN"] # comma separated list of labels
     
   ],
   "content": "<content-in-plain-text>",
@@ -251,10 +256,10 @@ When in conflict, the NIP-99 market specification addendum takes precedence over
   "tags": [
     ["d", "p:<businessPublicKey>"],
     ["rating", "<0 or 1>", "thumb"],  # Primary rating, 0 for thumbs down and 1 for thumbs up
-    // Optional rating categories
+    # Optional rating categories
     ["rating", "0.8", <label1-from-qts-labels-field-in-transaction-attestation-event], # rating between 0 and 1 with one decimal point.
-    ["rating", "1.0", <label1-from-qts-labels-field-in-transaction-attestation-event], # rating between 0 and 1 with one decimal point
-    ["rating", "0.6", <label1-from-qts-labels-field-in-transaction-attestation-event], # rating between 0 and 1 with one decimal point
+    ["rating", "1.0", <label2-from-qts-labels-field-in-transaction-attestation-event], # rating between 0 and 1 with one decimal point
+    ["rating", "0.6", <labelN-from-qts-labels-field-in-transaction-attestation-event], # rating between 0 and 1 with one decimal point
     # Add more labels as specified by the kind:9905 event.
     ["e", "<unsigned-9901-rumor.id>", "", "root"], # connects message to reservation thread
     ["verified", "<base64-encoded-transaction-attestation-event-kind-9905>"] 

--- a/rp.md
+++ b/rp.md
@@ -36,9 +36,9 @@ The following tags are used across the different kinds defined by this NIP:
 - `time`: inclusive reservation start Unix timestamp in seconds.
 - `tzid`: time zone of the reservation `time`, `earliest_time`, and `latest_time` Unix timestamps, as defined by the IANA Time Zone Database. e.g., `America/Costa_Rica`.
 - `duration`: duration of the reservation in seconds.
-- `name`: name of the requestor for the reservation.
-- `phone`: phone number of the requestor for the reservation.
-- `email`: email of the requestor for the reservation.
+- `name`: reservation holder.
+- `phone`: phone number for the reservation holder.
+- `email`: email for the reservation holder.
 - `earliest_time`: earliest start time Unix timestamp that the requestor would accept for the reservation.
 - `latest_time`: earliest time that the requestor would accept for the reservation.
 - `status`: status of the reservation as one of the following values `confirmed`, `declined`, or `cancelled`.
@@ -57,10 +57,10 @@ The following tags are used across the different kinds defined by this NIP:
     ["party_size", "<integer between 1 and 20>"],
     ["time", "<unix timestamp in seconds>"],
     ["tzid", "<IANA Time Zone Database identifier>"],
+    ["name", "<string, max 200 chars>"],
+    ["telephone", "<optional string, 'tel:' URI as per RFC 3966>"], # one of email or telephone must be included 
+    ["email", "<optional string, 'mailto:' URI as per RFC 6068>"],  # one of email or telephone must be included
     ["duration", <optional duration of reservation in seconds>"],
-    ["name", "<optional string, max 200 chars>"],
-    ["phone", "<optional string, max 64 chars>"],
-    ["email", "<optional email>"],
     ["earliest_time", "<optional unix timestamp in seconds>"],
     ["latest_time", "<optional unix timestamp in seconds>"]
   ],
@@ -86,7 +86,7 @@ The following tags are used across the different kinds defined by this NIP:
     ["status", "<confirmed|declined|cancelled>"],
     ["time", "<unix timestamp in seconds>"],
     ["tzid", "<IANA Time Zone Database identifier>"],
-    ["duration", <optional duration of reservation in seconds>"]
+    ["duration", <optional duration of reservation in seconds>"],
     # Additional tags MAY be included
   ],
   "content": "<reservation response message in plain text>"
@@ -110,17 +110,17 @@ The following tags are used across the different kinds defined by this NIP:
     ["e", "<unsigned-9901-rumor.id>", "", "root"], # connects message to reservation thread
     ["party_size", "<integer between 1 and 20>"],
     ["time", "<unix timestamp in seconds>"],
-    ["tzid", "<IANA Time Zone Database identifier>"],
+    ["tzid", "<IANA Time Zone Database identifier>"], 
+    ["name", "<optional string, max 200 chars>"],           
+    ["telephone", "<optional string, 'tel:' URI as per RFC 3966>"],  # must be included if present in reservation.request
+    ["email", "<optional string, 'mailto:' URI as per RFC 6068>"],   # must be included if present in reservation.request
     ["duration", <optional duration of reservation in seconds>"],
-    ["name", "<optional string, max 200 chars>"],
-    ["phone", "<optional string, max 64 chars>"],
-    ["email", "<optional email>"],
     ["earliest_time", "<optional unix timestamp in seconds>"],
     ["latest_time", "<optional unix timestamp in seconds>"]
     # Additional tags MAY be included
   ],
   "content": "<reservation modification request message in plain text>"
-  // Note: No signature field - this is an unsigned rumor
+  # Note: No signature field - this is an unsigned rumor
 }
 ```
 
@@ -183,14 +183,14 @@ The following tags are used across the different kinds defined by this NIP:
 
 ## Business Discovery 
 
-Businesses MUST advertise their capability to handle reservation messages by including in their `kind:0` profile event a NIP-32 label `reservations` within the namespace `com.synvya.merchant`.
+Businesses MUST advertise their support for the Reservation Protocol using an external content id tag for NIP-RP compliant with NIP-73. The value `rp` may be changed in the future for a number once a number is assigned to this NIP.
 
 ```yaml
 {
   "kind": 0,
   "tags": [
-    ["L", "com.synvya.merchant"],
-    ["l", "reservations", "com.synvya.merchant"],
+    ["i", "rp", "https://github.com/nostr-protocol/nips/blob/master/rp.md"],
+    ["k", "nip"],
     // additional tags
   ],
   // other fields...
@@ -232,7 +232,7 @@ The event is intended as a business transaction attestation token that the custo
     ["qts_labels", "label1, label2, ..., labelN"] # comma separated list of labels
     
   ],
-  "content": "<content-in-plain-text>",
+  "content": "",
   "sig": "<signed by businessPrivateKey>"
 }
 ```

--- a/rp.md
+++ b/rp.md
@@ -19,58 +19,53 @@ The Reservation Protocol uses four event kinds to support a complete negotiation
 - `reservation.modification.request` - `kind:9903`: Message sent to modify a firm reservation or a reservation under negotiation
 - `reservation.modification.response` - `kind:9904`: Message sent in response to a `reservation.modification.request`
 
+All four kinds are transmitted as unsigned rumors using [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md) gift wraps.
+
 Additionally, the Reservation Protocol also defines a transaction attestation event to enable verified business reviews. 
-- `transaction.attestation` - `kind:9905`: Message sent by the business to attest that a specific customer transacted with the business.
+- `transaction.attestation` - `kind:9905`: Message sent by the business to the customer via [NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md) private direct message to attest that a specific customer transacted with the business.
 
 
 Clients must support `kind:9901` and `kind:9902` messages. Support for `kind:9903`, `kind:9904` and `kind:9905` is optional but strongly recommended.
 
 ## Kind Definitions
 
+The following tags are used across the different kinds defined by this NIP:
+- `p`: public key of the recipient of the message.
+- `e`: tag used to connect all messages of the same reservation request (the reservation thread). Contains the `.id` field of the original `kind:9901` reservation request.
+- `party_size`: number of people in the reservation.
+- `time`: inclusive reservation start Unix timestamp in seconds.
+- `tzid`: time zone of the reservation `time`, `earliest_time`, and `latest_time` Unix timestamps, as defined by the IANA Time Zone Database. e.g., `America/Costa_Rica`.
+- `name`: name of the requestor for the reservation.
+- `phone`: phone number of the requestor for the reservation.
+- `email`: email of the requestor for the reservation.
+- `earliest_time`: earliest start time Unix timestamp that the requestor would accept for the reservation.
+- `latest_time`: earliest time that the requestor would accept for the reservation.
+- `status`: status of the reservation as one of the following values `confirmed`, `declined`, or `cancelled`.
+
 ### Reservation Request - Kind:9901
 
 **Rumor Event Structure:**
 ```yaml
 {
-  "id": "<32-byte hex of unsigned event hash>",
+  "id": "<32-byte hex of unsigned event hash>", # the thread id to be used by all other messages for this reservation
   "pubkey": "<senderPublicKey>",
   "created_at": <unix timestamp in seconds>,
   "kind": 9901,
   "tags": [
-    ["p", "<businessPublicKey>", "<relayUrl>"]
-    // Additional tags MAY be included
+    ["p", "<businessPublicKey>", "<relayUrl>"],
+    ["party_size", "<integer between 1 and 20>"],
+    ["time", "<unix timestamp in seconds>"],
+    ["tzid", "<IANA Time Zone Database identifier>"],
+    ["name", "<optional string, max 200 chars>"],
+    ["phone", "<optional string, max 64 chars>"],
+    ["email", "<optional email>"],
+    ["earliest_time", "<optional unix timestamp in seconds>"],
+    ["latest_time", "<optional unix timestamp in seconds>"]
   ],
-  "content": "<content-in-plain-text>"
+  "content": "<reservation request message in plain text>"
   // Note: No signature field - this is an unsigned rumor
 }
 ```
-
-**Content Structure:**
-```yaml
-{
-  "party_size": <integer between 1 and 20>,
-  "iso_time": "<ISO8601 datetime with timezone>",
-  "notes": "<optional string, max 2000 chars>",
-  "contact": {
-    "name": "<optional string, max 200 chars>",
-    "phone": "<optional string, max 64 chars>",
-    "email": "<optional email>"
-  },
-  "constraints": {
-    "earliest_iso_time": "<optional ISO8601 datetime>",
-    "latest_iso_time": "<optional ISO8601 datetime>",
-  }
-}
-```
-
-**Required Fields:**
-- `party_size`: Integer between 1 and 20
-- `iso_time`: ISO8601 datetime string with timezone offset
-
-**Optional Fields:**
-- `notes`: Additional notes or special requests (max 2000 characters)
-- `contact`: Contact information object
-- `constraints`: Preferences for negotiation
 
 ---
 
@@ -85,34 +80,16 @@ Clients must support `kind:9901` and `kind:9902` messages. Support for `kind:990
   "kind": 9902,
   "tags": [
     ["p", "<recipientPublicKey>", "<relay-url>"],
-    ["e", "<unsigned-9901-rumor-id>", "", "root"]
+    ["e", "<unsigned-9901-rumor.id>", "", "root"], # connects message to reservation thread
+    ["status", "<confirmed|declined|cancelled>"],
+    ["time", "<unix timestamp in seconds>"],
+    ["tzid", "<IANA Time Zone Database identifier>"],
     // Additional tags MAY be included
   ],
-  "content": "<content-in-plain-text>"
+  "content": "<reservation response message in plain text>"
   // Note: No signature field - this is an unsigned rumor
 }
 ```
-
-**Content Structure:**
-```yaml
-{
-  "status": "<confirmed|declined|cancelled>",
-  "iso_time": "<ISO8601 datetime with timezone> | null",
-  "message": "<optional string, max 2000 chars>",
-  "table": "<optional string | null>",
-}
-```
-
-**Required Fields:**
-- `status`: One of `"confirmed"`, `"declined"`, or `"cancelled"`
-- `iso_time`: ISO8601 datetime string with timezone offset
-
-**Optional Fields:**
-- `message`: Human-readable message to the customer
-- `table`: Table identifier (e.g., "A5", "12", "Patio 3")
-
-**Threading:**
-- MUST include an `e` tag with `["e", "<unsigned-9901-rumor-id>", "", "root"]` referencing the unsigned rumor ID of the original request (kind:9901).
 
 ---
 
@@ -127,43 +104,21 @@ Clients must support `kind:9901` and `kind:9902` messages. Support for `kind:990
   "kind": 9903,
   "tags": [
     ["p", "<recipientPublicKey>", "<relay-url>"],
-    ["e", "<unsigned-9901-rumor-id>", "", "root"],
+    ["e", "<unsigned-9901-rumor.id>", "", "root"], # connects message to reservation thread
+    ["party_size", "<integer between 1 and 20>"],
+    ["time", "<unix timestamp in seconds>"],
+    ["tzid", "<IANA Time Zone Database identifier>"],
+    ["name", "<optional string, max 200 chars>"],
+    ["phone", "<optional string, max 64 chars>"],
+    ["email", "<optional email>"],
+    ["earliest_time", "<optional unix timestamp in seconds>"],
+    ["latest_time", "<optional unix timestamp in seconds>"]
     // Additional tags MAY be included
   ],
-  "content": "<content-in-plain-text>"
+  "content": "<reservation modification request message in plain text>"
   // Note: No signature field - this is an unsigned rumor
 }
 ```
-
-**Content Structure:**
-```yaml
-{
-  "party_size": <integer between 1 and 20>,
-  "iso_time": "<ISO8601 datetime with timezone>",
-  "notes": "<optional string, max 2000 chars>",
-  "contact": {
-    "name": "<optional string, max 200 chars>",
-    "phone": "<optional string, max 64 chars>",
-    "email": "<optional email>"
-  },
-  "constraints": {
-    "earliest_iso_time": "<optional ISO8601 datetime>",
-    "latest_iso_time": "<optional ISO8601 datetime>",
-  }
-}
-```
-
-**Required Fields:**
-- `party_size`: Integer between 1 and 20
-- `iso_time`: ISO8601 datetime string with timezone offset
-
-**Optional Fields:**
-- `notes`: Additional notes or special requests (max 2000 characters)
-- `contact`: Contact information object
-- `constraints`: Preferences for negotiation
-
-**Threading:**
-- MUST include an `e` tags with `["e", "<unsigned-9901-rumor-id>", "", "root"]` referencing the unsigned rumor ID of the original request.
 
 ---
 
@@ -178,91 +133,16 @@ Clients must support `kind:9901` and `kind:9902` messages. Support for `kind:990
   "kind": 9904,
   "tags": [
     ["p", "<recipientPublicKey>", "<relay-url>"],
-    ["e", "<unsigned-9901-rumor-id>", "", "root"],
+    ["e", "<unsigned-9901-rumor.id>", "", "root"], # connects message to reservation thread
+    ["status", "<confirmed|declined|cancelled>"],
+    ["time", "<unix timestamp in seconds>"],
+    ["tzid", "<IANA Time Zone Database identifier>"],
     // Additional tags MAY be included
   ],
-  "content": "<content-in-plain-text>"
+  "content": "<creservation modification response message in plain text>"
   // Note: No signature field - this is an unsigned rumor
 }
 ```
-
-**Content Structure:**
-```yaml
-{
-  "status": "<confirmed|declined>",
-  "iso_time": "<ISO8601 datetime with timezone> | null",
-  "message": "<optional string, max 2000 chars>",
-}
-```
-
-**Required Fields:**
-- `status`: One of `"confirmed"` or `"declined"`
-- `iso_time`: ISO8601 datetime string with timezone offset
-
-**Optional Fields:**
-- `message`: Human-readable message to the customer
-
-
-**Threading:**
-- MUST include an `e` tags with `["e", "<unsigned-9901-rumor-id>", "", "root"]` referencing the unsigned rumor ID of the original request.
-
-
-## Encryption, Wrapping, and Threading
-
-All reservation messages MUST follow the [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md) Gift Wrap protocol:
-
-1. **Create Rumor**: Build an unsigned event of the appropriate kind (9901, 9902, 9903, or 9904) with plain text content
-2. **Create Seal**: Wrap the rumor in a `kind:13` seal event, encrypted with [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md)
-3. **Create Gift Wrap**: Wrap the seal in a `kind:1059` gift wrap event, addressed to the recipient via `p` tag
-
-### Encryption and Wrapping Details
-
-- **Content Encryption**: The JSON payload MUST be encrypted using [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) version 2 encryption
-- **Seal Encryption**: The serialized rumor JSON MUST be encrypted using [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) version 2 encryption with a conversation key derived from the sender's private key and recipient's public key
-- **Gift Wrap Encryption**: The serialized seal JSON MUST be encrypted using [NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md) version 2 encryption with a conversation key derived from a random ephemeral private key and recipient's public key
-
-Per [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md), `created_at` timestamps SHOULD be randomized up to 2 days in the past for both seal and gift wrap events to prevent metadata correlation attacks.
-
-### Sample Gift Wrap
-
-**Gift Wrap**
-```yaml
-{
-  "id": "<usual hash>",
-  "pubkey": randomPublicKey,
-  "created_at": randomTimeUpTo2DaysInThePast(),
-  "kind": 1059, // gift wrap
-  "tags": [
-    ["p", receiverPublicKey, "<relay-url>"] // receiver
-  ],
-  "content": nip44Encrypt(
-    {
-      "id": "<usual hash>",
-      "pubkey": senderPublicKey,
-      "created_at": randomTimeUpTo2DaysInThePast(),
-      "kind": 13, // seal
-      "tags": [], // no tags
-      "content": nip44Encrypt(unsignedKind990x, senderPrivateKey, receiverPublicKey),
-      "sig": "<signed by senderPrivateKey>"
-    },
-    randomPrivateKey, receiverPublicKey
-  ),
-  "sig": "<signed by randomPrivateKey>"
-}
-```
-
----
-
-### Threading
-
-Following [NIP-17](https://github.com/nostr-protocol/nips/blob/master/17.md) and [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md), senders SHOULD publish gift wraps to both the recipient AND themselves (self-addressed). This ensures:
-- Senders can retrieve their own messages across devices
-- Full conversation history is recoverable with the sender's private key
-- Each recipient gets a separately encrypted gift wrap
-
-All messages in a reservation conversation after the original `reservation.request` `kind:9901` message MUST be threaded using the **unsigned rumor ID** of the original request as the root.
----
-
 ## Protocol Flow
 
 ### Simple Reservation Request 
@@ -275,161 +155,42 @@ All messages in a reservation conversation after the original `reservation.reque
 2. Business responds with `reservation.modification.request` `kind:9903` message to the customer with proposed new time
 3. Customer responds with `reservation.modification.response` `kind:9904` message to the business with `"status":"confirmed"` or `"status":"declined"`
 4. Business responds with `reservation.response` `kind:9902` message to the customer with matching status `confirmed` or `declined`
-5. Message exchange ends
 
 ### Succesful Reservation Modification by Customer
 1. Customer sends `reservation.modification.request` `kind:9903` message to the business with proposed new time
 2. Business sends `reservation.modification.response` `kind:9904` message to the customer with `"status":"confirmed"` to indicate availability for the new time
 3. Customer sends `reservation.response` `kind:9902` message to the business with status `confirmed`
-4. Message exchange ends
 
-Note: *This flow assumes that there is an existing confirmed reservation initiated by a `reservation.request` `kind:9901` message sent by the customer to the business. All messages should include the `"e"` tag with the rumor ID of the original `reservation.request` message to match the modification to the original reservation.*
 
 ### Unsuccesful Reservation Modification by Customer
 1. Customer sends `reservation.modification.request` `kind:9903` message to the business with proposed new time
 2. Business sends `reservation.modification.response` `kind:9904` message to the customer with `"status":"declined"` to indicate lack of availability for the new time
 3. Customer sends `reservation.response` `kind:9902` message to the business with original time and status `"status":"confirmed"` to maintain original reservation or `"status":"cancelled"` to cancel the original reservation
-4. Message exchange ends
 
-Note: *This flow assumes that there is an existing confirmed reservation initiated by a `reservation.request` `kind:9901` message sent by the customer to the business. All messages should include the `"e"` tag with the rumor ID of the original `reservation.request` message to match the modification to the original reservation.*
 
 ### Reservation Cancellation Initated by the Business
-1. Business sends `reservation.response` `kind:9902` message to the customer with `"status":"cancelled"`. Including a note in the `content.message` field is highly encouraged. 
-2. Message exchange ends
+1. Business sends `reservation.response` `kind:9902` message to the customer with `"status":"cancelled"`. Including a note in the `.content` field of the event is highly recommended. 
 
-No further action is expected from the customer. 
-
-Note: *This flow assumes that there is an existing confirmed reservation initiated by a `reservation.request` `kind:9901` message sent by the customer to the business. All messages should include the `"e"` tag with the rumor ID of the original `reservation.request` message to match the modification to the original reservation.*
 
 ### Reservation Cancellation Initated by the Customer
-1. Customer sends `reservation.response` `kind:9902` message to the business with `"status":"cancelled"`. Including a note in the `content.message` field is highly encouraged. 
-2. Message exchange ends
+1. Customer sends `reservation.response` `kind:9902` message to the business with `"status":"cancelled"`. Including a note in the `.content` field of the event is highly recommended. 
 
-No further action is expected from the business.
-
-Note: *This flow assumes that there is an existing confirmed reservation initiated by a `reservation.request` `kind:9901` message sent by the customer to the business. All messages should include the `"e"` tag with the rumor ID of the original `reservation.request` message to match the modification to the original reservation.*
-
-## JSON Schema Validation
-
-Clients MUST validate payloads against JSON schemas before processing:
-
-- Kind 9901: Validate against `nostrability/schemata/nips/nip-rp/kind-9901/schema.yaml`
-- Kind 9902: Validate against `nostrability/schemata/nips/nip-rp/kind-9902/schema.yaml`
-- Kind 9903: Validate against `nostrability/schemata/nips/nip-rp/kind-9903/schema.yaml`
-- Kind 9904: Validate against `nostrability/schemata/nips/nip-rp/kind-9904/schema.yaml`
-
-
-Invalid payloads MUST be rejected and not processed further.
 
 ## Business Discovery 
 
-Businesses MUST advertise their capability to handle reservation messages using [NIP-89](https://github.com/nostr-protocol/nips/blob/master/89.md) Application Handlers.
-
-### Handler Information Event (kind:31990)
-
-Businesses MUST publish a `kind:31990` handler information event that declares support for all reservation message kinds:
+Businesses MUST advertise their capability to handle reservation messages by including in their `kind:0` profile event a NIP-32 label `reservations` within the namespace `com.synvya.merchant`.
 
 ```yaml
 {
-  "kind": 31990,
-  "pubkey": "<businessPublicKey>",
+  "kind": 0,
   "tags": [
-    ["d", "reservations-v1.0"],
-    ["k", "9901"],
-    ["k", "9902"],
-    ["k", "9903"],
-    ["k", "9904"]
+    ["L", "com.synvya.merchant"],
+    ["l", "reservations", "com.synvya.merchant"],
+    // additional tags
   ],
-  "content": ""
+  // other fields...
 }
 ```
-
-- The `d` tag MUST use the identifier `"reservations-v1.0"`
-- The `k` tags MUST include all four supported kinds: `9901`, `9902`, `9903`, and `9904`
-- The `content` field MAY be empty (clients will use the business' `kind:0` profile for display)
-
-### Handler Recommendation Events (kind:31989)
-
-Businesses MUST publish four `kind:31989` handler recommendation events, one for each supported event kind:
-
-**For kind:9901 (reservation.request):**
-```yaml
-{
-  "kind": 31989,
-  "pubkey": "<businessPublicKey>",
-  "tags": [
-    ["d", "9901"],
-    ["a", "31990:<businessPublicKey>:reservations-v1.0", "<relayUrl>", "all"]
-  ],
-  "content": ""
-}
-```
-
-**For kind:9902 (reservation.response):**
-```yaml
-{
-  "kind": 31989,
-  "pubkey": "<businessPublicKey>",
-  "tags": [
-    ["d", "9902"],
-    ["a", "31990:<businessPublicKey>:reservations-v1.0", "<relayUrl>", "all"]
-  ],
-  "content": ""
-}
-```
-
-**For kind:9903 (reservation.modification.request):**
-```yaml
-{
-  "kind": 31989,
-  "pubkey": "<businessPublicKey>",
-  "tags": [
-    ["d", "9903"],
-    ["a", "31990:<businessPublicKey>:reservations-v1.0", "<relayUrl>", "all"]
-  ],
-  "content": ""
-}
-```
-
-**For kind:9904 (reservation.modification.response):**
-```yaml
-{
-  "kind": 31989,
-  "pubkey": "<businessPublicKey>",
-  "tags": [
-    ["d", "9904"],
-    ["a", "31990:<businessPublicKey>:reservations-v1.0", "<relayUrl>", "all"]
-  ],
-  "content": ""
-}
-```
-
-- Each `kind:31989` event MUST have a `d` tag with the event kind it recommends (`"9901"`, `"9902"`, `"9903"`, or `"9904"`)
-- Each `kind:31989` event MUST include an `a` tag referencing the business' `kind:31990` handler information event
-- The `a` tag format MUST be: `"31990:<businessPublicKey>:reservations-v1.0"`
-- The second value of the `a` tag SHOULD be a relay URL hint for finding the handler
-- The third value of the `a` tag SHOULD be `"all"` to indicate the recommendation applies to all platforms
-
----
-
-### Publishing Requirements
-
-- Businesses MUST publish the `kind:31990` handler information event when first setting up their reservation system
-- Businesses MUST publish all four `kind:31989` recommendation events when first setting up their reservation system
-- Businesses SHOULD republish these events whenever their handler configuration changes or when updating their business profile
-- All handler events MUST be published to the same relays where reservation messages are expected to be received
-
----
-
-### Client Discovery
-
-Customer clients discovering businesses that support reservations SHOULD:
-
-1. Query for `kind:31989` events with `#d` filters for `["9901"]`, `["9902"]`, `["9903"]`, and `["9904"]`
-2. Extract the `a` tag values from recommendation events to find handler information events
-3. Query for the corresponding `kind:31990` handler information events using the `a` tag coordinates
-4. Verify that the handler information event includes all four `k` tags (`9901`, `9902`, `9903`, `9904`) before considering the business as fully supporting the protocol
-
 
 ## Verified Business Reviews
 Customers who succesfully complete a business transaction after creating a reservation using the Reservation Protocol may issue a verified business review. Verified business reviews are reviews from real customers and should be considered more relevant than unverified reviews from users for whom it is not possible to determine if they have transacted with the business. 
@@ -447,9 +208,9 @@ The verified business review follows the [QTS guidelines](https://habla.news/u/a
 
 ### Business Transaction Attestation – Kind:9905
 
-`kind:9905` is a **signed** nostr event created by the business to attest that a business transaction occurred under a given reservation. The event is created by the business when a reservation is fulfilled and sent privately to the customer using an encrypted direct message (`kind:14`). The `kind:9905` event is **never** published to public relays to maintain the business transaction private until the customer decides to publish a review.
+`kind:9905` is a **signed** nostr event created by the business to attest that a business transaction occurred under a given reservation. The event is created by the business when a reservation is fulfilled and sent privately to the customer as the content of a NIP-17 private direct chat message. The `kind:9905` event is **never** published to public relays to maintain the business transaction private until the customer decides to publish a review.
 
-The event is intended as a business transaction attestation token that the customer MAY later embed in a public review. If the customer does not publish a review, then the reservation and business transaction will remain private. 
+The event is intended as a business transaction attestation token that the customer MAY later embed in a public review. If the customer does not publish a review, then the reservation and business transaction will remain private. If the customer publishes a review, then the reservation and business transaction become public. 
 
 **Event Structure:**
 ```yaml
@@ -459,56 +220,24 @@ The event is intended as a business transaction attestation token that the custo
   "created_at": <unix timestamp in seconds>,
   "kind": 9905,
   "tags": [
-    ["e", "<unsigned-9901-rumor-id>"],  # Reservation thread id 
-    ["p", "<customerPublicKey>"]
+    ["p", "<customerPublicKey>"],
+    ["e", "<unsigned-9901-rumor.id>", "", "root"], # connects message to reservation thread
+    ["time", "<unix timestamp in seconds>"],
+    ["tzid", "<IANA Time Zone Database identifier>"],
+    ["qts_labels", "label1, label2, label3, ..., labelN"] # comma separated list of labels
+    
   ],
   "content": "<content-in-plain-text>",
   "sig": "<signed by businessPrivateKey>"
 }
 ```
 
-**Content Structure:**
-```yaml
-{
-  "iso_time": "<ISO8601 datetime with timezone>",
-  "qts_labels": [
-    "label1",
-    "label2",
-    "label3"
-    # Add more labels as needed
-  ]
-}
-```
-
-**Required Tags:**
-- `["e", "<unsigned-9901-rumor-id>"]`: MUST reference the unsigned rumor ID of the original reservation.request `kind:9901` message. This value is the reservation thread id.
-- `["p", "<customerPublicKey>"]`: MUST reference the customer associated with the transaction.
-- `iso_time`: reservation ISO8601 datetime string with timezone offset
-- `qts_labels`: the array of labels to be used for the QTS review
----
-
-The `transaction.attestation` `kind:9905` message is sent from the business to the customer as the content of a direct message `kind:14` with the same `<unsigned-9901-rumor-id>` thread ID to connect it to the reservation in question. 
-
-```yaml
-{
-  "kind": 14,
-  "pubkey": "<businessPublicKey>",
-  "created_at": <unix timestamp in seconds>,
-  "tags": [
-    ["p", "<customerPublicKey>"],
-    ["e", "<unsigned-9901-rumor-id>", "", "root"]
-  ],
-  "content": "<plain-text serialized and signed kind-9905 event>"
-  // no sig field – this is a rumor, encrypted and transported via NIP-59
-}
-```
 ---
 
 ### Verified Business Review - Kind 31555
-
-The verified business review is issued as a `kind:31555` nostr event following the NIP-99 market specification addendum with additional tags included for the verification process:
-- `verified` tag with the base64 encoding of the full serialized `transaction.attestation` `kind:9905` event
-- `e` tag with the original reservation thread id
+The customer issues a verified business review as a `kind:31555` nostr event following the NIP-99 market specification addendum with additional tags included for the verification process:
+- `verified`: base64 encoding of the full serialized `transaction.attestation` `kind:9905` event.
+- `e` tag used to connect all messages of the same reservation request (the reservation thread). Contains the `.id` field of the original `kind:9901` reservation request.
 
 When in conflict, the NIP-99 market specification addendum takes precedence over this NIP.
 
@@ -527,7 +256,7 @@ When in conflict, the NIP-99 market specification addendum takes precedence over
     ["rating", "1.0", <label1-from-qts-labels-field-in-transaction-attestation-event], # rating between 0 and 1 with one decimal point
     ["rating", "0.6", <label1-from-qts-labels-field-in-transaction-attestation-event], # rating between 0 and 1 with one decimal point
     # Add more labels as specified by the kind:9905 event.
-    ["e", "<unsigned-9901-rumor-id>"], # Reservation thread id 
+    ["e", "<unsigned-9901-rumor.id>", "", "root"], # connects message to reservation thread
     ["verified", "<base64-encoded-transaction-attestation-event-kind-9905>"] 
     # Additional tags MAY be included
   ],
@@ -536,57 +265,12 @@ When in conflict, the NIP-99 market specification addendum takes precedence over
 }
 ```
 
-**Required Tags**:
-	- `["d", "p:<businessPublicKey>"]`: MUST specify the business being reviewed.
-	- `["e", "<unsigned-9901-rumor-id>"]`: MUST reference the same reservation thread id used during the reservation flow.
-  - `["verified", "<base64-encoded-transaction-attestation-event-kind-9905>"]`: The value MUST be a base64 encoding of the full serialized kind:9905 transaction attestation event.
-	- `["rating", "<0 or 1>", "thumb"]`: Primary rating, 0 for thumbs down and 1 for thumbs up.
-	-	`["rating", "<empty> | <0 to 1>", <labelN-from-qts-labels-field-in-transaction-attestation-event]`: additional rating between 0 and 1 with one decimal point. All labels listed in the `kind:9905` event should be included. Value may be empty if user did not provide a rating for an specific label. 
-
 A client MAY treat a `kind:31555` event as a **verified business review** if all of the following conditions are met:
 1.	The event has a `["verified", "<payload>"]` tag. 
 2.	Decoding `<payload>` from base64 yields a valid nostr `transaction.attestation` `kind:9905` event with the following properties:
-  - The `pubkey` field matches the business public key indicated by the `kind:31555` `["d", "p:<businessPublicKey>"]` tag
+  - The `.pubkey` field matches the business public key indicated by the `kind:31555` `["d", "p:<businessPublicKey>"]` tag
   - The customer public key of the `["p", "<customerPublicKey>"]` tag matches the public key signing the `kind:31555` review event
-  - There is a `["e", "<unsigned-9901-rumor-id>"]` tag matching the `["e", "<unsigned-9901-rumor-id>"]` tag of the  `kind:31555` review event
+  - There is a `["e", "<unsigned-9901-rumor.id>", "", "root"]` tag matching the `["e", "<unsigned-9901-rumor.id>", "", "root"]` tag of the  `kind:31555` review event
   - The `transaction.attestation` `kind:9905` event has a valid signature computed according to NIP-01.
 
 If verification succeeds, clients MAY consider the review as a **verified business review**. If verification fails, clients SHOULD NOT display the review. 
-
----
-
-### Verified Business Review Flow
-
-#### Business Transaction Attestation Issued By The Business
-1. After the transaction is considered fulfilled, the business sends a `transaction.attestation` `kind:9905` message to the customer via a `kind:14` direct message. The `transaction.attestation` `kind:9905` message is **never** published to a relay.
-2. Message exchange ends
-
-No further action is expected from the business or the customer. 
-
-#### Customer Elects to Not Publish a Review
-1. Customer receives the `transaction.attestation` `kind:9905` message from the business.
-2. Customer chooses to not issue a review
-3. Message exchange ends
-
-The fact that the customer transacted with the business remains a private fact known only to the customer and the business. 
-
-#### Customer Elects to Publish a Review
-1. Customer receives the `transaction.attestation` `kind:9905` message from the business.
-2. Customer writes a review and publishes it as a `kind:31555` event that includes the `["verified", "<base64-encoded-transaction-attestation-event-kind-9905>"]` tag 
-3. Message exchange ends
-
-The fact that the customer transacted with the business becomes a public fact. 
-
-### JSON Schema Validation
-- Kind 9905: Validate against `nostrability/schemata/nips/nip-rp/kind-9905/schema.yaml`
-
----
-
-### Verified Reviews Discovery
-
-A client searching for verified reviews for a given business with `businessPublicKey` SHOULD:
-  1. Query for `kind:31555` events with:
-	  •	`["d", "p:<businessPublicKey>"]` to select reviews for this business
-	  •	For each review, check for a `["verified", "<payload>"]` tag and, if present, perform the verification steps defined in section [Verified Business Review - Kind:31555](#verified-business-review–kind:31555).
-
-If verification succeeds, the review MAY be treated as a **Verified Business Review**. 

--- a/rp.md
+++ b/rp.md
@@ -36,12 +36,13 @@ The following tags are used across the different kinds defined by this NIP:
 - `time`: inclusive reservation start Unix timestamp in seconds.
 - `tzid`: time zone of the reservation `time`, `earliest_time`, and `latest_time` Unix timestamps, as defined by the IANA Time Zone Database. e.g., `America/Costa_Rica`.
 - `duration`: duration of the reservation in seconds.
-- `name`: reservation holder.
+- `name`: reservation holder. May be different from the party initiating the reservation flow.
 - `phone`: phone number for the reservation holder.
 - `email`: email for the reservation holder.
 - `earliest_time`: earliest start time Unix timestamp that the requestor would accept for the reservation.
 - `latest_time`: earliest time that the requestor would accept for the reservation.
 - `status`: status of the reservation as one of the following values `confirmed`, `declined`, or `cancelled`.
+- `broker`: set to `True` if the party initiating the reservation flow is not the reservation holder
 
 ### Reservation Request - Kind:9901
 
@@ -49,7 +50,7 @@ The following tags are used across the different kinds defined by this NIP:
 ```yaml
 {
   "id": "<32-byte hex of unsigned event hash>", # the thread id to be used by all other messages for this reservation
-  "pubkey": "<senderPublicKey>",
+  "pubkey": "<senderPublicKey>", # may be reservation holder or a broker acting on behalf of reservation holder
   "created_at": <unix timestamp in seconds>,
   "kind": 9901,
   "tags": [
@@ -60,9 +61,10 @@ The following tags are used across the different kinds defined by this NIP:
     ["name", "<string, max 200 chars>"],
     ["telephone", "<optional string, 'tel:' URI as per RFC 3966>"], # one of email or telephone must be included 
     ["email", "<optional string, 'mailto:' URI as per RFC 6068>"],  # one of email or telephone must be included
-    ["duration", <optional duration of reservation in seconds>"],
+    ["duration", <optional, duration of reservation in seconds>"],
     ["earliest_time", "<optional unix timestamp in seconds>"],
-    ["latest_time", "<optional unix timestamp in seconds>"]
+    ["latest_time", "<optional unix timestamp in seconds>"],
+    ["broker", "<optional boolean, `True` | 'False'>"] 
   ],
   "content": "<reservation request message in plain text>"
   # Note: No signature field - this is an unsigned rumor
@@ -86,7 +88,7 @@ The following tags are used across the different kinds defined by this NIP:
     ["status", "<confirmed|declined|cancelled>"],
     ["time", "<unix timestamp in seconds>"],
     ["tzid", "<IANA Time Zone Database identifier>"],
-    ["duration", <optional duration of reservation in seconds>"],
+    ["duration", <duration of reservation in seconds>"],
     # Additional tags MAY be included
   ],
   "content": "<reservation response message in plain text>"
@@ -114,7 +116,7 @@ The following tags are used across the different kinds defined by this NIP:
     ["name", "<optional string, max 200 chars>"],           
     ["telephone", "<optional string, 'tel:' URI as per RFC 3966>"],  # must be included if present in reservation.request
     ["email", "<optional string, 'mailto:' URI as per RFC 6068>"],   # must be included if present in reservation.request
-    ["duration", <optional duration of reservation in seconds>"],
+    ["duration", <optional, duration of reservation in seconds>"],
     ["earliest_time", "<optional unix timestamp in seconds>"],
     ["latest_time", "<optional unix timestamp in seconds>"]
     # Additional tags MAY be included
@@ -141,10 +143,10 @@ The following tags are used across the different kinds defined by this NIP:
     ["status", "<confirmed|declined|cancelled>"],
     ["time", "<unix timestamp in seconds>"],
     ["tzid", "<IANA Time Zone Database identifier>"],
-    ["duration", <optional duration of reservation in seconds>"],
+    ["duration", <duration of reservation in seconds>"],
     # Additional tags MAY be included
   ],
-  "content": "<creservation modification response message in plain text>"
+  "content": "<reservation modification response message in plain text>"
   # Note: No signature field - this is an unsigned rumor
 }
 ```
@@ -206,6 +208,7 @@ Once a reservation is fulfilled, for example when the restaurant check is closed
 - It's created before the review is written
 - Does not endorse the content of the review
 
+Businesses MUST only issue a token if the `reservation.request` - `kind:9901` message had no `broker` tag or the tag was set to `False`. A token MUST never be issued for a reservation when the `broker` tag is set to `True`.
 
 The verified business review follows the [QTS guidelines](https://habla.news/u/arkinox@arkinox.tech/DLAfzJJpQDS4vj3wSleum) with labels specified by the business to ensure review uniformity regardless of the application used by the customer to issue the review. 
 

--- a/rp.md
+++ b/rp.md
@@ -6,7 +6,7 @@ Reservation Protocol v1.0
 
 `draft` `optional`
 
-This NIP defines a protocol to manage reservations via Nostr. The term "reservations" is used as a broad term and could be applied to restaurants, hotels, or any other business offering appointments. This NIP also defines a business transaction attestation event associated with a succesfully completed reservation so that customers can issue a **verified business review**.
+This NIP defines a protocol to manage reservations via Nostr. The term "reservations" is used as a broad term and could be applied to restaurants, hotels, or any other business offering appointments. This NIP also defines a business transaction attestation event associated with a successfully completed reservation so that customers can issue a **verified business review**.
 
 The reservation process uses 4 different messages, each with its own kind, that are sent unsigned, sealed, and gift wrapped between the parties to maintain the privacy of the customer. Only the customer and the business are aware of the reservation.
 
@@ -31,18 +31,34 @@ Clients must support `kind:9901` and `kind:9902` messages. Support for `kind:990
 
 The following tags are used across the different kinds defined by this NIP:
 - `p`: public key of the recipient of the message.
+- `relays`: one or more relay URLs identifying the author's preferred read relays for replies and follow-up messages in the reservation thread.
 - `e`: tag used to connect all messages of the same reservation request (the reservation thread). Contains the `.id` field of the original `kind:9901` reservation request.
 - `party_size`: number of people in the reservation.
 - `time`: inclusive reservation start Unix timestamp in seconds.
 - `tzid`: time zone of the reservation `time`, `earliest_time`, and `latest_time` Unix timestamps, as defined by the IANA Time Zone Database. e.g., `America/Costa_Rica`.
 - `duration`: duration of the reservation in seconds.
 - `name`: reservation holder. May be different from the party initiating the reservation flow.
-- `phone`: phone number for the reservation holder.
+- `telephone`: phone number for the reservation holder.
 - `email`: email for the reservation holder.
 - `earliest_time`: earliest start time Unix timestamp that the requestor would accept for the reservation.
-- `latest_time`: earliest time that the requestor would accept for the reservation.
+- `latest_time`: latest start time that the requestor would accept for the reservation.
 - `status`: status of the reservation as one of the following values `confirmed`, `declined`, or `cancelled`.
 - `broker`: set to `True` if the party initiating the reservation flow is not the reservation holder
+
+## Relay Routing
+
+This NIP follows the outbox model described by [NIP-65](https://github.com/nostr-protocol/nips/blob/master/65.md) for routing reservation rumors between the customer and the business.
+
+When sending a reservation rumor to a counterparty, clients MUST:
+1. Look up the recipient's latest `kind:10002` relay list metadata event.
+2. Publish the gift-wrapped event to the recipient's `read` relays from `kind:10002`. If a relay in `kind:10002` has no marker, it SHOULD be treated as both `read` and `write` as defined by NIP-65.
+3. Include a `["relays", "<relay1>", "<relay2>", ...]` tag in the unsigned rumor listing the author's own preferred `read` relays, so the recipient knows where to publish the next message in the reservation thread.
+
+The `relays` tag acts as a return address. In a `kind:9901` event, it tells the business where to publish a `kind:9902` or `kind:9903` reply for the customer. In a response from the business, it tells the customer where to publish any follow-up messages for the business.
+
+Clients MUST include a `relays` tag in `kind:9901`, `kind:9902`, `kind:9903`, and `kind:9904` messages. If the recipient has no discoverable `kind:10002`, clients MAY fall back to the most recent `relays` tag seen for that counterparty in the reservation thread. The optional relay URL in the `p` tag MAY be used only as a final compatibility fallback when no better routing information is available.
+
+The `p` tag identifies the recipient's public key. Clients MUST use the `relays` tag and `kind:10002` relay list metadata as the primary routing mechanism for this protocol.
 
 ### Reservation Request - Kind:9901
 
@@ -54,7 +70,8 @@ The following tags are used across the different kinds defined by this NIP:
   "created_at": <unix timestamp in seconds>,
   "kind": 9901,
   "tags": [
-    ["p", "<businessPublicKey>", "<relayUrl>"],
+    ["p", "<businessPublicKey>"],
+    ["relays", "<customerReadRelay1>", "<customerReadRelay2>", "..."],
     ["party_size", "<integer between 1 and 20>"],
     ["time", "<unix timestamp in seconds>"],
     ["tzid", "<IANA Time Zone Database identifier>"],
@@ -83,7 +100,8 @@ The following tags are used across the different kinds defined by this NIP:
   "created_at": <unix timestamp in seconds>,
   "kind": 9902,
   "tags": [
-    ["p", "<recipientPublicKey>", "<relay-url>"],
+    ["p", "<recipientPublicKey>"],
+    ["relays", "<authorReadRelay1>", "<authorReadRelay2>", "..."],
     ["e", "<unsigned-9901-rumor.id>", "", "root"], # connects message to reservation thread
     ["status", "<confirmed|declined|cancelled>"],
     ["time", "<unix timestamp in seconds>"],
@@ -100,6 +118,8 @@ The following tags are used across the different kinds defined by this NIP:
 
 ### Reservation Modification Request - Kind:9903
 
+`kind:9903` is used to propose a revised set of reservation terms for an existing reservation thread. It MAY be used by the business as a counter-proposal while responding to a `kind:9901` request, or by either party after a reservation has already been confirmed to propose a replacement reservation. The tags in the event describe the full proposed reservation state that the sender wants the recipient to evaluate.
+
 **Rumor Event Structure:**
 ```yaml
 {
@@ -108,14 +128,15 @@ The following tags are used across the different kinds defined by this NIP:
   "created_at": <unix timestamp in seconds>,
   "kind": 9903,
   "tags": [
-    ["p", "<recipientPublicKey>", "<relay-url>"],
+    ["p", "<recipientPublicKey>"],
+    ["relays", "<authorReadRelay1>", "<authorReadRelay2>", "..."],
     ["e", "<unsigned-9901-rumor.id>", "", "root"], # connects message to reservation thread
     ["party_size", "<integer between 1 and 20>"],
     ["time", "<unix timestamp in seconds>"],
     ["tzid", "<IANA Time Zone Database identifier>"], 
-    ["name", "<optional string, max 200 chars>"],           
-    ["telephone", "<optional string, 'tel:' URI as per RFC 3966>"],  # must be included if present in reservation.request
-    ["email", "<optional string, 'mailto:' URI as per RFC 6068>"],   # must be included if present in reservation.request
+    ["name", "<optional string, max 200 chars>"],
+    ["telephone", "<optional string, 'tel:' URI as per RFC 3966>"],  # if included, should match the reservation holder information for the thread
+    ["email", "<optional string, 'mailto:' URI as per RFC 6068>"],   # if included, should match the reservation holder information for the thread
     ["duration", <optional, duration of reservation in seconds>"],
     ["earliest_time", "<optional unix timestamp in seconds>"],
     ["latest_time", "<optional unix timestamp in seconds>"]
@@ -138,7 +159,8 @@ The following tags are used across the different kinds defined by this NIP:
   "created_at": <unix timestamp in seconds>,
   "kind": 9904,
   "tags": [
-    ["p", "<recipientPublicKey>", "<relay-url>"],
+    ["p", "<recipientPublicKey>"],
+    ["relays", "<authorReadRelay1>", "<authorReadRelay2>", "..."],
     ["e", "<unsigned-9901-rumor.id>", "", "root"], # connects message to reservation thread
     ["status", "<confirmed|declined|cancelled>"],
     ["time", "<unix timestamp in seconds>"],
@@ -153,34 +175,36 @@ The following tags are used across the different kinds defined by this NIP:
 ## Protocol Flow
 
 ### Simple Reservation Request 
-1. Customer sends `reservation.request` `kind:9901` message to the business
-2. Business responds with `reservation.response` `kind:9902` message to the customer with `"status":"confirmed"` or `"status":"declined"`
-3. Message exchange ends
+1. Customer fetches the business's `kind:10002` relay list metadata event
+2. Customer sends `reservation.request` `kind:9901` message to the business by publishing the gift wrap to the business's `read` relays and includes the customer's own `read` relays in the `relays` tag
+3. Business responds with `reservation.response` `kind:9902` message to the customer with `"status":"confirmed"` or `"status":"declined"` by publishing the gift wrap to the customer's `read` relays hinted in the `relays` tag or discoverable from the customer's `kind:10002`
+4. Message exchange ends
 
 ### Reservation Request With Business Suggesting Alternative Time
-1. Customer sends `reservation.request` `kind:9901` message to the business
-2. Business responds with `reservation.modification.request` `kind:9903` message to the customer with proposed new time
-3. Customer responds with `reservation.modification.response` `kind:9904` message to the business with `"status":"confirmed"` or `"status":"declined"`
-4. Business responds with `reservation.response` `kind:9902` message to the customer with matching status `confirmed` or `declined`
+1. Customer fetches the business's `kind:10002` relay list metadata event
+2. Customer sends `reservation.request` `kind:9901` message to the business by publishing the gift wrap to the business's `read` relays and includes the customer's own `read` relays in the `relays` tag
+3. Business responds with `reservation.modification.request` `kind:9903` message to the customer with proposed new time, publishing the gift wrap to the customer's `read` relays hinted in the request's `relays` tag or discoverable from the customer's `kind:10002`
+4. Customer responds with `reservation.modification.response` `kind:9904` message to the business with `"status":"confirmed"` or `"status":"declined"`, publishing the gift wrap to the business's `read` relays hinted in the business's `relays` tag or discoverable from the business's `kind:10002`
+5. Business responds with `reservation.response` `kind:9902` message to the customer with matching status `confirmed` or `declined`
 
-### Succesful Reservation Modification by Customer
-1. Customer sends `reservation.modification.request` `kind:9903` message to the business with proposed new time
-2. Business sends `reservation.modification.response` `kind:9904` message to the customer with `"status":"confirmed"` to indicate availability for the new time
-3. Customer sends `reservation.response` `kind:9902` message to the business with status `confirmed`
-
-
-### Unsuccesful Reservation Modification by Customer
-1. Customer sends `reservation.modification.request` `kind:9903` message to the business with proposed new time
-2. Business sends `reservation.modification.response` `kind:9904` message to the customer with `"status":"declined"` to indicate lack of availability for the new time
-3. Customer sends `reservation.response` `kind:9902` message to the business with original time and status `"status":"confirmed"` to maintain original reservation or `"status":"cancelled"` to cancel the original reservation
+### Successful Reservation Modification by Customer
+1. Customer sends `reservation.modification.request` `kind:9903` message to the business with proposed new time, publishing to the business's `read` relays discovered from `kind:10002` or the latest routing hints available in the reservation thread
+2. Business sends `reservation.modification.response` `kind:9904` message to the customer with `"status":"confirmed"` to indicate availability for the new time, publishing to the customer's `read` relays discovered from `kind:10002` or the latest routing hints available in the reservation thread
+3. Customer sends `reservation.response` `kind:9902` message to the business with status `confirmed`, publishing to the business's `read` relays discovered from `kind:10002` or the latest routing hints available in the reservation thread
 
 
-### Reservation Cancellation Initated by the Business
-1. Business sends `reservation.response` `kind:9902` message to the customer with `"status":"cancelled"`. Including a note in the `.content` field of the event is highly recommended. 
+### Unsuccessful Reservation Modification by Customer
+1. Customer sends `reservation.modification.request` `kind:9903` message to the business with proposed new time, publishing to the business's `read` relays discovered from `kind:10002` or the latest routing hints available in the reservation thread
+2. Business sends `reservation.modification.response` `kind:9904` message to the customer with `"status":"declined"` to indicate lack of availability for the new time, publishing to the customer's `read` relays discovered from `kind:10002` or the latest routing hints available in the reservation thread
+3. Customer sends `reservation.response` `kind:9902` message to the business with original time and status `"status":"confirmed"` to maintain original reservation or `"status":"cancelled"` to cancel the original reservation, publishing to the business's `read` relays discovered from `kind:10002` or the latest routing hints available in the reservation thread
 
 
-### Reservation Cancellation Initated by the Customer
-1. Customer sends `reservation.response` `kind:9902` message to the business with `"status":"cancelled"`. Including a note in the `.content` field of the event is highly recommended. 
+### Reservation Cancellation Initiated by the Business
+1. Business sends `reservation.response` `kind:9902` message to the customer with `"status":"cancelled"`, publishing to the customer's `read` relays discovered from `kind:10002` or the latest routing hints available in the reservation thread. Including a note in the `.content` field of the event is highly recommended. 
+
+
+### Reservation Cancellation Initiated by the Customer
+1. Customer sends `reservation.response` `kind:9902` message to the business with `"status":"cancelled"`, publishing to the business's `read` relays discovered from `kind:10002` or the latest routing hints available in the reservation thread. Including a note in the `.content` field of the event is highly recommended. 
 
 
 ## Business Discovery 
@@ -191,7 +215,7 @@ Businesses MUST advertise their support for the Reservation Protocol using an ex
 {
   "kind": 0,
   "tags": [
-    ["i", "rp", "https://github.com/nostr-protocol/nips/blob/master/rp.md"],
+    ["i", "rp", "https://github.com/Synvya/reservation-protocol/blob/main/nostr-protocols/nips/rp.md"],
     ["k", "nip"],
     // additional tags
   ],
@@ -200,7 +224,7 @@ Businesses MUST advertise their support for the Reservation Protocol using an ex
 ```
 
 ## Verified Business Reviews
-Customers who succesfully complete a business transaction after creating a reservation using the Reservation Protocol may issue a verified business review. Verified business reviews are reviews from real customers and should be considered more relevant than unverified reviews from users for whom it is not possible to determine if they have transacted with the business. 
+Customers who successfully complete a business transaction after creating a reservation using the Reservation Protocol may issue a verified business review. Verified business reviews are reviews from real customers and should be considered more relevant than unverified reviews from users for whom it is not possible to determine if they have transacted with the business.
 
 The Reservation Protocol supports verified business reviews by expanding upon reviews as specified by the [market specification](https://github.com/GammaMarkets/market-spec/blob/main/spec.md) addendum to [NIP-99](https://github.com/nostr-protocol/nips/blob/master/99.md).
 


### PR DESCRIPTION
This NIP defines a protocol to manage reservations via Nostr while maintaining the privacy of the customer.

The term "reservations" is used as a broad term and could be applied to restaurants, hotels, or any other business offering multiple appointments. This NIP also defines a business transaction attestation event associated with a successfully completed reservation so that customers can issue a **verified business review**.

The reservation process uses 4 different messages, each with its own kind, that are sent unsigned, sealed, and gift wrapped between the parties to maintain the privacy of the customer. Only the customer and the business are aware of the reservation.

The protocol defines a fifth new kind that businesses use to send a transaction attestation token to customers. Customers add this token to their reviews so that readers can identify this review as coming from a verified customer. The reservation and associated business transaction remain private until and unless the customer publishes a review. 

This NIP builds on the `kind:31555` review event used by the [Gamma Markets](https://github.com/GammaMarkets) [specification addendum](https://github.com/GammaMarkets/market-spec/blob/main/spec.md) to [NIP-99](https://github.com/nostr-protocol/nips/blob/master/99.md).

