### PR TITLE
NIP-29: define explicit role permissions and access schema on kind 39003

### DIFF
--- a/29.md
+++ b/29.md
@@ -42,11 +42,15 @@ Relays should prevent late publication (messages published now with a timestamp 
 
 ## Group management
 
-Groups can have any number of users with elevated access. These users are identified by role labels which are arbitrarily defined by the relays (see also the description of `kind:39003`). What each role is capable of not defined in this NIP either, it's a relay policy that can vary. Roles can be assigned by other users (as long as they have the capability to add roles) by publishing a `kind:9000` event with that user's pubkey in a `p` tag and the roles afterwards (even if the user is already a group member a `kind:9000` can be issued and the user roles must just be updated).
+Groups can have any number of users with elevated access. These users are identified by role labels defined by the relay (see also the description of `kind:39003`).
 
-The roles supported by the group as to having some special privilege assigned to them should be accessible on the event `kind:39003`, but the relay may also accept other role names, arbitrarily defined by clients, and just not do anything with them.
+Roles are identity and presentation labels. Roles by themselves MUST NOT imply moderation capability. Moderation capability is derived from explicit `role-permission` definitions in `kind:39003`.
 
-Users with any roles that have any privilege can be considered _admins_ in a broad sense and be returned in the `kind:39001` event for a group.
+Roles can be assigned by publishing a `kind:9000` event with that user's pubkey in a `p` tag and the roles afterwards (even if the user is already a group member a `kind:9000` can be issued and the user roles must just be updated).
+
+The roles supported by the group and their properties MUST be advertised in `kind:39003`. Relays MUST reject role assignments in `kind:9000` that include role names not advertised in the current `kind:39003` for that group.
+
+Users with roles that grant elevated capabilities can be listed in `kind:39001` as _admins_ in a broad sense, but `kind:39001` is informational and not the authorization source of truth.
 
 ## Event definitions
 
@@ -97,7 +101,9 @@ These are events expected to be sent by the relay master key or by group admins 
 
 - *moderation events* (`kinds:9000-9020`) (optional)
 
-Clients can send these events to a relay in order to accomplish a moderation action. Relays must check if the pubkey sending the event is capable of performing the given action based on its role and the relay's internal policy (see also the description of `kind:39003`).
+Clients can send these events to a relay in order to accomplish a moderation action. Relays MUST check if the pubkey sending the event is capable of performing the given action based on the group's current `kind:39003` role definitions.
+
+For privileged moderation actions, authorization MUST be derived from `role-permission` tags in `kind:39003`, not role names and not `role-order`.
 
 ```jsonc
 {
@@ -121,6 +127,10 @@ Each moderation action uses a different kind and requires different arguments, w
 | 9007 | `create-group`  |                                                                                  |
 | 9008 | `delete-group`  |                                                                                  |
 | 9009 | `create-invite` | arbitrary `code`                                                                 |
+
+For `kind:9000`, relays MUST reject assignments that reference unknown roles (roles that are not defined in current `kind:39003`).
+
+For `kind:9001`, relays SHOULD treat removal as clearing membership and role assignments for that user in the group.
 
 It's expected that the group state (of who is an allowed member or not, who is an admin and with which permission or not, what are the group name and picture etc) can be fully reconstructed from the canonical sequence of these events.
 
@@ -160,6 +170,8 @@ If the group is forked and hosted in multiple relays, there will be multiple ver
 
 Each admin is listed along with one or more roles. These roles SHOULD have a correspondence with the roles supported by the relay, as advertised by the `kind:39003` event.
 
+This event is informational. Relays MUST NOT use `kind:39001` as the source of truth for authorization decisions.
+
 ```jsonc
 {
   "kind": 39001,
@@ -178,6 +190,10 @@ Each admin is listed along with one or more roles. These roles SHOULD have a cor
 
 It's a list of pubkeys that are members of the group. Relays might choose to not to publish this information, to restrict what pubkeys can fetch it or to only display a subset of the members in it.
 
+Each `p` tag MAY include one or more role names after the pubkey, matching roles defined in `kind:39003`. This is informational and intended for client display.
+
+If multiple roles are present in one `p` tag, clients MAY treat the first role as the member's primary display role.
+
 Clients should not assume this will always be present or that it will contain a full list of members.
 
 ```jsonc
@@ -186,9 +202,9 @@ Clients should not assume this will always be present or that it will contain a 
   "content": "list of members for the pizza lovers group",
   "tags": [
     ["d", "<group-id>"],
-    ["p", "<admin1>"],
-    ["p", "<member-pubkey1>"],
-    ["p", "<member-pubkey2>"],
+    ["p", "<admin1>", "admin"],
+    ["p", "<member-pubkey1>", "member"],
+    ["p", "<member-pubkey2>", "supporter", "beta"],
     // other pubkeys...
   ],
   // other fields...
@@ -197,11 +213,22 @@ Clients should not assume this will always be present or that it will contain a 
 
 - *group roles* (`kind:39003`) (optional)
 
-This is an event that MAY be published by the relay informing users and clients about what are the roles supported by this relay according to its internal logic.
+This is an event that MAY be published by the relay informing users and clients about what are the roles supported by this group and how they are interpreted.
 
-For example, a relay may choose to support the roles `"admin"` and `"moderator"`, in which the `"admin"` will be allowed to edit the group metadata, delete messages and remove users from the group, while the `"moderator"` can only delete messages (or the relay may choose to call these roles `"ceo"` and `"secretary"` instead, the exact role name is not relevant).
+Role capabilities and access are described as tags in this event. Role names and role order are not sufficient to infer moderation capability.
 
-The process through which the relay decides what roles to support and how to handle moderation events internally based on them is specific to each relay and not specified here.
+Supported tags:
+
+- `role`: `['role', '<role-name>', '<optional-description>']`
+- `role-label`: `['role-label', '<role-name>', '<display-label>']`
+- `role-color`: `['role-color', '<role-name>', '<hue-0-255>']` where `<hue-0-255>` is an integer from `0` to `255`.
+- `role-order`: `['role-order', '<role-name>', '<integer>']` (for client display ordering only; MUST NOT grant moderation capability by itself)
+- `role-permission`: `['role-permission', '<role-name>', '<kind>']` where `<kind>` is a privileged moderation kind. In this NIP, the standardized values are `9000`, `9001`, `9002`, `9005`, `9009`.
+- `role-access`: `['role-access', '<role-name>', 'read|write|join']`
+
+`role-access` indicates whether members holding a role are granted group `read`, `write`, or `join` capability by relay policy. Multiple `role-access` tags MAY exist for the same role.
+
+If a relay computes role definitions using inheritance or broader internal policy, it MUST materialize the resolved role set for each group in that group's `kind:39003`. Group-level `kind:39003` remains authoritative for group validation so NIP-29-only implementations can interoperate.
 
 ```jsonc
 {
@@ -209,8 +236,25 @@ The process through which the relay decides what roles to support and how to han
   "content": "list of roles supported by this group",
   "tags": [
     ["d", "<group-id>"],
-    ["role", "<role-name>", "<optional-description>"],
-    ["role", "<role-name>", "<optional-description>"],
+    ["role", "admin", "full moderation role"],
+    ["role-label", "admin", "Admin"],
+    ["role-color", "admin", "8"],
+    ["role-order", "admin", "100"],
+    ["role-permission", "admin", "9000"],
+    ["role-permission", "admin", "9001"],
+    ["role-permission", "admin", "9002"],
+    ["role-permission", "admin", "9005"],
+    ["role-permission", "admin", "9009"],
+    ["role-access", "admin", "read"],
+    ["role-access", "admin", "write"],
+    ["role-access", "admin", "join"],
+
+    ["role", "supporter", "cosmetic role"],
+    ["role-label", "supporter", "Supporter"],
+    ["role-color", "supporter", "165"],
+    ["role-order", "supporter", "20"],
+    ["role-access", "supporter", "read"],
+    ["role-access", "supporter", "write"],
     // other roles...
   ],
   // other fields...

--- a/29.md
+++ b/29.md
@@ -48,9 +48,9 @@ Roles are identity and presentation labels. Roles by themselves MUST NOT imply m
 
 Roles can be assigned by publishing a `kind:9000` event with that user's pubkey in a `p` tag and the roles afterwards (even if the user is already a group member a `kind:9000` can be issued and the user roles must just be updated).
 
-The roles supported by the group and their properties MUST be advertised in `kind:39003`. Relays MUST reject role assignments in `kind:9000` that include role names not advertised in the current `kind:39003` for that group.
+The roles supported by the group and their properties MAY be advertised in `kind:39003`. Relays SHOULD reject role assignments in `kind:9000` that include role names not advertised in the current `kind:39003` for that group.
 
-Users with roles that grant elevated capabilities can be listed in `kind:39001` as _admins_ in a broad sense, but `kind:39001` is informational and not the authorization source of truth.
+Users with roles that grant elevated capabilities can be listed in `kind:39001` as _admins_, alongside their assigned roles.
 
 ## Event definitions
 
@@ -101,9 +101,7 @@ These are events expected to be sent by the relay master key or by group admins 
 
 - *moderation events* (`kinds:9000-9020`) (optional)
 
-Clients can send these events to a relay in order to accomplish a moderation action. Relays MUST check if the pubkey sending the event is capable of performing the given action based on the group's current `kind:39003` role definitions.
-
-For privileged moderation actions, authorization MUST be derived from `role-permission` tags in `kind:39003`, not role names and not `role-order`.
+Clients can send these events to a relay in order to accomplish a moderation action. Relays should authorize these actions according to the group's current policy, as reflected by the group's role definitions (for example in `kind:39003`).
 
 ```jsonc
 {
@@ -128,9 +126,7 @@ Each moderation action uses a different kind and requires different arguments, w
 | 9008 | `delete-group`  |                                                                                  |
 | 9009 | `create-invite` | arbitrary `code`                                                                 |
 
-For `kind:9000`, relays MUST reject assignments that reference unknown roles (roles that are not defined in current `kind:39003`).
-
-For `kind:9001`, relays SHOULD treat removal as clearing membership and role assignments for that user in the group.
+For `kind:9000`, relays SHOULD reject assignments that reference unknown roles (roles that are not defined in current `kind:39003`).
 
 It's expected that the group state (of who is an allowed member or not, who is an admin and with which permission or not, what are the group name and picture etc) can be fully reconstructed from the canonical sequence of these events.
 
@@ -169,8 +165,6 @@ If the group is forked and hosted in multiple relays, there will be multiple ver
 - *group admins* (`kind:39001`) (optional)
 
 Each admin is listed along with one or more roles. These roles SHOULD have a correspondence with the roles supported by the relay, as advertised by the `kind:39003` event.
-
-This event is informational. Relays MUST NOT use `kind:39001` as the source of truth for authorization decisions.
 
 ```jsonc
 {


### PR DESCRIPTION
This PR scopes to NIP-29 only (per [coracle/flotilla#47](https://gitea.coracle.social/coracle/flotilla/issues/47)) and centralizes role semantics on kind 39003.

**Changes**
- Clarifies authorization model:
  - permissions derive from role-permission
  - role names and role-order are non-authoritative for moderation capability

- Extends kind 39003 role schema with:
    - role
    - role-label
    - role-color (hue 0-255)
    - role-order (UI ordering only)
    - role-permission (explicit privileged 9xxx kinds: 9000, 9001, 9002, 9005, 9009)
    - role-access (read/write/join)

- Tightens assignment/listing behavior:
    - 9000 assignments referencing unknown roles MUST be rejected
    - 9001 removal SHOULD clear role assignments for that group
    - 39001 is explicitly informational, not source of truth for authorization
    - 39002 members MAY include role names after pubkey for client UX

- Adds compatibility guidance:
    - group-level 39003 remains authoritative for group validation
    - if inheritance exists internally, relays MUST materialize resolved roles into group 39003 for NIP-29 interoperability
    
    [NIP-43 follow-up tracked separately: [https://gitea.coracle.social/coracle/flotilla/issues/192](https://gitea.coracle.social/coracle/flotilla/issues/192) ]