### PR TITLE
NIP-51: add published_at as an optional tag for sets

### DIFF
--- a/51.md
+++ b/51.md
@@ -49,7 +49,7 @@ Sets are lists with well-defined meaning that can enhance the functionality and 
 
 For example, _relay sets_ can be displayed in a dropdown UI to give users the option to switch to which relays they will publish an event or from which relays they will read the replies to an event; _curation sets_ can be used by apps to showcase curations made by others tagged to different topics.
 
-Aside from their main identifier, the `"d"` tag, sets can optionally have a `"title"`, an `"image"` and a `"description"` tags that can be used to enhance their UI.
+Aside from their main identifier, the `"d"` tag, sets can optionally have a `"title"`, an `"image"`, a `"description"` and a `"published_at"` (unix timestamp in seconds, stringified, of the first time the set was published) tags that can be used to enhance their UI.
 
 | name                  | kind  | description                                                                                  | expected tag items                                                                  |
 | ---                   | ---   | ---                                                                                          | ---                                                                                 |

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 | `preimage`        | hash of `bolt11` invoice             | --                              | [57](57.md)                                        |
 | `price`           | price                                | currency, frequency             | [99](99.md)                                        |
 | `proxy`           | external ID                          | protocol                        | [48](48.md)                                        |
-| `published_at`    | unix timestamp (string)              | --                              | [23](23.md), [B0](B0.md)                           |
+| `published_at`    | unix timestamp (string)              | --                              | [23](23.md), [51](51.md), [B0](B0.md)              |
 | `relay`           | relay url                            | --                              | [42](42.md), [17](17.md)                           |
 | `relays`          | relay list                           | --                              | [57](57.md)                                        |
 | `repo`            | Reference to the origin repository   | --                              | [C0](C0.md)                                        |


### PR DESCRIPTION
Follow-up to https://github.com/nostr-protocol/nips/pull/2300

This time NIP-51 only.