### PR TITLE
NIP-09: Allow cascading deletion of reposts by the original author

### DIFF
--- a/09.md
+++ b/09.md
@@ -48,6 +48,12 @@ Clients MAY choose to inform the user that their request for deletion does not g
 
 Relays MAY validate that a deletion request event only references events that have the same `pubkey` as the deletion request itself, however this is not required since relays may not have knowledge of all referenced events.
 
+### Cascading Deletion of Reposts
+
+When a relay receives a `kind 5` deletion request, it SHOULD also delete any `kind 6` or `kind 16` repost events whose `p` tag matches the deletion request's `pubkey` and whose `e` tag references the deleted event. Relays SHOULD perform this cascading deletion even if they no longer hold the original event being deleted.
+
+This prevents reposts — which may contain a full copy of the original event in their `content` field — from continuing to serve content that the original author has requested to be deleted.
+
 ## Deletion Request of a Deletion Request
 
 Publishing a deletion request event against a deletion request has no effect.  Clients and relays are not obliged to support "unrequest deletion" functionality.


### PR DESCRIPTION
## Problem

Currently, when a user publishes a `kind 1` note and someone else reposts it (`kind 6` or `kind 16`), the original author has no way to request deletion of those reposts. This is a significant problem in cases where the original note contains accidentally leaked private information (e.g., personal data, credentials, sensitive photos). Even if the author deletes their own note via a `kind 5` deletion request, the repost — which may contain a full copy of the original event in its `content` field (as specified by NIP-18) — remains on relays indefinitely, perpetuating the leak.

This is not a theoretical concern. It is a realistic scenario that may have already occurred in practice.

## Precedent: NIP-59 Gift Wrap deletion

NIP-59 already establishes a precedent for allowing someone other than the event's signing key to request deletion. Specifically:

> Since signing keys are random, relays SHOULD delete `kind 1059` events whose p-tag matches the signer of NIP-09 deletions or NIP-62 vanish requests.

In this model, the **recipient** (identified by the `p` tag) of a gift wrap can request its deletion, even though the gift wrap was signed by a random ephemeral key. The relay honors this because the recipient is the legitimate stakeholder of that event.

## Change

This PR adds a "Cascading Deletion of Reposts" subsection under "Relay Usage" in NIP-09. When a relay receives a `kind 5` deletion request, it SHOULD also delete any `kind 6` or `kind 16` repost events whose `p` tag matches the deletion request's `pubkey` and whose `e` tag references the deleted event. Relays SHOULD perform this cascading deletion even if they no longer hold the original event being deleted.

This is a **relay-side** specification. It does not require changes to client behavior.

## Why this matters

- **Privacy and safety**: Accidentally leaked private information (personal data, intimate images, credentials) can currently be preserved indefinitely through reposts, even after the original author deletes their note. Under GDPR and similar privacy regulations, the inability to remove such content is problematic.
- **Harassment mitigation**: Reposts can be used to amplify harmful content. Even if the original author deletes the note (perhaps after being coerced into posting it), the repost continues to circulate. Cascading deletion gives the original author at least partial recourse.
- **Consistency with existing specs**: NIP-59 already allows non-author deletion in an analogous situation. NIP-70 (Protected Events) also demonstrates the protocol's willingness to let relays enforce author intent. This proposal is a natural extension of those principles.
- **Pragmatic, not absolute**: Like all deletion on Nostr, this is a *request*, not a guarantee. Events may already have been cached or replicated. But reducing the surface area of exposure is still valuable — the same rationale behind NIP-09 itself.

## Background

This proposal follows from the discussion in [#1413](https://github.com/nostr-protocol/nips/pull/1413), where removing the embedded event from the repost `content` was proposed but met with resistance. fiatjaf [suggested](https://github.com/nostr-protocol/nips/pull/1413#issuecomment-2272823853) that NIP-09 could be extended to allow relays to cascade deletes to reposts. This PR implements that approach.
