### PR TITLE
Simpler key migration

### DIFF
--- a/A1.md
+++ b/A1.md
@@ -6,7 +6,7 @@ Key Migration
 
 `draft` `optional`
 
-This NIP offers a simple mechanism to socially evaluate and authenticate a key migration.
+This NIP offers a simple mechanism to evaluate and authenticate a key migration socially.
 
 Users publish kind `39` events when migrating to a new key (`p` tag).
 
@@ -23,10 +23,9 @@ Users publish kind `39` events when migrating to a new key (`p` tag).
 ```
 
 Kind `39` events are either a legitimate migration and should be accepted, or a phishing attempt 
-by an attacker, which should be rejected and the main key unfollowed.
+by an attacker, which should be rejected, and the main key unfollowed.
 
-[NIP-22](22.md) comments SHOULD be used to debate if the event is legitimate. [NIP-56](56.md) reports 
-can be used to reveal malicious behavior. 
+[NIP-22](22.md) comments SHOULD be used to debate if the event is legitimate. 
 
 Clients SHOULD offer Web of Trust signals to help users make a decision.
 


### PR DESCRIPTION
I don't believe in cryptographic securities for key migration: they are not only way too complicated to be coded correctly by every small client out there, but require a global state which we don't have.

So, here's a straightforward scheme that simply gets the migration debate going for each key. 