### PR TITLE
Draft: NIP-222 - URI Scheme for Share Intents

### DIFF
--- a/222.md
+++ b/222.md
@@ -1,0 +1,38 @@
+NIP-XX
+======
+
+Title: URI Scheme for Content Creation (Share Intents)
+Author: [Ty13r]
+Status: Draft
+Type: Standards Track
+Created: 2026-03-13
+
+## Abstract
+This NIP proposes extending the `nostr:` URI scheme with a `nostr:share` path. The goal is to standardize cross-app interoperability, allowing external web applications and native OS intents to pre-fill content within Nostr clients (specifically `kind 1` text notes).
+
+## Motivation
+NIP-21 standardizes URIs for reading data (`nostr:npub`, `nostr:nevent`), but the protocol lacks a standard for deep-linking content *creation*. 
+
+While building the MVP for `re_terminal` (a gamified onboarding terminal for BTC/Nostr), I encountered a severe UX bottleneck. To claim a PoW-style reward, users must broadcast a payload to Nostr. On desktop, NIP-07 handles this seamlessly. On mobile, the absence of a share intent forces a fallback to `navigator.clipboard.writeText()`, requiring the user to manually switch apps, open the composer, and paste. 
+
+Attempting to pass payloads to bare `nostr:` URIs causes unhandled exceptions or "Invalid URI" errors in major clients like Amethyst. Standardizing a share intent bridges Nostr with the broader web, enabling one-click sharing from news sites, web3 games, and external apps without relying on OS-level clipboard hacks.
+
+## Specification
+
+We introduce the `share` path to the `nostr:` protocol.
+
+### URI Format
+`nostr:share?text=<URI-encoded-string>&url=<URI-encoded-string>`
+
+### Parameters
+* `text`: (Required) The URI-encoded body of the text.
+* `url`: (Optional) A URI-encoded URL to be appended to the text payload.
+
+### Example
+`nostr:share?text=Digital%20freedom%20mode%3A%20ACTIVE.&url=https%3A%2F%2Freterminal.xyz`
+
+### Client Implementation Rules
+1. **Intercept & Route:** Upon receiving a `nostr:share` URI, the client MUST route the user to its event composition view (e.g., creating a `kind 1` note).
+2. **Pre-fill Data:** The client MUST decode the `text` parameter and populate the input field. If `url` is provided, it SHOULD be appended to the text (e.g., separated by a newline).
+3. **Security (No Auto-Publish):** To prevent CSRF-style attacks and drive-by spam, the client MUST NOT automatically broadcast the event. The user MUST explicitly interact with the UI (e.g., click "Publish" or "Send") to sign and broadcast the event.
+4. **Error Handling:** If the parameters are empty or malformed, the client SHOULD fall back to opening an empty composition view rather than crashing.


### PR DESCRIPTION
Mobile UX for sharing into Nostr is broken. This draft proposes a standardized intent URI (nostr:share?text=...) to allow external web apps and games (like my project reterminal.xyz/activation l) to pre-fill notes securely without relying on clipboard fallbacks.