### PR TITLE
Update 34.md with nostrability tracker link

### DIFF
--- a/34.md
+++ b/34.md
@@ -246,3 +246,7 @@ The event SHOULD include a list of `g` tags with grasp service websocket URLs in
 ## Possible things to be added later
 
 - inline file comments kind (we probably need one for patches and a different one for merged files)
+
+## Git interoperability tracker
+
+See working discussion in https://github.com/nostrability/nostrability/issues/72.


### PR DESCRIPTION
added git/nip-34 nostrability tracker link