### PR TITLE
NIP-101g: Golf Events

### DIFF
--- a/101g.md
+++ b/101g.md
@@ -1,0 +1,363 @@
+NIP-101g
+========
+
+Golf Events
+-----------
+
+`draft` `optional`
+
+This NIP defines event kinds for golf scoring on Nostr: course definitions, round initiation, live scoring, and final round records.
+
+## Event Kinds
+
+| Kind | Name | Type | Description |
+|------|------|------|-------------|
+| `33501` | Golf Course | Addressable | Course metadata: holes, tees, ratings |
+| `1501` | Round Initiation | Regular | Immutable declaration that a round has started |
+| `31501` | Live Scorecard | Addressable | Replaceable live score updates |
+| `1502` | Final Round Record | Regular | Immutable final scores for a completed round |
+
+## Golf Course (kind `33501`)
+
+An addressable event ([NIP-01](01.md)) that defines a golf course. One event per course, identified by `kind + pubkey + d`. The publisher acts as editorial authority for the course data.
+
+Courses are **discovery and reference data** — mutable and replaceable by the author. When a round references a course, the round's embedded snapshot (not the 33501) is authoritative for scoring purposes.
+
+Multiple publishers may create events for the same physical course. Clients SHOULD allow users to select a preferred course publisher.
+
+The `.content` field is an optional free-text description of the course.
+
+### Tags
+
+#### Required
+
+| Tag | Format | Description |
+|-----|--------|-------------|
+| `d` | `<slug>` | Stable, lowercase, hyphenated course identifier |
+| `title` | `<text>` | Human-readable course name |
+| `location` | `<text>` | Human-readable location string. e.g. `Chesterland, Ohio, USA` |
+| `hole_tee` | `<hole>`, `<tee>`, `<par>`, `<yards>`, `<si>` | One tag per hole-tee combination. Always 6 elements; use `""` for unknown values (see below) |
+| `tee` | `<name>`, `<rating>`, `<slope>` | One tag per tee set. Rating: USGA course rating. Slope: 55–155 |
+
+#### Optional
+
+| Tag | Format | Description |
+|-----|--------|-------------|
+| `g` | `<geohash>` | Geohash for proximity filtering. Two recommended: 6-char (~1.2km) + 4-char (~39km) |
+| `t` | `<hashtag>` | Hashtag for discoverability. `golf` recommended |
+| `hole_geo` | `<hole>`, `<tee>`, `<tee_lat>`, `<tee_lon>`, `<green_lat>`, `<green_lon>` | Tee box and green center coordinates (WGS-84 decimal degrees) |
+| `website` | `<url>` | Course website |
+| `phone` | `<phone>` | Course phone number |
+| `architect` | `<text>` | Course architect |
+| `established` | `<year>` | Year the course opened |
+| `imeta` | (per [NIP-92](92.md)) | Course imagery |
+
+### `hole_tee` Tag
+
+```
+["hole_tee", "<hole_number>", "<tee_name>", "<par>", "<yards>", "<stroke_index>"]
+```
+
+Each tag encodes one hole for one tee set. A course with 18 holes and 4 tee sets produces 72 `hole_tee` tags. Tags MUST always contain all 6 elements — use empty string `""` for unknown values.
+
+- `hole_number`: 1-indexed (string)
+- `tee_name`: MUST exactly match a `tee` tag name (case-sensitive)
+- `par`: par for this hole from this tee (string, 3–6). Par may vary by tee (e.g. forward tees converting a par-5 to par-4)
+- `yards`: yardage from this tee, or `""` if unknown
+- `stroke_index`: handicap stroke allocation (1–18) for this hole from this tee, or `""` if unknown. Determines which holes receive handicap strokes first (1 = hardest)
+
+### `hole_geo` Tag
+
+```
+["hole_geo", "<hole_number>", "<tee_name>", "<tee_lat>", "<tee_lon>", "<green_lat>", "<green_lon>"]
+```
+
+One tag per hole per tee set. Different tee sets have different tee box locations; greens are typically shared. Courses without coordinate data simply omit `hole_geo` tags.
+
+### Example
+
+```jsonc
+{
+  "kind": 33501,
+  "content": "Pete Dye masterpiece in Geauga County.",
+  "tags": [
+    ["d", "fowlers-mill-golf-course"],
+    ["title", "Fowler's Mill Golf Course"],
+    ["location", "Chesterland, Ohio, USA"],
+    ["g", "dp3wjm"],
+    ["g", "dp3w"],
+    ["t", "golf"],
+    ["website", "https://fowlersmillgolf.com"],
+    ["architect", "Pete Dye"],
+    ["established", "1995"],
+    ["tee", "Gold", "74.7", "136"],
+    ["tee", "Black", "72.8", "133"],
+    ["tee", "Green", "69.9", "128"],
+    ["hole_tee", "1", "Gold", "4", "425", "5"],
+    ["hole_tee", "1", "Black", "4", "400", "5"],
+    ["hole_tee", "1", "Green", "4", "365", "5"],
+    ["hole_tee", "2", "Gold", "4", "390", "15"],
+    // ... one tag per hole per tee ...
+    ["hole_tee", "18", "Green", "5", "480", "2"],
+    ["hole_geo", "1", "Gold", "41.510850", "-81.271700", "41.509118", "-81.267861"],
+    ["hole_geo", "1", "Black", "41.510713", "-81.271618", "41.509118", "-81.267861"]
+    // ... one tag per hole per tee ...
+  ]
+  // other fields...
+}
+```
+
+## Round Initiation (kind `1501`)
+
+A regular (immutable) event published when a round begins. It declares the participants, course snapshot, and rules — establishing the authoritative context for all subsequent scoring events.
+
+The `content` field MUST be a JSON string containing a `course_snapshot` and a `rules_template`. These embedded objects are the authoritative source for scoring — not the referenced 33501 course event. The content is structured JSON rather than tags because it serves as a self-contained course and rules definition for the round, not relay-queryable metadata. The event signature guarantees integrity of the embedded data.
+
+Rounds may cover any subset of holes (e.g. front 9, back 9). The `holes` array in the course snapshot defines which holes are in play.
+
+### Content
+
+```jsonc
+{
+  "course_snapshot": {
+    "course_name": "<string>",
+    "tee_set": "<tee name>",
+    "hole_count": 18,
+    "holes": [
+      {
+        "hole_number": 1,
+        "par": 4,
+        "stroke_index": 5,  // optional
+        "yardage": 425       // optional
+      }
+      // ...
+    ]
+  },
+  "rules_template": {
+    "format": "stroke_play"  // stroke_play | match_play | stableford
+    // additional rules as needed
+  }
+}
+```
+
+`hole_count` MUST equal the length of the `holes` array. Examples use `jsonc` (JSON with comments) for readability; actual event content is valid JSON.
+
+### Tags
+
+| Tag | Required | Format | Description |
+|-----|----------|--------|-------------|
+| `p` | Yes | `<pubkey>`, `<relay-hint>`, `<role>` | One per participant. Relay hint SHOULD be included when known (empty string if unavailable). Role (e.g. `player`) is optional; generic clients will ignore it |
+| `a` | No | `<kind>:<pubkey>:<d-tag>`, `<relay-url>` | Reference to the course 33501 (informational only; relay URL optional) |
+| `alt` | No | `<text>` | Human-readable fallback (e.g. `Golf round at Fowler's Mill, 18 holes, stroke play`) |
+| `t` | No | `<hashtag>` | `golf` recommended |
+| `client` | No | `<client-name>` | Publishing client identifier |
+
+The round start time is represented by the event's `created_at` field. Clients that need to distinguish between round start time and publish time MAY add a `["published_at", "<unix-timestamp>"]` tag per [NIP-23](23.md).
+
+### Example
+
+```jsonc
+{
+  "kind": 1501,
+  "created_at": 1742166441,
+  "content": "{\"course_snapshot\":{\"course_name\":\"Fowler's Mill Golf Course\",\"tee_set\":\"Gold\",\"hole_count\":18,\"holes\":[{\"hole_number\":1,\"par\":4,\"stroke_index\":5},{\"hole_number\":2,\"par\":4,\"stroke_index\":15}]},\"rules_template\":{\"format\":\"stroke_play\"}}",
+  "tags": [
+    ["p", "55127fc9e1c03c6b459a3bab72fdb99def1644c5f239bdd09f3e5fb401ed9b21", "wss://relay.gambit.golf", "player"],
+    ["a", "33501:ca98e63891d90e38cacf1e9a53857a94d34cc1e0e47163257e15e29c3f4e7921:fowlers-mill-golf-course", "wss://relay.gambit.golf"],
+    ["alt", "Golf round at Fowler's Mill Golf Course, 18 holes, stroke play"],
+    ["t", "golf"],
+    ["client", "gambit-golf-ios"]
+  ]
+  // other fields...
+}
+```
+
+## Live Scorecard (kind `31501`)
+
+An addressable replaceable event ([NIP-01](01.md)) that tracks real-time scoring progress. This is a **UX convenience layer** — not authoritative. The final round record (kind `1502`) is the permanent scoring record.
+
+The event is addressed by `kind + pubkey + d` and replaced on each hole completion. The `.content` field is not used and SHOULD be empty.
+
+### Tags
+
+| Tag | Required | Format | Description |
+|-----|----------|--------|-------------|
+| `d` | Yes | `<event-id>` | The event ID of the corresponding kind `1501` initiation event |
+| `e` | Yes | `<event-id>`, `<relay-hint>` | Reference to the kind `1501` initiation event. Relay hint SHOULD be included when known |
+| `status` | Yes | `in_progress` \| `completed` | Current round status |
+| `score` | Yes | `<hole>`, `<strokes>` | One tag per completed hole. Strokes is always a positive integer (gross strokes) |
+| `p` | No | `<pubkey>`, `<relay-hint>` | Participants in the round. Relay hint SHOULD be included when known |
+| `alt` | No | `<text>` | Human-readable fallback |
+| `t` | No | `<hashtag>` | `golf` recommended |
+| `client` | No | `<client-name>` | Publishing client identifier |
+
+### Behavior
+
+- Clients SHOULD publish an updated `31501` after each hole is scored
+- The `d` tag uses the 1501 event ID as the round identifier, ensuring one live scorecard per round per player
+- When `status` changes to `completed`, clients SHOULD publish a final `31501` update alongside the kind `1502` record
+- Clients MAY treat `31501` events with `status=in_progress` that haven't been updated in 24 hours as abandoned
+
+### Example
+
+```jsonc
+{
+  "kind": 31501,
+  "content": "",
+  "tags": [
+    ["d", "d24c9d3a8e8d540797096d3ba3f0172f1f4c4cc4e282f3846f62e3eab7067b9d"],
+    ["e", "d24c9d3a8e8d540797096d3ba3f0172f1f4c4cc4e282f3846f62e3eab7067b9d", "wss://relay.gambit.golf"],
+    ["status", "in_progress"],
+    ["score", "1", "4"],
+    ["score", "2", "5"],
+    ["score", "3", "3"],
+    ["p", "91f076d94420cf6131a338e5acfc4947f0cbaf7d51be1e0039227ead8ad96115", "wss://relay.damus.io"],
+    ["p", "55127fc9e1c03c6b459a3bab72fdb99def1644c5f239bdd09f3e5fb401ed9b21", "wss://relay.gambit.golf"],
+    ["alt", "Live scorecard: 3 holes completed"],
+    ["t", "golf"],
+    ["client", "gambit-golf-ios"]
+  ]
+  // other fields...
+}
+```
+
+## Final Round Record (kind `1502`)
+
+A regular (immutable) event published when a round is complete. This is the permanent scoring record. The event author (`pubkey`) is the player whose scores are recorded.
+
+### Tags
+
+| Tag | Required | Format | Description |
+|-----|----------|--------|-------------|
+| `e` | Yes | `<event-id>`, `<relay-hint>` | Reference to the kind `1501` initiation event. Relay hint SHOULD be included when known |
+| `score` | Yes | `<hole>`, `<strokes>` | One tag per hole played. Strokes is always a positive integer (gross strokes) |
+| `total` | Yes | `<strokes>` | Total strokes for the round. Clients MUST verify that the sum of `score` tags equals `total`; events where they disagree SHOULD be rejected |
+| `a` | SHOULD | `<kind>:<pubkey>:<d-tag>`, `<relay-url>` | Reference to the course 33501. Clients SHOULD include this to enable course-level discovery queries |
+| `p` | No | `<pubkey>`, `<relay-hint>` | Other participants in the round. Relay hint SHOULD be included when known |
+| `alt` | No | `<text>` | Human-readable fallback (e.g. `Final round record: 36 over 9 holes at Fowler's Mill`) |
+| `t` | No | `<hashtag>` | `golf` recommended |
+| `client` | No | `<client-name>` | Publishing client identifier |
+
+### Behavior
+
+- Each player publishes their own `1502` for the round, referencing the shared `1501`
+- The `e` tag links to the round initiation, which contains the authoritative course snapshot and rules
+
+### Example
+
+```jsonc
+{
+  "kind": 1502,
+  "content": "Great day on the course.",
+  "tags": [
+    ["e", "ebaf50dbf44e318bdad2bd5e234627c767b178e4c0b5dabecb6304dcae341516", "wss://relay.gambit.golf"],
+    ["a", "33501:ca98e63891d90e38cacf1e9a53857a94d34cc1e0e47163257e15e29c3f4e7921:fowlers-mill-golf-course", "wss://relay.gambit.golf"],
+    ["score", "1", "4"],
+    ["score", "2", "4"],
+    ["score", "3", "3"],
+    ["score", "4", "5"],
+    ["score", "5", "4"],
+    ["score", "6", "3"],
+    ["score", "7", "4"],
+    ["score", "8", "5"],
+    ["score", "9", "4"],
+    ["total", "36"],
+    ["p", "91f076d94420cf6131a338e5acfc4947f0cbaf7d51be1e0039227ead8ad96115", "wss://relay.damus.io"],
+    ["alt", "Final round record: 36 over 9 holes"],
+    ["t", "golf"],
+    ["client", "gambit-golf-ios"]
+  ]
+  // other fields...
+}
+```
+
+## Round Lifecycle
+
+```
+33501 ──▶ 1501 ──▶ 31501
+(course)   (start)   (live scores)
+             │
+             ▼
+           1502
+           (final record)
+```
+
+- `1501` references `33501` via optional `a` tag (informational)
+- `31501` references `1501` via `e` and `d` tags
+- `1502` references `1501` via `e` tag, and `33501` via optional `a` tag
+
+### Flow
+
+1. A course publisher creates a `33501` with hole and tee data
+2. A player starts a round by publishing a `1501` with an embedded course snapshot and rules
+3. As holes are played, the client updates a `31501` live scorecard
+4. When the round is complete, each player publishes a `1502` final record referencing the `1501`
+
+## Multiplayer
+
+Multiple players can participate in the same round:
+
+- All players are listed as `p` tags in the `1501` initiation event
+- Each player publishes their own `31501` updates (addressed by their pubkey + the shared `d` tag)
+- Each player publishes their own `1502` final record, all referencing the same `1501`
+- Clients reconstruct the group scorecard by fetching all `31501`/`1502` events that reference the same `1501`
+- Clients SHOULD verify that the author of a `31501` or `1502` is listed as a `p` tag in the referenced `1501`. Events from authors not in the participant list SHOULD be ignored
+
+## Comments
+
+Clients MAY use [NIP-22](22.md) comments on kind `1501` events for round commentary.
+
+## Suggested Filter Patterns
+
+To fetch all rounds by a player:
+```json
+{"kinds": [1502], "authors": ["<pubkey>"]}
+```
+
+To reconstruct a multiplayer round (all final records referencing the same initiation):
+```json
+{"kinds": [1502], "#e": ["<1501-event-id>"]}
+```
+
+To fetch all final records for a course:
+```json
+{"kinds": [1502], "#a": ["33501:<pubkey>:<d-tag>"]}
+```
+
+To fetch live scorecards for a round:
+```json
+{"kinds": [31501], "#d": ["<1501-event-id>"]}
+```
+
+To browse courses by geohash:
+```json
+{"kinds": [33501], "#g": ["dp3w"]}
+```
+
+Note: Multi-letter tags (`hole_tee`, `score`, `status`, etc.) are not relay-indexed per [NIP-01](01.md). Queries should use standard indexed tags (`#d`, `#e`, `#g`, `#p`, `#t`, `#a`) and parse non-indexed tags client-side.
+
+## Verification
+
+A verifier can confirm round integrity:
+
+1. Fetch the `1502` final record
+2. Follow the `e` tag to the `1501` initiation event — the event signature guarantees the embedded snapshot and rules have not been tampered with
+3. Parse `course_snapshot` and `rules_template` from the `1501` content
+4. Verify score totals and apply rules
+
+Rounds are self-contained and verifiable even if the referenced `33501` course is later updated or deleted.
+
+## Client Implementation Notes
+
+- Clients MUST ignore unknown tags for forward compatibility
+- Clients SHOULD validate that `tee_name` values in `hole_tee` tags match `tee` tag names exactly (case-sensitive)
+- Clients SHOULD compute total par client-side from `hole_tee` tags rather than storing it as a tag
+- Courses without `hole_geo` data should degrade gracefully (e.g. hide map features)
+- Published rounds are permanent on relays; clients SHOULD confirm with the user before publishing a `1502`
+
+## References
+
+- [NIP-01: Basic protocol flow description](01.md)
+- [NIP-22: Comments](22.md)
+- [NIP-23: Long-form Content](23.md)
+- [NIP-92: Media Attachments](92.md)


