### PR TITLE
NIP-55: Try to explain how to correctly initiate a connection

### DIFF
--- a/55.md
+++ b/55.md
@@ -107,6 +107,13 @@ Send the Intent:
 launcher.launch(intent)
 ```
 
+### Initiating a connection
+
+- Client send a get_public_key `Intent`
+- Signer responds with the user `pubkey` and it's `packageName`
+- Client saves the `pubkey` and `packageName` somewhere and NEVER calls `get_public_key` again
+- Client now can send `content resolvers` and `Intents` for the other methods
+
 #### Methods
 
 - **get_public_key**
@@ -298,33 +305,6 @@ If the user chose to always reject the event, signer application will return the
 Clients SHOULD save the user pubkey locally and avoid calling the `get_public_key` after the user is logged in to the Client
 
 #### Methods
-
-- **get_public_key**
-  - params:
-
-    ```kotlin
-    val result = context.contentResolver.query(
-        Uri.parse("content://com.example.signer.GET_PUBLIC_KEY"),
-        listOf(hex_pub_key),
-        null,
-        null,
-        null
-    )
-    ```
-  - result:
-    - Will return the **pubkey** in the result column
-
-      ```kotlin
-        if (result == null) return
-
-        if (it.getColumnIndex("rejected") > -1) return
-
-        if (result.moveToFirst()) {
-            val index = it.getColumnIndex("result")
-            if (index < 0) return
-            val pubkey = it.getString(index)
-        }
-      ```
 
 - **sign_event**
   - params:


### PR DESCRIPTION
From time to time some developer shoots himself at the foot when using nip 55 after they implement multiple users sessions.
This tries to explain how they should initiate a connection and how the usage of the get_public_key method should be, removing the get_public_key from the background and just calling it once when connecting