### PR TITLE
NIP-5D: nostr web applets

### DIFF
--- a/5D.md
+++ b/5D.md
@@ -103,7 +103,7 @@ NUB specs MUST:
 Napplets are untrusted code. The shell is trusted. The browser enforces iframe sandbox boundaries. `MessageEvent.source` provides unforgeable sender identity.
 
 **Mitigations:**
-1. Iframe sandbox: `allow-scripts` is the only required token -- shells MUST NOT add `allow-same-origin`.
+1. Iframe sandbox: `allow-scripts` is the only required token -- shells MUST NOT add `allow-same-origin`. Adding `allow-same-origin` would grant the napplet a real origin, allowing it to register a service worker, read shell `localStorage`, and bypass shell mediation entirely -- this prohibition is the load-bearing precondition for browser-enforced isolation of any kind.
 2. postMessage `'*'` origin is required for opaque-origin iframes; sender identification uses `MessageEvent.source`, NOT `event.origin`.
 3. Identity binding: the shell maps `MessageEvent.source` to napplet identity at iframe creation. The browser's `MessageEvent.source` is unforgeable within the same browsing context.
 4. Aggregate hash verification against [NIP-5A](5A.md) manifests; mismatch MAY result in napplet rejection.
@@ -111,6 +111,8 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 6. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.
 
 Storage isolation, relay access control, and ACL enforcement are defined by their respective NUB specs.
+
+**Class-posture delegation.** NUBs MAY define napplet classes with different security postures delivered through shell-controlled HTTP response headers. Class taxonomy, the mechanism for assigning a class to a napplet, and the wire or header shapes used to express a class are out of scope for this NIP. NUB specs that define class-contributing capabilities document their own posture and their own shell responsibilities; NIP-5D provides only the transport, identity, manifest-negotiation, and capability-query primitives on which such NUB-level machinery can layer.
 
 **Non-Guarantees:** The protocol does NOT protect against a compromised browser, a malicious shell, side-channel attacks, or social engineering.
 

--- a/5D.md
+++ b/5D.md
@@ -1,0 +1,119 @@
+NIP-5D
+======
+
+Nostr Web Applets
+-----------------
+
+`draft` `optional`
+
+This NIP defines a protocol for sandboxed web applications ("napplets") running in iframes to communicate with a hosting application ("shell") via postMessage using a generic JSON envelope. Protocol messages are defined by NUB (Napplet Unified Blueprint) extension specs.
+
+## Philosophy
+
+A napplet is a Nostr applet - a small, focused application that does one thing well. Napplets SHOULD be single-purpose rather than monolithic. A chat widget, a feed viewer, a profile editor, and a relay manager are four napplets, not one application with four tabs. The shell composes napplets; napplets do not compose themselves.
+ 
+## Terminology
+
+| Term | Definition |
+|------|------------|
+| Shell | Web application hosting napplet iframes |
+| Napplet | Sandboxed iframe application communicating with the shell via postMessage |
+| dTag | Napplet type identifier from the [NIP-5A](5A.md) manifest `d` tag |
+| Aggregate hash | SHA-256 of napplet build files per [NIP-5A](5A.md) |
+| NUB | Napplet Unified Blueprint -- extension spec defining protocol messages for a capability domain |
+
+## Transport
+
+Communication uses `postMessage`. Napplet to shell: `window.parent.postMessage(msg, '*')`. Shell to napplet: `iframeWindow.postMessage(msg, '*')`. The `'*'` target origin is required because napplets have opaque origins (no `allow-same-origin`).
+
+Napplet iframes MUST use this sandbox attribute:
+
+    sandbox="allow-scripts"
+
+The `allow-same-origin` token MUST NOT be present. Shells MAY add additional sandbox tokens (`allow-forms`, `allow-modals`, `allow-downloads`, `allow-popups`) based on shell policy. Napplets have no access to `localStorage`, `sessionStorage`, `IndexedDB`, direct WebSocket connections, or signing keys. All storage, signing, encryption, and relay access is proxied through the shell.
+
+The shell identifies senders via `MessageEvent.source` (unforgeable Window reference). Messages from unknown sources (iframes not created by the shell) MUST be silently dropped.
+
+Shells MUST NOT provide `window.nostr` (NIP-07) to napplet iframes. Signing and encryption are security-critical operations that MUST be mediated by the shell. See the Security Rationale section below.
+
+## Wire Format
+
+All messages between napplet and shell are JSON objects with a `type` field:
+
+    { "type": "<domain>.<action>", ...payload }
+
+The `type` field is a string discriminant in `domain.action` format. Domains correspond to NUB capability names (e.g., a NUB named `foo` owns all `foo.*` types). NUB specs define the valid type strings and payload shapes for their domain. This NIP does not enumerate message types.
+
+Example — a hypothetical `foo` NUB with a request/response pattern:
+
+    { "type": "foo.bar", "id": "abc", "data": {...} }
+    { "type": "foo.bar.result", "id": "abc", "result": {...} }
+
+Messages with an unrecognized `type` MUST be silently ignored. This allows forward compatibility as new NUBs are defined.
+
+## Identity
+
+The shell assigns napplet identity at iframe creation time. No negotiation is required.
+
+When the shell creates a napplet iframe, it maps the iframe's `Window` reference to the napplet's `(dTag, aggregateHash)` tuple from the [NIP-5A](5A.md) manifest. This mapping is the napplet's identity for the session. How the shell internally represents or derives identity is an implementation detail.
+
+The shell MUST verify `MessageEvent.source` on every inbound message. Messages from Window references not mapped to a napplet identity MUST be silently dropped.
+
+## Manifest and NUB Negotiation
+
+Napplet manifests ([NIP-5A](5A.md) kind 35128) declare required capabilities using `requires` tags:
+
+    ["requires", "<nub-name>"]
+
+Each `requires` value is a short NUB name matching a NUB domain (e.g., `foo`). Manifests MUST NOT use spec identifiers (e.g., use `foo`, not `NUB-FOO`).
+
+At napplet load time, the shell checks `requires` tags against its own capabilities. If a required capability is absent, the shell SHOULD reject the napplet or display a compatibility warning. If the manifest has no `requires` tags, the shell loads the napplet with whatever capabilities it provides.
+
+### Runtime Capability Query
+
+Napplets query capability support at runtime:
+
+    window.napplet.shell.supports('foo')           // NUB capability — boolean
+    window.napplet.shell.supports('perm:popups')   // permission — boolean
+
+Shells MUST implement `window.napplet.shell.supports()`. The argument is a namespaced capability string:
+
+| Prefix   | Example            | Meaning                         |
+|----------|--------------------|---------------------------------|
+| *(bare)* | `'relay'`          | Shorthand for `'nub:relay'`     |
+| `nub:`   | `'nub:identity'`   | Shell implements the identity NUB |
+| `perm:`  | `'perm:popups'`    | Shell grants popup permission   |
+
+Napplets MUST gracefully degrade when a capability is absent.
+
+## NUB Extension Framework
+
+Protocol messages are defined by NUB (Napplet Unified Blueprint) specs. Each NUB owns a message domain and defines the `type` strings, payload shapes, and semantics for that domain. A NUB spec is self-contained — it references this NIP only for envelope format and transport.
+
+For example, a NUB named `foo` would own all `foo.*` message types (e.g., `foo.bar`, `foo.bar.result`) and define their payloads and shell behavior.
+
+NUB specs MUST:
+- Define all valid `type` strings for their domain
+- Specify the payload shape for each message type
+- Document expected shell behavior for each message
+- Be independently implementable — a shell MAY support any subset of NUBs
+
+## Security Considerations
+
+Napplets are untrusted code. The shell is trusted. The browser enforces iframe sandbox boundaries. `MessageEvent.source` provides unforgeable sender identity.
+
+**Mitigations:**
+1. Iframe sandbox: `allow-scripts` is the only required token -- shells MUST NOT add `allow-same-origin`.
+2. postMessage `'*'` origin is required for opaque-origin iframes; sender identification uses `MessageEvent.source`, NOT `event.origin`.
+3. Identity binding: the shell maps `MessageEvent.source` to napplet identity at iframe creation. The browser's `MessageEvent.source` is unforgeable within the same browsing context.
+4. Aggregate hash verification against [NIP-5A](5A.md) manifests; mismatch MAY result in napplet rejection.
+5. Unrecognized message types are silently ignored, preventing capability probing.
+6. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.
+
+Storage isolation, relay access control, and ACL enforcement are defined by their respective NUB specs.
+
+**Non-Guarantees:** The protocol does NOT protect against a compromised browser, a malicious shell, side-channel attacks, or social engineering.
+
+## References
+
+- [NIP-5A](5A.md) -- Napplet manifest format and aggregate hash