### PR DESCRIPTION
## Summary

NIP-101g defines event kinds for golf scoring on Nostr:

- **kind 33501** — Golf Course (addressable): course metadata with per-hole per-tee data (`hole_tee` tags), tee ratings, coordinates (`hole_geo`), and course imagery
- **kind 1501** — Round Initiation (regular, immutable): declares participants, embeds an authoritative course snapshot and rules template in content. The embedded snapshot — not the 33501 — is the source of truth for scoring
- **kind 31501** — Live Scorecard (addressable, replaceable): real-time score updates as a UX convenience layer, addressed by the 1501 event ID
- **kind 1502** — Final Round Record (regular, immutable): permanent scoring record with per-hole scores, referencing the 1501

### Design highlights

- **Self-contained rounds**: The 1501 embeds a full course snapshot so rounds are verifiable even if the 33501 is updated or deleted
- **Multiplayer**: All players listed as `p` tags in the 1501; each publishes their own 31501/1502. Roster validation via p-tag check
- **Course discovery**: `g` (geohash) tags enable relay-indexed proximity queries. Multiple publishers can create 33501s for the same physical course
- **Relay-friendly queries**: Filter recipes use standard indexed tags (`#e`, `#d`, `#a`, `#g`). Domain-specific tags (`hole_tee`, `score`, etc.) are parsed client-side

### Reference implementation

- **Client**: [Gambit Golf](https://gambit.golf) (iOS) — fully implements all 4 kinds
- **Relay**: `wss://relay.gambit.golf` — stores and serves all kinds

### Related

- Part of the NIP-101 sports/activity family (alongside NIP-101e for exercise)
- Uses [NIP-22](https://github.com/nostr-protocol/nips/blob/master/22.md) for round commentary
- Comparable to [NIP-64](https://github.com/nostr-protocol/nips/blob/master/64.md) (Chess) as a domain-specific event spec

🏌️ Built with [Claude Code](https://claude.ai/code)