### PR TITLE
Adds window.nostr.peekPublicKey

### DIFF
--- a/07.md
+++ b/07.md
@@ -12,6 +12,7 @@ That object must define the following methods:
 
 ```
 async window.nostr.getPublicKey(): string // returns a public key as hex
+async window.nostr.peekPublicKey(): string // returns a public key as hex, without prompting the user, only if auto-login is on, else returns empty string
 async window.nostr.signEvent(event: { created_at: number, kind: number, tags: string[][], content: string }): Event // takes an event object, adds `id`, `pubkey` and `sig` and returns it
 ```
 


### PR DESCRIPTION
The nip07's "peekPublicKey" method is a way for extensions to provide an auto-login feature.
If extension's user has previously enabled auto-login, `window.nostr.peekPublicKey()` returns the same as `window.nostr.getPublicKey()`, though won't prompt the user for confirmation.

Expected flow is that apps should do the following on page load, without the need for the user to click a button:

```
const maybePubkey = await window.nostr?.peekPublicKey?.()
if (maybePubkey) loginUser(maybePubkey)
```

Implemented at [44billion.net](https://44billion.net/). There, auto-login is always on, i.e. the user logs in to 44billion.net then when it opens an app inside the platform, if the app has the above code running, the app learns what is the user's pubkey automatically.