### PR TITLE
Add NIP-57A: Phantom Zaps

### DIFF
--- a/57A.md
+++ b/57A.md
@@ -1,0 +1,269 @@
+NIP-57A
+======
+
+Phantom Zaps
+--------------
+
+`draft` `optional`
+
+This NIP defines two new event types for recording subjective-value lightning
+payments between users. `6969` is a `phantom zap request`, representing a
+payer's request to a recipient's lightning wallet for a 0-sat invoice. `6970`
+is a `phantom zap receipt`, representing the confirmation by the recipient's
+lightning wallet that the 0-sat invoice issued in response to a `phantom zap
+request` has been settled.
+
+Having phantom zap receipts on nostr allows clients to display high-impact
+social signaling from entities on the network independent of actual
+cryptographic settlement. This de-couples the social graph from financial
+overhead, allowing users to express subjective appreciation at scales that would
+otherwise be constrained by liquidity limits.
+
+## Protocol flow
+
+1. Client calculates a recipient's lnurl pay request url from
+  the `zap` tag on the event being zapped (see Appendix G), or by
+  decoding their lud16 field on their profile according to the [lnurl
+  specifications](https://github.com/lnurl/luds). The client MUST send a GET
+  request to this url and parse the response. If `allowsPhantomZaps` exists and it
+  is `true`, and if `phantomNostrPubkey` exists and is a valid BIP 340 public key
+  in hex, the client should associate this information with the user.
+2. Clients SHOULD display a UI affordance for Phantom Zaps on each post or on a
+  user's profile to enable zero-fee social signaling.
+3. When a user (the "sender") indicates they want to send a phantom zap to
+  another user (the "recipient"), the client should create a `phantom zap request`
+  event as described in Appendix A of this NIP and sign it.
+4. Instead of publishing the `phantom zap request`, the `6969` event should
+  instead be sent to the `callback` url received from the lnurl pay endpoint for
+  the recipient using a GET request. The actual HTTP `amount` parameter MUST be
+  `0`. See Appendix B for details.
+5. The recipient's lnurl server will receive this `phantom zap request` and
+  validate it. See Appendix C for details on how to properly configure an lnurl
+  server to support phantom zaps, and Appendix D for details on how to validate
+  the `nostr` query parameter.
+6. If the `phantom zap request` is valid, the server SHOULD fetch a 0-sat
+  description hash invoice where the description is this `phantom zap request`
+  note.
+7. On receiving the 0-sat invoice, the client MAY settle it automatically in the
+  background, or handle it via standard wallet routing.
+8. Once the invoice is settled, the recipient's lnurl server MUST generate a
+  `phantom zap receipt` as described in Appendix E, and publish it to the `relays`
+  specified in the `phantom zap request`.
+9. Clients fetching `phantom zap receipt`s on posts and profiles MUST
+  authorize their validity as described in Appendix F. Clients MUST display the
+  `phantom_amount` tag as the primary UI value to ensure proper social graph
+  propagation.
+
+## Reference and examples
+
+### Appendix A: Phantom Zap Request Event
+
+A `phantom zap request` is an event of kind `6969` that is _not_ published to
+relays, but is instead sent to a recipient's lnurl pay `callback` url. This
+event's `content` MAY be an optional message to send along with the social
+signal. The event MUST include the following tags:
+
+- `relays` is a list of relays the recipient's wallet should publish its
+  `phantom zap receipt` to.
+- `phantom_amount` is the subjective amount in _millisats_ the sender intends to
+  signal, formatted as a string.
+- `amount` is the settlement amount in _millisats_, which MUST always be `"0"`.
+- `lnurl` is the lnurl pay url of the recipient, encoded using bech32 with the
+  prefix `lnurl`.
+- `p` is the hex-encoded pubkey of the recipient.
+
+In addition, the event MAY include the following tags:
+
+- `e` is an optional hex-encoded event id. Clients MUST include this if zapping
+  an event rather than a person.
+- `a` is an optional event coordinate that allows tipping addressable events
+  such as NIP-23 long-form notes.
+- `k` is the stringified kind of the target event.
+
+Example:
+
+```javascript
+{
+  "kind": 6969,
+  "content": "You absolute legend",
+  "tags": [
+    ["relays", "wss://nostr-pub.wellorder.com", "wss://anotherrelay.example.com"],
+    ["phantom_amount", "1000000000"],
+    ["amount", "0"],
+    ["lnurl", "lnurl1dp68gurn8ghj7um5v93kketj9ehx2amn9uh8wetvdskkkmn0wahz7mrww4excup0dajx2mrv92x9xp"],
+    ["p", "04c915daefee38317fa734444acee390a8269fe5810b2241e5e6dd343dfbecc9"],
+    ["e", "9ae37aa68f48645127299e9453eb5d908a0cbb6058ff340d528ed4d37c8994fb"],
+    ["k", "1"]
+  ],
+  "pubkey": "97c70a44366a6535c145b333f973ea86dfdc2d7a99da618c40c64705ad98e322",
+  "created_at": 1711929600,
+  "id": "30efed56a035b2549fcaeec0bf2c1595f9a9b3bb4b1a38abaf8ee9041c4b7d93",
+  "sig": "f2cb581a84ed10e4dc84937bd98e27acac71ab057255f6aa8dfa561808c981fe8870f4a03c1e3666784d82a9c802d3704e174371aa13d63e2aeaf24ff5374d9d"
+}
+```
+
+### Appendix B: Phantom Zap Request HTTP Request
+
+A signed `phantom zap request` event is not published, but is instead sent using
+a HTTP GET request to the recipient's `callback` url. This request should have
+the following query parameters defined:
+
+- `amount` is the amount in _millisats_ the sender intends to settle. For a
+  phantom zap, this MUST be `0`.
+- `nostr` is the `6969` `phantom zap request` event, JSON encoded then URI
+  encoded
+- `lnurl` is the lnurl pay url of the recipient, encoded using bech32 with the
+  prefix `lnurl`
+
+This request should return a JSON response with a `pr` key, which is the 0-sat
+invoice the sender must settle to finalize their phantom zap. Here is an example
+flow in javascript:
+
+```javascript
+const senderPubkey // The sender's pubkey
+const recipientPubkey = // The recipient's pubkey
+const callback = // The callback received from the recipients lnurl pay endpoint
+const lnurl = // The recipient's lightning address, encoded as a lnurl
+const subjectiveSats = 1000000
+
+const phantomAmount = subjectiveSats * 1000
+const settlementAmount = 0
+const relays = ['wss://nostr-pub.wellorder.net']
+const event = encodeURI(JSON.stringify(await signEvent({
+  kind: 6969,
+  content: "",
+  pubkey: senderPubkey,
+  created_at: Math.round(Date.now() / 1000),
+  tags: [
+    ["relays", ...relays],
+    ["phantom_amount", phantomAmount.toString()],
+    ["amount", settlementAmount.toString()],
+    ["lnurl", lnurl],
+    ["p", recipientPubkey],
+  ],
+})))
+
+const {pr: invoice} = await fetchJson(`${callback}?amount=${settlementAmount}&nostr=${event}&lnurl=${lnurl}`)
+```
+
+### Appendix C: LNURL Server Configuration
+
+The lnurl server will need some additional pieces of information so that clients
+can know that phantom zap invoices are supported:
+
+1. Add a `phantomNostrPubkey` to the lnurl-pay static endpoint
+  `/.well-known/lnurlp/<user>`, where `phantomNostrPubkey` is the nostr pubkey
+  your server will use to sign `phantom zap receipt` events.
+2. Add an `allowsPhantomZaps` field and set it to true.
+
+### Appendix D: LNURL Server Phantom Zap Request Validation
+
+When a client sends a `phantom zap request` event to a server's lnurl-pay
+callback URL, there will be a `nostr` query parameter whose value is that event
+which is URI- and JSON-encoded. If present, the `phantom zap request` event must
+be validated in the following ways:
+
+1. It MUST have a valid nostr signature
+2. It MUST have tags
+3. It MUST have only one `p` tag
+4. It MUST have 0 or 1 `e` tags
+5. There should be a `relays` tag with the relays to send the `phantom zap receipt` to.
+6. It MUST have a `phantom_amount` tag.
+7. It MUST have an `amount` tag that is exactly `"0"`.
+8. The `amount` query parameter MUST be `0`.
+9. If there is an `a` tag, it MUST be a valid event coordinate
+10. There MUST be 0 or 1 `P` tags. If there is one, it MUST be equal to the `phantom zap receipt`'s `pubkey`.
+
+The event MUST then be stored for use later, when the 0-sat invoice is settled.
+
+### Appendix E: Phantom Zap Receipt Event
+
+A `phantom zap receipt` is created by a lightning node when a 0-sat invoice
+generated by a `phantom zap request` is paid. `Phantom zap receipt`s are
+only created when the invoice description (committed to the description hash)
+contains a `phantom zap request` note.
+
+When receiving a payment, the following steps are executed:
+
+1. Get the description for the invoice.
+2. Parse the bolt11 description as a JSON nostr event. This SHOULD be validated
+  based on the requirements in Appendix D.
+3. Create a nostr event of kind `6970` as described below, and publish it to the
+  `relays` declared in the `phantom zap request`.
+
+The following should be true of the `phantom zap receipt` event:
+
+- The `content` SHOULD be empty.
+- The `created_at` date SHOULD be set to the invoice `paid_at` date for idempotency.
+- `tags` MUST include the `p` tag (zap recipient) AND optional `e` tag from the
+  `phantom zap request` AND optional `a` tag from the `phantom zap request` AND
+  optional `P` tag from the pubkey of the `phantom zap request` (zap sender).
+- The `phantom zap receipt` MUST have a `bolt11` tag containing the 0-sat description hash bolt11 invoice.
+- The `phantom zap receipt` MUST contain a `description` tag which is the JSON-encoded phantom zap request.
+- The `phantom zap receipt` MUST contain a `phantom_amount` tag matching the requested subjective amount.
+- `SHA256(description)` SHOULD match the description hash in the bolt11 invoice.
+- The `phantom zap receipt` MAY contain a `preimage` tag.
+
+The `phantom zap receipt` serves as a cryptographic attestation of intent rather
+than a proof of cryptographic settlement. The existence of the receipt confirms
+the sender successfully signaled their subjective valuation to the recipient.
+
+Example `phantom zap receipt`:
+
+```javascript
+{
+    "id": "67b48a14fb66c60c8f9070bdeb37afdfcc3d08ad01989460448e4081eddda446",
+    "pubkey": "9630f464cca6a5147aa8a35f0bcdd3ce485324e732fd39e09233b1d848238f31",
+    "created_at": 1711929605,
+    "kind": 6970,
+    "tags": [
+      ["p", "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245"],
+      ["P", "97c70a44366a6535c145b333f973ea86dfdc2d7a99da618c40c64705ad98e322"],
+      ["e", "3624762a1274dd9636e0c552b53086d70bc88c165bc4dc0f9e836a1eaf86c3b8"],
+      ["k", "1"],
+      ["phantom_amount", "1000000000"],
+      ["bolt11", "lnbc0p1p3unwfusp5t9r3yymhpfqculx78u027lxspgxcr2n2987mx2j55nnfs95nxnzqpp5jmrh92pfld78spqs78v9euf2385t83uvpwk9ldrlvf6ch7tpascqhp5zvkrmemgth3tufcvflmzjzfvjt023nazlhljz2n9hattj4f8jq8qxqyjw5qcqpjrzjqtc4fc44feggv7065fqe5m4ytjarg3repr5j9el35xhmtfexc42yczarjuqqfzqqqqqqqqlgqqqqqqgq9q9qxpqysgq079nkq507a5tw7xgttmj4u990j7wfggtrasah5gd4ywfr2pjcn29383tphp4t48gquelz9z78p4cq7ml3nrrphw5w6eckhjwmhezhnqpy6gyf0"],
+      ["description", "{\"pubkey\":\"97c70a44366a6535c145b333f973ea86dfdc2d7a99da618c40c64705ad98e322\",\"content\":\"\",\"id\":\"d9cc14d50fcb8c27539aacf776882942c1a11ea4472f8cdec1dea82fab66279d\",\"created_at\":1711929600,\"sig\":\"77127f636577e9029276be060332ea565deaf89ff215a494ccff16ae3f757065e2bc59b2e8c113dd407917a010b3abd36c8d7ad84c0e3ab7dab3a0b0caa9835d\",\"kind\":6969,\"tags\":[[\"e\",\"3624762a1274dd9636e0c552b53086d70bc88c165bc4dc0f9e836a1eaf86c3b8\"],[\"p\",\"32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245\"],[\"relays\",\"wss://relay.damus.io\"],[\"phantom_amount\",\"1000000000\"],[\"amount\",\"0\"]]}"],
+      ["preimage", "0000000000000000000000000000000000000000000000000000000000000000"]
+    ],
+    "content": "",
+  }
+```
+
+### Appendix F: Validating Phantom Zap Receipts
+
+A client can retrieve `phantom zap receipt`s on events and pubkeys using a
+NIP-01 filter, for example `{"kinds": [6970], "#e": [...]}`. Phantom Zaps MUST
+be validated using the following steps:
+
+- The `phantom zap receipt` event's `pubkey` MUST be the same as the recipient's
+  lnurl provider's `phantomNostrPubkey` (retrieved in step 1 of the protocol
+  flow).
+- The `amount` tag in the `description` tag MUST equal `0`.
+- The `phantom_amount` tag in the `phantom zap receipt` MUST equal the
+  `phantom_amount` tag in the `phantom zap request`.
+- The client MUST strictly separate the `phantom_amount` from the `bolt11`
+  invoice amount in the UI layer. To prevent UX fragmentation between social value
+  and settlement value, clients MUST NOT render the `bolt11` amount alongside
+  the `phantom_amount`.
+
+### Appendix G: `pzap` tag on other events
+
+When an event includes one or more `pzap` (phantom zap) tags, clients wishing
+to phantom zap it SHOULD calculate the lnurl pay request based on the tags
+value instead of the event author's profile field. The tag's second argument
+is the `hex` string of the receiver's pub key and the third argument is the
+relay to download the receiver's metadata (Kind-0). An optional fourth parameter
+specifies the weight assigned to the respective receiver's social signaling
+distribution.
+
+```javascript
+{
+    "tags": [
+        [ "pzap", "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2", "wss://nostr.oxtr.dev", "1" ],
+        [ "pzap", "fa984bd7dbb282f07e16e7ae87b26a2a7b9b90b7246a44771f0cf5ae58018f52", "wss://nostr.wine/",    "1" ]
+    ]
+}
+```
+
+Clients MAY display the phantom zap split configuration in the note.


### PR DESCRIPTION
This PR adds NIP-57A, which allows users to send zaps that display a custom high
amount in the client UI, while resolving to a 0-sat invoice on the Lightning
network.

**Why?**
To let users participate in the zap ecosystem and signal appreciation without
needing actual sats or routing liquidity.

**What's included:**
*   **Kind `6969` (Phantom Zap Request):** Sent to the LNURL callback with an
	HTTP `amount` of 0, but includes a `phantom_amount` tag for the UI.
*   **Kind `6970` (Phantom Zap Receipt):** Published to relays containing the
	`phantom_amount` so clients know what number to render.
*   **LNURL updates:** Adds `allowsPhantomZaps` and `phantomNostrPubkey` to the
	LNURL pay endpoint response.

**Client implementation:**
If a client sees a `6970` event, it should display the `phantom_amount` tag
value and ignore the `bolt11` invoice amount.
