### PR TITLE
Stringify supported nips

### DIFF
--- a/11.md
+++ b/11.md
@@ -70,7 +70,7 @@ An alternative contact may be listed under the `contact` field as well, with the
 
 ### Supported NIPs
 
-As the Nostr protocol evolves, some functionality may only be available by relays that implement a specific `NIP`.  This field is an array of the integer identifiers of `NIP`s that are implemented in the relay. Examples would include `1`, for `"NIP-01"` and `9`, for `"NIP-09"`.  Client-side `NIPs` SHOULD NOT be advertised, and can be ignored by clients.
+As the Nostr protocol evolves, some functionality may only be available by relays that implement a specific `NIP`.  This field is an array of the `string` identifiers of `NIP`s that are implemented in the relay.  Examples would include `1`, for `"NIP-01"` and `9a`, for `"NIP-9a"`.  Client-side `NIPs` SHOULD NOT be advertised, and can be ignored by clients. For historical reasons, this MAY be a list of integers, and should be coerced to strings before making comparisons.
 
 ### Software
 
@@ -209,7 +209,7 @@ Relays that require payments may want to expose their fee schedules.
   "payments_url": "https://nostr.wine/invoices",
   "pubkey": "4918eb332a41b71ba9a74b1dc64276cfff592e55107b93baae38af3520e55975",
   "software": "https://nostr.wine",
-  "supported_nips": [ 1, 2, 4, 9, 11, 40, 42, 50, 70, 77 ],
+  "supported_nips": [ "1", "2", "4", "9", "11", "40", "42", "50", "70", "77" ],
   "terms_of_service": "https://nostr.wine/terms",
   "version": "0.3.3"
 }
@@ -221,7 +221,7 @@ Relays that require payments may want to expose their fee schedules.
   "pubkey": "52b4a076bcbbbdc3a1aefa3735816cf74993b1b8db202b01c883c58be7fad8bd",
   "software": "NFDB",
   "icon": "https://i.nostr.build/b3thno790aodH8lE.jpg",
-  "supported_nips": [ 1, 2, 4, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 19, 21, 22, 23, 24, 25, 27, 28, 30, 31, 32, 34, 35, 36, 37, 38, 39, 40, 42, 44, 46, 47, 48, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 65, 68, 69, 71, 72, 73, 75, 78, 84, 88, 89, 90, 92, 99 ],
+  "supported_nips": [ "1", "2", "4", "8", "9", "10", "11", "13", "14", "15", "16", "17", "18", "19", "21", "22", "23", "24", "25", "27", "28", "30", "31", "32", "34", "35", "36", "37", "38", "39", "40", "42", "44", "46", "47", "48", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "64", "65", "68", "69", "71", "72", "73", "75", "78", "84", "88", "89", "90", "92", "99" ],
   "version": "1.0.0",
   "limitation": {
     "payment_required": true,


### PR DESCRIPTION
This is supported by coracle, flotilla, and implemented by zooid. I'm making this change because of [NIP `9a`](https://github.com/nostr-protocol/nips/pull/2194)