--- a/5D.md
+++ b/5D.md
@@ -6,7 +6,7 @@ Nostr Web Applets
 
 `draft` `optional`
 
-This NIP defines a protocol for sandboxed web applications ("napplets") running in iframes to communicate with a hosting application ("shell") via postMessage using a generic JSON envelope. Protocol messages are defined by NUB (Napplet Unified Blueprint) extension specs.
+This NIP defines a protocol for sandboxed web applications ("napplets") running in iframes to communicate with a hosting application ("shell") via postMessage using a generic JSON envelope. Protocol messages are defined by NAP (Nostr Applet Protocol) extension specs.
 
 ## Philosophy
 
@@ -20,7 +20,7 @@ A napplet is a Nostr applet - a small, focused application that does one thing w
 | Napplet | Sandboxed iframe application communicating with the shell via postMessage |
 | dTag | Napplet type identifier from the [NIP-5A](5A.md) manifest `d` tag |
 | Aggregate hash | SHA-256 of napplet build files per [NIP-5A](5A.md) |
-| NUB | Napplet Unified Blueprint -- extension spec defining protocol messages for a capability domain |
+| NAP | Nostr Applet Protocol -- extension spec defining protocol messages for a capability domain |
 
 ## Transport
 
@@ -42,14 +42,14 @@ All messages between napplet and shell are JSON objects with a `type` field:
 
     { "type": "<domain>.<action>", ...payload }
 
-The `type` field is a string discriminant in `domain.action` format. Domains correspond to NUB capability names (e.g., a NUB named `foo` owns all `foo.*` types). NUB specs define the valid type strings and payload shapes for their domain. This NIP does not enumerate message types.
+The `type` field is a string discriminant in `domain.action` format. Domains correspond to NAP capability names (e.g., a NAP named `foo` owns all `foo.*` types). NAP specs define the valid type strings and payload shapes for their domain. This NIP does not enumerate message types.
 
-Example — a hypothetical `foo` NUB with a request/response pattern:
+Example — a hypothetical `foo` NAP with a request/response pattern:
 
     { "type": "foo.bar", "id": "abc", "data": {...} }
     { "type": "foo.bar.result", "id": "abc", "result": {...} }
 
-Messages with an unrecognized `type` MUST be silently ignored. This allows forward compatibility as new NUBs are defined.
+Messages with an unrecognized `type` MUST be silently ignored. This allows forward compatibility as new NAPs are defined.
 
 ## Identity
 
@@ -59,13 +59,13 @@ When the shell creates a napplet iframe, it maps the iframe's `Window` reference
 
 The shell MUST verify `MessageEvent.source` on every inbound message. Messages from Window references not mapped to a napplet identity MUST be silently dropped.
 
-## Manifest and NUB Negotiation
+## Manifest and NAP Negotiation
 
 Napplet manifests ([NIP-5A](5A.md) kind 35128) declare required capabilities using `requires` tags:
 
-    ["requires", "<nub-name>"]
+    ["requires", "<nap-name>"]
 
-Each `requires` value is a short NUB name matching a NUB domain (e.g., `foo`). Manifests MUST NOT use spec identifiers (e.g., use `foo`, not `NUB-FOO`).
+Each `requires` value is a short NAP name matching a NAP domain (e.g., `foo`). Manifests MUST NOT use spec identifiers (e.g., use `foo`, not `NAP-FOO`).
 
 At napplet load time, the shell checks `requires` tags against its own capabilities. If a required capability is absent, the shell SHOULD reject the napplet or display a compatibility warning. If the manifest has no `requires` tags, the shell loads the napplet with whatever capabilities it provides.
 
