### PR TITLE
Add `shape` field to NIP-24 kind 0 metadata

### DIFF
--- a/24.md
+++ b/24.md
@@ -17,6 +17,7 @@ These are extra fields not specified in NIP-01 that may be present in the string
   - `banner`: an URL to a wide (~1024x768) picture to be optionally displayed in the background of a profile screen.
   - `bot`: a boolean to clarify that the content is entirely or partially the result of automation, such as with chatbots or newsfeeds.
   - `birthday`: an object representing the author's birth date. The format is { "year": number, "month": number, "day": number }. Each field MAY be omitted.
+  - `shape`: a single emoji character whose silhouette is used as an alpha mask over the user's avatar image. When absent or invalid, clients SHOULD fall back to displaying the avatar as a circle.
 
 #### Deprecated fields
 


### PR DESCRIPTION
Profile shapes allow people to set the shape of their avatar to a shape besides a circle. Some examples:

<img width="592" height="768" alt="Screenshot from 2026-03-15 17-26-24" src="https://github.com/user-attachments/assets/6dc0b71b-7df9-4d4a-a980-67f1c0a50cc8" />

This is implemented by https://ditto.pub