### PR TITLE
Add nip extensions to NIP-11

### DIFF
--- a/11.md
+++ b/11.md
@@ -20,6 +20,7 @@ When a relay receives an HTTP(s) request with an `Accept` header of `application
   "self": <relay's own pubkey>,
   "contact": <administrative alternate contact>,
   "supported_nips": <a list of NIP numbers supported by the relay>,
+  "nips": <an object with supported NIP extensions>,
   "software": <string identifying relay software URL>,
   "version": <string version identifier>,
   "terms_of_service": <a link to a text file describing the relay's term of service>
@@ -71,6 +72,37 @@ An alternative contact may be listed under the `contact` field as well, with the
 ### Supported NIPs
 
 As the Nostr protocol evolves, some functionality may only be available by relays that implement a specific `NIP`.  This field is an array of the integer identifiers of `NIP`s that are implemented in the relay. Examples would include `1`, for `"NIP-01"` and `9`, for `"NIP-09"`.  Client-side `NIPs` SHOULD NOT be advertised, and can be ignored by clients.
+
+### NIPs
+
+This field lists NIP extensions supported by the relay. If a NIP is listed on "supported_nips" but not on "nips", it means that even though the specific NIP is supported, the relay doesn't support any extensions for that NIP.
+
+```jsonc
+{
+  "nips": {
+    "45": {
+      "extensions": [
+        {
+          "extension": "hll"
+        }
+      ]
+    },
+    "50": {
+      "extensions": [
+        {
+          "extension": "include:spam",
+          "description": "Include likely spam"
+        },
+        {
+          "extension": "lang:<code>",
+          "description": "Filter to content in a specific language (e.g. \\"lang:en lang:pt\\")"
+        }
+      ]
+    }
+  }
+  // other fields...
+}
+```
 
 ### Software
 


### PR DESCRIPTION
This is a way to advertise support for NIP-50 extensions such as `include:spam`. Also added NIP-45's `hll` (hyperloglog) to the example. These are the only NIPs that have extensions afaik.

This was inspired by the [nuts field](https://github.com/cashubtc/nuts/blob/main/06.md).

Added it to my relay but of course I'm open to changing it.