### PR TITLE
NIP-24: add published_at as a general tag for replaceable and addressable events

### DIFF
--- a/24.md
+++ b/24.md
@@ -41,3 +41,4 @@ These tags may be present in multiple event kinds. Whenever a different meaning 
   - `i`: an external id the event is referring to in some way - see [NIP-73](73.md).
   - `title`: name of [NIP-51](51.md) sets, [NIP-52](52.md) calendar event, [NIP-53](53.md) live event or [NIP-99](99.md) listing.
   - `t`: a hashtag. The value MUST be a lowercase string.
+  - `published_at`: the unix timestamp in seconds (stringified) of the first time the event was published. For replaceable and addressable events, where `created_at` reflects the time of the latest version, clients SHOULD preserve this tag across updates.

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `preimage`        | hash of `bolt11` invoice             | --                              | [57](57.md)                                        |
 | `price`           | price                                | currency, frequency             | [99](99.md)                                        |
 | `proxy`           | external ID                          | protocol                        | [48](48.md)                                        |
-| `published_at`    | unix timestamp (string)              | --                              | [23](23.md), [B0](B0.md)                           |
+| `published_at`    | unix timestamp (string)              | --                              | [23](23.md), [24](24.md), [B0](B0.md)              |
 | `relay`           | relay url                            | --                              | [42](42.md), [17](17.md)                           |
 | `relays`          | relay list                           | --                              | [57](57.md)                                        |
 | `repo`            | Reference to the origin repository   | --                              | [C0](C0.md)                                        |


### PR DESCRIPTION
NIP-23 defines `published_at` for articles, which is a generally useful tag for replaceable events.

This tag is for display purposes only, and expects no special behavior from relays or clients. Clients can choose to use it to indicate the original publish date for an event (eg "joined at" for kind 0 profiles).

If the value is equal to the event's created_at, clients display that the event was "created" when the event is shown in feeds, while if it differs, clients can display that the event was "updated" when shown in feeds.