### PR TITLE
nip70: reposts that embed protected events must be rejected

### DIFF
--- a/70.md
+++ b/70.md
@@ -14,6 +14,8 @@ The default behavior of a relay MUST be to reject any event that contains `["-"]
 
 Relays that want to accept such events MUST first require that the client perform the [NIP-42](42.md) `AUTH` flow and then check if the authenticated client has the same pubkey as the event being published and only accept the event in that case.
 
+Reposts of protected events MUST NOT embed the reposted event. If a repost of a protected event embeds the event anyway, relays SHOULD summarily reject it.
+
 ## The tag
 
 The tag is a simple tag with a single item: `["-"]`. It may be added to any event.


### PR DESCRIPTION
I thought we had this here already, but apparently not.

@pablof7z hadn't you added it a while ago?