### PR TITLE
NIP58 - Badge Event "Request" and "Denial"

### DIFF
--- a/58.md
+++ b/58.md
@@ -16,9 +16,9 @@ user profiles:
 3. A "Profile Badges" event is defined as an _addressable event_ with kind `30008` with a `d` tag with the value `profile_badges`.
 Profile badges contain an ordered list of pairs of `a` and `e` tags referencing a `Badge Definition` and a `Badge Award` for each badge to be displayed.
 
-4. A "Badge Request" event is defined as an addressable event with kind `30058` where a user requests a badge from an issuer. The `d` tag contains the badge's `a` tag identifier, ensuring one active request per badge per user.
+4. A "Badge Request" event is defined as an addressable event with kind `30058` where a user requests a badge from an issuer. The `d` tag contains the badge's `a` tag identifier, ensuring one active request per badge per user. Requests can be withdrawn by deleting with NIP-09.
 
-5. A "Badge Denial" event is defined as an addressable event with kind `30059` where an issuer formally denies a badge request. The `d` tag contains the request event id, ensuring one denial per request.
+5. A "Badge Denial" event is defined as an addressable event with kind `30059` where an issuer formally denies a badge request. The `d` tag contains the request event id, ensuring one denial per request. Denials can be revoked by deleting with NIP-09.
 
 ### Badge Definition event
 
@@ -70,11 +70,10 @@ The following tags MUST be present:
 The following tags MAY be present:
 
 - One or more `proof` tags containing evidence to support the request (URL, text, or nostr event id)
-- A `status` tag with value `withdrawn` to withdraw the request
 
 The `content` field MAY contain a message to the issuer.
 
-Publishing a new request for the same badge updates/replaces the previous one. Clients MUST ignore requests with `["status", "withdrawn"]`.
+To withdraw a request, delete it using NIP-09 (kind `5` deletion event).
 
 ### Badge Denial event
 
@@ -87,22 +86,19 @@ The following tags MUST be present:
 - An `e` tag referencing the request event
 - A `p` tag with the requester's pubkey
 
-The following tags MAY be present:
-
-- A `status` tag with value `revoked` to revoke the denial
-
 The `content` field MAY contain the reason for denial.
 
-Denials are soft by design. A denied user MAY submit a new request for the same badge, generating a new event id and making the old denial obsolete. Clients MUST ignore denials with `["status", "revoked"]`.
+Denials are soft by design. A denied user MAY submit a new request for the same badge. To revoke a denial, delete it using NIP-09 (kind `5` deletion event).
 
 ### Request States
 
-A badge request can be in one of four states, checked in priority order:
+A badge request can be in one of three states, checked in priority order:
 
 1. **Fulfilled** - A Badge Award (kind `8`) exists for this badge and user
-2. **Withdrawn** - Request has `["status", "withdrawn"]` tag
-3. **Denied** - A Badge Denial (kind `30059`) exists for this request (without `["status", "revoked"]`)
-4. **Pending** - Request exists, none of the above apply
+2. **Denied** - A Badge Denial (kind `30059`) exists for this request (and has not been deleted)
+3. **Pending** - Request exists, none of the above apply
+
+To withdraw a request, simply delete it using NIP-09. Deleted requests will no longer be found by clients.
 
 Clients SHOULD check for an existing award before displaying a denial.
 

--- a/58.md
+++ b/58.md
@@ -6,7 +6,7 @@ Badges
 
 `draft` `optional`
 
-Three special events are used to define, award and display badges in
+Five special events are used to define, award, request, deny and display badges in
 user profiles:
 
 1. A "Badge Definition" event is defined as an addressable event with kind `30009` having a `d` tag with a value that uniquely identifies the badge (e.g. `bravery`) published by the badge issuer. Badge definitions can be updated.
@@ -15,6 +15,10 @@ user profiles:
 
 3. A "Profile Badges" event is defined as an _addressable event_ with kind `30008` with a `d` tag with the value `profile_badges`.
 Profile badges contain an ordered list of pairs of `a` and `e` tags referencing a `Badge Definition` and a `Badge Award` for each badge to be displayed.
