### PR TITLE
NIP-C4 - Nostr Apps (aka napps or nsites v3)

### DIFF
--- a/C4.md
+++ b/C4.md
@@ -60,7 +60,13 @@ The bundle MUST use the same `d` tag as its corresponding app listing.
 The app listing event is an addressable event as defined in [NIP-01](01.md). It contains metadata for discovery and display: the app's name, summary, icon, categories, and availability.
 
 > [!TIP]
-> App listings should be uploaded to specialized "app marketplace* relays such as [wss://relay.44billion.net](wss://relay.44billion.net). It should also be uploaded to the author's NIP-65 write relays.
+> App listings should be uploaded to specialized "app marketplace* relays such as [wss://relay.44billion.net](wss://relay.44billion.net). These should also be published to the author's NIP-65 write relays.
+
+> [!IMPORTANT]
+> If the website has no NIP-07 support, it can't be strictly considered a Nostr app. In that case, do not publish an app listing event, just the app bundle event.
+
+> [!IMPORTANT]
+> Your app ideally SHOULD support this [NIP-07 extension](https://github.com/nostr-protocol/nips/pull/2233).
 
 | Channel | Kind  |
 |---------|-------|


### PR DESCRIPTION
This is the spec I'm using at the [44billion.net](https://44billion.net/) (beta) platform.

Now that it's based on Blossom, it is essentially `nsite` with an extra event for showing these apps on "app marketplaces" aka app stores.

As `nsite` is about to transition to a new structure with a new event kind (as seen on #1538 comments), I thought it would be ideal to reuse the same event kind I'm using for app bundle so that we can interoperate.

One important difference is that this spec makes it possible for an author to have many apps under his pubkey instead of creating a key for each app/site.

@dskvr @hzrd149 @alexgleason @fiatjaf 

Saw this [note](https://jumble.social/notes/nevent1qvzqqqqqqypzpem34u9stj8ftlxldl4n2qz5f5hmrnxns3uga86fpwe7u28ga4n0qythwumn8ghj7un9d3shjtnswf5k6ctv9ehx2ap0qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qpq5evj4pac9svsd4ayk2tfhqrg4hfcg3v4y9mzks9z7xm06dm6py6q0u4dln) and rushed to write this down so nsites and napps can become one, after all they are really just static websites.