### PR TITLE
nip46: `switch_relays`

### DIFF
--- a/46.md
+++ b/46.md
@@ -97,18 +97,25 @@ Each of the following are methods that the _client_ sends to the _remote-signer_
 
 | Command                  | Params                                                                        | Result                                                                 |
 | ------------------------ | -------------------------------------------------                             | ---------------------------------------------------------------------- |
-| `connect`                | `[<remote-signer-pubkey>, <optional_secret>, <optional_requested_permissions>]`        | "ack" OR `<required-secret-value>`                                                                  |
+| `connect`                | `[<remote-signer-pubkey>, <optional_secret>, <optional_requested_perms>]`     | `"ack"` OR `<required-secret-value>`                                   |
 | `sign_event`             | `[<{kind, content, tags, created_at}>]`                                       | `json_stringified(<signed_event>)`                                     |
-| `ping`                   | `[]`                                                                          | "pong"                                                                 |
-| `get_public_key`         | `[]`                                                                          | `<user-pubkey>`                                                         |
+| `ping`                   | `[]`                                                                          | `"pong"`                                                               |
+| `get_public_key`         | `[]`                                                                          | `<user-pubkey>`                                                        |
 | `nip04_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`                              | `<nip04_ciphertext>`                                                   |
 | `nip04_decrypt`          | `[<third_party_pubkey>, <nip04_ciphertext_to_decrypt>]`                       | `<plaintext>`                                                          |
 | `nip44_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`                              | `<nip44_ciphertext>`                                                   |
 | `nip44_decrypt`          | `[<third_party_pubkey>, <nip44_ciphertext_to_decrypt>]`                       | `<plaintext>`                                                          |
+| `switch_relays`          | `[]`                                                                          | `["<relay-url>", "<relay-url>", ...]` OR `null`                        |
 
 ### Requested permissions
 
-The `connect` method may be provided with `optional_requested_permissions` for user convenience. The permissions are a comma-separated list of `method[:params]`, i.e. `nip44_encrypt,sign_event:4` meaning permissions to call `nip44_encrypt` and to call `sign_event` with `kind:4`. Optional parameter for `sign_event` is the kind number, parameters for other methods are to be defined later. Same permission format may be used for `perms` field of `metadata` in `nostrconnect://` string.
+The `connect` method may be provided with `optional_requested_perms` for user convenience. The permissions are a comma-separated list of `method[:params]`, i.e. `nip44_encrypt,sign_event:4` meaning permissions to call `nip44_encrypt` and to call `sign_event` with `kind:4`. Optional parameter for `sign_event` is the kind number, parameters for other methods are to be defined later. Same permission format may be used for `perms` field of `metadata` in `nostrconnect://` string.
+
+### Switching relays
+
+At all times, the _remote-signer_ should be in control of what relays are being used for the connection between it and the _client_. Therefore it should be possible for it to evolve its set of relays over time as old relays go out of operation and new ones appear. Even more importantly, in the case of the connection initiated by the _client_ the client may pick relays completely foreign to the _remote-signer_'s preferences, so it must be possible for it to switch those immediately.
+
+Therefore, compliant clients should send a `switch_relays` request immediately upon establishing a connection (always, or at reasonable intervals). Upon receiving such requests, the _remote-signer_ should reply with its updated list of relays, or `null` if there is nothing to be changed. Immediately upon receiving an updated relay list, the _client_ should update its local state and send further requests on the new relays. The `remote-signer` should then be free to disconnect from the previous relays if that is desired.
 
 ## Response Events `kind:24133`
 


### PR DESCRIPTION
## problems:

1. the "scan QR code flow" is cool, but it eventually would cause bunkers to have to listen to hundreds of different relays, causing harm to the planet.
2. relays go out of operation, and this gives the user/bunker a way for slowly phase out old relays and introduce new ones so they don't have to redo the login process on apps.

## solution:

clients should be prepared to switch the relays they have in store for any given bunker connection they store.

## implementation:

clients that decide to support this just have to do a simple method call upon connection. it can probably be done transparently by libraries.

bunkers that decide to support this will just get a new request and can either answer with `null` or with the update list of relays.

(after considering both ways I concluded that it was much simpler if this was initiated from the client side and not from the bunker side)

## backwards-compatibility

clients that don't implement this continue to work as they were.

bunkers that don't implement this will just get a request they don't understand and probably reply with an error or ignore it.

@staab @greenart7c3 @vitorpamplona @zharliew @dtonon @sondreb @pablof7z @erskingardner @Letdown2491 @haorendashu @hzrd149 @alexgleason @nogringo (please mention others)