### PR TITLE
Add duration field to NIP-94 file metadata

### DIFF
--- a/94.md
+++ b/94.md
@@ -27,6 +27,7 @@ This NIP specifies the use of the `1063` event kind, having in `content` a descr
 * `alt` (optional) description for accessibility
 * `fallback` (optional) zero or more fallback file sources in case `url` fails
 * `service` (optional) service type which is serving the file (eg. [NIP-96](96.md))
+* `duration` (optional) length of audio or video content in seconds (may include decimals, e.g. `"29.223"`)
 
 ```jsonc
 {
@@ -44,7 +45,8 @@ This NIP specifies the use of the `1063` event kind, having in `content` a descr
     ["thumb", <string with thumbnail URI>, <Hash SHA-256>],
     ["image", <string with preview URI>, <Hash SHA-256>],
     ["summary", <excerpt>],
-    ["alt", <description>]
+    ["alt", <description>],
+    ["duration", <duration of audio/video in seconds>]
   ],
   "content": "<caption>",
   // other fields...


### PR DESCRIPTION
Adds `duration` to the NIP-94 file metadata field list, making it a standard field available to all events using NIP-94 tags (including NIP-92 `imeta`).

### Context

NIP-71 (video events) already defines `duration` as an `imeta` property via PR #1723. However, it's only specified in NIP-71 as an extension, not in NIP-94's canonical field list. This means:

- NIP-92 says `imeta` MAY include any NIP-94 field, but `duration` isn't listed in NIP-94
- Clients implementing NIP-92 without NIP-71 awareness won't know `duration` is a valid field
- Audio events (podcasts, voice messages) also need duration but aren't covered by NIP-71

Adding `duration` to NIP-94 closes this gap and makes it a first-class file metadata field alongside `size`, `dim`, and `thumb`.

### Change

One line added to the field list:

```
* `duration` (optional) length of audio or video content in seconds (may include decimals, e.g. `"29.223"`)
```

And added to the example JSON block.

### Precedent

- NIP-71 already uses `duration` in `imeta` tags (merged in #1723)
- NIP-A0 (voice messages, #1984) also references duration for audio content
- This promotes an existing convention to the canonical field list