### PR TITLE
NIP-B9: Zap Poll Events for paid polling on Nostr

### DIFF
--- a/57.md
+++ b/57.md
@@ -38,6 +38,7 @@ In addition, the event MAY include the following tags:
 - `e` is an optional hex-encoded event id. Clients MUST include this if zapping an event rather than a person.
 - `a` is an optional event coordinate that allows tipping addressable events such as NIP-23 long-form notes.
 - `k` is the stringified kind of the target event.
+- `poll_option` is a tag used for voting on [zap poll events](B9.md).
 
 Example:
 

--- a/B9.md
+++ b/B9.md
@@ -1,0 +1,131 @@
+# NIP-B9: Zap Poll Events
+
+`draft` `optional` `author:toadlyBroodle`
+
+A zap poll note is a [nostr event](01.md) (kind `6969`) for conducting paid polls. A poll presents two or more voting options, which participants may vote on by sending regular [zap events](57.md) that include an additional `poll_option` vote tag. Polls may include multiple recipients which participants may choose from when zapping their votes. Polls may specify `value_maximum` and `value_minimum` satoshi valuations for determining which zaps are included in the tally. Polls may specify a `consensus_threshold` for assessing the state of consensus. Polls should specify a `closed_at` time, after which results are unblinded, closed to new votes, and the tally considered final.
+
+## Purpose
+
+The purpose of zap poll notes is to conduct quantitative public opinion polls over nostr by requiring voters pay to participate. By tying results to real satoshi valuations, zap polls intend to provide superior signal compared to free polling models such as [NIP-88](88.md). Imposing real monetary costs for participation should also discourage undesired attempts to sway results.
+
+Pollers may specify multiple `p` keys, to allow participants to choose which recipient they zap, regardless of their vote choice. The option for such distribution of funds should also incentivize participation by increasing voter optionality, poller authenticity, and legitimacy of results by mitigating certain unauthentic attack vectors.
+
+By including a `value_maximum` limit, polls can stop single 'whale' votes discounting many smaller 'shrimp' votes. Likewise, by including a `value_minimum` limit, polls can make automated low-value vote flooding attacks prohibitively expensive. However, both limits remain optional to allow for freedom in poll design.
+
+By setting `value_maximum` and `value_minimum` equal, a more traditional style poll may be designed, which weights each vote equal and limits each participant to a single vote.
+
+The optional `consensus_threshold` is intended as a simple 'measuring bar', defined as the minimum percentage for any single `poll_option`'s percentage of the total tally to attain poll consensus status.
+
+A careful balancing of all poll attributes should enable pollers to conduct tailored polls that deliver meaningful and valuable outcomes.
+
+## Relationship to NIP-88
+
+[NIP-88](88.md) defines free polls (kind `1068`) where participation has no cost. Zap polls (this NIP) are complementary: they require lightning payments to vote, providing Sybil resistance and skin-in-the-game signal that free polls cannot offer. Together, NIP-88 and NIP-B9 give clients both free and paid polling options.
+
+Key differences:
+
+| | NIP-88 (Free Polls) | NIP-B9 (Zap Polls) |
+|---|---|---|
+| Event kind | `1068` | `6969` |
+| Response kind | `1018` | `9734` (zap request) |
+| Cost to vote | Free | Satoshis (configurable) |
+| Sybil resistance | None (relies on WoT) | Economic (cost per vote) |
+| Vote weighting | Equal (one vote per key) | Proportional to sats (or equal with min=max) |
+
+## Zap poll format
+
+A poll event:
+* MUST specify 1 or more `p` tags, each including the same primary hosting relay
+* If an `e` tag is specified (for replying to or referencing another event), it:
+  * MUST include the same primary hosting relay URL as the `p` tags
+* MUST contain a primary description string, specified in the `content` field
+* MUST contain at least 2 `poll_option` tags, each specifying an index and a unique description string, formatted as below
+* SHOULD specify a `closed_at` time:
+  * a `closed_at` value of null or less than or equal to the `created_at` field indicates a poll SHOULD NOT be closed
+* MAY specify a `value_maximum` satoshi value for zapped votes to be included in the tally
+* MAY specify a `value_minimum` satoshi value for zapped votes to be included in the tally
+  * `value_minimum` MUST be less than or equal to `value_maximum`, when both are specified
+* MAY include a `consensus_threshold` (0-100), representing a percentage threshold for any single vote option to achieve poll consensus
+  * a `consensus_threshold` of '0' indicates no threshold is specified.
+
+```json
+{
+  "id": <32-bytes lowercase hex-encoded sha256 of the serialized event data>,
+  "pubkey": <32-bytes lowercase hex-encoded public key of the event creator>,
+  "created_at": <unix timestamp in seconds>,
+  "kind": 6969,
+  "tags": [
+    ["p", <32-bytes hex of the key>, <primary poll host relay URL>],
+    ["poll_option", "0", "poll option 0 description string"],
+    ["poll_option", "1", "poll option 1 description string"],
+    ["poll_option", "n", "poll option <n> description string"],
+    ["value_maximum", "maximum satoshi value for inclusion in tally"],
+    ["value_minimum", "minimum satoshi value for inclusion in tally"],
+    ["consensus_threshold", "required percentage to attain consensus <0..100>"],
+    ["closed_at", "unix timestamp in seconds"]
+  ],
+  "content": <primary poll description string>,
+  "sig": <64-bytes hex of the signature of the sha256 hash of the serialized event data, which is the same as the "id" field>
+}
+```
+
+## Zap voting
+
+Poll options are voted on by sending [zap events](57.md) (referencing the original poll event's `e` and `p` values) that indicate their chosen vote option in a `poll_option` tag. To ensure all eligible votes are included in the tally, all `e` and `p` tags must specify the same primary hosting relay.
+
+A voting client:
+* SHOULD NOT allow submission of zap events with amounts greater than `value_maximum` (when specified)
+* SHOULD NOT allow submission of zap events with amounts less than `value_minimum` (when specified)
+* SHOULD NOT allow submission of zap events after `closed_at` time (when specified)
+* SHOULD NOT allow poll author to vote on their own polls
+* SHOULD hide tally results, until after a user has zapped the note
+
+## Zap vote format
+
+The zap request event (kind `9734`):
+* MUST specify an `e` tag that references the original poll event
+  * MUST include a primary hosting relay URL in the `e` tag
+* MUST include at least 1 `p` tag specifying the recipient's key, chosen from the original poll event's list of keys
+  * MUST include the same primary hosting relay URL in all `p` tags as is specified in the `e` tag
+* MUST include a `k` tag with the stringified kind of the poll event (i.e. `"6969"`)
+* MUST include exactly 1 `poll_option` tag which references the chosen vote option by its corresponding index `n`
+
+```json
+...
+"tags": [
+  ["e", <32-bytes hex of the id of the original poll event>, <primary poll host relay URL>],
+  ["p", <32-bytes hex of the recipient's key>, <primary poll host relay URL>],
+  ["k", "6969"],
+  ["poll_option", "n"],
+  ...
+],
+...
+```
+
+## Zap poll outcome
+
+Poll results are tallied by summing the exact satoshi values from all eligible zaps for each `poll_option`. The total tally is the sum of all individual `poll_option` tallies, and `poll_option` results are calculated by their percentage of the total tally value.
+
+To avoid ambiguity of results, strict adherence to the following rules is vital when tallying and rendering poll outcomes.
+
+A tallying client:
+* MUST ONLY include full satoshi value amounts in option tallies from ALL eligible zaps that meet ALL following criteria:
+* MUST ONLY tally zaps that reference the original poll event by its `e` tag value
+* MUST ONLY tally zaps sent to a `p` key specified in the original poll event
+* MUST NOT tally zaps from the poll author's `p`
+* MUST ONLY include zap amounts less than or equal to `value_maximum`, if specified
+* MUST ONLY include zap amounts greater than or equal to `value_minimum`, if specified
+* if both `value_maximum` and `value_minimum` are specified AND are equal:
+  * MUST ONLY count 1 zap per option, per participant
+* if a `closed_at` time is specified, clients:
+  * MUST ONLY tally zaps including a valid `created_at` time greater than or equal to the original poll event's `created_at` time
+  * MUST ONLY tally zaps including a valid `created_at` time less than or equal to the original poll event's `closed_at` time
+
+Additionally, a tallying client:
+* MUST display the distribution percentages, from the tally total, for each vote option tally
+* MUST display the `consensus_threshold` (if specified) relative to the winning vote percentage
+* SHOULD show tally results to all note zappers, even if they haven't voted on an option
+* SHOULD publicly show results after the `closed_at` time has passed (if specified)
+* MAY display the counts of zap events received for each option, along with other poll statistics
+
+Strict adherence to these requirements should enable a standardized means of quantitatively assessing the distribution of opinion regarding a poll's content amongst poll participants, determining a winning outcome, and possibly achieving consensus. However, until this protocol is further tested, refined, and proven robust, polls should probably not be considered authoritative nor binding.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-A4: Public Messages](A4.md)
 - [NIP-B0: Web Bookmarks](B0.md)
 - [NIP-B7: Blossom](B7.md)
+- [NIP-B9: Zap Poll Events](B9.md)
 - [NIP-BE: Nostr BLE Communications Protocol](BE.md)
 - [NIP-C0: Code Snippets](C0.md)
 - [NIP-C7: Chats](C7.md)
@@ -181,6 +182,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `4550`        | Community Post Approval         | [72](72.md)                            |
 | `5000`-`5999` | Job Request                     | [90](90.md)                            |
 | `6000`-`6999` | Job Result                      | [90](90.md)                            |
+| `6969`        | Zap Poll                        | [B9](B9.md)                            |
 | `7000`        | Job Feedback                    | [90](90.md)                            |
 | `7374`        | Reserved Cashu Wallet Tokens    | [60](60.md)                            |
 | `7375`        | Cashu Wallet Tokens             | [60](60.md)                            |


### PR DESCRIPTION
## Reopening NIP-69 as NIP-B9: Zap Poll Events (kind `6969`)

This PR reopens the original [PR #320](https://github.com/nostr-protocol/nips/pull/320), which was open from March 2023 to May 2025 but never merged.

### Why it was blocked

The single blocking objection from @staab was that the spec required zaps for poll participation, with no free alternative on Nostr. @vitorpamplona repeatedly advocated for merging, arguing: "Not having a non-zap version doesn't make this a bad idea. The procedure is sound as a polling option."

### What changed

**[NIP-88](88.md) (Polls) has since been merged**, establishing `kind:1068` as the standard for free, non-zap polls. This resolves the original objection. With NIP-88 handling traditional polls, NIP-B9 focuses on what it does best: paid polls with skin-in-the-game.

The spec was also updated to fix issues accumulated over two years of inactivity:

- **Renumbered** from NIP-69/NIP-100 to NIP-B9
- **Added `k` tag** to zap vote format per current NIP-57 convention
- **Removed non-standard `ots` top-level field** from JSON examples (NIP-03 now uses separate `kind:1040` events)
- **Added "Relationship to NIP-88" section** documenting how zap polls complement free polls
- **Fixed typos** and clarified `e` tag usage in poll events
- **Rebased cleanly** on current master

### Why zap polls need their own NIP

NIP-88 handles free polls, but free polls are inherently vulnerable to Sybil attacks. Zap polls require lightning payments to vote:

| | NIP-88 (Free Polls) | NIP-B9 (Zap Polls) |
|---|---|---|
| Event kind | `1068` | `6969` |
| Response kind | `1018` | `9734` (zap request) |
| Cost to vote | Free | Satoshis (configurable) |
| Sybil resistance | None (relies on WoT) | Economic (cost per vote) |
| Vote weighting | Equal (one vote per key) | Proportional to sats (or equal with min=max) |

Together they provide both free and paid polling options for Nostr.

### Existing implementations

[Amethyst](https://github.com/vitorpamplona/amethyst) has implemented a simplified version of the zap poll spec since the original 2023 PR.