### PR TITLE
NIP-71 feat: video multiple audio tracks

### DIFF
--- a/71.md
+++ b/71.md
@@ -199,7 +199,7 @@ Additionally `service nip96` may be included to allow clients to search the auth
       "url https://example.com/audio.mp4",
       "x b2e0a7a82ac9f3f3a71f1d9a78c381d5be9d1cf19dce258765c17c8a76287c93",
       "m audio/mp4",
-      "l", "en", "ISO-639-1", "ov"
+      "l en ISO-639-1 ov"
     ],
 
     ["duration", <duration in seconds>],

--- a/71.md
+++ b/71.md
@@ -47,6 +47,7 @@ This NIP defines the following additional `imeta` properties aside from those li
 
 * `duration` (recommended) the duration of the video/audio in seconds (floating point number)
 * `bitrate` (recommended) the average bitrate of the video/audio in bits/sec
+* `waveform` (optional, audio only) amplitude values over time, space separated full integers, less than 100 values should be enough to render a nice visual
 
 Example:
 ```json
@@ -93,6 +94,7 @@ Example:
     "url https://myaudio.com/audio/en/12345.mp4",
     "x b2e0a7a82ac9f3f3a71f1d9a78c381d5be9d1cf19dce258765c17c8a76287c93",
     "m audio/mp4",
+    "waveform 0 7 35 8 100 100 49 8 4 16 8 10 7 2 20 10 100 100 100 100 100 100 15 100 100 100 25 60 5 4 3 1 0 100 100 15 100 29 88 0 33 11 39 100 100 19 4 100 42 35 5 0 1 5 0 0 11 38 100 94 17 11 44 58 5 100 100 100 55 14 72 100 100 57 6 1 14 2 16 100 100 40 16 100 100 6 32 14 13 41 36 16 14 6 3 0 1 2 1 6 0",
     "l en ISO-639-1 ov",
     "fallback https://myotherserver.com/audio/en/12345.mp4",
     "fallback https://andanotherserver.com/audio/en/12345.mp4",

--- a/71.md
+++ b/71.md
@@ -38,7 +38,10 @@ The `.content` of these events is a summary or description on the video content.
 
 The primary source of video information is the `imeta` tags which is defined in [NIP-92](92.md)
 
-Each `imeta` tag can be used to specify a variant of the video by the `dim` & `m` properties.
+Each `imeta` tag can be used to specify a variant of the video by the `dim` & `m` properties, as well as multiple audio tracks (languages).
+
+Clients should check if audio tracks are available and prefer them over in-video audio 
+to allow smooth resolution switching without interrupting audio. The `ov` (original version) flags the original language track.
 
 This NIP defines the following additional `imeta` properties aside from those listed in [NIP-92](92.md) & [NIP-94](94.md):
 
@@ -85,6 +88,17 @@ Example:
     "fallback https://andanotherserver.com/720/12345.m3u8",
     "service nip96",
     "duration 29.21"
+  ],
+  ["imeta",
+    "url https://myaudio.com/audio/en/12345.mp4",
+    "x b2e0a7a82ac9f3f3a71f1d9a78c381d5be9d1cf19dce258765c17c8a76287c93",
+    "m audio/mp4",
+    "l", "en", "ISO-639-1", "ov",
+    "fallback https://myotherserver.com/audio/en/12345.mp4",
+    "fallback https://andanotherserver.com/audio/en/12345.mp4",
+    "service nip96",
+    "bitrate  320000",
+    "duration 29.24"
   ],
 ]
 ```
@@ -179,6 +193,13 @@ Additionally `service nip96` may be included to allow clients to search the auth
       "blurhash eVF$^OI:${M{%LRjWBoLoLaeR*",
       "image https://example.com/thumb.jpg",
       "x 3093509d1e0bc604ff60cb9286f4cd7c781553bc8991937befaacfdc28ec5cdc"
+    ],
+    // audio data
+    ["imeta",
+      "url https://example.com/audio.mp4",
+      "x b2e0a7a82ac9f3f3a71f1d9a78c381d5be9d1cf19dce258765c17c8a76287c93",
+      "m audio/mp4",
+      "l", "en", "ISO-639-1", "ov"
     ],
 
     ["duration", <duration in seconds>],

--- a/71.md
+++ b/71.md
@@ -93,7 +93,7 @@ Example:
     "url https://myaudio.com/audio/en/12345.mp4",
     "x b2e0a7a82ac9f3f3a71f1d9a78c381d5be9d1cf19dce258765c17c8a76287c93",
     "m audio/mp4",
-    "l", "en", "ISO-639-1", "ov",
+    "l en ISO-639-1 ov",
     "fallback https://myotherserver.com/audio/en/12345.mp4",
     "fallback https://andanotherserver.com/audio/en/12345.mp4",
     "service nip96",

--- a/71.md
+++ b/71.md
@@ -91,13 +91,13 @@ Example:
     "duration 29.21"
   ],
   ["imeta",
-    "url https://myaudio.com/audio/en/12345.mp4",
+    "url https://myaudio.com/audio/en/12345.mp3",
     "x b2e0a7a82ac9f3f3a71f1d9a78c381d5be9d1cf19dce258765c17c8a76287c93",
-    "m audio/mp4",
+    "m audio/mp3",
     "waveform 0 7 35 8 100 100 49 8 4 16 8 10 7 2 20 10 100 100 100 100 100 100 15 100 100 100 25 60 5 4 3 1 0 100 100 15 100 29 88 0 33 11 39 100 100 19 4 100 42 35 5 0 1 5 0 0 11 38 100 94 17 11 44 58 5 100 100 100 55 14 72 100 100 57 6 1 14 2 16 100 100 40 16 100 100 6 32 14 13 41 36 16 14 6 3 0 1 2 1 6 0",
     "l en ISO-639-1 ov",
-    "fallback https://myotherserver.com/audio/en/12345.mp4",
-    "fallback https://andanotherserver.com/audio/en/12345.mp4",
+    "fallback https://myotherserver.com/audio/en/12345.mp3",
+    "fallback https://andanotherserver.com/audio/en/12345.mp3",
     "service nip96",
     "bitrate  320000",
     "duration 29.24"
@@ -198,9 +198,9 @@ Additionally `service nip96` may be included to allow clients to search the auth
     ],
     // audio data
     ["imeta",
-      "url https://example.com/audio.mp4",
+      "url https://example.com/audio.mp3",
       "x b2e0a7a82ac9f3f3a71f1d9a78c381d5be9d1cf19dce258765c17c8a76287c93",
-      "m audio/mp4",
+      "m audio/mp3",
       "l en ISO-639-1 ov"
     ],
 


### PR DESCRIPTION
adds audio `imeta` tags:

``` json
  ["imeta",
    "url https://myaudio.com/audio/en/12345.mp4",
    "x b2e0a7a82ac9f3f3a71f1d9a78c381d5be9d1cf19dce258765c17c8a76287c93",
    "m audio/mp4",
    "l", "en", "ISO-639-1", "ov",
    "fallback https://myotherserver.com/audio/en/12345.mp4",
    "fallback https://andanotherserver.com/audio/en/12345.mp4",
    "service nip96",
    "bitrate  320000",
    "duration 29.24"
  ],
  ```
  
allows:
- Audio-only streaming (video podcasts)
- Switching resolution while audio stays stable
- Multiple audio languages and formats (DTS, etc.)
- Reduced storage if servers do not embed audio directly into video files

caveats:
 Clients should check if audio tracks are available.
 This is especially important if servers optimize for storage by not embedding audio directly into the video files.


