### PR TITLE
Add NIP-C1: Agent TUI Messages

### DIFF
--- a/C1.md
+++ b/C1.md
@@ -1,0 +1,157 @@
+NIP-C1
+======
+
+Agent TUI Messages
+------------------
+
+`draft` `optional`
+
+Defines a structured message format for AI agents to send interactive UI elements (buttons, cards, tables) through Nostr DMs. Compatible clients render these as rich components; others display raw JSON or plain-text fallback.
+
+## Motivation
+
+NIP-AE defines agent identity and capability discovery. This NIP complements it by standardizing the message format agents use to communicate interactively with users. Plain text limits what agents can express -- agents need to present actionable buttons, information cards, and data tables.
+
+Without a standard format, every agent-client pair invents its own rendering protocol. This NIP provides a minimal, extensible schema that clients can adopt incrementally.
+
+## Message Format
+
+TUI messages are JSON objects embedded in the `content` field of NIP-17 private messages (or NIP-04 for legacy compatibility). They are distinguished from plain text by the presence of a `"type"` field.
+
+### Detection
+
+Clients detect TUI messages by checking:
+
+1. Content starts with `{`
+2. Content parses as valid JSON
+3. JSON object has a `"type"` field with a known value
+
+If parsing fails, the content MUST be displayed as plain text.
+
+## Message Types
+
+### `text`
+
+Structured text message from an agent.
+
+```json
+{
+  "type": "text",
+  "content": "Hello! How can I help you today?"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `content` | string | YES | Message text |
+
+### `buttons`
+
+A row of tappable action buttons.
+
+```json
+{
+  "type": "buttons",
+  "text": "What would you like to do?",
+  "items": [
+    {"id": "weather", "label": "Check Weather", "style": "primary"},
+    {"id": "news", "label": "Read News", "style": "secondary"},
+    {"id": "cancel", "label": "Cancel", "style": "danger"}
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `text` | string | NO | Prompt text displayed above buttons |
+| `items` | array of Button | YES | List of buttons |
+
+**Button object:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | YES | Callback identifier sent back to agent |
+| `label` | string | YES | Display text |
+| `style` | string | NO | One of `primary`, `secondary`, `danger` |
+
+### `card`
+
+An information card with optional actions.
+
+```json
+{
+  "type": "card",
+  "title": "Tokyo Weather",
+  "description": "Clear skies, 22C. High: 25C, Low: 18C.",
+  "image_url": "https://example.com/weather-icon.png",
+  "actions": [
+    {"id": "forecast", "label": "5-Day Forecast", "style": "primary"}
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `title` | string | YES | Card title |
+| `description` | string | NO | Card body text |
+| `image_url` | string | NO | Image URL (HTTPS only) |
+| `actions` | array of Button | NO | Action buttons |
+
+### `table`
+
+A key-value data table.
+
+```json
+{
+  "type": "table",
+  "title": "Portfolio Summary",
+  "rows": [
+    ["Asset", "Value"],
+    ["BTC", "$67,000"],
+    ["ETH", "$3,400"]
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `title` | string | NO | Table title |
+| `rows` | array of [string, string] | YES | Key-value pairs |
+
+## Button Callbacks
+
+When a user activates a button, the client sends a plain-text message back to the agent:
+
+```
+sigil:callback:<button_id>
+```
+
+For example, tapping the "Check Weather" button sends `sigil:callback:weather`.
+
+Agents SHOULD handle unknown callback IDs gracefully by responding with a help message or ignoring them.
+
+## Fallback Rendering
+
+Clients that do not support TUI messages SHOULD render them as plain text:
+
+- **text**: Display the `content` field
+- **buttons**: Display `text` followed by a numbered list of button labels
+- **card**: Display `title` on one line, `description` below
+- **table**: Display each row as `key: value`
+
+## Extensibility
+
+New message types MAY be added in future revisions. Clients that encounter an unknown `type` value SHOULD display the raw JSON or a "unsupported message type" placeholder rather than hiding the message entirely.
+
+## Security Considerations
+
+- **Image URLs**: Clients SHOULD only load images over HTTPS. Clients MAY proxy images to prevent IP leaks.
+- **Callback injection**: Button `id` values are opaque strings. Clients MUST NOT execute them as code. They are identifiers returned to the agent as-is.
+- **Content size**: Clients SHOULD reject TUI messages larger than 64 KB to prevent abuse.
+- **XSS**: Clients rendering TUI messages in web contexts MUST sanitize all string fields before insertion into the DOM.
+
+## Reference Implementation
+
+- [sigil-core](https://github.com/lmanchu/sigil) (Rust) -- `sigil_core::tui::TuiMessage`
+- [sigil-cli](https://github.com/lmanchu/sigil) -- Ratatui terminal rendering
+- Sigil iOS -- SwiftUI native component rendering


### PR DESCRIPTION
## Summary

Defines a structured message format for AI agents to send interactive UI elements through Nostr DMs:

- **text** — structured text from agents
- **buttons** — tappable action buttons with callback protocol
- **card** — information cards with optional image and actions
- **table** — key-value data display

Complements NIP-AE (Agents) by standardizing the message layer between agents and clients. NIP-AE covers identity and discovery; NIP-C1 covers what agents actually *say*.

## Design Decisions

- **Embedded in DM content**: TUI messages live inside NIP-17/NIP-04 encrypted message content as JSON. No new event kinds needed.
- **Graceful degradation**: Non-supporting clients see raw JSON. Spec includes plain-text fallback rendering rules.
- **Callback protocol**: Simple `sigil:callback:<id>` string for button responses. No new event kind, just a plain message back.
- **Extensible**: New `type` values can be added without breaking existing clients.

## Reference Implementation

- [sigil-core](https://github.com/lmanchu/sigil) — Rust library with `TuiMessage` enum
- sigil-cli — Ratatui terminal rendering
- Sigil iOS — SwiftUI native component rendering
- Verified E2E with Damus interop (plain text fallback works)

## Relationship to NIP-AE

NIP-AE defines agent definitions (kind 4199), lessons (kind 4129), nudges (kind 4201), and attribution. This NIP is orthogonal — it defines the *message format* agents use within existing DM infrastructure. An agent defined via NIP-AE would use NIP-C1 messages to communicate with users.