### PR TITLE
NIP-24: Add optional 'languages' field to kind 0 extra metadata

### DIFF
--- a/24.md
+++ b/24.md
@@ -17,7 +17,7 @@ These are extra fields not specified in NIP-01 that may be present in the string
   - `banner`: an URL to a wide (~1024x768) picture to be optionally displayed in the background of a profile screen.
   - `bot`: a boolean to clarify that the content is entirely or partially the result of automation, such as with chatbots or newsfeeds.
   - `birthday`: an object representing the author's birth date. The format is { "year": number, "month": number, "day": number }. Each field MAY be omitted.
-  - `language`: a string representing the author's preferred language, in the format defined by [IETF BCP 47](https://tools.ietf.org/html/bcp47) (e.g., "en", "en-US", "es", "es-AR").
+  - `languages`: an array of strings representing the author's preferred languages (in order of preference), each in the format defined by [IETF BCP 47](https://tools.ietf.org/html/bcp47) (e.g., `["en", "ja"]`, `["es-AR", "en-US"]`). The first element is the primary language.
 
 #### Deprecated fields
 


### PR DESCRIPTION
This pull request proposes adding a new optional extra field called `languages` (plural, as an array) to kind 0 (user metadata) events in NIP-24.

The field is an array of strings following the IETF BCP 47 language tag format (e.g., `["en"]`, `["ja", "en-US"]`, `["es-AR", "fr", "en"]`), indicating the author's preferred languages in order of preference (first element = primary).

#### Motivation
Nostr is a global protocol with diverse multilingual users. Many people are fluent in multiple languages and want to indicate support for more than one.

A single-language field is limiting for such users. Changing to an array:
- Allows expressing multiple preferred languages with priority.
- Enables clients to suggest relays matching any or the primary language.
- Facilitates building and discovering language-specific or multilingual relays more effectively.
- Improves content discovery, filtering, and community features in multilingual environments.
