### PR TITLE
NIP-30: Update shortcode description to include hyphens

### DIFF
--- a/30.md
+++ b/30.md
@@ -14,7 +14,7 @@ Custom emoji may be added to **kind 0**, **kind 1**, **kind 7** ([NIP-25](25.md)
 
 Where:
 
-- `<shortcode>` is a name given for the emoji, which MUST be comprised of only alphanumeric characters and underscores.
+- `<shortcode>` is a name given for the emoji, which MUST be comprised of only alphanumeric characters, hyphens, and underscores.
 - `<image-url>` is a URL to the corresponding image file of the emoji.
 - `<emoji-set-address>` is an optional address pointer (`kind:pubkey:d-tag`) to the kind 30030 emoji set ([NIP-51](51.md)) the emoji belongs to.
 


### PR DESCRIPTION
This rule has been violated repeatedly since the NIP was introduced, so maybe it's time to just accept it.