### PR TITLE
Update C7 to only allow kind 9 messages in chat views

### DIFF
--- a/C7.md
+++ b/C7.md
@@ -27,3 +27,5 @@ A reply to a `kind 9` is an additional `kind 9` which quotes the parent using a 
   ]
 }
 ```
+
+Clients that render a "chat view" as a stream of ordered events MUST only fetch `kind 9` events in order to prevent missing context across implementations. Other content types MAY be quoted within in a `kind 9` following [NIP 18](./18.md).


### PR DESCRIPTION
Based on [this conversation](https://coracle.social/nostr:nevent1qvzqqqqqqypzqla9dawkjc4trc7dgf88trpsq2uxvhmmpkxua607nc5g6a634sv5qy28wumn8ghj7mrfva58gmnfdenjuun9vshszxnhwden5te0wpuhyctdd9jzuenfv96x5ctx9e3k7mf0qyt8wumn8ghj7un9d3shjtnyd968gmewwp6kytcqyz5zls890z8nx54rxv7km0mh5sreeyx3j8dnnfsfufuzgzpn7kghvgtnhe4)