### PR TITLE
NIP-DC: Nostr Webxdc

### DIFF
--- a/DC.md
+++ b/DC.md
@@ -12,7 +12,7 @@ This spec covers public webxdc communication only. Private communication may be 
 
 ## Attachment
 
-A webxdc app is attached to any event by including the `.xdc` file URL in the content and an `imeta` tag with MIME type `application/vnd.webxdc+zip`.
+A webxdc app is attached to any event by including the `.xdc` file URL in the content and an `imeta` tag with MIME type `application/x-webxdc`.
 
 The `imeta` tag SHOULD include a `webxdc` property with a randomly generated unique string. This serves as the coordination identifier for state updates and realtime channels. If omitted, the app can still run but state won't work.
 
@@ -23,7 +23,7 @@ The `imeta` tag SHOULD include a `webxdc` property with a randomly generated uni
   "tags": [
     ["imeta",
       "url https://blossom.example.com/abc123.xdc",
-      "m application/vnd.webxdc+zip",
+      "m application/x-webxdc",
       "x a1b2c3d4e5f6...",
       "webxdc 9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
     ]
@@ -39,7 +39,7 @@ A webxdc MAY also be published as a kind `1063` (NIP-94) file metadata event:
   "content": "A collaborative chess game. Play with friends over Nostr!",
   "tags": [
     ["url", "https://blossom.example.com/abc123.xdc"],
-    ["m", "application/vnd.webxdc+zip"],
+    ["m", "application/x-webxdc"],
     ["x", "a1b2c3d4e5f6..."],
     ["alt", "Webxdc app: Chess"],
     ["webxdc", "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"]


### PR DESCRIPTION
This is an attempt to bring webxdc https://webxdc.org/ apps to Nostr

Webxdc enables people to share "mini apps" that groups of people can interact with.

Here is a demo of one embedded in a kind 1 using an imeta tag: https://mew.ditto.pub/nevent1qgsqgc0uhmxycvm5gwvn944c7yfxnnxm0nyh8tt62zhrvtd3xkj8fhgqyz2j47ku4z4xfpx2ynumth3k89gk5vg0yr83dhvv4e4klwh6xzvd67pfm94

Webxdc is normally used in small, closed groups. On Nostr they are public to everyone. It's an interesting element of chaos. Nostr could support private webxdc, but that's out of scope for now.

Each time you post a webxdc app a session is created tied to that posting. So the Tetris scoreboard is confined to my post. if I posted the app again, it would have a different scoreboard.

On web I am using an iframe. But it was actually harder to achieve that than you'd think. Webxdc is designed for native apps (to run in web views), not for the web. So it will work everywhere.