### PR TITLE
NIP-5A: Add Bitcoin Name Resolution (NSIT)

### DIFF
--- a/5A.md
+++ b/5A.md
@@ -161,3 +161,178 @@ Kind `34128` is marked as legacy/deprecated. This kind was used for individual s
 Host servers MAY still support kind `34128` for backward compatibility with existing sites, but new sites SHOULD use kind `15128` (root site manifest) or kind `35128` (named site manifest) instead.
 
 Read the [legacy version](https://github.com/hzrd149/nips/blob/41e77b45a1e8a8d170097e363f7d7254797cc5c5/nsite.md) for more details.
+
+---
+
+## Bitcoin Name Resolution (NSIT)
+
+This section defines a Bitcoin-native name system for mapping human-readable names to Nostr pubkeys. Names are registered on the Bitcoin blockchain using OP_RETURN transactions and published to Nostr relays as index events, allowing any client to resolve `name → pubkey` without running a Bitcoin full node.
+
+### Motivation
+
+Pubkeys are not human-readable. An npub like `npub1qe3e2054qkxsyt0yzem0xxv5gdpgmstahaqma3ja6pv2n9auqelqh2q4jf` cannot be memorized, spoken aloud, or printed on a business card. Existing workarounds (NIP-05, gateway subdomains) reintroduce DNS dependency.
+
+Bitcoin name resolution provides:
+- Human-readable names (`nsite://titan` instead of `nsite://npub1qe3e...`)
+- Permanent registration (no renewals, no expiration)
+- Decentralized ownership (no registrar, no governance committee)
+- Transferable ownership (built on Bitcoin's UTXO model)
+
+### URL Scheme
+
+Native clients SHOULD use the `nsite://` scheme:
+
+```
+nsite://<host>[/<path>]
+
+host = <name> | npub1<bech32>
+path = file path within manifest (default: /)
+```
+
+When `host` is a registered name, the client resolves it to a pubkey via the name index (kind `35129`), then fetches the named site manifest (kind `35128`, `d=<name>`).
+
+When `host` is an npub, the client decodes the pubkey directly and fetches the root site manifest (kind `15128`).
+
+### OP_RETURN Wire Format
+
+Every name operation is encoded in a single Bitcoin OP_RETURN output:
+
+```
+Offset  Size  Field       Description
+0       4     magic       "NSIT" (0x4E534954)
+4       1     version     0x01
+5       1     action      0x00 = register, 0x01 = transfer
+6       1     name_len    Length of name (1-41 bytes)
+7       N     name        ASCII name [a-z0-9-]
+7+N     32    pubkey      32-byte x-only Schnorr public key (same as Nostr pubkey)
+```
+
+Total: 39 + N bytes. Maximum 80 bytes (Bitcoin OP_RETURN limit).
+
+#### Name Rules
+
+- Characters: lowercase ASCII letters (`a-z`), digits (`0-9`), and hyphens (`-`)
+- No leading or trailing hyphens
+- No consecutive hyphens (`--`)
+- Minimum length: 1 character
+- Maximum length: 41 characters
+- Case-insensitive (automatically lowercased)
+
+#### Registration (action 0x00)
+
+A Bitcoin transaction with a valid NSIT OP_RETURN registers the name if it has not been previously registered. First-in-chain wins. If the same name appears multiple times in the same block, the transaction with the lower index wins.
+
+The first non-OP_RETURN output of the registration transaction becomes the **ownership UTXO**.
+
+The registered name corresponds to a named site's `d` tag. Registering `titan` means the site manifest is kind `35128` with `d=titan`.
+
+#### Transfer (action 0x01)
+
+A transfer updates the pubkey a name resolves to and/or transfers ownership. The transaction MUST spend the current ownership UTXO as one of its inputs. The `pubkey` field contains the new Nostr pubkey.
+
+The first non-OP_RETURN output of the transfer transaction becomes the new ownership UTXO. This enables full ownership transfer — send the output to a new address.
+
+If the ownership UTXO is spent in a regular transaction without an NSIT OP_RETURN, the name becomes **permanently frozen**. It still resolves to its current pubkey, but can never be transferred again. There is no recovery mechanism.
+
+### Nostr Name Index Events
+
+An indexer service scans the Bitcoin blockchain for NSIT OP_RETURN outputs and publishes the name index as Nostr events. Clients query these events to resolve names without running a Bitcoin full node.
+
+The index is deterministic — any node scanning the same blockchain will arrive at the same name→pubkey mappings. Multiple independent indexers can publish identical records, providing redundancy.
+
+#### Kind 35129 — Name Record (addressable, `d=name`)
+
+Current state of a registered name. Replaceable — transfers update the existing event.
+
+```jsonc
+{
+  "kind": 35129,
+  "pubkey": "<indexer-service-pubkey>",
+  "tags": [
+    ["d", "titan"],
+    ["p", "<registered-nostr-pubkey-hex>"],
+    ["owner_txid", "<txid-of-registration-or-transfer>"],
+    ["owner_vout", "<vout-index-of-ownership-utxo>"],
+    ["txid", "<txid-of-most-recent-action>"],
+    ["block", "<block-height>"],
+    ["action", "register"],
+    ["reg_txid", "<original-registration-txid>"],
+    ["reg_block", "<original-registration-block-height>"]
+  ],
+  "content": ""
+}
+```
+
+Transfer events additionally include:
+- `["prev_pubkey", "<previous-nostr-pubkey-hex>"]`
+- `["prev_txid", "<previous-action-txid>"]`
+
+Clients query: `{ "kinds": [35129], "#d": ["<name>"], "authors": ["<indexer-pubkey>"] }`
+
+#### Kind 1129 — Name History (regular, non-replaceable)
+
+One event per registration or transfer action. These accumulate to form the complete chain of custody for a name.
+
+```jsonc
+{
+  "kind": 1129,
+  "pubkey": "<indexer-service-pubkey>",
+  "tags": [
+    ["d", "titan"],
+    ["p", "<nostr-pubkey-hex>"],
+    ["owner_txid", "<txid>"],
+    ["owner_vout", "<vout>"],
+    ["txid", "<txid>"],
+    ["block", "<block-height>"],
+    ["action", "register"]
+  ],
+  "content": ""
+}
+```
+
+Transfer history events additionally include `prev_pubkey` and `prev_txid` tags.
+
+Clients query: `{ "kinds": [1129], "#d": ["<name>"], "authors": ["<indexer-pubkey>"] }`
+
+#### Kind 15129 — Index Stats (replaceable)
+
+Current sync state of the indexer. One per indexer pubkey.
+
+```jsonc
+{
+  "kind": 15129,
+  "pubkey": "<indexer-service-pubkey>",
+  "tags": [
+    ["block", "<current-block-height>"],
+    ["hash", "<current-block-hash>"],
+    ["names", "<total-registered-names>"]
+  ],
+  "content": ""
+}
+```
+
+### Client Resolution Flow
+
+1. **Parse host**: If the host is an npub, decode to pubkey directly (skip to step 3). If the host is a name, proceed to step 2.
+2. **Name lookup**: Query relays for kind `35129` with `#d=<name>` and `authors=<indexer-pubkey>`. Extract the pubkey from the `p` tag.
+3. **Relay discovery**: Query for the pubkey's kind `10002` ([NIP-65](65.md)) relay list.
+4. **Manifest fetch**: Query the pubkey's relays for the site manifest — kind `35128` with `d=<name>` for named sites, or kind `15128` for root sites.
+5. **Path resolution**: Match the requested path against `path` tags in the manifest to get a SHA-256 blob hash.
+6. **Blob fetch**: Retrieve the blob from Blossom servers listed in the manifest's `server` tags, the pubkey's kind `10063` event, or fallback servers. Verify the SHA-256 hash.
+7. **Render**: Display the content.
+
+Clients SHOULD use a race-then-linger search strategy for all relay queries: subscribe across multiple relays, return on the first event, then wait 200ms for additional responses. The newest event by `created_at` wins.
+
+### Security Considerations
+
+- **Name integrity**: Secured by Bitcoin proof-of-work. Reversing a registration requires a 51% attack.
+- **Content integrity**: Every blob is verified against its SHA-256 hash. Blossom servers cannot serve tampered content.
+- **Manifest authenticity**: Nostr events are cryptographically signed by the site owner's keypair.
+- **Index trust**: The Nostr name index is a convenience layer, not a trust layer. Any party scanning the same blockchain produces the same mappings. Clients MAY verify index events against their own chain scan.
+- **UTXO protection**: Users MUST protect ownership UTXOs from accidental spending. Spending an ownership UTXO without an NSIT OP_RETURN permanently freezes the name.
+
+### Reference Implementation
+
+- Browser: [Titan](https://github.com/btcjt/titan) (Rust + Tauri 2)
+- Indexer: [nsit-indexer](https://github.com/btcjt/titan) (TypeScript, publishes kinds 35129, 1129, 15129)
+- Registration tool: `nsite://titan/register` (interactive bitcoin-cli command builder)


### PR DESCRIPTION
## Summary

Extends NIP-5A (Pubkey Static Websites) with a Bitcoin-native name system that maps human-readable names to Nostr pubkeys using OP_RETURN transactions.

**The problem**: npubs are not human-readable. `npub1qe3e2054qkxsyt0yzem0xxv5gdpgmstahaqma3ja6pv2n9auqelqh2q4jf` cannot be memorized, spoken aloud, or printed on a business card. Gateway subdomains reintroduce DNS dependency.

**The solution**: Register a name on Bitcoin once (~$0.10 tx fee). It's yours forever. `nsite://titan` instead of `nsite://npub1qe3e...`.

## What this adds to NIP-5A

- **`nsite://` URL scheme** for native clients (name or npub as host)
- **NSIT OP_RETURN wire format** — 39-80 bytes encoding name + pubkey in Bitcoin transactions
- **UTXO-based ownership** — first non-OP_RETURN output controls the name, transferable
- **Nostr name index events**:
  - Kind `35129` (addressable, d=name) — current name state, replaceable on transfer
  - Kind `1129` (regular) — name history log, one per action, non-replaceable
  - Kind `15129` (replaceable) — indexer sync stats
- **Client resolution flow** — name → kind 35129 → pubkey → kind 10002 → kind 35128 → Blossom → render
- **Security model** — Bitcoin PoW for name integrity, SHA-256 for content, Nostr signatures for manifests

## Key properties

- **Permanent**: No renewals, no expiration, no seizure
- **First-come-first-served**: First valid registration on-chain wins
- **Transferable**: Spend the ownership UTXO with a new pubkey
- **Deterministic**: Any node scanning the same blockchain arrives at the same mappings
- **No full node required**: Clients query Nostr relays for index events

## Live implementation

- **Browser**: [Titan](https://github.com/btcjt/titan) (Rust + Tauri 2) — macOS, Linux, Windows
- **Indexer**: nsit-indexer (TypeScript, k8s) — watches Bitcoin blocks, publishes kinds 35129/1129/15129
- **7 names registered** on Bitcoin mainnet (titan, bitcoin, josh, video, music, westernbtc, vinney)
- **Registration tool**: `nsite://titan/register` — interactive bitcoin-cli command builder

The protocol is live and working today.