### PR TITLE
fix: remove redundant embedded event in replies

### DIFF
--- a/C7.md
+++ b/C7.md
@@ -21,7 +21,7 @@ A reply to a `kind 9` is an additional `kind 9` which quotes the parent using a 
 ```json
 {
   "kind": 9,
-  "content": "nostr:nevent1...\nyes",
+  "content": "yes",
   "tags": [
     ["q", <event-id>, <relay-url>, <pubkey>]
   ]


### PR DESCRIPTION
cc @fiatjaf @staab @wcat7 