@@ -73,30 +73,30 @@ At napplet load time, the shell checks `requires` tags against its own capabilit
 
 Napplets query capability support at runtime:
 
-    window.napplet.shell.supports('foo')           // NUB capability — boolean
+    window.napplet.shell.supports('foo')           // NAP capability — boolean
     window.napplet.shell.supports('perm:popups')   // permission — boolean
 
 Shells MUST implement `window.napplet.shell.supports()`. The argument is a namespaced capability string:
 
 | Prefix   | Example            | Meaning                         |
 |----------|--------------------|---------------------------------|
-| *(bare)* | `'relay'`          | Shorthand for `'nub:relay'`     |
-| `nub:`   | `'nub:identity'`   | Shell implements the identity NUB |
+| *(bare)* | `'relay'`          | Shorthand for `'nap:relay'`     |
+| `nap:`   | `'nap:identity'`   | Shell implements the identity NAP |
 | `perm:`  | `'perm:popups'`    | Shell grants popup permission   |
 
 Napplets MUST gracefully degrade when a capability is absent.
 
-## NUB Extension Framework
+## NAP Extension Framework
 
-Protocol messages are defined by NUB (Napplet Unified Blueprint) specs. Each NUB owns a message domain and defines the `type` strings, payload shapes, and semantics for that domain. A NUB spec is self-contained — it references this NIP only for envelope format and transport.
+Protocol messages are defined by NAP (Nostr Applet Protocol) specs. Each NAP owns a message domain and defines the `type` strings, payload shapes, and semantics for that domain. A NAP spec is self-contained — it references this NIP only for envelope format and transport.
 
-For example, a NUB named `foo` would own all `foo.*` message types (e.g., `foo.bar`, `foo.bar.result`) and define their payloads and shell behavior.
+For example, a NAP named `foo` would own all `foo.*` message types (e.g., `foo.bar`, `foo.bar.result`) and define their payloads and shell behavior.
 
-NUB specs MUST:
+NAP specs MUST:
 - Define all valid `type` strings for their domain
 - Specify the payload shape for each message type
 - Document expected shell behavior for each message
-- Be independently implementable — a shell MAY support any subset of NUBs
+- Be independently implementable — a shell MAY support any subset of NAPs
 
 ## Security Considerations
 
@@ -110,9 +110,9 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 5. Unrecognized message types are silently ignored, preventing capability probing.
 6. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.
 
-Storage isolation, relay access control, and ACL enforcement are defined by their respective NUB specs.
+Storage isolation, relay access control, and ACL enforcement are defined by their respective NAP specs.
 
-**Class-posture delegation.** NUBs MAY define napplet classes with different security postures delivered through shell-controlled HTTP response headers. Class taxonomy, the mechanism for assigning a class to a napplet, and the wire or header shapes used to express a class are out of scope for this NIP. NUB specs that define class-contributing capabilities document their own posture and their own shell responsibilities; NIP-5D provides only the transport, identity, manifest-negotiation, and capability-query primitives on which such NUB-level machinery can layer.
+**Class-posture delegation.** NAPs MAY define napplet classes with different security postures delivered through shell-controlled HTTP response headers. Class taxonomy, the mechanism for assigning a class to a napplet, and the wire or header shapes used to express a class are out of scope for this NIP. NAP specs that define class-contributing capabilities document their own posture and their own shell responsibilities; NIP-5D provides only the transport, identity, manifest-negotiation, and capability-query primitives on which such NAP-level machinery can layer.
 
 **Non-Guarantees:** The protocol does NOT protect against a compromised browser, a malicious shell, side-channel attacks, or social engineering.
 

--- a/5D.md
+++ b/5D.md
@@ -18,8 +18,9 @@ A napplet is a Nostr applet - a small, focused application that does one thing w
 |------|------------|
 | Shell | Web application hosting napplet iframes |
 | Napplet | Sandboxed iframe application communicating with the shell via postMessage |
-| dTag | Napplet type identifier from the [NIP-5A](5A.md) manifest `d` tag |
-| Aggregate hash | SHA-256 of napplet build files per [NIP-5A](5A.md) |
+| dTag | Napplet identifier from the napplet manifest `d` tag |
+| Aggregate hash | A napplet's content address — `sha256` over its manifest `path` entries (see [Manifest](#manifest)) |
+| Napplet manifest | Nostr event (kind `15129` / `35129`) describing a napplet; tag schema adopted from [NIP-5A](5A.md) |
 | NAP | Nostr Applet Protocol -- extension spec defining protocol messages for a capability domain |
 
 ## Transport
@@ -53,28 +54,37 @@ Messages with an unrecognized `type` MUST be silently ignored. This allows forwa
 
 ## Identity
 
-A napplet is a single self-contained `/index.html`, published per [NIP-5A](5A.md). Its identity is the `(dTag, aggregateHash)` tuple. The runtime **computes** this identity from the napplet's own bytes; it MUST NOT accept it from a host.
+A napplet's identity is the `(dTag, aggregateHash)` tuple. The runtime **computes** it from the napplet's own bytes; it MUST NOT accept it from a host.
 
 Before creating the iframe, the runtime MUST:
 
