### PR TITLE
NIP-34 add `nostr://` clone urls spec

### DIFF
--- a/34.md
+++ b/34.md
@@ -37,6 +37,29 @@ The `r` tag annotated with the `"euc"` marker should be the commit ID of the ear
 
 Except `d`, all tags are optional.
 
+### Nostr Clone URL format
+
+A `nostr://` URL can be used to reference a repository announcement in a way that is compatible with `git clone` when a [git-remote-nostr](https://git-scm.com/docs/gitremote-helpers) helper is installed:
+
+```
+nostr://<naddr>
+nostr://<npub|nip05>/<identifier>
+nostr://<npub|nip05>/<relay-hint>/<identifier>
+```
+
+`<relay-hint>` is a relay URL whose `wss://` scheme may be omitted for brevity and MUST be percent-encoded per [RFC 3986 §2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1).
+
+`<identifier>` is the `d` tag value of the kind `30617` event.
+
+Examples:
+
+```
+nostr://npub15qydau2hjma6ngxkl2cyar74wzyjshvl65za5k5rl69264ar2exs5cyejr/relay.ngit.dev/ngit
+nostr://npub15qydau2hjma6ngxkl2cyar74wzyjshvl65za5k5rl69264ar2exs5cyejr/my%20%F0%9F%9A%80%20repo
+nostr://danconwaydev.com/ws%3A%2F%2Flocalhost%3A7334/my-local-only-repo
+nostr://danconwaydev.com/relay.ngit.dev/ngit
+```
+
 ## Repository state announcements
 
 An optional source of truth for the state of branches and tags in a repository.
@@ -239,7 +262,7 @@ The event SHOULD include a list of `g` tags with grasp service websocket URLs in
   "content": "",
   "tags": [
     ["g", "<grasp-service-websocket-url>"], // zero or more grasp sever urls
-  ]
+  ],
 }
 ```
 

--- a/34.md
+++ b/34.md
@@ -47,9 +47,7 @@ nostr://<npub|nip05>/<identifier>
 nostr://<npub|nip05>/<relay-hint>/<identifier>
 ```
 
-`<relay-hint>` is a relay URL whose `wss://` scheme may be omitted for brevity and MUST be percent-encoded per [RFC 3986 §2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1).
-
-`<identifier>` is the `d` tag value of the kind `30617` event.
+Both `<relay-hint>` and `<identifier>` MUST be percent-encoded per [RFC 3986 §2.1](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1). `<relay-hint>` is a relay URL whose `wss://` scheme may be omitted for brevity. `<identifier>` is the `d` tag value of the kind `30617` event.
 
 Examples:
 


### PR DESCRIPTION
`nostr://` has already been in the wild for a while now. Its implemented as a clone url by shakespeare and ngit as a git-remote-nostr. Its displayed in quite a few clients including gitworkshop.dev, and nostrhub.io.

I note that nak supports `nostr://` without nip05 support.

Many clients use this format without the `nostr://` prefix for url routes for addressable event references.

The renewed desire to get the spec formalised in nip34 is repo announcements that dont follow the kebab-case recommendation for `d` identifier tag can produce `nostr://` urls that dont match git-remote-helper spec, or really any URL spec. so the second commit in this PR seeks to address this.