### PR TITLE
NIP-CF "Combine Forces": Interoperable napps

### DIFF
--- a/CF.md
+++ b/CF.md
@@ -55,7 +55,7 @@ Both `name` and `icon` MUST be present for a listing to be considered complete. 
 | `self`        | `["self", "<pubkey>"]`                          | The app's own Nostr profile pubkey. |
 | `auto`        | `["auto", "<field>"]`                           | Marks a field (`name`, `summary`, or `icon`) as auto-derived (e.g. extracted from HTML metadata). Clients updating the listing SHOULD overwrite auto-derived fields but SHOULD NOT overwrite manually-set fields. |
 | `description` | `["description", "<text>", "<lang>?"]`          | Long description. Optional ISO 639-1 language code. |
-| `key-art`     | `["key-art", "<sha256>"]`                       | Main image (e.g. to show on an app card). |
+| `key-art`     | `["key-art", "<sha256>", "<mime>"]`                       | Main image (e.g. to show on an app card). |
 | `screenshot`  | `["screenshot", "<sha256>", "<mime>"]`                    | Screenshot image. May appear multiple times. |
 
 #### Example


### PR DESCRIPTION
## Summary

NIP-CF ("Combine Forces") is an alternative to NIP-C4 (#2274) that achieves interoperability with the [Static Websites NIP and ecosystem (_nsite_)](#1538) that has been in production for 1.5 years by using its site manifest format (kind `35128`) as the file storage layer rather than defining a separate bundle format.

## Motivation

NIP-C4 and the Static Websites NIP both solve overlapping problems, getting static files served over nostr via Blossom. Rather than have two competing file manifest formats, NIP-CF proposes that nostr Apps be a **metadata and discovery layer** on top of the Static Websites spec. A _napp_ is a static website with a _napp_ listing event on top.

This is not a rejection of NIP-C4, it preserves the app listing structure, categories, channels, _napp_ entity encoding, and publishing flow. The substantive change is:

- **File manifest reuse**: Instead of app-specific bundle kinds (37448-37450), apps reference a Static Websites site manifest (kind `35128`) via an `a` tag. Any _nsite_ host server can serve a _napp_ without knowing about NIP-CF.

With the above change, the following changes are adopted (*)

- **MIME types optional**: The `path` tag supports an optional fourth element for MIME when needed (e.g., `favicon.ico`), but omitting it is encouraged to keep events small, especially relevant for NIP-44 encrypted payloads in the NIP-46 auth case. This one concession increases the upper limit for total paths in a "Static Website" by ~1.5-3x (depending on path string length) over NIP-C4.
- **Blossom server hints**: File resolution uses `server` hints from the site manifest with `10063` as a fallback, aligning with how nsite already works. This one concession increases resolution speed by reducing hops and implicitly reduces error rates in the happy path, with no loss of functionality when compared with NIP-C4.
- **No `nostr` subdomain prefix**: The subdomain prefix from NIP-C4 adds complexity and naming limitations for unexplained reasons; _**likely multi-protocol support**_. URL routing builds on the Static Websites NIP, with NIP-CF adding channel resolution (main/next/draft) to select the appropriate site manifest.

## Why "Combine Forces"

The nsite spec and NIP-C4 share authors, reviewers, and implementers. The _nsite_ spec and the static website specification in the _napp_ spec are **functionally the same with only semantic differences**. Shipping two incompatible file manifest formats fragments that effort. This PR is an invitation to converge:

- **nsite authors** get app discovery and categorization for free, any static website can become a listed app by publishing one additional event.
- **NIP-C4 authors** get the hosting and resolution infrastructure that _nsite_ already defines, without having to respecify it. Implementing NIP-C4 will be easier and UNIX-like. 
- **Implementers** get one file manifest format to support, not two.

The app listing structure from NIP-C4 is fantastic work and is preserved here almost entirely. The goal is to build on it, not replace it.

## Why separate Static Websites from nostr Apps?

Static Websites are a primitive. Many sites, a blog, a personal page, random activism page have no need for app listings categories, channels, or marketplace discovery. Bundling those concerns into the same spec forces unnecessary complexity on publishers who just want to put files on nostr.

  Keeping them separate benefits both sides:

  - **Static websites** get room to evolve in their own domain, optimizing file resolution, caching, hosting, without being constrained by app-layer concerns.
  - **napps** get a stable foundation to build on. When _nsite_ improves, apps inherit those improvements for free.
  - **Interoperability** provides a natural upgrade path: a static website can become _napp_ by publishing a single listing event, and a _napp_ can be served as a plain website by any _nsite_ host that knows nothing about NIP-CF.

Using existing "Static Websites" NIP introduces no logical regressions over the pattern proposed in NIP-C4, only net benefits for all changed criteria. The Static Website definitions are functionally the same other than the removal of the prefix and arbitrary changes. Those changes remain logically unjustified as of the publishing of this NIP. 

## What this PR is asking for

Feedback. This is a draft meant to start a conversation about convergence, not a take-it-or-leave-it proposal. If there are reasons the bundle kinds need to stay separate, or if the channel model needs rethinking for this architecture, those are discussions worth having. 

## Important notes
- NIP-CF is a good faith NIP to **propose a functional, and non-destructive alternative to NIP-C4**
- (*) NIP-CF assumes that the "Static Websites" NIP proposed by @hzrd149 switches to base36 in subdomain encoding and defines mime-types as optional in `path` tags.