### PR TITLE
Key migration

### DIFF
--- a/41.md
+++ b/41.md
@@ -6,7 +6,7 @@ Nostr Key Migration
 
 `draft` `optional`
 
-This NIP defines a simple mechanism which allows users to migrate to a new key and invalidate their current account. It combines signatures, social key recovery, Open Timestamp Attestations, and some trust assumptions to prevent hijacking by an attacker or loss of control through over-reliance on the social graph.
+This NIP defines a simple mechanism which allows users to migrate to a new key and invalidate their current account. It combines signatures, social key recovery, OpenTimestamp Attestations, and some trust assumptions to prevent hijacking by an attacker or loss of control through over-reliance on the social graph.
 
 ## Creating a Migration Key
 
@@ -64,9 +64,9 @@ These risks can be mitigated (but not solved) in classically nostr fashion by sp
 
 However these relays are chosen, the entire network MUST use the same set. Network partitioning is unacceptable in this case. Selection of actual relays is left to the nostr community.
 
-All `kind 360` and `kind 361` events MUST be published to all `migration` relays along with an accompanying `kind 1040` [Open Timestamp Attestation](03.md) event. If multiple conflicting events exist, the first one published MUST be used.
+All `kind 360` and `kind 361` events MUST be published to all `migration` relays along with an accompanying `kind 1040` [OpenTimestamp Attestation](03.md) event. If multiple conflicting events exist, the first one published MUST be used.
 
-In both cases, only the first event of each kind published by a given key is valid. `migration` relays MUST validate Open Timestamp attestations, and ensure that only `kind 361` events that match a valid `kind 360` event are stored. Clients SHOULD also perform this validation. `migration` relays MUST NOT delete `kind 360` or `kind 361` events for any reason.
+In both cases, only the first event of each kind published by a given key is valid. `migration` relays MUST validate OpenTimestamp attestations, and ensure that only `kind 361` events that match a valid `kind 360` event are stored. Clients SHOULD also perform this validation. `migration` relays MUST NOT delete `kind 360` or `kind 361` events for any reason.
 
 ## Appendix B: In-Band Social Key Recovery
 


### PR DESCRIPTION
This NIP was sketched out in a session at nostr.xxx. It's based on @pablof7z's [original migration proposal](https://github.com/nostr-protocol/nips/pull/829) with some elements from https://github.com/nostr-protocol/nips/pull/2114.

Differences from prior art:

- There is no holding period of 30-60 days. Migration events can be validated immediately.
- Instead of migrating directly from the parent to the successor, an intermediate, single-use `migration` key is introduced. This can be stored however a user prefers, but it's recommended to use social key recovery with shamir secret sharding, which prevents single points of failure in the user's backup strategy.
- Migration is only used to signal to clients that users should update their follow lists (and mutes, follow packs, etc), NOT establish a live link between an old key and a new key (or its successors). This means that migrations mean mentions etc are not maintained, messages are lost, etc., but implementation is much less onerous (and can be done manually by users as well).

Important downsides:

- The worst case scenario occurs when an attacker gets key material and the user hasn't yet published a precommit, in which case the attacker can execute the migration flow himself. This is worse than the status quo, since currently users retain the ability to spam an identity. For this reason, migration should always be presented to a user with context, not automatically implemented. Additional affordances, like migration attestations (where web of trust is used to validate the authenticity of a migration) might be added to buttress user certainty.
- There is no recourse for all key material being lost. Social key recovery on its own compromises the integrity of keys as a root identity, which I think is a bridge too far. However, informal migration is still possible on the social layer.
- This NIP relies on a **central group of trusted relays** to guarantee precommit availability and event validation (ordering is guaranteed by OTS, but not completeness). I would be interested in a proposal to put precommits on a blockchain directly in order to remove this flaw. An OP_RETURN in the form of `<40 bytes of pubkey 1><40 bytes of pubkey 2>` might suffice.