### PR TITLE
NIP-32: describe use of Wikidata properties in labeling

### DIFF
--- a/32.md
+++ b/32.md
@@ -142,20 +142,38 @@ Author is labeling their note language as English using ISO-639-1.
 }
 ```
 
-Reaction events may use `l` and `L` tags to describe the category (`P31`, instance of) of the entity being reacted to
-with [Wikidata](https://www.wikidata.org/) identifiers. This can help clarify whether the target is, for example, a place,
-person, or work. Only the relevant tags need to be included alongside the rest of the reaction fields. When using RDF-style
-prefixes, set `L` to the prefix (`wikidata` in this example) and place the predicate and object together in the `l` value
-(here separated by a space) while keeping the same mark as the `L` tag.
+[Wikidata](https://www.wikidata.org/) systematically collects rich predicates and objects. For example, suppose you want
+to label an event as "a book review." `Q637866` is the entity representing a "book review," and `P31` is the property
+representing "instance of."
+
+When using RDF-style prefixes, set `L` to the prefix (`wikidata` in this example) and place the predicate and object
+together in the `l` value (here separated by a space) while keeping the same mark as the `L` tag. The statement can be
+expressed as an event like the following:
 
 ```jsonc
 {
-  "kind": 17, // NIP-25 reaction event
-  "content": "+",
+  "kind": 1985,
+  "content": "",
   "tags": [
-    // NIP-73 external content IDs
-    ["k", "wikidata"],
-    ["i", "wd:Q116423243"], // Subject (target entity): Q116423243 "nostr"
+    ["e", <event_id>, <relay_url>],
+    ["L", "wikidata"], // Prefix namespace
+    ["l", "wdt:P31 wd:Q637866", "wikidata"] // Predicate + Object: P31 "instance of" + Q637866 "book review"
+  ],
+  // other fields...
+}
+```
+
+This is practically useful when annotating reactions to Wikidata (See [NIP-73](./73.md)). This can help clarify whether
+the target is, for example, a place, person, or work. Only the relevant tags need to be included alongside the rest of
+the reaction fields. Suppose we have a reaction event that `+` reacts to the Nostr (`Q116423243`), which is an instance
+of a "communication protocol" (`Q637866`):
+
+```jsonc
+{
+  "kind": 1985,
+  "content": "",
+  "tags": [
+    ["e", <event_id>, <relay_url>, "mentioned"], // Specifies that the target is mentioned in the content, not the event itself
     ["L", "wikidata"], // Prefix namespace
     ["l", "wdt:P31 wd:Q132364", "wikidata"] // Predicate + Object: P31 "instance of" + Q132364 "communication protocol"
   ],


### PR DESCRIPTION
## Summary

This PR expands NIP-32 to include a standard method for using Wikidata properties within `l` and `L` tags.

## Motivation

Currently, when tagging external entities, it is often necessary to clarify what the entity is (e.g., a "communication protocol" vs. a "location"). Wikidata provides a robust ontology for this via properties like `P31` (instance of).

This proposal was conceived as an extension for implementing applications on top of [Thingstr](https://thingstr.pages.dev/) (See #2150). I would appreciate your feedback on this approach.

## Details

Explains how to format the tags using RDF-style prefixes (e.g., `wdt:P31`).

Provides a concrete example of a Kind 17 event reacting to the Nostr entity (`Q116423243`) and classifying it (`P31`) as a communication protocol (`Q132364`).