### PR TITLE
Update NIP-73 to allow references to relays

### DIFF
--- a/73.md
+++ b/73.md
@@ -16,6 +16,7 @@ There are certain established global content identifiers such as [Book ISBNs](ht
 | Type                   | `i` tag                                                    | `k` tag                  |
 | ---                    | ---                                                        | ---                      |
 | URLs                   | "`<URL, normalized, no fragment>`"                         | "web"                    |
+| Relay                  | "`<WebSocket URL, normalized>`"                            | "relay"                  |
 | Books                  | "isbn:`<id, without hyphens>`"                             | "isbn"                   |
 | Geohashes              | "geo:`<geohash, lowercase>`"                               | "geo"                    |
 | Movies                 | "isan:`<id, without version part>`"                        | "isan"                   |


### PR DESCRIPTION
Update NIP-73 to allow references to relays, so that NIP-22 kind:1111 comments to reference relays.

Given the role of relays, I think it would be useful to let users leave comments about them (which may be posted to other relays, of course).