### PR TITLE
nip73: Add OSM tag kind

### DIFF
--- a/73.md
+++ b/73.md
@@ -59,13 +59,7 @@ Geohashes are a geocoding system that encodes geographic locations into short st
 - Way: `["i", "osm:way:5013364"]` – https://www.openstreetmap.org/way/5013364  
 - Relation: `["i", "osm:relation:62422"]` – https://www.openstreetmap.org/relation/62422  
 
-OpenStreetMap object references are globally unique identifiers for map elements. They use the format `osm:<type>:<id>` where `<type>` is one of `node`, `way`, or `relation`, and `<id>` is a numeric identifier.
-
-- **Nodes** represent single geographic points (e.g., POIs, address points).
-- **Ways** represent linear features or closed areas (e.g., roads, buildings).
-- **Relations** represent structured groupings of nodes, ways, and/or other relations (e.g., routes, administrative boundaries, multipolygons).
-
-These identifiers are stable and unique within their object type. The `<type>` MUST be lowercase and the `<id>` MUST be a positive integer.
+OpenStreetMap object IDs are globally unique identifiers. They use the lowercase format `osm:<type>:<id>` where `<type>` is one of `node`, `way`, or `relation`, and `<id>` is a numeric identifier.
 
 ### Countries:
 


### PR DESCRIPTION
### OpenStreetMap Object References:

- Node: `["i", "osm:node:240949599"]` – https://www.openstreetmap.org/node/240949599  
- Way: `["i", "osm:way:5013364"]` – https://www.openstreetmap.org/way/5013364  
- Relation: `["i", "osm:relation:62422"]` – https://www.openstreetmap.org/relation/62422  

OpenStreetMap object references are globally unique identifiers for map elements. They use the format `osm:<type>:<id>` where `<type>` is one of `node`, `way`, or `relation`, and `<id>` is a numeric identifier.

- **Nodes** represent single geographic points (e.g., POIs, address points).
- **Ways** represent linear features or closed areas (e.g., roads, buildings).
- **Relations** represent structured groupings of nodes, ways, and/or other relations (e.g., routes, administrative boundaries, multipolygons).

These identifiers are stable and unique within their object type. The `<type>` MUST be lowercase and the `<id>` MUST be a positive integer.