+
+4. A "Badge Request" event is defined as an addressable event with kind `30058` where a user requests a badge from an issuer. The `d` tag contains the badge's `a` tag identifier, ensuring one active request per badge per user.
+
+5. A "Badge Denial" event is defined as an addressable event with kind `30059` where an issuer formally denies a badge request. The `d` tag contains the request event id, ensuring one denial per request.
 
 ### Badge Definition event
 
@@ -53,11 +57,64 @@ The following tags MAY be present:
 ignore `a` without corresponding `e` tag and viceversa. Badge Awards referenced
 by the `e` tags should contain the same `a` tag.
 
+### Badge Request event
+
+An addressable event where a user requests a badge from an issuer.
+
+The following tags MUST be present:
+
+- A `d` tag with the badge's `a` tag identifier (e.g. `30009:<issuer-pubkey>:<badge-d-tag>`)
+- An `a` tag referencing the kind `30009` Badge Definition event
+- A `p` tag with the issuer's pubkey
+
+The following tags MAY be present:
+
+- One or more `proof` tags containing evidence to support the request (URL, text, or nostr event id)
+- A `status` tag with value `withdrawn` to withdraw the request
+
+The `content` field MAY contain a message to the issuer.
+
+Publishing a new request for the same badge updates/replaces the previous one. Clients MUST ignore requests with `["status", "withdrawn"]`.
+
+### Badge Denial event
+
+An addressable event where an issuer formally denies a badge request.
+
+The following tags MUST be present:
+
+- A `d` tag with the request event id
+- An `a` tag referencing the kind `30009` Badge Definition event
+- An `e` tag referencing the request event
+- A `p` tag with the requester's pubkey
+
+The following tags MAY be present:
+
+- A `status` tag with value `revoked` to revoke the denial
+
+The `content` field MAY contain the reason for denial.
+
+Denials are soft by design. A denied user MAY submit a new request for the same badge, generating a new event id and making the old denial obsolete. Clients MUST ignore denials with `["status", "revoked"]`.
+
+### Request States
+
+A badge request can be in one of four states, checked in priority order:
+
+1. **Fulfilled** - A Badge Award (kind `8`) exists for this badge and user
+2. **Withdrawn** - Request has `["status", "withdrawn"]` tag
+3. **Denied** - A Badge Denial (kind `30059`) exists for this request (without `["status", "revoked"]`)
+4. **Pending** - Request exists, none of the above apply
+
+Clients SHOULD check for an existing award before displaying a denial.
+
 ### Motivation
 
 Users MAY be awarded badges (but not limited to) in recognition, in gratitude, for participation, or in appreciation of a certain goal, task or cause.
 
 Users MAY choose to decorate their profiles with badges for fame, notoriety, recognition, support, etc., from badge issuers they deem reputable.
+
+Users MAY request badges they believe they are eligible for, optionally providing proof to support their request.
+
+Issuers MAY formally deny requests, providing feedback to requesters on why they were denied.
 
 ### Recommendations
 
@@ -70,6 +127,12 @@ Badge thumbnail image recommended dimensions are: 512x512 (xl), 256x256 (l), 64x
 Clients MAY choose to render less badges than those specified by users in the Profile Badges event or replace the badge image and thumbnails with ones that fits the theme of the client.
 
 Clients SHOULD attempt to render the most appropriate badge thumbnail according to the number of badges chosen by the user and space available. Clients SHOULD attempt render the high-res version on user action (click, tap, hover).
+
+Clients SHOULD display a "Request Badge" option on badges the user does not have.
+
+Clients SHOULD provide issuers with an inbox for incoming badge requests.
+
+Clients SHOULD rate-limit request submissions to prevent spam.
 
 ### Example of a Badge Definition event
 
@@ -117,6 +180,42 @@ Honorable Bob The Brave:
     ["e", "<bravery badge award event id>", "wss://nostr.academy"],
     ["a", "30009:alice:honor"],
     ["e", "<honor badge award event id>", "wss://nostr.academy"]
