### PR TITLE
NIP-73: Add Wikidata identifiers

### DIFF
--- a/73.md
+++ b/73.md
@@ -26,6 +26,7 @@ There are certain established global content identifiers such as [Book ISBNs](ht
 | Podcast Publishers     | "podcast:publisher:guid:`<guid>`"                          | "podcast:publisher:guid" |
 | Blockchain Transaction | "`<blockchain>`:[`<chainId>`:]tx:`<txid, hex, lowercase>`" | "`<blockchain>`:tx"      |
 | Blockchain Address     | "`<blockchain>`:[`<chainId>`:]address:`<address>`"         | "`<blockchain>`:address" |
+| Wikidata Entities      | "wd:`<Qid>`" or "wdt:`<Pid>`"                              | "wikidata"               |
 
 ---
 
@@ -115,7 +116,25 @@ E.g. https://gnosisscan.io/tx/0x98f7812be496f97f80e2e98d66358d1fc733cf34176a8356
 ]
 ```
 
+### Wikidata
 
+E.g. "Nostr" entity on Wikidata https://www.wikidata.org/wiki/Q116423243
+
+```jsonc
+[
+  ["i", "wd:Q116423243"],
+  ["k", "wikidata"]
+]
+```
+
+E.g. "instance of" property on Wikidata https://www.wikidata.org/wiki/Property:P31
+
+```jsonc
+[
+  ["i", "wdt:P31"],
+  ["k", "wikidata"]
+]
+```
 
 ---
 


### PR DESCRIPTION
## Summary

This pull request adds [Wikidata](https://www.wikidata.org/) support to NIP-73 External Content IDs. 

It introduces the `wikidata` key for the `k` tag. 

For the `i` tag value, standardized RDF prefixes officially used by Wikidata should be used:
* `wd:Q...` for entities (e.g., `wd:Q42`)
* `wdt:P...` for properties (e.g., `wdt:P31`)

## Application Example

Wikidata assigns IDs to virtually everything in the world. Combined with NIP-25, this allows reactions to "anything" to be recorded as Nostr events. 

As a proof of concept, I created **Thingstr**: https://thingstr.pages.dev/

*Note: Events generated by Thingstr currently use tags in ways not explicitly defined by NIPs yet. For compatibility reasons, they are currently sent only to my dedicated relay.*

## Concept Description

The original idea for Thingstr is described in my article from last year: 
https://yakihonne.com/article/naddr1qvzqqqr4gupzqpuqfduxc63mgq9hkgxehly52q6l8tfp8kne0vx9p928vlpht32rqq255efedpr9snp3v4p564tgd4ury4n8fc6yx8asnpt

## Additional Notes

The current Thingstr implementation also uses `l`/`L` tags in ways not currently defined in NIPs. I plan to propose a separate specification for those (potentially in NIP-32) in the future. This PR focuses solely on the Wikidata ID definition for NIP-73.