### PR TITLE
fix terms of use paragraph

### DIFF
--- a/11.md
+++ b/11.md
@@ -82,7 +82,7 @@ The relay MAY choose to publish its software version as a string attribute. The 
 
 ### Terms of Service
 
-The relay MAY choose to publish its software version as a string attribute. The string format is defined by the relay implementation. It is recommended this be a version number or commit identifier.
+The relay owner/admin MAY choose to link to a terms of service document.
 
 Extra Fields
 ------------


### PR DESCRIPTION
missing "terms of use" paragraph in #1946 