### PR TITLE
NIP-50: add sort extensions (top, hot, zaps, new)

### DIFF
--- a/50.md
+++ b/50.md
@@ -53,3 +53,7 @@ Relay MAY support these extensions:
 - `language:<two letter ISO 639-1 language code>` - include only events of a specified language
 - `sentiment:<negative/neutral/positive>` - include only events of a specific sentiment
 - `nsfw:<true/false>` - include or exclude nsfw events (default: true)
+- `sort:top` - sort by total engagement count
+- `sort:hot` - sort by engagement weighted with time decay, surfacing trending content
+- `sort:zaps` - sort by total zap amount received
+- `sort:new` - sort chronologically by `created_at` descending, overriding any relevance-based default


### PR DESCRIPTION
These search extensions allow sorting by the best posts of all time (sort:top), the best posts recently (sort:hot), top zapped (sort:zapped), and chronologically (sort:new) (which is an escape hatch for NIP-50's default sort by "quality" descending)