### PR TITLE
Fix typos and broken links across multiple NIPs

### DIFF
--- a/46.md
+++ b/46.md
@@ -204,7 +204,7 @@ _client_ should display (in a popup or new tab) the URL from the `error` field a
 
 ### Announcing _remote-signer_ metadata
 
-_remote-signer_ MAY publish it's metadata by using [NIP-05](05.md) and [NIP-89](89.md). With NIP-05, a request to `<remote-signer>/.well-known/nostr.json?name=_` MAY return this:
+_remote-signer_ MAY publish its metadata by using [NIP-05](05.md) and [NIP-89](89.md). With NIP-05, a request to `<remote-signer>/.well-known/nostr.json?name=_` MAY return this:
 ```jsonc
 {
     "names":{

--- a/66.md
+++ b/66.md
@@ -67,7 +67,7 @@ Tags include:
 - `frequency` - The frequency in seconds at which the monitor publishes events.
 - `timeout` (optional) - The timeout values for various checks conducted by a monitor. Index `1` is the monitor's timeout in milliseconds. Index `2` describes what test the timeout is used for. If no index `2` is provided, it is inferred that the timeout provided applies to all tests.
 - `c` - a lowercase string describing the checks conducted by a monitor. Examples include `open`, `read`, `write`, `auth`, `nip11`, `dns`, and `geo`.
-- `g` - [NIP-52](https://github.com/nostr-protocol/nips/blob/master/11.md) geohash tag
+- `g` - [NIP-52](https://github.com/nostr-protocol/nips/blob/master/52.md) geohash tag
 
 Monitors SHOULD also publish a `kind 0` profile and a `kind 10002` relay selections event.
 

--- a/71.md
+++ b/71.md
@@ -26,7 +26,7 @@ The primary source of video information is the `imeta` tags which is defined in 
 
 Each `imeta` tag can be used to specify a variant of the video by the `dim` & `m` properties.
 
-This NIP defines the following additional `imeta` properties aside form those listen in [NIP-92](92.md) & [NIP-94](94.md):
+This NIP defines the following additional `imeta` properties aside from those listed in [NIP-92](92.md) & [NIP-94](94.md):
 
 * `duration` (recommended) the duration of the video/audio in seconds (floating point number)
 * `bitrate` (recommended) the average bitrate of the video/audio in bits/sec

--- a/72.md
+++ b/72.md
@@ -41,7 +41,7 @@ The goal of this NIP is to enable public communities. It defines the replaceable
 
 ## Posting to a community
 
-[NIP-22](NIP-22) kind 1111 events SHOULD be used for text notes posted to a community, with the `A` tag always scoped to the community definition.
+[NIP-22](22.md) kind 1111 events SHOULD be used for text notes posted to a community, with the `A` tag always scoped to the community definition.
 
 ### Top-level posts
 

--- a/88.md
+++ b/88.md
@@ -48,7 +48,7 @@ Example Event
 
 The response event is a `kind:1018` event. It contains an e tag with the poll event it is referencing, followed by one or more response tags.
 
-- **response** : The tag contains "response" as it's first positional argument followed by the option Id selected.
+- **response** : The tag contains "response" as its first positional argument followed by the option Id selected.
 
 The responses are meant to be published to the relays specified in the poll event.
 

--- a/90.md
+++ b/90.md
@@ -58,7 +58,7 @@ All tags are optional.
     * `<input-type>`: The way this argument should be interpreted. MUST be one of:
         * `url`: A URL to be fetched of the data that should be processed.
         * `event`: A Nostr event ID.
-        * `job`: The output of a previous job with the specified event ID. The dermination of which output to build upon is up to the service provider to decide (e.g. waiting for a signaling from the customer, waiting for a payment, etc.)
+        * `job`: The output of a previous job with the specified event ID. The determination of which output to build upon is up to the service provider to decide (e.g. waiting for a signaling from the customer, waiting for a payment, etc.)
         * `text`: `<data>` is the value of the input, no resolution is needed
     * `<relay>`: If `event` or `job` input-type, the relay where the event/job was published, otherwise optional or empty string
     * `<marker>`: An optional field indicating how this input should be used within the context of the job

--- a/C0.md
+++ b/C0.md
@@ -25,7 +25,7 @@ The `.content` field contains the actual code snippet text.
 - `runtime` - Runtime or environment specification (e.g., "node v18.15.0", "python 3.11")
 - `license` - License under which the code (along with any related data contained within the event, when available, such as the description) is shared. This MUST be a standard [SPDX](https://spdx.org/licenses/) short identifier (e.g., "MIT", "GPL-3.0-or-later", "Apache-2.0") when available. An additional parameter containing a reference to the actual text of the license MAY be provided. This tag can be repeated, to indicate multi-licensing, allowing recipients to use the code under any license of choosing among the referenced ones
 - `dep` - Dependency required for the code to run (can be repeated)
-- `repo` - Reference to a repository where this code originates. This MUST be a either standard URL or, alternatively, the address of a [NIP-34](34.md) Git repository announcement event in the form `"30617:<32-bytes hex a pubkey>:<d tag value>"`. If a repository announcement is referenced, a recommended relay URL where to find the event should be provided as an additional parameter
+- `repo` - Reference to a repository where this code originates. This MUST be either a standard URL or, alternatively, the address of a [NIP-34](34.md) Git repository announcement event in the form `"30617:<32-bytes hex a pubkey>:<d tag value>"`. If a repository announcement is referenced, a recommended relay URL where to find the event should be provided as an additional parameter
 
 ## Format
 


### PR DESCRIPTION
## Summary

This PR fixes typos, grammatical errors, and broken links across 7 NIP files:

| File | Issue | Fix |
|------|-------|-----|
| NIP-46 | "it's metadata" | "its metadata" (possessive) |
| NIP-66 | Link to 11.md instead of 52.md | Corrected geohash reference to 52.md |
| NIP-71 | "aside form those listen" | "aside from those listed" |
| NIP-72 | `[NIP-22](NIP-22)` broken link | `[NIP-22](22.md)` |
| NIP-88 | "it's first" | "its first" (possessive) |
| NIP-90 | "dermination" | "determination" |
| NIP-C0 | "a either standard URL" | "either a standard URL" |

## Test plan

- [x] All links verified to point to correct files
- [x] Grammar corrections reviewed