### PR TITLE
NIP-39: moves i tags out of kind 0

### DIFF
--- a/39.md
+++ b/39.md
@@ -8,16 +8,11 @@ External Identities in Profiles
 
 ## Abstract
 
-Nostr protocol users may have other online identities such as usernames, profile pages, keypairs etc. they control and they may want to include this data in their profile metadata so clients can parse, validate and display this information.
-
-## `i` tag on a metadata event
-
-A new optional `i` tag is introduced for `kind 0` metadata event defined in [NIP-01](01.md):
+Users can declare their control over one or more online identities such as usernames, profile pages, keypairs in kind `10011` using `i` tags.
 
 ```jsonc
 {
-  "id": <id>,
-  "pubkey": <pubkey>,
+  "kind": 10011,
   "tags": [
     ["i", "github:semisol", "9721ce4ee4fceb91c9711ca2a6c9a5ab"],
     ["i", "twitter:semisol_public", "1619358434134196225"],
@@ -28,7 +23,7 @@ A new optional `i` tag is introduced for `kind 0` metadata event defined in [NIP
 }
 ```
 
-An `i` tag will have two parameters, which are defined as the following:
+An `i` tag MUST have two parameters, which are defined as the following:
 1. `platform:identity`: This is the platform name (for example `github`) and the identity on that platform (for example `semisol`) joined together with `:`.
 2. `proof`: String or object that points to the proof of owning this identity.
 


### PR DESCRIPTION
This PR moves `i` tags, which almost nobody supports, from kind 0 to its own kind 10011. 

There is no point in growing the size of kind 0 with lots of tags nobody supports. 

I feel like we can merge this faster since no one really supports these tags. 

@Semisol 