### PR TITLE
Add NIP-AD: MCP Server and Skill Announcements

### DIFF
--- a/AD.md
+++ b/AD.md
@@ -1,0 +1,73 @@
+NIP-AD
+======
+
+MCP Server and Skill Announcements
+----------------------------------
+
+`draft` `optional`
+
+Defines event kinds for announcing MCP servers and skills.
+
+---
+
+## MCP Server Announcement (Kind 4200)
+
+Announces an MCP server that provides tools to agents.
+
+```json
+{
+  "kind": 4200,
+  "pubkey": "<publisher-pubkey>",
+  "tags": [
+    ["name", "<server-name>"],
+    ["description", "<what-the-server-does>"],
+    ["command", "<execution-command>"]
+  ],
+  "content": ""
+}
+```
+
+### Tags
+
+- `name` — Server identifier
+- `description` — What the server provides
+- `command` — Command to start the server (e.g., `npx @anthropic-ai/mcp-server-fetch`)
+
+---
+
+## Skill Announcement (Kind 4202)
+
+Announces a skill—packaged capabilities with instructions and associated files.
+
+```json
+{
+  "kind": 4202,
+  "pubkey": "<publisher-pubkey>",
+  "tags": [
+    ["title", "<skill-name>"],
+    ["description", "<what-the-skill-does>"],
+    ["e", "<1063-event-id>"],
+    ["license", "<SPDX-identifier>"]
+  ],
+  "content": "<skill-instructions>"
+}
+```
+
+### Tags
+
+- `title` — Skill name
+- `description` — One-line description
+- `e` — Reference to NIP-94 file metadata (kind 1063), one or more
+- `license` — SPDX license identifier
+
+### Content
+
+Contains skill instructions in markdown, injected into agent context when active.
+
+### Referenced Files
+
+Each `e` tag references a kind 1063 event with:
+- `url` — File location
+- `name` — Relative filepath for installation
+- `m` — MIME type
+- `x` — SHA-256 hash

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-99: Classified Listings](99.md)
 - [NIP-A0: Voice Messages](A0.md)
 - [NIP-A4: Public Messages](A4.md)
+- [NIP-AD: MCP Server and Skill Announcements](AD.md)
 - [NIP-B0: Web Bookmarks](B0.md)
 - [NIP-B7: Blossom](B7.md)
 - [NIP-BE: Nostr BLE Communications Protocol](BE.md)
@@ -178,6 +179,8 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `2003`        | Torrent                         | [35](35.md)                            |
 | `2004`        | Torrent Comment                 | [35](35.md)                            |
 | `2022`        | Coinjoin Pool                   | [joinstr][joinstr]                     |
+| `4200`        | MCP Server Announcement         | [AD](AD.md)                            |
+| `4202`        | Skill Announcement              | [AD](AD.md)                            |
 | `4550`        | Community Post Approval         | [72](72.md)                            |
 | `5000`-`5999` | Job Request                     | [90](90.md)                            |
 | `6000`-`6999` | Job Result                      | [90](90.md)                            |


### PR DESCRIPTION
I'm using these events on TENEX to announce mcp servers and skills.

Needless to say, these can have NIP-22 comments/discussions.

[Read here](https://github.com/nostr-protocol/nips/blob/72f63c9e3b36eea2c7784125adf5aa22dd69ad7c/AD.md)