### PR TITLE
Add k tag to 39000

### DIFF
--- a/29.md
+++ b/29.md
@@ -144,7 +144,8 @@ If the group is forked and hosted in multiple relays, there will be multiple ver
     ["picture", "https://pizza.com/pizza.png"],
     ["about", "a group for people who love pizza"],
     ["private"],
-    ["closed"]
+    ["closed"],
+    ["k", "9"]
   ]
   // other fields...
 }
@@ -155,6 +156,7 @@ If the group is forked and hosted in multiple relays, there will be multiple ver
 - `restricted` indicates that only members can _write_ messages to the group. Omitting this tag indicates that anyone can send messages to the group.
 - `hidden` indicates that relays should hide group metadata from non-members. Omitting this tag indicates that anyone can request group metadata events.
 - `closed` indicates that join requests are ignored. Omitting this tag indicates that users can expect join requests to be honored.
+- One or more `k` tags can be included to indicate what event kinds are accepted in this group. If no `k` tags are included, anything is acceptable.
 
 - *group admins* (`kind:39001`) (optional)
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `h`               | group id                             | --                              | [29](29.md)                                        |
 | `i`               | external identity                    | proof, url hint                 | [35](35.md), [39](39.md), [73](73.md)              |
 | `I`               | root external identity               | --                              | [22](22.md)                                        |
-| `k`               | kind                                 | --                              | [18](18.md), [25](25.md), [72](72.md), [73](73.md) |
+| `k`               | kind                                 | --                              | [18](18.md), [25](25.md), [72](72.md), [73](73.md), [29](29.md) |
 | `K`               | root scope                           | --                              | [22](22.md)                                        |
 | `l`               | label, label namespace, language name| --                              | [32](32.md), [C0](C0.md)                           |
 | `L`               | label namespace                      | --                              | [32](32.md)                                        |


### PR DESCRIPTION
Based on the discussion [here](https://github.com/nostr-protocol/nips/pull/2238#issuecomment-4033034976). This is backwards compatible and optional; if clients ignore it they will just get an error like they already would.