### PR TITLE
add archive relay tag to 65.md

### DIFF
--- a/65.md
+++ b/65.md
@@ -8,7 +8,8 @@ Relay List Metadata
 
 Defines a replaceable event using `kind:10002` to advertise relays where the user generally **writes** to and relays where the user generally **reads** mentions.
 
-The event MUST include a list of `r` tags with relay URLs as value and an optional `read` or `write` marker. If the marker is omitted, the relay is both **read** and **write**.
+The event MUST include a list of `r` tags with relay URLs as value and an optional `read`, `write`, or `archive` marker. If the marker
+is omitted, the relay is both **read** and **write**.
 
 ```jsonc
 {
@@ -18,6 +19,8 @@ The event MUST include a list of `r` tags with relay URLs as value and an option
     ["r", "wss://brando-relay.com"],
     ["r", "wss://expensive-relay.example2.com", "write"],
     ["r", "wss://nostr-relay.example.com", "read"]
+    ["r", "wss://old-relay.example.com", "archive"]
+
   ],
   "content": "",
   // other fields...
@@ -34,9 +37,24 @@ When publishing an event, clients SHOULD:
 - Send the event to all **read** relays of each tagged user
 - Send the author's `kind:10002` event to all relays the event was published to
 
+ ### Archive relays
+
+The `archive` marker indicates a relay where the user previously
+published but no longer actively writes to. Clients updating a user's
+relay list SHOULD offer to mark removed write relays as `archive`
+rather than deleting them.
+
+When fetching historical content (events older than the user's current
+relay list), clients MAY query `archive`-tagged relays.
+
+Clients MUST NOT publish new events to `archive` relays.
+
+Clients SHOULD NOT add `archive` tags without user consent.
+
 ### Size
 
-Clients SHOULD guide users to keep `kind:10002` lists small (2-4 relays of each category).
+Clients SHOULD guide users to keep `kind:10002` lists small (2-4 relays of each `read`/`write` category). `archive` tags are
+supplementary and do not count toward this recommendation.
 
 ### Discoverability
 


### PR DESCRIPTION
###  Motivation                                                                                                                                                         
                                                                                                                                                                     
Event recall drops dramatically at longer time windows. Across benchmarks of 4 profiles and 277 relays, algorithm recall falls from 83% at 7 days to 24% at 1 year (https://github.com/nostrability/outbox).

Relay retention is not the main cause — median relay event availability at 1 year is 77%. The dominant factor is relay discovery: a user's current kind-10002 lists where they write now, not where they wrote a year ago. When users change relays, the link to their old content is lost.

### Why not other approaches?

Historical kind-10002 events: Kind-10002 is replaceable per NIP-01. In probing six (6) major relays, all correctly discard old versions. The data doesn't exist on the network as far as I know.

Append-only relay history event: Requires a new event kind, adds storage burden, and creates a public log of every relay a user has ever touched.

Hardcoded archival relay lists: Centralizing.

###  Why archive marker?

When a user migrates from relay A to relay B, their client marks relay A as archive instead of removing it. Clients fetching old content check archive relays. No new event kinds, no NIP-01 changes, backward compatible. 

Clients that don't understand archive already ignore unknown markers.