### PR TITLE
Update 66.md with defensive measures

### DIFF
--- a/66.md
+++ b/66.md
@@ -98,6 +98,6 @@ Example:
 
  ## Risk Mitigation                                                                                                                                                 
                                                                                                                                                                    
-  - Clients SHOULD have a fallback if `30166` events cannot be located.
+  - Clients MUST NOT require `30166` events to function. Absence of monitoring data MUST NOT prevent relay connections.
   - A monitor may publish erroneous `30166` events, either by misconfiguration or malicious intent.
   - Clients SHOULD NOT trust a single source. Defenses include: web-of-trust filtering, querying multiple monitors, and discarding filter results if they would remove an unreasonable proportion of relays.


### PR DESCRIPTION
based on discussion of [nip-66 benchmark learnings](https://github.com/nostrability/outbox) in [nostrability/outbox](https://github.com/nostrability/nostrability/issues/69) and elsewhere, multiple devs have concerns with current nip-66 spec and/or potential implementation implications/consequences/gaps.

therefore, this PR seeks to explicitly address dev concerns of nip-66 unhappy paths with prospective call-outs/solutions.