+  ],
+  // other fields...
+}
+```
+
+### Example of a Badge Request event
+
+Bob requests the bravery badge from Alice:
+```jsonc
+{
+  "kind": 30058,
+  "pubkey": "bob",
+  "content": "I helped rescue the trapped hikers last month!",
+  "tags": [
+    ["d", "30009:alice:bravery"],
+    ["a", "30009:alice:bravery", "wss://relay"],
+    ["p", "alice"],
+    ["proof", "https://news.example/hiker-rescue-article"]
+  ],
+  // other fields...
+}
+```
+
+### Example of a Badge Denial event
+
+Alice denies Bob's request:
+```jsonc
+{
+  "kind": 30059,
+  "pubkey": "alice",
+  "content": "Please provide photo evidence or witness confirmation.",
+  "tags": [
+    ["d", "<bob's request event id>"],
+    ["a", "30009:alice:bravery", "wss://relay"],
+    ["e", "<bob's request event id>", "wss://relay"],
+    ["p", "bob"]
   ],
   // other fields...
 }


### PR DESCRIPTION
# NIP-58 Extended - Badge Requests

`draft` `optional`

This aim for discussion to extend [NIP-58](https://github.com/nostr-protocol/nips/blob/master/58.md) with badge requests and denials.

## Motivation

NIP-58 defines badge creation and awarding but provides no mechanism for users to request badges. This extending would add:

- Users can request badges from issuers
- Issuers can formally deny requests
- Users can withdraw requests
- Issuers can revoke denials

## Event Kinds

| Kind | Name | Publisher | Type |
|------|------|-----------|------|
| 30009 | Badge Definition | Issuer | Addressable |
| 8 | Badge Award | Issuer | Regular |
| 30008 | Profile Badges | Recipient | Addressable |
| **30058** | **Badge Request** | **Requester** | **Addressable** |
| **30059** | **Badge Denial** | **Issuer** | **Addressable** |

## Badge Request (kind 30058)

An addressable event where a user requests a badge from an issuer.

```json
{
  "kind": 30058,
  "content": "<message to issuer>",
  "tags": [
    ["d", "30009:<issuer-pubkey>:<badge-d-tag>"],
    ["a", "30009:<issuer-pubkey>:<badge-d-tag>", "<relay-url>"],
    ["p", "<issuer-pubkey>"]
  ]
}
```

- The `d` tag MUST be the badge's `a` tag identifier
- This ensures one active request per badge per user
- Publishing a new request for the same badge updates/replaces the previous one

### Proof Tag

Requesters MAY include evidence to support their request:

```json
["proof", "<url, text, or nostr event id>"]
```

Multiple `proof` tags are allowed. Verification method is left to the issuer.

### Withdrawal

To withdraw a request, publish with `status` tag:

```json
{
  "kind": 30058,
  "content": "",
  "tags": [
    ["d", "30009:<issuer-pubkey>:<badge-d-tag>"],
    ["a", "30009:<issuer-pubkey>:<badge-d-tag>"],
    ["p", "<issuer-pubkey>"],
    ["status", "withdrawn"]
  ]
}
```

Clients MUST ignore or CAN honor requests with `["status", "withdrawn"]`.

## Badge Denial (kind 30059)

An addressable event where an issuer formally denies a badge request.

```json
{
  "kind": 30059,
  "content": "<reason for denial>",
  "tags": [
    ["d", "<request-event-id>"],
    ["a", "30009:<issuer-pubkey>:<badge-d-tag>", "<relay-url>"],
    ["e", "<request-event-id>", "<relay-url>"],
    ["p", "<requester-pubkey>"]
  ]
}
```

- The `d` tag MUST be the request event id
- This ensures one denial per request event

### Soft Denial

Denials are **soft** by design. A denied user CAN submit a new request for the same badge (e.g., with better proof). The new request generates a new event id, making the old denial obsolete.

### Revocation

To revoke a denial, publish with `status` tag:

```json
{
  "kind": 30059,
  "content": "",
  "tags": [
    ["d", "<request-event-id>"],
    ["a", "30009:<issuer-pubkey>:<badge-d-tag>"],
    ["e", "<request-event-id>"],
    ["p", "<requester-pubkey>"],
    ["status", "revoked"]
  ]
}
```

Clients MUST ignore denials with `["status", "revoked"]`.

## Request States

A request can be in one of four states:

| State | Priority | Condition |
|-------|----------|-----------|
| **Fulfilled** | 1 (highest) | Badge Award (kind 8) exists for this badge+user |
| **Denied** | 2 | Badge Denial (kind 30059) exists for this request |
| **Withdrawn** | 3 | Request has `["status", "withdrawn"]` |
| **Pending** | 4 (lowest) | Request exists, none of the above |

### State Resolution

```
1. Check for Badge Award (kind 8) from issuer to requester for this badge
   → If exists: FULFILLED

2. Check request for ["status", "withdrawn"]
   → If exists: WITHDRAWN

3. Check for Badge Denial (kind 30059) referencing this request
   → If exists and not ["status", "revoked"]: DENIED

4. Otherwise: PENDING
```

### Edge Cases

| Scenario | Result |
|----------|--------|
| Award exists + Denial exists | Fulfilled (award takes precedence) |
| Request withdrawn + Denial exists | Withdrawn (denial invalid) |
| User re-requests after denial | New pending request (old denial obsolete) |
| Denial without valid request | Invalid (clients ignore) |

## Querying

**Issuer finds incoming requests:**
```json
{"kinds": [30058], "#p": ["<issuer-pubkey>"]}
```

**User finds own outgoing requests:**
```json
{"kinds": [30058], "authors": ["<user-pubkey>"]}
```

**User finds denials:**
```json
{"kinds": [30059], "#p": ["<user-pubkey>"]}
```

## Protocol Flow

```
USER                                              ISSUER
  │                                                  │
  │         ┌─────────────────────────┐              │
  │         │ Badge Definition        │              │
  │         │ (kind 30009)            │◀─────────────┤
  │         └───────────┬─────────────┘              │
  │                     │                            │
  │              discover                            │
  │                     ▼                            │
  │         ┌─────────────────────────┐              │
  ├────────▶│ Badge Request           │              │
  │         │ (kind 30058)            │─────────────▶│
  │         │ + optional proof        │              │
  │         └───────────┬─────────────┘              │
  │                     │                            │
  │        ┌────────────┤                   ┌────────┴────────┐
  │        │            │                   │     REVIEW      │
  │        ▼            │                   └────────┬────────┘
  │  ┌───────────┐      │              ┌─────────────┼─────────────┐
  │  │ WITHDRAW  │      │              │             │             │
  │  │ status:   │      │              ▼             ▼             ▼
  │  │ withdrawn │      │          APPROVE         DENY         IGNORE
  │  └───────────┘      │              │             │
  │                     │              ▼             ▼
  │                     │         ┌────────┐   ┌──────────┐
  │                     │         │ Award  │   │ Denial   │
  │                     │         │ kind 8 │   │kind 30059│
  │                     │         └───┬────┘   └────┬─────┘
  │                     │             │             │
  │◀──────────────────────────────────┘             │
  │  FULFILLED                                      │
  │                                                 │
  │◀────────────────────────────────────────────────┘
  │  DENIED (can re-request)
  │
  │         ┌─────────────────────────┐
  ├────────▶│ Accept to Profile       │
  │         │ (kind 30008)            │
  │         └─────────────────────────┘
```

## Examples

### Request with Proof

```json
{
  "kind": 30058,
  "pubkey": "a1b2c3...",
  "created_at": 1704067200,
  "content": "I contributed the auth module!",
  "tags": [
    ["d", "30009:x1y2z3:contributor"],
    ["a", "30009:x1y2z3:contributor", "wss://relay.damus.io"],
    ["p", "x1y2z3..."],
    ["proof", "https://github.com/project/repo/pull/42"]
  ]
}
```

### Denial with Reason

```json
{
  "kind": 30059,
  "pubkey": "x1y2z3...",
  "created_at": 1704153600,
  "content": "Please provide ticket confirmation.",
  "tags": [
    ["d", "req123..."],
    ["a", "30009:x1y2z3:attendee"],
    ["e", "req123...", "wss://relay.damus.io"],
    ["p", "a1b2c3..."]
  ]
}
```

## Backward Compatibility

Fully backward compatible with NIP-58:

- Existing kind 30009, 8, 30008 events unchanged
- Badge award without request still works
- Clients unaware of 30058/30059 simply ignore them

## Security Considerations

- Proof is self-reported; issuers must verify
- Requests are public; users should be aware
- Denial reasons are public; issuers may leave empty
- Clients should rate-limit requests to prevent spam
