### PR TITLE
Update NIP-50 with NIP-66 reference

### DIFF
--- a/50.md
+++ b/50.md
@@ -34,8 +34,11 @@ extensions they don't support.
 Clients may specify several search filters, i.e. `["REQ", "", { "search": "orange" }, { "kinds": [1, 2], "search": "purple" }]`. Clients may 
 include `kinds`, `ids` and other filter field to restrict the search results to particular event kinds.
 
-Clients SHOULD use the supported_nips field to learn if a relay supports `search` filter. Clients MAY send `search` 
-filter queries to any relay, if they are prepared to filter out extraneous responses from relays that do not support this NIP.
+Clients SHOULD use the supported_nips field to learn if a relay supports `search` filter. 
+
+Clients MAY use [NIP-66 relay discovery/liveness events](https://raw.githubusercontent.com/nostr-protocol/nips/refs/heads/master/66.md) to identify relays that support this NIP, rather than connecting to relays individually to check their supported_nips. 
+
+Clients MAY send `search` filter queries to any relay, if they are prepared to filter out extraneous responses from relays that do not support this NIP.
 
 Clients SHOULD query several relays supporting this NIP to compensate for potentially different 
 implementation details between relays.


### PR DESCRIPTION
add optional/ "MAY" reference suggesting that NIP-50 search/apps MAY utilize NIP-66 relay liveness monitor events to improve search relay performance.