### PR TITLE
add prefix matching filters to NIP-13

### DIFF
--- a/13.md
+++ b/13.md
@@ -100,3 +100,15 @@ Delegated Proof of Work
 -----------------------
 
 Since the `NIP-01` note id does not commit to any signature, PoW can be outsourced to PoW providers, perhaps for a fee. This provides a way for clients to get their messages out to PoW-restricted relays without having to do any work themselves, which is useful for energy-constrained devices like mobile phones.
+
+Relay Filter Support
+--------------------
+
+The `ids` and `authors` lists **MAY** contain lowercase hexadecimal strings, which may either be an exact 64-character match or a prefix of the event value. A prefix match is when the filter string is an exact string prefix of the event value. The use of prefixes allows for filtering against event ids and pubkeys with `n` bits of difficulty.
+
+```
+{
+  ids: ['000'],
+  authors: ['000000']
+}
+```


### PR DESCRIPTION
prefix matching was removed from NIP-01 a long time ago and that makes a lot of sense because it is awkward/difficult to implement and has limited, if any, relevance for most cases.

This PR adds prefix matching into NIP-13, using the same text that used to be in NIP-01, only slightly reworded.  

**Rationale:**
There is no way to filter against NIP-13 events

**Impact on relays:** 
None, not a single relay flags support for NIP-13.

**Impact on clients:**
None, no client details have been changed in this PR.

_ship it_