### PR TITLE
add relay tag

### DIFF
--- a/01.md
+++ b/01.md
@@ -4,7 +4,7 @@ NIP-01
 Basic protocol flow description
 -------------------------------
 
-`draft` `mandatory`
+`draft` `mandatory` `relay`
 
 This NIP defines the basic protocol that should be implemented by everybody. New NIPs may add new optional (or mandatory) fields and messages and features to the structures and flows described here.
 

--- a/04.md
+++ b/04.md
@@ -6,7 +6,7 @@ NIP-04
 Encrypted Direct Message
 ------------------------
 
-`final` `unrecommended` `optional`
+`final` `unrecommended` `optional` `relay`
 
 A special event with kind `4`, meaning "encrypted direct message". It is supposed to have the following attributes:
 

--- a/09.md
+++ b/09.md
@@ -4,7 +4,7 @@ NIP-09
 Event Deletion Request
 ----------------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 A special event with kind `5`, meaning "deletion request" is defined as having a list of one or more `e` or `a` tags, each referencing an event the author is requesting to be deleted. Deletion requests SHOULD include a `k` tag for the kind of each event being requested for deletion.
 

--- a/11.md
+++ b/11.md
@@ -4,7 +4,7 @@ NIP-11
 Relay Information Document
 --------------------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 Relays may provide server metadata to clients to inform them of capabilities, administrative contacts, and various server attributes.  This is made available as a JSON document over HTTP, on the same URI as the relay's websocket.
 

--- a/13.md
+++ b/13.md
@@ -4,7 +4,7 @@ NIP-13
 Proof of Work
 -------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 This NIP defines a way to generate and interpret Proof of Work for nostr notes. Proof of Work (PoW) is a way to add a proof of computational work to a note. This is a bearer proof that all relays and clients can universally validate with a small amount of code. This proof can be used as a means of spam deterrence.
 

--- a/17.md
+++ b/17.md
@@ -4,7 +4,7 @@ NIP-17
 Private Direct Messages
 -----------------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 This NIP defines an encrypted chat scheme which uses [NIP-44](44.md) encryption and [NIP-59](59.md) seals and gift wraps.
 

--- a/26.md
+++ b/26.md
@@ -6,7 +6,7 @@ NIP-26
 Delegated Event Signing
 -----------------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 This NIP defines how events can be delegated so that they can be signed by other keypairs.
 

--- a/29.md
+++ b/29.md
@@ -4,7 +4,7 @@ NIP-29
 Relay-based Groups
 ------------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 This NIP defines a standard for groups that are only writable by a closed set of users. They can be public for reading by external users or not.
 

--- a/40.md
+++ b/40.md
@@ -4,7 +4,7 @@ NIP-40
 Expiration Timestamp
 --------------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 The `expiration` tag enables users to specify a unix timestamp at which the message SHOULD be considered expired (by relays and clients) and SHOULD be deleted by relays.
 

--- a/42.md
+++ b/42.md
@@ -4,7 +4,7 @@ NIP-42
 Authentication of clients to relays
 -----------------------------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 This NIP defines a way for clients to authenticate to relays by signing an ephemeral event.
 

--- a/43.md
+++ b/43.md
@@ -4,7 +4,7 @@ NIP-43
 Relay Access Metadata and Requests
 ----------------------------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 This NIP defines a way for relays to advertise membership lists, and for clients to request admission to relays on behalf of users.
 

--- a/45.md
+++ b/45.md
@@ -4,7 +4,7 @@ NIP-45
 Event Counts
 ------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 Relays may support the verb `COUNT`, which provides a mechanism for obtaining event counts.
 

--- a/46.md
+++ b/46.md
@@ -41,7 +41,7 @@ There are two ways to initiate a connection:
 
 _remote-signer_ provides connection token in the form:
 
-```
+ `relay`
 bunker://<remote-signer-pubkey>?relay=<wss://relay-to-connect-on>&relay=<wss://another-relay-to-connect-on>&secret=<optional-secret-value>
 ```
 

--- a/50.md
+++ b/50.md
@@ -4,7 +4,7 @@ NIP-50
 Search Capability
 -----------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 ## Abstract
 

--- a/59.md
+++ b/59.md
@@ -4,7 +4,7 @@ NIP-59
 Gift Wrap
 ---------
 
-`optional`
+`optional` `relay`
 
 This NIP defines a protocol for encapsulating any nostr event. This makes it possible to obscure most metadata
 for a given event, perform collaborative signing, and more.

--- a/62.md
+++ b/62.md
@@ -4,7 +4,7 @@ NIP-62
 Request to Vanish
 -----------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 This NIP offers a Nostr-native way to request a complete reset of a key's fingerprint on the web. This procedure is legally binding in some jurisdictions, and thus, supporters of this NIP should truly delete events from their database. 
 

--- a/66.md
+++ b/66.md
@@ -4,7 +4,7 @@ NIP-66
 Relay Discovery and Liveness Monitoring
 -------------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 This NIP defines events for relay discovery and the announcement of relay monitors.
 

--- a/70.md
+++ b/70.md
@@ -4,7 +4,7 @@ NIP-70
 Protected Events
 ----------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 When the `"-"` tag is present, that means the event is "protected".
 

--- a/77.md
+++ b/77.md
@@ -4,7 +4,7 @@ NIP-77
 Negentropy Syncing
 ------------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 This document describes a protocol extension for syncing events. It works for both client-relay and relay-relay scenarios. If both sides of the sync have events in common, then this protocol will use less bandwidth than transferring the full set of events (or even just their IDs).
 


### PR DESCRIPTION
It's not immediately clear from looking at Nostr's NIP documents whether a given NIP imposes requirements on relays. As a result, some relay developers are likely overlooking the implementation of certain required/suggested NIPs. This pull request adds a 'relay' tag to NIP documents that require/suggest relay implementation.
