### PR TITLE
feat: add optional emoji set address to emoji tags

### DIFF
--- a/30.md
+++ b/30.md
@@ -9,13 +9,14 @@ Custom Emoji
 Custom emoji may be added to **kind 0**, **kind 1**, **kind 7** ([NIP-25](25.md)) and **kind 30315** ([NIP-38](38.md)) events by including one or more `"emoji"` tags, in the form:
 
 ```
-["emoji", <shortcode>, <image-url>]
+["emoji", <shortcode>, <image-url>, <emoji-set-address>]
 ```
 
 Where:
 
 - `<shortcode>` is a name given for the emoji, which MUST be comprised of only alphanumeric characters and underscores.
 - `<image-url>` is a URL to the corresponding image file of the emoji.
+- `<emoji-set-address>` is an optional address pointer (`kind:pubkey:d-tag`) to the kind 30030 emoji set ([NIP-51](51.md)) the emoji belongs to.
 
 For each emoji tag, clients should parse emoji shortcodes (aka "emojify") like `:shortcode:` in the event to display custom emoji.
 
@@ -46,7 +47,7 @@ In kind 1 events, the `content` should be emojified.
   "kind": 1,
   "content": "Hello :gleasonator: 😂 :ablobcatrainbow: :disputed: yolo",
     "tags": [
-    ["emoji", "ablobcatrainbow", "https://gleasonator.com/emoji/blobcat/ablobcatrainbow.png"],
+    ["emoji", "ablobcatrainbow", "https://gleasonator.com/emoji/blobcat/ablobcatrainbow.png", "30030:79c2cae114ea28a981e7559b4fe7854a473521a8d22a66bbab9fa248eb820ff6:blobcats"],
     ["emoji", "disputed", "https://gleasonator.com/emoji/Fun/disputed.png"],
     ["emoji", "gleasonator", "https://gleasonator.com/emoji/Gleasonator/gleasonator.png"]
   ],


### PR DESCRIPTION
I'm using this in Chachi for emoji set discovery. When you see an emoji you like you can click it and it opens the set, allowing you to bookmark it.