### PR TITLE
[NIP-55] - document rejected field for intent-based signer responses

### DIFF
--- a/55.md
+++ b/55.md
@@ -107,6 +107,13 @@ Send the Intent:
 launcher.launch(intent)
 ```
 
+If the signer rejected the request, it MUST send `RESULT_OK` with a `rejected` field set to `true` instead of using `RESULT_CANCELED`, so the client can distinguish between a user rejection and a system cancellation (e.g. the signer crashing):
+ 
+```kotlin
+activity?.setResult(RESULT_OK, Intent().also { it.putExtra("rejected", true) })
+```
+
+
 ### Initiating a connection
 
 - Client send a get_public_key `Intent`


### PR DESCRIPTION
Currently when a signer crash the client doesn't know if it was a crash or a user rejection, with this signers can tell the client that the user rejected the request