### PR TITLE
NIP-XX: Nostr Key File (.nostrkey)

### DIFF
--- a/XX.md
+++ b/XX.md
@@ -16,7 +16,7 @@ The biggest barrier to Nostr adoption is key management. Asking non-technical us
 
 A standard file format enables:
 
-- **Download-on-signup**: clients generate a keypair, encrypt it, and offer a file download — the user never sees or handles a raw `nsec`.
+- **Download-on-signup**: once a keypair is generated, clients encrypt it and offer a file download — the user never sees or handles a raw `nsec`.
 - **Upload-to-login**: clients accept a file upload and a password, decrypt locally, and start a session — no key material is pasted or stored in the browser.
 - **Portability**: a key file produced by one client can be used to log in to any other client that implements this NIP.
 - **Offline backup**: the file can be stored on a USB drive, in a password manager, or printed as a QR code.


### PR DESCRIPTION
This NIP defines a standard file format (.nostrkey) for storing and transporting NIP-49 encrypted private keys. It standardizes the JSON container, file extension, client behavior for signup/login, and error handling.

Why: NIP-49 defines the ncryptsec encryption format but not how to package, store, or exchange that string between clients. Users currently copy-paste raw nsec or ncryptsec strings — error-prone and insecure. A file-plus-password model requires zero cryptographic literacy and maps to a mental model every computer user already has.

What it enables:

- **Download-on-signup** — once a keypair is generated, the client encrypts it and hands the user a .nostrkey file. They never see a raw nsec.
- **Upload-to-login** — user uploads the file, enters their password, done. Works across any client that implements this NIP.
- **Offline backup** — store on a USB drive, in a password manager, or print as a QR code.

Implementation cost is minimal — clients that already support NIP-49 ncryptsec paste just need to add a file picker and parse a small JSON wrapper.

Test vectors use the same ncryptsec from NIP-49, with a verified npub derivation.