-1. Resolve the [NIP-5A](5A.md) manifest event from relays and verify its signature.
+1. Resolve the napplet manifest event (kind `15129` or `35129`, see [Manifest](#manifest)) from relays and verify its signature.
 2. Fetch each `path` blob from Blossom by its sha256 and verify `sha256(blob)` matches the `path` hash.
-3. Recompute the aggregate from the `path` tags (per [NIP-5A](5A.md)) and assert it equals the `x` tag; this is `aggregateHash`.
+3. Compute the aggregate over the verified `path` entries; this is `aggregateHash`.
 4. Inject the verified bytes via `srcdoc` (never a navigated `src`) and map the iframe's `Window` reference to `(dTag, aggregateHash)`.
 
 A gateway MAY serve the bytes as an accelerator or fallback, but the runtime MUST verify its output against the signed manifest — the gateway is never trusted.
 
 Identity is thus fixed before any code runs and bound to the exact bytes that run. The shell MUST verify `MessageEvent.source` on every inbound message and silently drop messages from Window references not mapped to a napplet.
 
-## Manifest and NAP Negotiation
+## Manifest
 
-Napplet manifests ([NIP-5A](5A.md) kind 35128) declare required capabilities using `requires` tags:
+A napplet is published as a **napplet manifest** event. Its tag schema is adopted from [NIP-5A](5A.md) (`path`, `server`, and optional `title` / `description` / `source`), under NIP-5D's own kinds:
+
+| Kind | Type | `d` tag |
+|------|------|---------|
+| `15129` | root napplet (replaceable) | none |
+| `35129` | named napplet (addressable) | identifier |
+
+Distinct kinds keep napplets out of nsite gateway resolution: a napplet is resolved and verified by the runtime ([Identity](#identity)), never served as an nsite.
+
+A napplet is a single self-contained `/index.html`. The manifest MUST include a `path` tag per file — `["path", "/index.html", "<sha256>"]` — and `server` tags SHOULD hint the Blossom servers holding those blobs. `aggregateHash` is `sha256` over the `path` entries sorted by path, each rendered as the line `"<path> <sha256>"`.
+
+The manifest declares required capabilities with `requires` tags:
 
     ["requires", "<nap-name>"]
 
-Each `requires` value is a short NAP name matching a NAP domain (e.g., `foo`). Manifests MUST NOT use spec identifiers (e.g., use `foo`, not `NAP-FOO`).
-
-At napplet load time, the shell checks `requires` tags against its own capabilities. If a required capability is absent, the shell SHOULD reject the napplet or display a compatibility warning. If the manifest has no `requires` tags, the shell loads the napplet with whatever capabilities it provides.
+Each value is a bare NAP domain (e.g. `relay`, never `NAP-RELAY`). At load the shell checks `requires` against its capabilities; if one is absent it SHOULD reject the napplet or warn. With no `requires` tags it loads with whatever the shell provides.
 
 ### Runtime Capability Query
 
@@ -113,7 +123,7 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 1. Iframe sandbox: `allow-scripts` is the only required token -- shells MUST NOT add `allow-same-origin`. Adding `allow-same-origin` would grant the napplet a real origin, allowing it to register a service worker, read shell `localStorage`, and bypass shell mediation entirely -- this prohibition is the load-bearing precondition for browser-enforced isolation of any kind.
 2. postMessage `'*'` origin is required for opaque-origin iframes; sender identification uses `MessageEvent.source`, NOT `event.origin`.
 3. Identity binding: the runtime computes `(dTag, aggregateHash)` from the napplet's verified bytes before execution and maps it to the iframe `Window`. `MessageEvent.source` is unforgeable within the same browsing context.
-4. Content-addressed loading: the runtime verifies the manifest signature, each blob's sha256, and the aggregate against the `x` tag (see [Identity](#identity)); a napplet failing any check MUST be rejected. Gateways are untrusted — their output is verified against the signed manifest.
+4. Content-addressed loading: the runtime verifies the manifest signature and each blob's sha256, then computes `aggregateHash` from the verified `path` entries (see [Identity](#identity)); a napplet failing any check MUST be rejected. Gateways are untrusted — their output is verified against the signed manifest.
 5. Unrecognized message types are silently ignored, preventing capability probing.
 6. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.
 
@@ -125,4 +135,4 @@ Storage isolation, relay access control, and ACL enforcement are defined by thei
 
 ## References
 
-- [NIP-5A](5A.md) -- Napplet manifest format and aggregate hash
+- [NIP-5A](5A.md) -- manifest tag schema adopted by the napplet manifest

--- a/5D.md
+++ b/5D.md
@@ -6,7 +6,7 @@ Nostr Web Applets
 
 `draft` `optional`
 
-This NIP defines a protocol for sandboxed web applications ("napplets") running in iframes to communicate with a hosting application ("shell") via postMessage using a generic JSON envelope. Protocol messages are defined by NAP (Nostr Applet Protocol) extension specs.
+This NIP defines a web projection for sandboxed web applications ("napplets") running in iframes to communicate with a hosting application ("shell"). Shells expose granted NAP (Nostr Applet Protocol) domains through an injected `window.napplet` namespace. Under that namespace, domain calls are carried over `postMessage` using a generic JSON envelope. Protocol messages are defined by NAP extension specs.
 
 ## Philosophy
 
@@ -25,7 +25,7 @@ A napplet is a Nostr applet - a small, focused application that does one thing w
 
 ## Transport
 
-Communication uses `postMessage`. Napplet to shell: `window.parent.postMessage(msg, '*')`. Shell to napplet: `iframeWindow.postMessage(msg, '*')`. The `'*'` target origin is required because napplets have opaque origins (no `allow-same-origin`).
+Communication uses an injected `window.napplet` namespace backed by `postMessage`. Napplet to shell: `window.parent.postMessage(msg, '*')`. Shell to napplet: `iframeWindow.postMessage(msg, '*')`. The `'*'` target origin is required because napplets have opaque origins (no `allow-same-origin`).
 
 Napplet iframes are loaded via `srcdoc` (see [Identity](#identity)) and MUST use this sandbox attribute:
 
@@ -34,6 +34,8 @@ Napplet iframes are loaded via `srcdoc` (see [Identity](#identity)) and MUST use
 The `allow-same-origin` token MUST NOT be present. Shells MAY add additional sandbox tokens (`allow-forms`, `allow-modals`, `allow-downloads`, `allow-popups`) based on shell policy. Napplets have no access to `localStorage`, `sessionStorage`, `IndexedDB`, direct WebSocket connections, or signing keys. All storage, signing, encryption, and relay access is proxied through the shell.
 
 The shell identifies senders via `MessageEvent.source` (unforgeable Window reference). Messages from unknown sources (iframes not created by the shell) MUST be silently dropped.
+
+Shells MUST inject `window.napplet` before any napplet script runs, including classic scripts, module scripts, reloads, and development wrappers. The namespace MUST contain only the NAP domain objects the shell exposes to that napplet. Presence of a domain object means that domain is available to the napplet. Absence means unavailable.
 
 Shells MUST NOT provide `window.nostr` (NIP-07) to napplet iframes. Signing and encryption are security-critical operations that MUST be mediated by the shell. See the Security Rationale section below.
 
@@ -87,26 +89,15 @@ The manifest declares required capabilities with `requires` tags:
 
 Each value is a bare NAP domain (e.g. `relay`, never `NAP-RELAY`). At load the shell checks `requires` against its capabilities; if one is absent it SHOULD reject the napplet or warn. With no `requires` tags it loads with whatever the shell provides.
 
-### Runtime Capability Query
+### Runtime Domain Availability
 
-Napplets query capability support at runtime:
+Napplets detect runtime domain availability from the injected namespace. If `window.napplet.<domain>` is present, the shell exposes that NAP domain to the napplet. If it is absent, the napplet MUST gracefully degrade or stop using that domain.
 
-    window.napplet.shell.supports('foo')           // NAP capability — boolean
-    window.napplet.shell.supports('perm:popups')   // permission — boolean
-
-Shells MUST implement `window.napplet.shell.supports()`. The argument is a namespaced capability string:
-
-| Prefix   | Example            | Meaning                         |
-|----------|--------------------|---------------------------------|
-| *(bare)* | `'relay'`          | Shorthand for `'nap:relay'`     |
-| `nap:`   | `'nap:identity'`   | Shell implements the identity NAP |
-| `perm:`  | `'perm:popups'`    | Shell grants popup permission   |
-
-Napplets MUST gracefully degrade when a capability is absent.
+Domain object presence is only an availability signal. It does not define the domain's operations, payloads, error model, version support, or semantics. Those contracts remain in the matching NAP specs. If a domain needs semantic compatibility checks, version negotiation, or diagnostics, that domain MUST define them in its own NAP.
 
 ## NAP Extension Framework
 
-Protocol messages are defined by [NAP (Nostr Applet Protocol)](https://github.com/napplet/naps) specs. Each NAP owns a message domain and defines the `type` strings, payload shapes, and semantics for that domain. A NAP spec is self-contained — it references this NIP only for envelope format and transport.
+Protocol messages are defined by [NAP (Nostr Applet Protocol)](https://github.com/napplet/naps) specs. Each NAP owns a message domain and defines the `type` strings, payload shapes, injected domain object behavior, and semantics for that domain. A NAP spec is self-contained — it references this NIP only for web namespace injection, envelope format, and transport.
 
 For example, a NAP named `foo` would own all `foo.*` message types (e.g., `foo.bar`, `foo.bar.result`) and define their payloads and shell behavior.
 
@@ -125,8 +116,9 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 2. postMessage `'*'` origin is required for opaque-origin iframes; sender identification uses `MessageEvent.source`, NOT `event.origin`.
 3. Identity binding: the runtime computes `(dTag, aggregateHash)` from the napplet's verified bytes before execution and maps it to the iframe `Window`. `MessageEvent.source` is unforgeable within the same browsing context.
 4. Content-addressed loading: the runtime verifies the manifest signature and each blob's sha256, then recomputes the aggregate from the `path` tags and asserts it equals any `x` tag (see [Identity](#identity)); a napplet failing any check MUST be rejected. Gateways are untrusted — their output is verified against the signed manifest.
-5. Unrecognized message types are silently ignored, preventing capability probing.
-6. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.
+5. Runtime injection is outside the signed napplet artifact. It MUST be limited to the `window.napplet` namespace and MUST NOT change the napplet bytes used to compute `aggregateHash`.
+6. Unrecognized message types are silently ignored, preventing capability probing.
+7. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.
 
 Storage isolation, relay access control, and ACL enforcement are defined by their respective NAP specs.
 
@@ -135,4 +127,4 @@ Storage isolation, relay access control, and ACL enforcement are defined by thei
 ## References
 
 - [NIP-5A](5A.md) -- manifest tag schema adopted by the napplet manifest
-- [NAPs](https://github.com/napplet/naps) -- NAP interface and message-protocol registry
+- [NAPs](https://github.com/napplet/naps) -- NAP domain and message-protocol registry

--- a/5D.md
+++ b/5D.md
@@ -31,7 +31,7 @@ Napplet iframes are loaded via `srcdoc` (see [Identity](#identity)) and MUST use
 
     sandbox="allow-scripts"
 
-The `allow-same-origin` token MUST NOT be present. Shells MAY add additional sandbox tokens (`allow-forms`, `allow-modals`, `allow-downloads`, `allow-popups`) based on shell policy. Napplets have no access to `localStorage`, `sessionStorage`, `IndexedDB`, direct WebSocket connections, or signing keys. All storage, signing, encryption, and relay access is proxied through the shell.
+The `allow-same-origin` token MUST NOT be present. Napplets have no access to `localStorage`, `sessionStorage`, `IndexedDB`, direct WebSocket connections, or signing keys. All storage, signing, encryption, and relay access is proxied through the shell.
 
 The shell identifies senders via `MessageEvent.source` (unforgeable Window reference). Messages from unknown sources (iframes not created by the shell) MUST be silently dropped.
 

--- a/5D.md
+++ b/5D.md
@@ -26,7 +26,7 @@ A napplet is a Nostr applet - a small, focused application that does one thing w
 
 Communication uses `postMessage`. Napplet to shell: `window.parent.postMessage(msg, '*')`. Shell to napplet: `iframeWindow.postMessage(msg, '*')`. The `'*'` target origin is required because napplets have opaque origins (no `allow-same-origin`).
 
-Napplet iframes MUST use this sandbox attribute:
+Napplet iframes are loaded via `srcdoc` (see [Identity](#identity)) and MUST use this sandbox attribute:
 
     sandbox="allow-scripts"
 
@@ -53,11 +53,18 @@ Messages with an unrecognized `type` MUST be silently ignored. This allows forwa
 
 ## Identity
 
-The shell assigns napplet identity at iframe creation time. No negotiation is required.
+A napplet is a single self-contained `/index.html`, published per [NIP-5A](5A.md). Its identity is the `(dTag, aggregateHash)` tuple. The runtime **computes** this identity from the napplet's own bytes; it MUST NOT accept it from a host.
 
-When the shell creates a napplet iframe, it maps the iframe's `Window` reference to the napplet's `(dTag, aggregateHash)` tuple from the [NIP-5A](5A.md) manifest. This mapping is the napplet's identity for the session. How the shell internally represents or derives identity is an implementation detail.
+Before creating the iframe, the runtime MUST:
 
-The shell MUST verify `MessageEvent.source` on every inbound message. Messages from Window references not mapped to a napplet identity MUST be silently dropped.
+1. Resolve the [NIP-5A](5A.md) manifest event from relays and verify its signature.
+2. Fetch each `path` blob from Blossom by its sha256 and verify `sha256(blob)` matches the `path` hash.
+3. Recompute the aggregate from the `path` tags (per [NIP-5A](5A.md)) and assert it equals the `x` tag; this is `aggregateHash`.
+4. Inject the verified bytes via `srcdoc` (never a navigated `src`) and map the iframe's `Window` reference to `(dTag, aggregateHash)`.
+
+A gateway MAY serve the bytes as an accelerator or fallback, but the runtime MUST verify its output against the signed manifest — the gateway is never trusted.
+
+Identity is thus fixed before any code runs and bound to the exact bytes that run. The shell MUST verify `MessageEvent.source` on every inbound message and silently drop messages from Window references not mapped to a napplet.
 
 ## Manifest and NAP Negotiation
 
@@ -105,8 +112,8 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 **Mitigations:**
 1. Iframe sandbox: `allow-scripts` is the only required token -- shells MUST NOT add `allow-same-origin`. Adding `allow-same-origin` would grant the napplet a real origin, allowing it to register a service worker, read shell `localStorage`, and bypass shell mediation entirely -- this prohibition is the load-bearing precondition for browser-enforced isolation of any kind.
 2. postMessage `'*'` origin is required for opaque-origin iframes; sender identification uses `MessageEvent.source`, NOT `event.origin`.
-3. Identity binding: the shell maps `MessageEvent.source` to napplet identity at iframe creation. The browser's `MessageEvent.source` is unforgeable within the same browsing context.
-4. Aggregate hash verification against [NIP-5A](5A.md) manifests; mismatch MAY result in napplet rejection.
+3. Identity binding: the runtime computes `(dTag, aggregateHash)` from the napplet's verified bytes before execution and maps it to the iframe `Window`. `MessageEvent.source` is unforgeable within the same browsing context.
+4. Content-addressed loading: the runtime verifies the manifest signature, each blob's sha256, and the aggregate against the `x` tag (see [Identity](#identity)); a napplet failing any check MUST be rejected. Gateways are untrusted — their output is verified against the signed manifest.
 5. Unrecognized message types are silently ignored, preventing capability probing.
 6. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.
 

--- a/5D.md
+++ b/5D.md
@@ -106,7 +106,7 @@ Napplets MUST gracefully degrade when a capability is absent.
 
 ## NAP Extension Framework
 
-Protocol messages are defined by NAP (Nostr Applet Protocol) specs. Each NAP owns a message domain and defines the `type` strings, payload shapes, and semantics for that domain. A NAP spec is self-contained — it references this NIP only for envelope format and transport. NAPs are defined and registered in the NAP track: <https://github.com/napplet/naps>.
+Protocol messages are defined by [NAP (Nostr Applet Protocol)](https://github.com/napplet/naps) specs. Each NAP owns a message domain and defines the `type` strings, payload shapes, and semantics for that domain. A NAP spec is self-contained — it references this NIP only for envelope format and transport.
 
 For example, a NAP named `foo` would own all `foo.*` message types (e.g., `foo.bar`, `foo.bar.result`) and define their payloads and shell behavior.
 

--- a/5D.md
+++ b/5D.md
@@ -19,8 +19,8 @@ A napplet is a Nostr applet - a small, focused application that does one thing w
 | Shell | Web application hosting napplet iframes |
 | Napplet | Sandboxed iframe application communicating with the shell via postMessage |
 | dTag | Napplet identifier from the napplet manifest `d` tag |
-| Aggregate hash | A napplet's content address — `sha256` over its manifest `path` entries (see [Manifest](#manifest)) |
-| Napplet manifest | Nostr event (kind `15129` / `35129`) describing a napplet; tag schema adopted from [NIP-5A](5A.md) |
+| Aggregate hash | A napplet's content address — the [NIP-5A](5A.md) aggregate hash of its `path` tags, carried in the manifest `x` tag |
+| Napplet manifest | Nostr event (kind `5129` / `15129` / `35129`) describing a napplet; tag schema adopted from [NIP-5A](5A.md) |
 | NAP | Nostr Applet Protocol -- extension spec defining protocol messages for a capability domain |
 
 ## Transport
@@ -58,9 +58,9 @@ A napplet's identity is the `(dTag, aggregateHash)` tuple. The runtime **compute
 
 Before creating the iframe, the runtime MUST:
 
-1. Resolve the napplet manifest event (kind `15129` or `35129`, see [Manifest](#manifest)) from relays and verify its signature.
+1. Resolve the napplet manifest event (kind `5129`, `15129`, or `35129`, see [Manifest](#manifest)) from relays and verify its signature.
 2. Fetch each `path` blob from Blossom by its sha256 and verify `sha256(blob)` matches the `path` hash.
-3. Compute the aggregate over the verified `path` entries; this is `aggregateHash`.
+3. Recompute the aggregate hash from the `path` tags per [NIP-5A](5A.md); if the manifest carries an `x` tag it MUST match. This is `aggregateHash`.
 4. Inject the verified bytes via `srcdoc` (never a navigated `src`) and map the iframe's `Window` reference to `(dTag, aggregateHash)`.
 
 A gateway MAY serve the bytes as an accelerator or fallback, but the runtime MUST verify its output against the signed manifest — the gateway is never trusted.
@@ -69,16 +69,17 @@ Identity is thus fixed before any code runs and bound to the exact bytes that ru
 
 ## Manifest
 
-A napplet is published as a **napplet manifest** event. Its tag schema is adopted from [NIP-5A](5A.md) (`path`, `server`, and optional `title` / `description` / `source`), under NIP-5D's own kinds:
+A napplet is published as a **napplet manifest** event. Its tag schema is adopted from [NIP-5A](5A.md) — `path`, the `x` aggregate tag, `server`, and optional `title` / `description` / `source` — under NIP-5D's own kinds:
 
 | Kind | Type | `d` tag |
 |------|------|---------|
+| `5129` | snapshot (regular) | none |
 | `15129` | root napplet (replaceable) | none |
 | `35129` | named napplet (addressable) | identifier |
 
 Distinct kinds keep napplets out of nsite gateway resolution: a napplet is resolved and verified by the runtime ([Identity](#identity)), never served as an nsite.
 
-A napplet is a single self-contained `/index.html`. The manifest MUST include a `path` tag per file — `["path", "/index.html", "<sha256>"]` — and `server` tags SHOULD hint the Blossom servers holding those blobs. `aggregateHash` is `sha256` over the `path` entries sorted by path, each rendered as the line `"<path> <sha256>"`.
+A napplet is a single self-contained `/index.html`. The manifest MUST include a `path` tag per file — `["path", "/index.html", "<sha256>"]` — and `server` tags SHOULD hint the Blossom servers holding those blobs. `aggregateHash` is the [NIP-5A](5A.md) aggregate hash of the `path` tags, carried in the `x` tag (`["x", "<sha256-hex>", "aggregate"]`). A `5129` snapshot is a regular event pinning a specific napplet version, per [NIP-5A](5A.md).
 
 The manifest declares required capabilities with `requires` tags:
 
@@ -123,7 +124,7 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 1. Iframe sandbox: `allow-scripts` is the only required token -- shells MUST NOT add `allow-same-origin`. Adding `allow-same-origin` would grant the napplet a real origin, allowing it to register a service worker, read shell `localStorage`, and bypass shell mediation entirely -- this prohibition is the load-bearing precondition for browser-enforced isolation of any kind.
 2. postMessage `'*'` origin is required for opaque-origin iframes; sender identification uses `MessageEvent.source`, NOT `event.origin`.
 3. Identity binding: the runtime computes `(dTag, aggregateHash)` from the napplet's verified bytes before execution and maps it to the iframe `Window`. `MessageEvent.source` is unforgeable within the same browsing context.
-4. Content-addressed loading: the runtime verifies the manifest signature and each blob's sha256, then computes `aggregateHash` from the verified `path` entries (see [Identity](#identity)); a napplet failing any check MUST be rejected. Gateways are untrusted — their output is verified against the signed manifest.
+4. Content-addressed loading: the runtime verifies the manifest signature and each blob's sha256, then recomputes the aggregate from the `path` tags and asserts it equals any `x` tag (see [Identity](#identity)); a napplet failing any check MUST be rejected. Gateways are untrusted — their output is verified against the signed manifest.
 5. Unrecognized message types are silently ignored, preventing capability probing.
 6. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.
 

--- a/5D.md
+++ b/5D.md
@@ -106,7 +106,7 @@ Napplets MUST gracefully degrade when a capability is absent.
 
 ## NAP Extension Framework
 
-Protocol messages are defined by NAP (Nostr Applet Protocol) specs. Each NAP owns a message domain and defines the `type` strings, payload shapes, and semantics for that domain. A NAP spec is self-contained — it references this NIP only for envelope format and transport.
+Protocol messages are defined by NAP (Nostr Applet Protocol) specs. Each NAP owns a message domain and defines the `type` strings, payload shapes, and semantics for that domain. A NAP spec is self-contained — it references this NIP only for envelope format and transport. NAPs are defined and registered in the NAP track: <https://github.com/napplet/naps>.
 
 For example, a NAP named `foo` would own all `foo.*` message types (e.g., `foo.bar`, `foo.bar.result`) and define their payloads and shell behavior.
 
@@ -137,3 +137,4 @@ Storage isolation, relay access control, and ACL enforcement are defined by thei
 ## References
 
 - [NIP-5A](5A.md) -- manifest tag schema adopted by the napplet manifest
+- [NAPs](https://github.com/napplet/naps) -- NAP interface and message-protocol registry

--- a/5D.md
+++ b/5D.md
@@ -130,8 +130,6 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 
 Storage isolation, relay access control, and ACL enforcement are defined by their respective NAP specs.
 
-**Class-posture delegation.** NAPs MAY define napplet classes with different security postures delivered through shell-controlled HTTP response headers. Class taxonomy, the mechanism for assigning a class to a napplet, and the wire or header shapes used to express a class are out of scope for this NIP. NAP specs that define class-contributing capabilities document their own posture and their own shell responsibilities; NIP-5D provides only the transport, identity, manifest-negotiation, and capability-query primitives on which such NAP-level machinery can layer.
-
 **Non-Guarantees:** The protocol does NOT protect against a compromised browser, a malicious shell, side-channel attacks, or social engineering.
 
 ## References

--- a/5D.md
+++ b/5D.md
@@ -125,9 +125,11 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 A conservative baseline is:
 
     <meta http-equiv="Content-Security-Policy"
-          content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; worker-src 'none'; child-src 'none'; frame-src 'none'; media-src 'none'; object-src 'none'; manifest-src 'none'; base-uri 'none'; form-action 'none'">
+          content="default-src 'none'; script-src 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; worker-src 'none'; child-src 'none'; frame-src 'none'; media-src 'none'; object-src 'none'; manifest-src 'none'; base-uri 'none'; form-action 'none'">
 
 If a separate host policy intentionally permits direct network access, `connect-src` MAY name only the exact granted origins. Such access is outside NIP-5D's shell-mediated NAP model; wildcard or scheme-wide sources SHOULD NOT be used.
+
+The `'wasm-unsafe-eval'` source expression permits WebAssembly byte compilation and instantiation. It does not permit JavaScript string compilation such as `eval()` or `Function()`. Shells MUST NOT substitute the broader `'unsafe-eval'` source expression merely to support WebAssembly.
 
 Per [Content Security Policy Level 3](https://www.w3.org/TR/CSP/), `report-uri`, `frame-ancestors`, and `sandbox` are not enforced when delivered through a `meta` element. A shell that needs to restrict its own embedders MUST set `frame-ancestors` on the shell's HTTP response. The CSP is defense in depth and does not replace artifact verification, the required iframe sandbox, or `MessageEvent.source` checks.
 

--- a/5D.md
+++ b/5D.md
@@ -120,6 +120,17 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 6. Unrecognized message types are silently ignored, preventing capability probing.
 7. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.
 
+**Content Security Policy advisory.** An opaque sandbox origin does not by itself prevent `fetch`, WebSocket, Worker, or subresource requests. Because a `srcdoc` document has no HTTP response on which to carry a Content Security Policy header, shells SHOULD inject a CSP `meta` element as the first element in `head`, before any napplet-controlled resource or script is parsed. The shell MUST inject the policy only after verifying the signed artifact bytes, and the injected policy MUST remain outside the bytes used to compute `aggregateHash`, just like the injected `window.napplet` namespace.
+
+A conservative baseline is:
+
+    <meta http-equiv="Content-Security-Policy"
+          content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; connect-src 'none'; worker-src 'none'; child-src 'none'; frame-src 'none'; media-src 'none'; object-src 'none'; manifest-src 'none'; base-uri 'none'; form-action 'none'">
+
+If a separate host policy intentionally permits direct network access, `connect-src` MAY name only the exact granted origins. Such access is outside NIP-5D's shell-mediated NAP model; wildcard or scheme-wide sources SHOULD NOT be used.
+
+Per [Content Security Policy Level 3](https://www.w3.org/TR/CSP/), `report-uri`, `frame-ancestors`, and `sandbox` are not enforced when delivered through a `meta` element. A shell that needs to restrict its own embedders MUST set `frame-ancestors` on the shell's HTTP response. The CSP is defense in depth and does not replace artifact verification, the required iframe sandbox, or `MessageEvent.source` checks.
+
 Storage isolation, relay access control, and ACL enforcement are defined by their respective NAP specs.
 
 **Non-Guarantees:** The protocol does NOT protect against a compromised browser, a malicious shell, side-channel attacks, or social engineering.
@@ -128,3 +139,4 @@ Storage isolation, relay access control, and ACL enforcement are defined by thei
 
 - [NIP-5A](5A.md) -- manifest tag schema adopted by the napplet manifest
 - [NAPs](https://github.com/napplet/naps) -- NAP domain and message-protocol registry
+- [Content Security Policy Level 3](https://www.w3.org/TR/CSP/) -- CSP processing and `meta` delivery


### PR DESCRIPTION
## Summary

NIP-5D defines a `postMessage` protocol for sandboxed web applets ("napplets") running in iframes (or web-views) to communicate with a hosting application ("shell"). The NIP is deliberately a thin core: it specifies the envelope, sandbox rules, sender identification, and manifest-based capability negotiation. Actual protocol messages, relay access, storage, signing, theming, Inter-Napplet Communication, and so on are defined by **NAP** (Nostr Applet Protocol) extension specs, each of which owns a capability domain.

NIP-5D depends on [NIP-5A](https://github.com/nostr-protocol/nips/blob/master/5A.md) for napplet manifests and aggregate hash verification (see [PR #2287](https://github.com/nostr-protocol/nips/pull/2287)).

## What's in the spec

- **Transport** - `postMessage` with `'*'` target origin (required for opaque-origin sandboxed iframes). Sender identification via `MessageEvent.source` (unforgeable `Window` reference), **not** `event.origin`.
- **Sandbox** - Napplet iframes MUST use `sandbox="allow-scripts"` without `allow-same-origin`. Shells MUST NOT provide `window.nostr` (NIP-07); signing and encryption are security-critical and mediated by the shell through NAP-defined APIs.
- **Wire format** - Generic JSON envelope: `{ "type": "<domain>.<action>", ...payload }`. The `type` field is a `domain.action` discriminant where the domain corresponds to a NAP capability name (e.g., a NAP named `foo` owns all `foo.*` types). The NIP does not enumerate message types. Unknown types MUST be silently ignored to preserve forward compatibility.
- **Identity** - The shell assigns napplet identity at iframe creation time by mapping the iframe's `Window` reference to the `(dTag, aggregateHash)` tuple from the NIP-5A manifest. No handshake, no challenge-response, no negotiation. Messages from unmapped `MessageEvent.source` values MUST be silently dropped.
- **Manifest-level NAP negotiation** - NIP-5A napplet manifests declare required capabilities via `["requires", "<nap-name>"]` tags. Shells check these at load time and SHOULD reject or warn on mismatch.
- **Runtime capability query** - `window.napplet.shell.supports('<capability>')` returns a boolean. Capability strings are namespaced: bare/`nap:` for NAP capabilities (e.g., `'relay'`, `'nap:identity'`), `perm:` for permissions (e.g., `'perm:popups'`). Napplets MUST gracefully degrade when a capability is absent.
- **Security model** - Iframe sandbox enforcement, unforgeable `MessageEvent.source` identity binding, aggregate hash verification against NIP-5A manifests, cleartext-only napplet output (shells MUST NOT sign or broadcast ciphertext supplied by a napplet), and silent-drop of unrecognized types to prevent capability probing.

## What's NOT in the spec

Specific protocol messages - relay proxy, signer proxy, storage, IFC, theming, feeds, chat, and so on - are defined externally as **NAP** (Nostr Applet Protocol) proposals. The NAP ecosystem is organized in a track

- **NAP-<DOMAIN>** (interfaces) - canonical specs for shell-provided API surfaces (e.g., a relay NAP owning the `relay.*` domain and `window.napplet.relay`, a storage NAP owning `storage.*` and `window.napplet.storage`). One spec per domain name.

This split keeps the NIP focused on the core primitive and lets the capability ecosystem iterate independently.

## NAP (Nostr Applet Protocol) 

- https://github.com/napplet/naps

## Motivation

More secure, better UX and easier DX. This NIP is a inspired by some prototypes made during early stages of nsite v1

1. https://github.com/sandwichfarm/napp.run/ - _[Summer 2025]_ -  Tauri nsite browser
2.  https://github.com/sandwichfarm/dryft  - _[Summer 2025]_ - Nostr browser, forked from Thorium  

## Implementations

- SDK: https://github.com/napplet/napplet
- Runtime Packags: https://github.com/kehto/web
- Runtime Demo: https://kehto.github.io/web/

## Information
- https://napplet.run

## Dependencies

- Requires [NIP-5A](https://github.com/nostr-protocol/nips/blob/master/5A.md) for napplet manifest format and aggregate hash verification ([PR #2287](https://github.com/nostr-protocol/nips/pull/2287))
- References [NIP-07](https://github.com/nostr-protocol/nips/blob/master/07.md) (MUST NOT be exposed to napplet iframes)
