### PR TITLE
NIP-66: restructure relay discovery tags, add W/l tags, check types table

### DIFF
--- a/66.md
+++ b/66.md
@@ -10,50 +10,147 @@ This NIP defines events for relay discovery and the announcement of relay monito
 
 ## Relay Discovery Events
 
-`30166` relay discovery events document relay characteristics inferred either from a relay's [NIP 11](https://github.com/nostr-protocol/nips/blob/master/11.md) document, or via probing.
+Kind `30166` relay discovery events document relay characteristics inferred either from a relay's [NIP-11](11.md) document, or via probing.
 
-Information corresponding to field in a relay's NIP 11 document MAY contradict actual values if monitors find that a different policy is implemented than is advertised.
+Information corresponding to fields in a relay's NIP-11 document MAY contradict actual values if monitors find that a different policy is implemented than is advertised. Probing results take precedence over self-reported NIP-11 data.
 
 `content` MAY include the stringified JSON of the relay's NIP-11 informational document.
 
 The only required tag is the `d` tag, which MUST be set to the relay's [normalized](https://datatracker.ietf.org/doc/html/rfc3986#section-6) URL. For relays not accessible via URL, a hex-encoded pubkey MAY be used instead.
 
-Other tags include:
+### Indexed Tags
 
-- `rtt-open` - The relay's open round-trip time in milliseconds.
-- `rtt-read` - The relay's read round-trip time in milliseconds.
-- `rtt-write` - The relay's write round-trip time in milliseconds.
+These single-letter tags can be used directly as relay subscription filters (e.g. `{"#T": ["Search"]}`):
+
 - `n` - The relay's network type. SHOULD be one of `clearnet`, `tor`, `i2p`, `loki`
 - `T` - The relay type. Enumerated [relay type](https://github.com/nostr-protocol/nips/issues/1282) formatted as `PascalCase`, e.g. `PrivateInbox`
+- `W` - A relay attribute sourced from the relay's NIP-11 `attributes` field (see [NIP-11](11.md)). One tag per entry, preserving the original `PascalCase` value
 - `N` - NIPs supported by the relay
-- `R` - Keys corresponding to requirements per [NIP 11](https://github.com/nostr-protocol/nips/blob/master/11.md)'s `limitations` array, including `auth`, `writes`, `pow`, and `payment`. False values should be specified using a `!` prefix, for example `!auth`.
+- `R` - Keys corresponding to requirements per [NIP-11](11.md)'s `limitations` array, including `auth`, `writes`, `pow`, and `payment`. False values should be specified using a `!` prefix, for example `!auth`
 - `t` - A topic associated with this relay
-- `k` - Accepted and unaccepted kinds (false values prepended by `!`) 
-- `g` - A [NIP-52](https://github.com/nostr-protocol/nips/blob/master/52.md) geohash
+- `k` - Accepted and unaccepted kinds (false values prepended by `!`); sourced from the relay's NIP-11 document or determined via probing
+- `l` - A [NIP-32](32.md) label for any filterable value, following the NIP-32 format `["l", "<value>", "<namespace>"]`. Monitors SHOULD emit `l` tags for any value that clients may want to filter against. Examples:
+  - `["l", "en", "ISO-639-1"]` — language
+  - `["l", "DE", "ISO-3166-1"]` — country (ISO 3166-1 alpha-2)
+  - `["l", "24940", "IANA-asn"]` — ASN number
+  - `["l", "Hetzner Online GmbH", "IANA-asnOrg"]` — ASN organization
+  - `["l", "Berlin", "nip66.label.city"]` — city
+  - `["l", "Europe/Berlin", "IANA-tz"]` — IANA timezone
+- `g` - A [NIP-52](52.md) geohash indicating the relay's physical location
+
+Note: multi-letter output tags (e.g. `geo-country`, `net-ip`, `ssl-expires`) are **informational only** and cannot be used as relay subscription filters. For any value that clients may want to filter, monitors SHOULD emit both the multi-letter tag (for readability) and the corresponding `l` label (for filterability).
+
+### RTT (Round-Trip Time) Tags
+
+Round-trip time measurements in milliseconds:
+
+- `rtt-open` - Time to establish WebSocket connection
+- `rtt-read` - Time to receive first event after subscription
+- `rtt-write` - Time to receive OK after publishing an event
+
+### SSL/TLS Tags
+
+SSL/TLS certificate information (clearnet `wss://` relays only):
+
+- `ssl` - Certificate validity status: `valid` or `!valid`
+- `ssl-expires` - Certificate expiration as Unix timestamp in seconds
+- `ssl-issuer` - Certificate Authority (CA) organization name
+
+### Network Tags
+
+Network identification data derived from IP address lookup:
+
+- `net-ip` - Resolved IPv4 address of the relay
+- `net-ipv6` - Resolved IPv6 address of the relay (if available)
+- `net-asn` - [Autonomous System Number](https://en.wikipedia.org/wiki/Autonomous_system_(Internet))
+- `net-asn-org` - ASN organization name
+
+### Geographic Tags
+
+Geographic location data derived from IP address lookup:
+
+- `g` - A [NIP-52](52.md) geohash (also listed under Indexed Tags for discoverability)
+- `geo-country` - [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code
+- `geo-city` - City name
+- `geo-lat` - Latitude coordinate as decimal string
+- `geo-lon` - Longitude coordinate as decimal string
+- `geo-tz` - [IANA timezone](https://www.iana.org/time-zones) identifier
+
+While approximate coordinates can be inferred from the `g` (geohash) tag, a geohash encodes a bounding box rather than a point. `geo-lat` and `geo-lon` provide the exact coordinates directly, without requiring geohash decoding.
+
+### DNS Tags
+
+DNS resolution data (clearnet relays only):
+
+- `dns-ip` - Primary A record (IPv4 address)
+- `dns-ip6` - Primary AAAA record (IPv6 address)
+- `dns-cname` - CNAME target hostname, if present
+- `dns-ttl` - DNS record TTL in seconds
+
+### HTTP Tags
+
+HTTP server metadata captured during WebSocket upgrade handshake:
+
+- `http-server` - Value of the `Server` response header
+- `http-powered-by` - Value of the `X-Powered-By` response header
+
+### Tag Formatting
 
 Tags with more than one value should be repeated, rather than putting all values in a single tag, for example `[["t", "cats"], ["t", "dogs"]]`, rather than `[["t", "cats", "dogs"]]`.
 
-Example:
+### Example
 
 ```json
 {
   "id": "<eventid>",
   "pubkey": "<monitor's pubkey>",
-  "created_at": "<created_at  [some recent date ...]>",
-  "signature": "<signature>",
-  "content": "<optional nip 11 document>",
+  "created_at": 1703116800,
+  "sig": "<signature>",
+  "content": "<optional nip-11 document>",
   "kind": 30166,
   "tags": [
-    ["d","wss://some.relay/"],
+    ["d", "wss://relay.example.com/"],
     ["n", "clearnet"],
-    ["N", "40"],
-    ["N", "33"],
+    ["N", "1"],
+    ["N", "11"],
+    ["N", "50"],
     ["R", "!payment"],
-    ["R", "auth"],
-    ["g", "ww8p1r4t8"],
-    ["l", "en", "ISO-639-1"],
-    ["t", "nsfw" ],
-    ["rtt-open", "234" ]
+    ["R", "!auth"],
+    ["T", "PublicInbox"],
+    ["W", "Public"],
+    ["W", "Search"],
+    ["t", "bitcoin"],
+    ["l", "en",                  "ISO-639-1"],
+    ["l", "NL",                  "ISO-3166-1"],
+    ["l", "15169",               "IANA-asn"],
+    ["l", "Google LLC",          "IANA-asnOrg"],
+    ["l", "Amsterdam",           "nip66.label.city"],
+    ["l", "Europe/Amsterdam",    "IANA-tz"],
+    ["g", "u173zq37x"],
+
+    ["rtt-open", "89"],
+    ["rtt-read", "123"],
+    ["rtt-write", "156"],
+
+    ["ssl", "valid"],
+    ["ssl-expires", "1735689600"],
+    ["ssl-issuer", "Let's Encrypt"],
+
+    ["net-ip",      "93.184.216.34"],
+    ["net-ipv6",    "2606:2800:220:1:248:1893:25c8:1946"],
+    ["net-asn",     "15169"],
+    ["net-asn-org", "Google LLC"],
+
+    ["geo-country", "NL"],
+    ["geo-city",    "Amsterdam"],
+    ["geo-lat",     "52.3676"],
+    ["geo-lon",     "4.9041"],
+    ["geo-tz",      "Europe/Amsterdam"],
+
+    ["dns-ip",  "93.184.216.34"],
+    ["dns-ttl", "3600"],
+
+    ["http-server", "nginx"]
   ]
 }
 ```
@@ -62,42 +159,97 @@ Example:
 
 Kind `10166` relay monitor announcements advertise the author's intent to publish `30166` events. This event is optional and is intended for monitors who intend to provide monitoring services at a regular and predictable frequency.
 
-Tags include:
+### Tags
 
-- `frequency` - The frequency in seconds at which the monitor publishes events.
-- `timeout` (optional) - The timeout values for various checks conducted by a monitor. Index `1` is the monitor's timeout in milliseconds. Index `2` describes what test the timeout is used for. If no index `2` is provided, it is inferred that the timeout provided applies to all tests.
-- `c` - a lowercase string describing the checks conducted by a monitor. Examples include `open`, `read`, `write`, `auth`, `nip11`, `dns`, and `geo`.
-- `g` - [NIP-52](https://github.com/nostr-protocol/nips/blob/master/52.md) geohash tag
+- `frequency` - The frequency in seconds at which the monitor publishes `30166` events
+- `timeout` (optional) - The timeout for a specific check type, formatted as `["timeout", "<check>", "<milliseconds>"]`. If no check name is provided, the timeout applies to all checks
+- `c` - A lowercase string identifying a check type performed by this monitor. The following check types are defined; implementations MAY define additional types
+- `n` - Network types monitored. SHOULD be one or more of: `clearnet`, `tor`, `i2p`, `loki`
+- `g` - A [NIP-52](52.md) geohash indicating the monitor's geographic location
 
 Monitors SHOULD also publish a `kind 0` profile and a `kind 10002` relay selections event.
 
-Example:
+### Check Types
+
+The `c` tag declares which checks a monitor performs. Each check type defines the tags that SHOULD be emitted when the check succeeds. Partial results are permitted; monitors SHOULD omit tags for data that could not be retrieved.
+
+| Check   | Description                  | Tags SHOULD emit when successful                                                   |
+|---------|------------------------------|------------------------------------------------------------------------------------|
+| `open`  | WebSocket connection test    | `rtt-open`                                                                         |
+| `read`  | Subscription/read test       | `rtt-read`                                                                         |
+| `write` | Event publish test           | `rtt-write`                                                                        |
+| `nip11` | NIP-11 document fetch        | `content` (raw NIP-11 JSON); MAY also emit `N`, `R`, `T`, `W`, `t`, `l`, `k`     |
+| `ssl`   | SSL/TLS certificate check    | `ssl`, `ssl-expires`, `ssl-issuer`                                                 |
+| `geo`   | Geographic location lookup   | `g`, `geo-country`, `geo-city`, `geo-lat`, `geo-lon`, `geo-tz`                    |
+| `net`   | Network/ASN lookup           | `net-ip`, `net-ipv6`, `net-asn`, `net-asn-org`                                    |
+| `dns`   | DNS resolution               | `dns-ip`, `dns-ip6`, `dns-cname`, `dns-ttl`                                       |
+| `http`  | HTTP server headers          | `http-server`, `http-powered-by`                                                   |
+
+### Example
 
 ```json
 {
   "id": "<eventid>",
   "pubkey": "<monitor's pubkey>",
-  "created_at": "<created_at  [some recent date ...]>",
-  "signature": "<signature>",
+  "created_at": 1703116800,
+  "sig": "<signature>",
   "content": "",
+  "kind": 10166,
   "tags": [
-    [ "timeout", "open", "5000"  ],
-    [ "timeout", "read", "3000"  ],
-    [ "timeout", "write", "3000" ],
-    [ "timeout", "nip11", "3000" ],
-    [ "frequency", "3600" ],
-    [ "c", "ws" ],
-    [ "c", "nip11" ],
-    [ "c", "ssl" ],
-    [ "c", "dns" ],
-    [ "c", "geo" ]
-    [ "g", "ww8p1r4t8" ]
+    ["frequency", "3600"],
+    ["n", "clearnet"],
+
+    ["timeout", "open", "5000"],
+    ["timeout", "read", "3000"],
+    ["timeout", "write", "3000"],
+    ["timeout", "nip11", "3000"],
+    ["timeout", "ssl", "10000"],
+    ["timeout", "dns", "5000"],
+    ["timeout", "http", "5000"],
+
+    ["c", "open"],
+    ["c", "read"],
+    ["c", "write"],
+    ["c", "nip11"],
+    ["c", "ssl"],
+    ["c", "geo"],
+    ["c", "net"],
+    ["c", "dns"],
+    ["c", "http"],
+
+    ["g", "u173zq37x"]
   ]
 }
 ```
 
- ## Risk Mitigation                                                                                                                                                 
-                                                                                                                                                                   
-  - Clients MUST NOT require `30166` events to function. Absence of monitoring data MUST NOT prevent relay connections.
-  - A monitor may publish erroneous `30166` events, either by misconfiguration or malicious intent.
-  - Clients SHOULD NOT trust a single source. Defenses include: web-of-trust filtering, querying multiple monitors, and discarding filter results if they would remove an unreasonable proportion of relays.
+## Use Cases
+
+### SSL/TLS Monitoring
+- **Security monitoring**: Identify relays with expired or invalid certificates
+- **Proactive alerts**: Warn operators before certificate expiration
+- **Trust assessment**: Evaluate relay trustworthiness based on Certificate Authority
+
+### Geographic Filtering
+- **Privacy-aware routing**: Avoid relays in specific jurisdictions
+- **Latency optimization**: Select geographically proximate relays
+- **Regulatory compliance**: GDPR, data residency requirements
+
+### Network Diversity
+- **Redundancy planning**: Diversify relay selection across different networks
+- **Censorship resistance**: Identify relays across different Autonomous Systems
+- **Outage correlation**: Link relay issues to network-wide problems
+
+## Privacy Considerations
+
+Geographic and network information may be sensitive for relay operators who prefer anonymity. All tags defined in this NIP are optional, allowing monitors to publish only the information they deem appropriate.
+
+Relay operators concerned about privacy can:
+- Use Tor/I2P network types (overlay networks don't expose public IPs)
+- Request monitors exclude their relay from detailed lookups
+- Run their own monitor publishing limited information
+
+## Risk Mitigation
+
+- Clients MUST NOT require `30166` events to function. Absence of monitoring data MUST NOT prevent relay connections.
+- A monitor may publish erroneous `30166` events, either by misconfiguration or malicious intent.
+- Clients SHOULD NOT trust a single source. Defenses include: web-of-trust filtering, querying multiple monitors, and discarding filter results if they would remove an unreasonable proportion of relays.

--- a/66.md
+++ b/66.md
@@ -20,7 +20,7 @@ The only required tag is the `d` tag, which MUST be set to the relay's [normaliz
 
 ### Indexed Tags
 
-These single-letter tags can be used directly as relay subscription filters (e.g. `{"#T": ["Search"]}`):
+These single-letter tags can be used directly as relay subscription filters (e.g. `{"#W": ["Search"]}` or `{"#T": ["PublicInbox"]}`):
 
 - `n` - The relay's network type. SHOULD be one of `clearnet`, `tor`, `i2p`, `loki`
 - `T` - The relay type. Enumerated [relay type](https://github.com/nostr-protocol/nips/issues/1282) formatted as `PascalCase`, e.g. `PrivateInbox`
@@ -29,7 +29,8 @@ These single-letter tags can be used directly as relay subscription filters (e.g
 - `R` - Keys corresponding to requirements per [NIP-11](11.md)'s `limitations` array, including `auth`, `writes`, `pow`, and `payment`. False values should be specified using a `!` prefix, for example `!auth`
 - `t` - A topic associated with this relay
 - `k` - Accepted and unaccepted kinds (false values prepended by `!`); sourced from the relay's NIP-11 document or determined via probing
-- `l` - A [NIP-32](32.md) label for any filterable value, following the NIP-32 format `["l", "<value>", "<namespace>"]`. Monitors SHOULD emit `l` tags for any value that clients may want to filter against. Examples:
+- `L` - A [NIP-32](32.md) label namespace corresponding to emitted `l` tags. Monitors that emit namespace-qualified `l` tags SHOULD emit one `L` tag per namespace so clients can query both namespace and value, for example `{"#L": ["ISO-3166-1"], "#l": ["NL"]}`
+- `l` - A [NIP-32](32.md) label for any filterable value, following the NIP-32 format `["l", "<value>", "<namespace>"]`. Monitors SHOULD emit `l` tags for any value that clients may want to filter against, and SHOULD also emit the matching `L` tags. Examples:
   - `["l", "en", "ISO-639-1"]` — language
   - `["l", "DE", "ISO-3166-1"]` — country (ISO 3166-1 alpha-2)
   - `["l", "24940", "IANA-asn"]` — ASN number
@@ -38,7 +39,7 @@ These single-letter tags can be used directly as relay subscription filters (e.g
   - `["l", "Europe/Berlin", "IANA-tz"]` — IANA timezone
 - `g` - A [NIP-52](52.md) geohash indicating the relay's physical location
 
-Note: multi-letter output tags (e.g. `geo-country`, `net-ip`, `ssl-expires`) are **informational only** and cannot be used as relay subscription filters. For any value that clients may want to filter, monitors SHOULD emit both the multi-letter tag (for readability) and the corresponding `l` label (for filterability).
+Note: multi-letter output tags (e.g. `geo-country`, `net-ip`, `ssl-expires`) are **informational only** and cannot be used as relay subscription filters. For any value that clients may want to filter, monitors SHOULD emit both the multi-letter tag (for readability) and the corresponding `L` and `l` tags (for filterability).
 
 ### RTT (Round-Trip Time) Tags
 
@@ -120,6 +121,12 @@ Tags with more than one value should be repeated, rather than putting all values
     ["W", "Public"],
     ["W", "Search"],
     ["t", "bitcoin"],
+    ["L", "ISO-639-1"],
+    ["L", "ISO-3166-1"],
+    ["L", "IANA-asn"],
+    ["L", "IANA-asnOrg"],
+    ["L", "nip66.label.city"],
+    ["L", "IANA-tz"],
     ["l", "en",                  "ISO-639-1"],
     ["l", "NL",                  "ISO-3166-1"],
     ["l", "15169",               "IANA-asn"],
@@ -178,7 +185,7 @@ The `c` tag declares which checks a monitor performs. Each check type defines th
 | `open`  | WebSocket connection test    | `rtt-open`                                                                         |
 | `read`  | Subscription/read test       | `rtt-read`                                                                         |
 | `write` | Event publish test           | `rtt-write`                                                                        |
-| `nip11` | NIP-11 document fetch        | `content` (raw NIP-11 JSON); MAY also emit `N`, `R`, `T`, `W`, `t`, `l`, `k`     |
+| `nip11` | NIP-11 document fetch        | `content` (raw NIP-11 JSON); MAY also emit `N`, `R`, `T`, `W`, `t`, `L`, `l`, `k` |
 | `ssl`   | SSL/TLS certificate check    | `ssl`, `ssl-expires`, `ssl-issuer`                                                 |
 | `geo`   | Geographic location lookup   | `g`, `geo-country`, `geo-city`, `geo-lat`, `geo-lon`, `geo-tz`                    |
 | `net`   | Network/ASN lookup           | `net-ip`, `net-ipv6`, `net-asn`, `net-asn-org`                                    |


### PR DESCRIPTION
Updating this PR with a significantly more complete revision. The original proposal addressed the bug fixes from issue #2171; this expanded version also:

- Renames "Other tags include" to a structured **Indexed Tags** section with a note on filter usage (`{"#T": ["Search"]}`)
- Adds `W` tag — mirrors NIP-11 `attributes` as an indexed tag for relay-discovery filtering
- Adds `l` tag (NIP-32 labels) with standardized namespaces: `ISO-639-1`, `ISO-3166-1`, `IANA-asn`, `IANA-tz`, `nip66.label.city`
- Clarifies the dual-tag pattern: emit multi-letter tags for readability AND `l` labels for filterability
- Adds dedicated sections for RTT, SSL/TLS, Network, Geographic, DNS, and HTTP tags
- Adds a Check Types table with SHOULD/MAY language; explicitly extensible (`implementations MAY define additional types`)
- Adds Use Cases, Privacy Considerations, and Risk Mitigation sections
- Fixes the example events (wrong field names, missing `kind`, invalid check type names like `ws`)
- Fixes absolute URLs to relative paths

All changes are fully backwards-compatible — all tags remain optional, existing monitor implementations are unaffected.

Closes #2171