### PR TITLE
nip-11: add access_control field for gated relay discovery

### DIFF
--- a/11.md
+++ b/11.md
@@ -176,6 +176,44 @@ Relays that require payments may want to expose their fee schedules.
 }
 ```
 
+### Access Control
+
+Relays that gate access behind external conditions (subscriptions, token holdings, group membership, allowlists, etc.) may advertise those requirements so clients can surface them to the user *before* connecting or publishing, rather than reactively after a `restricted:` close.
+
+```jsonc
+{
+  "access_control": {
+    "authentication": "required",
+    "permissions": [
+      { "action": "read",  "kinds": [30402, 30403] },
+      { "action": "write", "kinds": [1, 30023] }
+    ],
+    "description": "Active subscription required for access to premium content.",
+    "info_url": "https://example.com/subscribe"
+  },
+  // other fields...
+}
+```
+
+- `authentication`: either `"required"` or `"optional"`. Indicates whether [NIP-42](42.md) auth is needed before the gated actions can be performed. This complements `limitation.auth_required`, which only covers connection-level auth.
+
+- `permissions`: an array of `{ action, kinds }` objects describing what the relay gates. `action` is one of `"read"` or `"write"`. `kinds` is the list of event kinds the gate applies to; an empty or omitted `kinds` array means the gate applies to all kinds for that action. Multiple entries with the same action MAY be used to describe disjoint kind sets. This field does not attempt to describe *how* the relay evaluates access, only *what* is gated.
+
+- `description`: a human-readable string a client MAY render to the user (for example: "Active subscription required"). Plain text, no markup.
+
+- `info_url`: an optional URL where a user can obtain access (subscribe, join, acquire tokens, etc.). Clients SHOULD NOT auto-follow this URL and SHOULD present it as a user-initiated action.
+
+This field describes *capability advertisement*, not runtime policy. Arbitrary access policy cannot be meaningfully introspected, and this NIP does not attempt to. Relays implementing role-based access control via a future NIP (e.g. a relay-level extension of [NIP-29](29.md)) MAY use `access_control` alongside it: `access_control` tells a client what the relay gates and where a non-member can go to become one; the RBAC NIP describes how an authenticated member's role maps to permissions once they are known.
+
+When a relay denies a gated action, it SHOULD use a human-meaningful reason after the standard `restricted:` prefix defined in [NIP-42](42.md) and [NIP-01](01.md), so that clients can surface an actionable message rather than an opaque failure:
+
+```
+["CLOSED", "<sub-id>", "restricted: no active subscription"]
+["OK", "<event-id>", false, "restricted: write access requires membership"]
+```
+
+Clients encountering a `restricted:` reason SHOULD render it to the user together with `access_control.info_url` when available.
+
 ### Examples
 
 ```yaml


### PR DESCRIPTION
Adds an optional `access_control` field to NIP-11 so relays that gate access (subscriptions, token holdings, group membership, allowlists, etc.) can advertise what they gate, and clients can render actionable UI before connecting rather than reacting to opaque `restricted:` closes after the fact.

Discussed in issue #2311.

## Motivation

Today, a client has no pre-connection signal that a relay gates read or write access. It connects, sends a `REQ` or `EVENT`, receives a `CLOSED` or `OK: false` with a `restricted:` prefix, and has to reactively surface an error to the user. In mixed-feed scenarios (a timeline including a premium post whose relay the user may or may not be subscribed to, or an `naddr` pointing at a gated relay) the client cannot render "locked, subscribe" on first paint because it has no way to know the relay is gated or where to send the user to obtain access.

This PR fills that gap with capability advertisement, not policy introspection.

## Scope

**In scope:**
- A way for relays to declare *that* read or write is gated, at event-kind granularity
- A way for clients to discover where a non-member can go to obtain access
- A standard shape for `restricted: <reason>` messages so clients can render them uniformly

**Explicitly out of scope:**
- Describing *how* a relay evaluates access (arbitrary policy cannot be meaningfully introspected, per earlier discussion in #2311)
- Role-based access control for authenticated members (belongs in a future RBAC NIP, sketched by @staab for NIP-43; this proposal composes with it rather than duplicating)

## Shape

```jsonc
{
  "access_control": {
    "authentication": "required",
    "permissions": [
      { "action": "read",  "kinds": [30402, 30403] },
      { "action": "write", "kinds": [1, 30023] }
    ],
    "description": "Active subscription required for access to premium content.",
    "info_url": "https://example.com/subscribe"
  }
}
```

- `authentication`: `"required"` or `"optional"`. Distinct from `limitation.auth_required`, which only covers connection-level auth.
- `permissions`: array of `{ action, kinds }` with `action` ∈ `"read"` | `"write"`. Empty/omitted `kinds` means "all kinds for this action." Nomenclature chosen to align with @staab's "read/write policies per event kind" suggestion from #2311 and to read naturally alongside a future NIP-43 RBAC extension.
- `description`: human-readable string clients can render.
- `info_url`: optional URL where a user can obtain access (subscribe, join, etc.). Clients SHOULD NOT auto-follow.

Plus a standardized denial format:

```
["CLOSED", "<sub-id>", "restricted: no active subscription"]
["OK", "<event-id>", false, "restricted: write access requires membership"]
```

## Composition with future RBAC

The spec text explicitly positions this as complementary to a future role-based access NIP. In short:

- **`access_control`**: "this relay gates kind X for read, here is where to become a member"
- **Future RBAC NIP**: "this authenticated member has role Y, which grants these permissions"

A client rendering a mixed timeline can use both: `access_control` tells it the relay gates the post's kind; the RBAC event tells it whether *this user* satisfies the gate. No probing, no try-and-see, right state on first paint for both subscribed and non-subscribed users.

## Reference implementation

Live in production on a creator platform:

- Relay advertising the field: [Nostreon/relay-auth](https://github.com/Nostreon/relay-auth)
- The field is served on `GET /` with `Accept: application/nostr+json` at `wss://premium.nostreon.com`

## History

This started in #2311 as a broader proposal for a relay-to-backend callback protocol. @staab pushed back that the relay-to-backend direction has no interoperability surface (it's implementation detail), which was correct. The proposal was refocused onto the client-facing discovery + denial-format side, which *is* an interop surface, and @staab [confirmed](https://github.com/nostr-protocol/nips/issues/2311#issuecomment-4244993832) it probably makes sense to add to NIP-11. This PR is that change.