### PR TITLE
[Draft/RFC] On-graph checkout layer for NIP-99 markets: order flow, escrow, and dispute

### DIFF
--- a/115.md
+++ b/115.md
@@ -1,394 +1,86 @@
-# NIP-XX: Freedom of Interaction Protocol (Identity & Commerce)
+# NIP-XX: Marketplace Escrow & Dispute Extension
 
-> **Status:** DRAFT  
-> **Kind(s):** 30402 (Offer/Reuse NIP-99), 30404 (Company), 30405 (Credential), 30406 (Review), 30407 (Ticket Created), 30408 (Ticket Status)  
-> **Authors:** Deniz Yilmaz <<dezooyi@gmail.com>>  
-> **License:** CC0  
-> **Discussions-To:** [github.com/nostr-protocol/nips/pull/2323](https://github.com/nostr-protocol/nips/pull/2323)  
-> **Protocol Specification:** [github.com/Colabonate/Colabonate_Protocol](https://github.com/Colabonate/Colabonate_Protocol)
+`draft` `optional`
 
----
+This NIP extends the marketplace order flow defined by the GammaMarkets market-spec
+(NIP-99 e-commerce extension, `kind:16` order / `kind:17` payment receipt) with the two
+pieces that spec explicitly leaves out: **escrow** and **dispute resolution**.
 
-## Abstract
+It defines two event kinds that reference an existing order by its `order` identifier:
 
-This NIP defines the foundational layer for a "Freedom of Interaction" protocol over Nostr, designed to dismantle digital monopolies and enable sovereign, trust-minimized collaboration. Ranging from simple local commerce to complex, multi-party cooperations, it combines verifiable Human Identities (HID, L0-L3), trust-weighted reputation scoring, and Bitcoin/Lightning-native escrow mechanisms. By extending NIP-99 (Classified Listings) with structured transaction semantics, addressable company profiles, and soulbound credentials, it establishes the base infrastructure for self-organized economic ecosystems.
+- an **Escrow State** event (Lightning hold-invoice lifecycle), and
+- a **Dispute** event (a neutral, third-party-resolvable claim against an order).
 
-**Key differentiators from NIP-99:**
-- Service/offline-delivery offers (not just physical goods)
-- Multi-level identity verification (L0-L3) via NIP-98 auth
-- Escrow-aware offers with milestone-based release
-- Identity-level-weighted reputation scoring
-- Company profiles with UNSPSC classification
+**Visibility note.** market-spec order messages are NIP-17 encrypted DMs. Escrow and
+dispute events defined here are **public** addressable events, by design: an escrow held
+by a third party and a dispute resolved by an arbitrator both require a party *other than
+buyer and seller* to read the record. Implementations that need private orders and public
+escrow accept this asymmetry explicitly.
 
----
+## Escrow State — `kind:NN`
 
-## Supported Kinds
+An addressable event published by the escrow holder (or, in self-custodial setups, the
+payer) tracking the state of funds held against an order.
 
-| Kind | Name | Layer | Status |
-|------|------|-------|--------|
-| 30402 | Service Offer (extends NIP-99) | Marketplace | Extends NIP-99 |
-| 30404 | Company Profile | Marketplace | **NEW – needs assignment** |
-| 30405 | Verification Credential | Identity | **NEW – needs assignment** |
-| 30406 | Reputation Review | Reputation | **NEW – needs assignment** |
-
-*Ticket events (30407, 30408) and additional identity events defined in Colabonate protocol but out of scope for initial NIP submission.*
-
----
-
-## Motivation
-
-### Why extend NIP-99 instead of using NIP-15?
-
-NIP-99 (Classified Listings) is simpler and more flexible than NIP-15 (Stall/Product model). Colabonate:
-1. Primarily sells **services** (not physical goods)
-2. Requires **Lightning escrow** with milestone releases
-3. Has **identity levels** that affect trust
-4. Needs **reputation weighting** by identity level
-
-Rather than fork from scratch, extending NIP-99 allows:
-- Existing NIP-99 clients can still display Colabonate offers (basic view)
-- Colabonate adds structured fields for escrow, identity, and milestones
-
-### What this NIP adds over NIP-99:
-
-| Feature | NIP-99 | This NIP |
-|---------|--------|----------|
-| Service offers | ✅ (via price/frequency) | ✅ + delivery semantics |
-| Lightning escrow | ❌ | ✅ (phase-based release) |
-| Identity levels | ❌ | ✅ (L0-L3 via tags) |
-| Milestone support | ❌ | ✅ (partial delivery) |
-| Reputation weighting | ❌ | ✅ (by identity level) |
-| Company profiles | ❌ | ✅ (Kind 30404) |
-
----
-
-## Specification (Kind 30402 – Service Offer, extends NIP-99)
-
-> **Extends:** NIP-99 (`kind:30402` Classified Listing)  
-> **Purpose:** A seller publishes a service offer with Lightning escrow support.
-
-### Base (per NIP-99)
-
-All NIP-99 fields and tags apply. Clients SHOULD display Colabonate offers using NIP-99 rendering.
-
-### Colabonate Extension Tags
-
-```json
+```jsonc
 {
-  "kind": 30402,
-  "pubkey": "<seller-pubkey-hex>",
-  "created_at": 1234567890,
+  "kind": NN,
   "tags": [
-    ["d", "<offer-id>"],
-    ["title", "<offer-title>"],
-    ["price", "5000", "sats"],
-    ["t", "service"],
-    ["published_at", "1234567890"],
-    // NIP-99 standard tags...
-    // Colabonate extension tags:
-    ["offer_type", "service"],
-    ["delivery_time_days", "7"],
-    ["delivery_cost_sats", "0"],
-    ["escrow", "milestone"],
-    ["identity_min", "1"],
-    ["category", "services/consulting"]
+    ["d", "<order-id>"],                                  // addressable by order
+    ["order", "<order-id>"],                               // market-spec order ref
+    ["item", "30402:<seller-pubkey>:<listing-d>", "<qty>"], // NIP-99 listing, market-spec `item` convention
+    ["amount", "<sats>"],
+    ["status", "<escrow-status>"],
+    ["payment", "lightning", "<bolt11>", "<payment-hash>"]
   ],
-  "content": "<offer-description>",
-  "sig": "<schnorr-signature>"
+  "content": "<optional note>"
 }
 ```
 
-### Extension Tags
+### Escrow status values
 
-| Tag | Format | Description |
-|-----|--------|-------------|
-| `offer_type` | `service` \| `product` \| `item` | Required for Colabonate extension |
-| `delivery_time_days` | Integer | Estimated delivery in days |
-| `delivery_cost_sats` | Integer | Delivery cost (0 = digital/remote) |
-| `escrow` | `milestone` \| `direct` \| `none` | Escrow type |
-| `identity_min` | `0` \| `1` \| `2` \| `3` | Minimum identity level to purchase |
-| `milestones` | JSON array | Milestone titles + percentages |
-| `location` | ISO 3166-1 alpha-2 | Seller country code |
+| Status      | Meaning |
+| ----------- | ------- |
+| HELD        | Funds locked (e.g. Lightning hold invoice accepted, not settled) |
+| RELEASED    | Funds released to the seller |
+| REFUNDED    | Funds returned to the buyer |
+| DISPUTED    | Release/refund paused pending dispute resolution |
 
-### Content Format
+## Dispute — `kind:MM`
 
-Same as NIP-99. Markdown supported. Max 4096 characters.
+An addressable event opening or updating a dispute against an order. Public so a neutral
+party can review it.
 
-### Escrow Semantics
-
-When `escrow: "milestone"`:
-- Buyer pays into Lightning escrow (hold invoice)
-- Release phased: 25% → 50% → 25% (configurable per offer)
-- Seller delivers, each milestone triggers partial release
-- Disputes routed to Kind 30409 (new, out of scope)
-
-When `escrow: "direct"`:
-- Single payment, released directly to seller on completion
-
-### Validation Rules (Colabonate extension)
-
-| Rule | Scope |
-|------|-------|
-| If `escrow: "milestone"` and price > 10000 sats, `milestones` tag required | Client |
-| If `identity_min` > 0, offer MUST include Kind 30405 credential reference | Client |
-| `delivery_time_days` must be positive integer if present | Client |
-
----
-
-## Specification (Kind 30404 – Company Profile)
-
-> **Kind:** 30404 (proposed new assignment)  
-> **Layer:** Marketplace  
-> **Purpose:** A seller operating as a company publishes their profile for trust and discovery.
-
-### Event Shape
-
-```json
+```jsonc
 {
-  "kind": 30404,
-  "pubkey": "<company-owner-pubkey>",
-  "created_at": 1234567890,
+  "kind": MM,
   "tags": [
-    ["d", "<company-id>"],
-    ["name", "<company-name>"],
-    ["fields", "<unspsc-code>"],
-    ["radius", "50", "km"],
-    ["logo", "<url>"],
-    ["banner", "<url>"],
-    ["images", "<url-1>", "<url-2>"],
-    ["nostr", "<owner-pubkey>"]
+    ["d", "<dispute-id>"],
+    ["order", "<order-id>"],
+    ["p", "<buyer-pubkey>"],
+    ["p", "<seller-pubkey>"],
+    ["status", "<dispute-status>"],
+    ["reason", "<reason-slug>"]
   ],
-  "content": "<company-description>",
-  "sig": "<schnorr-signature>"
+  "content": "<claim description; evidence hashes>"
 }
 ```
 
-### Required Tags
+### Dispute status values
 
-| Tag | Format | Description |
-|-----|--------|-------------|
-| `d` | UUID | Unique company ID |
-| `name` | String | Company display name |
+`OPEN` → `IN_REVIEW` → `RESOLVED`. A resolution event references the verdict and the
+resulting escrow transition (`RELEASED` / `REFUNDED` / split).
 
-### Optional Tags
+## Open design questions (seeking feedback)
 
-| Tag | Format | Description |
-|-----|--------|-------------|
-| `fields` | UNSPSC code(s) | Business category codes |
-| `radius` | Integer + "km" | Cooperation/delivery radius |
-| `logo` | URL | Logo image URL |
-| `banner` | URL | Banner image URL |
-| `images` | URLs | Image gallery URLs (multiple in one tag) |
-| `nostr` | Hex pubkey | Owner's Nostr pubkey (for verification) |
-| `lnurl` | LNURL string | Lightning address for payments |
-| `web` | URL | Company website |
+1. **Escrow as a new kind vs. an extra `type` on market-spec `kind:16`** — the Gamma
+   collective may prefer escrow to live as a new `type` value on the existing order kind.
+2. **Who signs the escrow event** — the hold-invoice provider, or either party?
+3. **Dispute neutrality** — does a generic "marketplace dispute" belong in this NIP, or
+   should it be a separate, resolver-agnostic NIP that escrow merely points to?
 
-### Content
+## Relation to other specs
 
-Company description. Markdown supported. Max 4096 characters.
-
-### Validation Rules
-
-| Rule | Scope |
-|------|-------|
-| `name` must be 1-80 characters | Client + Relay |
-| `d` tag must be unique per `pubkey` | Client |
-| If `nostr` tag present, must be valid pubkey | Client |
-
----
-
-## Specification (Kind 30405 – Verification Credential)
-
-> **Kind:** 30405 (proposed new assignment)  
-> **Layer:** Identity  
-> **Purpose:** Publishes a non-transferable (soulbound) credential tied to a Nostr pubkey. Issued via NIP-98 auth.
-
-### Event Shape
-
-```json
-{
-  "kind": 30405,
-  "pubkey": "<subject-pubkey>",
-  "created_at": 1234567890,
-  "tags": [
-    ["d", "<credential-id>"],
-    ["credential_type", "identity_level_1"],
-    ["hid_level", "1"],
-    ["issued_by", "<issuer-pubkey>"]
-  ],
-  "content": "{\"credential_type\":\"identity_level_1\",\"subject\":\"<pubkey>\",\"issued_at\":1234567890,\"expires_at\":null}",
-  "sig": "<schnorr-signature>"
-}
-```
-
-### Required Tags
-
-| Tag | Format | Description |
-|-----|--------|-------------|
-| `d` | UUID | Unique credential ID |
-| `credential_type` | String | See credential type table |
-| `hid_level` | `0` \| `1` \| `2` \| `3` | Identity level granted |
-| `issued_by` | Hex pubkey | Pubkey of the issuing entity |
-
-### Credential Types
-
-| `credential_type` | Description | Issuer | NIP-98 Required |
-|------------------|-------------|--------|-----------------|
-| `identity_level_1` | Nostr profile + LNURL verified | Self | Yes |
-| `identity_level_2` | Peer-verified (2 verifiers) | Verifiers | Yes |
-| `identity_level_3` | Humanode biometric verified | Protocol | Yes |
-| `mediator` | Authorized dispute mediator | Foundation DAO | No |
-| `arbitrator` | DAO court member | DAO vote | No |
-
-### NIP-98 Authorization
-
-For `identity_level_1` credentials, the event MUST be authorized via NIP-98 HTTP Auth:
-- Client signs HTTP request to `POST /api/identity/upgrade-l1`
-- Server validates `Authorization: Nostr <base64-encoded-event>` header
-- Event pubkey must match claimed `nostrPubkey`
-
-### Soulbound Guarantee
-
-The credential is bound to the `pubkey` field. Since Nostr events are signed with the corresponding private key, the credential cannot be transferred without re-issuance.
-
----
-
-## Specification (Kind 30406 – Reputation Review)
-
-> **Kind:** 30406 (proposed new assignment)  
-> **Layer:** Reputation  
-> **Purpose:** After a completed transaction, either party publishes a review. Permanent, identity-level-weighted.
-
-### Event Shape
-
-```json
-{
-  "kind": 30406,
-  "pubkey": "<reviewer-pubkey>",
-  "created_at": 1234567890,
-  "tags": [
-    ["d", "<review-id>"],
-    ["review_for", "<reviewed-pubkey>"],
-    ["ticket", "<ticket-id>"],
-    ["stars", "5"],
-    ["hid_level_reviewer", "2"],
-    ["col_points_reviewer", "150"]
-  ],
-  "content": "<review-text>",
-  "sig": "<schnorr-signature>"
-}
-```
-
-### Required Tags
-
-| Tag | Format | Description |
-|-----|--------|-------------|
-| `d` | UUID | Unique review ID |
-| `review_for` | Hex pubkey | Pubkey of the person being reviewed |
-| `ticket` | UUID | Reference to the completed ticket |
-| `stars` | Integer 1–5 | Star rating |
-
-### Optional Tags
-
-| Tag | Format | Description |
-|-----|--------|-------------|
-| `hid_level_reviewer` | `0` \| `1` \| `2` \| `3` | Reviewer's identity level |
-| `col_points_reviewer` | Integer | Reviewer's COL-Points balance at time of review |
-
-### Validation Rules
-
-| Rule | Scope |
-|------|-------|
-| The referenced ticket must have status `COMPLETED` | Client |
-| Review must be published within 14 days of completion | Client |
-| Reviews are permanent — cannot be deleted | Client |
-| Reviews without prior completed ticket receive 0.0 weight | Client |
-
-### Identity-Level Weighting
-
-| Reviewer Level | Weight Multiplier |
-|---------------|-------------------|
-| L0 | 1.0 |
-| L1 | 1.0 |
-| L2 | 1.2 |
-| L3 | 1.5 |
-
----
-
-## Relay Behavior
-
-All kinds in this NIP:
-- **SHOULD** be stored by any relay that receives them
-- **MAY** be filtered by `pubkey`, `kind`, and `d` tag
-- **SHOULD NOT** require authentication or payment to store
-- **SHOULD** support NIP-33 parameterized replaceable event queries
-
----
-
-## Compatibility
-
-### Depends On
-
-| NIP | Purpose |
-|-----|---------|
-| NIP-01 | Base event format, Schnorr signatures |
-| NIP-33 | Parameterized replaceable events |
-| NIP-99 | Base Classified Listing (for Kind 30402) |
-| NIP-98 | HTTP auth for credential issuance (Kind 30405) |
-
-### Does Not Conflict With
-
-- NIP-57 (Lightning zaps) – compatible
-- NIP-09 (Event deletion) – Kind 5 works
-- NIP-15 (Stall/Product) – separate kinds, no overlap
-- NIP-17 (Private DMs) – separate event range
-- NIP-69 (Peer-to-peer Order events, kind 38383) – separate layer, complementary
-
----
-
-## Reference Implementations & Protocols
-
-The reference software implementation is currently being prepared for open-source release. In the meantime, the full protocol specifications and workflow documentation are public:
-
-- [Colabonate Protocol Repository](https://github.com/Colabonate/Colabonate_Protocol)
-- [NIP-99 Reference](https://github.com/nostr-protocol/nips/blob/master/99.md)
-
----
-
-## Security Considerations
-
-1. **Signature validation:** All events validated per NIP-01
-2. **NIP-98 credential auth:** Server must verify event signature matches claim
-3. **Replacement events:** NIP-33 rules apply
-4. **Review manipulation:** Weight requires prior ticket history
-
----
-
-## Limitations
-
-1. **No guaranteed relay storage:** Relays may drop events
-2. **Escrow off-protocol:** Lightning escrow handled via external service (LNBits)
-3. **Dispute resolution out of scope:** Future NIP for Kind 30409
-
----
-
-## Changelog
-
-| Date | Change |
-|------|--------|
-| 2026-04-10 | Initial draft for community review |
-
----
-
-## Authors
-
-**Deniz Yilmaz** – Founder, Colabonate  
-Contact: [dezooyi@gmail.com](mailto:dezooyi@gmail.com)  
-Nostr: `npub1jcqnaxvmrqteazz9y323gj6r3v0q0rslhng69e7jdslcjadsxa4scpp2sv`  
-Project: [colabonate.com](https://colabonate.com)
-
----
-
-## Discussion
-
-Open an issue at [github.com/nostr-protocol/nips](https://github.com/nostr-protocol/nips) or reply to this PR.
+- **GammaMarkets market-spec** — the order/payment flow this extends (`kind:16`/`17`).
+- [NIP-99] — the underlying classified listing (`30402`), referenced via market-spec's `item` tag.
+- [NIP-57] — a zap receipt MAY serve as a `RELEASED` payment proof.

--- a/115.md
+++ b/115.md
@@ -17,11 +17,24 @@ Escrow is **opt-in**. WoT and p2p settlement cover most commerce. These events
 activate only when both parties choose escrow — high-value items, first-time
 counterparties, anonymous markets, or physical delivery with a time gap.
 
-**Visibility note.** market-spec order messages are NIP-17 encrypted DMs.
-Escrow and dispute events defined here are **public** addressable events, by design:
-an escrow held by a third party and a dispute resolved by an arbitrator both require
-a party other than buyer and seller to read the record. Implementations that need
-private orders and public escrow accept this asymmetry explicitly.
+## Visibility model — the merchant's choice
+
+Checkout visibility is a deliberate choice, not a mandate. Two flows coexist:
+
+- **Private commerce (default).** Normal p2p orders stay NIP-17 encrypted between
+  buyer and seller (market-spec `kind:16`/`17`). No third party can read them, and
+  this NIP does not change that. Most commerce never needs anything else — running
+  a public business or revealing what you buy is never required.
+- **Escrow-backed commerce (opt-in).** When two parties choose escrow, the escrow
+  and dispute events defined here are **public** addressable events. This is
+  structural, not cosmetic: an escrow held by a third party and a dispute resolved
+  by an arbitrator both require a party *other than buyer and seller* to read the
+  record. A NIP-17 gift-wrapped order is only decryptable by sender and recipient,
+  so an arbitrator could not act on it.
+
+A merchant opts into public escrow only for the subset of transactions that warrant
+it. The two flows are **vocabulary-compatible, not wire-compatible**: an encrypted
+market-spec client will not read the public escrow events, and vice versa.
 
 ## Payment-agnostic proof tag
 
@@ -78,6 +91,16 @@ The spec defines only these four states. How funds arrive in `HELD` — Lightnin
 hold invoice, Cashu mint, onchain timelock, EVM contract — is left to the escrow
 provider and is out of scope for this spec.
 
+### State projection — richer internal machines are fine
+
+These four states are the **interoperable surface**, not a constraint on
+implementations. A provider may run a far richer internal state machine and project
+it onto these four for the public event. For example, the reference implementation
+(Colabonate) runs a 10-state, 3-phase hold-invoice machine internally and projects
+every "funds locked" phase onto `HELD`, its cancellation onto `REFUNDED`, and so on.
+Other clients read only the four public states and never need to know the internal
+phases. This keeps the protocol minimal while letting products differentiate.
+
 ## Dispute — `kind:MM`
 
 An addressable event opening or updating a dispute against an order. Public so a
@@ -114,6 +137,8 @@ A resolution event references the verdict and the resulting escrow transition
 An escrow provider is a Nostr actor with a persistent pubkey. Their reliability
 and track record are visible on-graph through the events they sign. Clients can
 filter for escrow providers by reputation the same way they filter for sellers.
+This makes escrow a competitive market of providers rather than a single point of
+failure: if one provider is unreliable, the market prices it in.
 
 ## Open design questions
 

--- a/115.md
+++ b/115.md
@@ -54,6 +54,7 @@ OPTIONAL — when the amount is not carried on this event, the tag MAY be the
 |------|-------|---------|
 | `lightning` | payment preimage | `["payment","lightning","<preimage>","21000","sat"]` |
 | `cashu` | Cashu token | `["payment","cashu","<token>","21000","sat"]` |
+| `fedimint` | Fedimint ecash token | `["payment","fedimint","<ecash-token>","21000","sat"]` |
 | `onchain` | txid | `["payment","onchain","<txid>","21000","sat"]` |
 | `liquid` | Liquid txid | `["payment","liquid","<txid>","21000","sat"]` |
 | `evm` | contract tx hash | `["payment","evm","<txhash>","21000","sat"]` |
@@ -154,6 +155,10 @@ failure: if one provider is unreliable, the market prices it in.
 
 4. **Payment tag shape** — does `["payment","<type>","<proof>","<amount>","<unit>"]`
    cover all mechanisms, or is there a better shape?
+
+5. **Escrow provider and arbiter discovery** — how does a buyer or seller find a
+   suitable escrow provider or arbitrator? An extension event kind, a NIP-78
+   app-specific record, or WoT ranking on the existing provider pubkeys?
 
 ## Relation to other specs
 

--- a/115.md
+++ b/115.md
@@ -1,37 +1,65 @@
-# NIP-XX: Marketplace Escrow & Dispute Extension
+# NIP-XX: On-graph Checkout Layer for NIP-99 Marketplaces
 
 `draft` `optional`
 
-This NIP extends the marketplace order flow defined by the GammaMarkets market-spec
-(NIP-99 e-commerce extension, `kind:16` order / `kind:17` payment receipt) with the two
-pieces that spec explicitly leaves out: **escrow** and **dispute resolution**.
+This NIP defines the missing checkout layer for NIP-99 marketplaces: public,
+addressable Nostr events that carry the post-"buy now" state (escrow and dispute)
+on-graph so any client, arbitrator, or reputation system can read it.
 
-It defines two event kinds that reference an existing order by its `order` identifier:
+It extends the marketplace order flow defined by the GammaMarkets market-spec
+(`kind:16` order / `kind:17` payment receipt) with two event kinds that reference
+an existing order by its `order` identifier:
 
-- an **Escrow State** event (Lightning hold-invoice lifecycle), and
-- a **Dispute** event (a neutral, third-party-resolvable claim against an order).
+- an **Escrow State** event tracking held funds through their lifecycle, and
+- a **Dispute** event for neutral, third-party-resolvable claims against an order.
 
-**Visibility note.** market-spec order messages are NIP-17 encrypted DMs. Escrow and
-dispute events defined here are **public** addressable events, by design: an escrow held
-by a third party and a dispute resolved by an arbitrator both require a party *other than
-buyer and seller* to read the record. Implementations that need private orders and public
-escrow accept this asymmetry explicitly.
+Escrow is **opt-in**. WoT and p2p settlement cover most commerce. These events
+activate only when both parties choose escrow — high-value items, first-time
+counterparties, anonymous markets, or physical delivery with a time gap.
+
+**Visibility note.** market-spec order messages are NIP-17 encrypted DMs.
+Escrow and dispute events defined here are **public** addressable events, by design:
+an escrow held by a third party and a dispute resolved by an arbitrator both require
+a party other than buyer and seller to read the record. Implementations that need
+private orders and public escrow accept this asymmetry explicitly.
+
+## Payment-agnostic proof tag
+
+Different implementations use different payment mechanisms. The spec does not
+hardcode any of them. The payment proof tag uses an extensible shape:
+
+```
+["payment", "<type>", "<proof>", "<amount>", "<unit>"]
+```
+
+`type` determines how `proof` is interpreted. A new mechanism = a new `type` value.
+No schema change needed.
+
+| type | proof | example |
+|------|-------|---------|
+| `lightning` | payment preimage | `["payment","lightning","<preimage>","21000","sat"]` |
+| `cashu` | Cashu token | `["payment","cashu","<token>","21000","sat"]` |
+| `onchain` | txid | `["payment","onchain","<txid>","21000","sat"]` |
+| `liquid` | Liquid txid | `["payment","liquid","<txid>","21000","sat"]` |
+| `evm` | contract tx hash | `["payment","evm","<txhash>","21000","sat"]` |
 
 ## Escrow State — `kind:NN`
 
-An addressable event published by the escrow holder (or, in self-custodial setups, the
-payer) tracking the state of funds held against an order.
+An addressable event published by the escrow provider (or, in self-custodial
+setups, either party) tracking the state of funds held against an order.
 
 ```jsonc
 {
   "kind": NN,
   "tags": [
-    ["d", "<order-id>"],                                  // addressable by order
-    ["order", "<order-id>"],                               // market-spec order ref
-    ["item", "30402:<seller-pubkey>:<listing-d>", "<qty>"], // NIP-99 listing, market-spec `item` convention
+    ["d", "<order-id>"],
+    ["order", "<order-id>"],
+    ["item", "30402:<seller-pubkey>:<listing-d>", "<qty>"],
     ["amount", "<sats>"],
     ["status", "<escrow-status>"],
-    ["payment", "lightning", "<bolt11>", "<payment-hash>"]
+    ["payment", "<type>", "<proof>", "<amount>", "<unit>"],
+    ["p", "<buyer-pubkey>"],
+    ["p", "<seller-pubkey>"]
   ],
   "content": "<optional note>"
 }
@@ -39,17 +67,21 @@ payer) tracking the state of funds held against an order.
 
 ### Escrow status values
 
-| Status      | Meaning |
-| ----------- | ------- |
-| HELD        | Funds locked (e.g. Lightning hold invoice accepted, not settled) |
-| RELEASED    | Funds released to the seller |
-| REFUNDED    | Funds returned to the buyer |
-| DISPUTED    | Release/refund paused pending dispute resolution |
+| Status | Meaning |
+|--------|---------|
+| `HELD` | Funds locked — escrow provider holds them |
+| `RELEASED` | Funds released to the seller |
+| `REFUNDED` | Funds returned to the buyer |
+| `DISPUTED` | Release/refund paused pending dispute resolution |
+
+The spec defines only these four states. How funds arrive in `HELD` — Lightning
+hold invoice, Cashu mint, onchain timelock, EVM contract — is left to the escrow
+provider and is out of scope for this spec.
 
 ## Dispute — `kind:MM`
 
-An addressable event opening or updating a dispute against an order. Public so a neutral
-party can review it.
+An addressable event opening or updating a dispute against an order. Public so a
+neutral party can review and resolve it.
 
 ```jsonc
 {
@@ -62,25 +94,42 @@ party can review it.
     ["status", "<dispute-status>"],
     ["reason", "<reason-slug>"]
   ],
-  "content": "<claim description; evidence hashes>"
+  "content": "<claim description and evidence hashes>"
 }
 ```
 
 ### Dispute status values
 
-`OPEN` → `IN_REVIEW` → `RESOLVED`. A resolution event references the verdict and the
-resulting escrow transition (`RELEASED` / `REFUNDED` / split).
+`OPEN` -> `IN_REVIEW` -> `RESOLVED`
 
-## Open design questions (seeking feedback)
+A resolution event references the verdict and the resulting escrow transition
+(`RELEASED` / `REFUNDED`).
 
-1. **Escrow as a new kind vs. an extra `type` on market-spec `kind:16`** — the Gamma
-   collective may prefer escrow to live as a new `type` value on the existing order kind.
-2. **Who signs the escrow event** — the hold-invoice provider, or either party?
-3. **Dispute neutrality** — does a generic "marketplace dispute" belong in this NIP, or
-   should it be a separate, resolver-agnostic NIP that escrow merely points to?
+### Reason slugs (suggested)
+
+`non_delivery` | `quality` | `non_payment` | `terms_violation` | `other`
+
+## Escrow provider identity
+
+An escrow provider is a Nostr actor with a persistent pubkey. Their reliability
+and track record are visible on-graph through the events they sign. Clients can
+filter for escrow providers by reputation the same way they filter for sellers.
+
+## Open design questions
+
+1. **New kind vs. extra `type` on market-spec `kind:16`** — the Gamma collective
+   may prefer escrow to extend the existing order kind rather than define a new one.
+
+2. **Who signs the escrow event** — the escrow provider, or either party?
+
+3. **Dispute neutrality** — does a generic marketplace dispute belong in this NIP,
+   in a separate resolver-agnostic NIP, or is it client-defined?
+
+4. **Payment tag shape** — does `["payment","<type>","<proof>","<amount>","<unit>"]`
+   cover all mechanisms, or is there a better shape?
 
 ## Relation to other specs
 
 - **GammaMarkets market-spec** — the order/payment flow this extends (`kind:16`/`17`).
-- [NIP-99] — the underlying classified listing (`30402`), referenced via market-spec's `item` tag.
+- [NIP-99] — the underlying classified listing (`30402`), referenced via `item` tag.
 - [NIP-57] — a zap receipt MAY serve as a `RELEASED` payment proof.

--- a/115.md
+++ b/115.md
@@ -46,7 +46,9 @@ hardcode any of them. The payment proof tag uses an extensible shape:
 ```
 
 `type` determines how `proof` is interpreted. A new mechanism = a new `type` value.
-No schema change needed.
+No schema change needed. `type` and `proof` are required; `amount` and `unit` are
+OPTIONAL — when the amount is not carried on this event, the tag MAY be the
+3-element form `["payment", "<type>", "<proof>"]`.
 
 | type | proof | example |
 |------|-------|---------|

--- a/115.md
+++ b/115.md
@@ -1,0 +1,394 @@
+# NIP-XX: Freedom of Interaction Protocol (Identity & Commerce)
+
+> **Status:** DRAFT  
+> **Kind(s):** 30402 (Offer/Reuse NIP-99), 30404 (Company), 30405 (Credential), 30406 (Review), 30407 (Ticket Created), 30408 (Ticket Status)  
+> **Authors:** Deniz Yilmaz <<dezooyi@gmail.com>>  
+> **License:** CC0  
+> **Discussions-To:** [github.com/nostr-protocol/nips/pull/2323](https://github.com/nostr-protocol/nips/pull/2323)  
+> **Protocol Specification:** [github.com/Colabonate/Colabonate_Protocol](https://github.com/Colabonate/Colabonate_Protocol)
+
+---
+
+## Abstract
+
+This NIP defines the foundational layer for a "Freedom of Interaction" protocol over Nostr, designed to dismantle digital monopolies and enable sovereign, trust-minimized collaboration. Ranging from simple local commerce to complex, multi-party cooperations, it combines verifiable Human Identities (HID, L0-L3), trust-weighted reputation scoring, and Bitcoin/Lightning-native escrow mechanisms. By extending NIP-99 (Classified Listings) with structured transaction semantics, addressable company profiles, and soulbound credentials, it establishes the base infrastructure for self-organized economic ecosystems.
+
+**Key differentiators from NIP-99:**
+- Service/offline-delivery offers (not just physical goods)
+- Multi-level identity verification (L0-L3) via NIP-98 auth
+- Escrow-aware offers with milestone-based release
+- Identity-level-weighted reputation scoring
+- Company profiles with UNSPSC classification
+
+---
+
+## Supported Kinds
+
+| Kind | Name | Layer | Status |
+|------|------|-------|--------|
+| 30402 | Service Offer (extends NIP-99) | Marketplace | Extends NIP-99 |
+| 30404 | Company Profile | Marketplace | **NEW – needs assignment** |
+| 30405 | Verification Credential | Identity | **NEW – needs assignment** |
+| 30406 | Reputation Review | Reputation | **NEW – needs assignment** |
+
+*Ticket events (30407, 30408) and additional identity events defined in Colabonate protocol but out of scope for initial NIP submission.*
+
+---
+
+## Motivation
+
+### Why extend NIP-99 instead of using NIP-15?
+
+NIP-99 (Classified Listings) is simpler and more flexible than NIP-15 (Stall/Product model). Colabonate:
+1. Primarily sells **services** (not physical goods)
+2. Requires **Lightning escrow** with milestone releases
+3. Has **identity levels** that affect trust
+4. Needs **reputation weighting** by identity level
+
+Rather than fork from scratch, extending NIP-99 allows:
+- Existing NIP-99 clients can still display Colabonate offers (basic view)
+- Colabonate adds structured fields for escrow, identity, and milestones
+
+### What this NIP adds over NIP-99:
+
+| Feature | NIP-99 | This NIP |
+|---------|--------|----------|
+| Service offers | ✅ (via price/frequency) | ✅ + delivery semantics |
+| Lightning escrow | ❌ | ✅ (phase-based release) |
+| Identity levels | ❌ | ✅ (L0-L3 via tags) |
+| Milestone support | ❌ | ✅ (partial delivery) |
+| Reputation weighting | ❌ | ✅ (by identity level) |
+| Company profiles | ❌ | ✅ (Kind 30404) |
+
+---
+
+## Specification (Kind 30402 – Service Offer, extends NIP-99)
+
+> **Extends:** NIP-99 (`kind:30402` Classified Listing)  
+> **Purpose:** A seller publishes a service offer with Lightning escrow support.
+
+### Base (per NIP-99)
+
+All NIP-99 fields and tags apply. Clients SHOULD display Colabonate offers using NIP-99 rendering.
+
+### Colabonate Extension Tags
+
+```json
+{
+  "kind": 30402,
+  "pubkey": "<seller-pubkey-hex>",
+  "created_at": 1234567890,
+  "tags": [
+    ["d", "<offer-id>"],
+    ["title", "<offer-title>"],
+    ["price", "5000", "sats"],
+    ["t", "service"],
+    ["published_at", "1234567890"],
+    // NIP-99 standard tags...
+    // Colabonate extension tags:
+    ["offer_type", "service"],
+    ["delivery_time_days", "7"],
+    ["delivery_cost_sats", "0"],
+    ["escrow", "milestone"],
+    ["identity_min", "1"],
+    ["category", "services/consulting"]
+  ],
+  "content": "<offer-description>",
+  "sig": "<schnorr-signature>"
+}
+```
+
+### Extension Tags
+
+| Tag | Format | Description |
+|-----|--------|-------------|
+| `offer_type` | `service` \| `product` \| `item` | Required for Colabonate extension |
+| `delivery_time_days` | Integer | Estimated delivery in days |
+| `delivery_cost_sats` | Integer | Delivery cost (0 = digital/remote) |
+| `escrow` | `milestone` \| `direct` \| `none` | Escrow type |
+| `identity_min` | `0` \| `1` \| `2` \| `3` | Minimum identity level to purchase |
+| `milestones` | JSON array | Milestone titles + percentages |
+| `location` | ISO 3166-1 alpha-2 | Seller country code |
+
+### Content Format
+
+Same as NIP-99. Markdown supported. Max 4096 characters.
+
+### Escrow Semantics
+
+When `escrow: "milestone"`:
+- Buyer pays into Lightning escrow (hold invoice)
+- Release phased: 25% → 50% → 25% (configurable per offer)
+- Seller delivers, each milestone triggers partial release
+- Disputes routed to Kind 30409 (new, out of scope)
+
+When `escrow: "direct"`:
+- Single payment, released directly to seller on completion
+
+### Validation Rules (Colabonate extension)
+
+| Rule | Scope |
+|------|-------|
+| If `escrow: "milestone"` and price > 10000 sats, `milestones` tag required | Client |
+| If `identity_min` > 0, offer MUST include Kind 30405 credential reference | Client |
+| `delivery_time_days` must be positive integer if present | Client |
+
+---
+
+## Specification (Kind 30404 – Company Profile)
+
+> **Kind:** 30404 (proposed new assignment)  
+> **Layer:** Marketplace  
+> **Purpose:** A seller operating as a company publishes their profile for trust and discovery.
+
+### Event Shape
+
+```json
+{
+  "kind": 30404,
+  "pubkey": "<company-owner-pubkey>",
+  "created_at": 1234567890,
+  "tags": [
+    ["d", "<company-id>"],
+    ["name", "<company-name>"],
+    ["fields", "<unspsc-code>"],
+    ["radius", "50", "km"],
+    ["logo", "<url>"],
+    ["banner", "<url>"],
+    ["images", "<url-1>", "<url-2>"],
+    ["nostr", "<owner-pubkey>"]
+  ],
+  "content": "<company-description>",
+  "sig": "<schnorr-signature>"
+}
+```
+
+### Required Tags
+
+| Tag | Format | Description |
+|-----|--------|-------------|
+| `d` | UUID | Unique company ID |
+| `name` | String | Company display name |
+
+### Optional Tags
+
+| Tag | Format | Description |
+|-----|--------|-------------|
+| `fields` | UNSPSC code(s) | Business category codes |
+| `radius` | Integer + "km" | Cooperation/delivery radius |
+| `logo` | URL | Logo image URL |
+| `banner` | URL | Banner image URL |
+| `images` | URLs | Image gallery URLs (multiple in one tag) |
+| `nostr` | Hex pubkey | Owner's Nostr pubkey (for verification) |
+| `lnurl` | LNURL string | Lightning address for payments |
+| `web` | URL | Company website |
+
+### Content
+
+Company description. Markdown supported. Max 4096 characters.
+
+### Validation Rules
+
+| Rule | Scope |
+|------|-------|
+| `name` must be 1-80 characters | Client + Relay |
+| `d` tag must be unique per `pubkey` | Client |
+| If `nostr` tag present, must be valid pubkey | Client |
+
+---
+
+## Specification (Kind 30405 – Verification Credential)
+
+> **Kind:** 30405 (proposed new assignment)  
+> **Layer:** Identity  
+> **Purpose:** Publishes a non-transferable (soulbound) credential tied to a Nostr pubkey. Issued via NIP-98 auth.
+
+### Event Shape
+
+```json
+{
+  "kind": 30405,
+  "pubkey": "<subject-pubkey>",
+  "created_at": 1234567890,
+  "tags": [
+    ["d", "<credential-id>"],
+    ["credential_type", "identity_level_1"],
+    ["hid_level", "1"],
+    ["issued_by", "<issuer-pubkey>"]
+  ],
+  "content": "{\"credential_type\":\"identity_level_1\",\"subject\":\"<pubkey>\",\"issued_at\":1234567890,\"expires_at\":null}",
+  "sig": "<schnorr-signature>"
+}
+```
+
+### Required Tags
+
+| Tag | Format | Description |
+|-----|--------|-------------|
+| `d` | UUID | Unique credential ID |
+| `credential_type` | String | See credential type table |
+| `hid_level` | `0` \| `1` \| `2` \| `3` | Identity level granted |
+| `issued_by` | Hex pubkey | Pubkey of the issuing entity |
+
+### Credential Types
+
+| `credential_type` | Description | Issuer | NIP-98 Required |
+|------------------|-------------|--------|-----------------|
+| `identity_level_1` | Nostr profile + LNURL verified | Self | Yes |
+| `identity_level_2` | Peer-verified (2 verifiers) | Verifiers | Yes |
+| `identity_level_3` | Humanode biometric verified | Protocol | Yes |
+| `mediator` | Authorized dispute mediator | Foundation DAO | No |
+| `arbitrator` | DAO court member | DAO vote | No |
+
+### NIP-98 Authorization
+
+For `identity_level_1` credentials, the event MUST be authorized via NIP-98 HTTP Auth:
+- Client signs HTTP request to `POST /api/identity/upgrade-l1`
+- Server validates `Authorization: Nostr <base64-encoded-event>` header
+- Event pubkey must match claimed `nostrPubkey`
+
+### Soulbound Guarantee
+
+The credential is bound to the `pubkey` field. Since Nostr events are signed with the corresponding private key, the credential cannot be transferred without re-issuance.
+
+---
+
+## Specification (Kind 30406 – Reputation Review)
+
+> **Kind:** 30406 (proposed new assignment)  
+> **Layer:** Reputation  
+> **Purpose:** After a completed transaction, either party publishes a review. Permanent, identity-level-weighted.
+
+### Event Shape
+
+```json
+{
+  "kind": 30406,
+  "pubkey": "<reviewer-pubkey>",
+  "created_at": 1234567890,
+  "tags": [
+    ["d", "<review-id>"],
+    ["review_for", "<reviewed-pubkey>"],
+    ["ticket", "<ticket-id>"],
+    ["stars", "5"],
+    ["hid_level_reviewer", "2"],
+    ["col_points_reviewer", "150"]
+  ],
+  "content": "<review-text>",
+  "sig": "<schnorr-signature>"
+}
+```
+
+### Required Tags
+
+| Tag | Format | Description |
+|-----|--------|-------------|
+| `d` | UUID | Unique review ID |
+| `review_for` | Hex pubkey | Pubkey of the person being reviewed |
+| `ticket` | UUID | Reference to the completed ticket |
+| `stars` | Integer 1–5 | Star rating |
+
+### Optional Tags
+
+| Tag | Format | Description |
+|-----|--------|-------------|
+| `hid_level_reviewer` | `0` \| `1` \| `2` \| `3` | Reviewer's identity level |
+| `col_points_reviewer` | Integer | Reviewer's COL-Points balance at time of review |
+
+### Validation Rules
+
+| Rule | Scope |
+|------|-------|
+| The referenced ticket must have status `COMPLETED` | Client |
+| Review must be published within 14 days of completion | Client |
+| Reviews are permanent — cannot be deleted | Client |
+| Reviews without prior completed ticket receive 0.0 weight | Client |
+
+### Identity-Level Weighting
+
+| Reviewer Level | Weight Multiplier |
+|---------------|-------------------|
+| L0 | 1.0 |
+| L1 | 1.0 |
+| L2 | 1.2 |
+| L3 | 1.5 |
+
+---
+
+## Relay Behavior
+
+All kinds in this NIP:
+- **SHOULD** be stored by any relay that receives them
+- **MAY** be filtered by `pubkey`, `kind`, and `d` tag
+- **SHOULD NOT** require authentication or payment to store
+- **SHOULD** support NIP-33 parameterized replaceable event queries
+
+---
+
+## Compatibility
+
+### Depends On
+
+| NIP | Purpose |
+|-----|---------|
+| NIP-01 | Base event format, Schnorr signatures |
+| NIP-33 | Parameterized replaceable events |
+| NIP-99 | Base Classified Listing (for Kind 30402) |
+| NIP-98 | HTTP auth for credential issuance (Kind 30405) |
+
+### Does Not Conflict With
+
+- NIP-57 (Lightning zaps) – compatible
+- NIP-09 (Event deletion) – Kind 5 works
+- NIP-15 (Stall/Product) – separate kinds, no overlap
+- NIP-17 (Private DMs) – separate event range
+- NIP-69 (Peer-to-peer Order events, kind 38383) – separate layer, complementary
+
+---
+
+## Reference Implementations & Protocols
+
+The reference software implementation is currently being prepared for open-source release. In the meantime, the full protocol specifications and workflow documentation are public:
+
+- [Colabonate Protocol Repository](https://github.com/Colabonate/Colabonate_Protocol)
+- [NIP-99 Reference](https://github.com/nostr-protocol/nips/blob/master/99.md)
+
+---
+
+## Security Considerations
+
+1. **Signature validation:** All events validated per NIP-01
+2. **NIP-98 credential auth:** Server must verify event signature matches claim
+3. **Replacement events:** NIP-33 rules apply
+4. **Review manipulation:** Weight requires prior ticket history
+
+---
+
+## Limitations
+
+1. **No guaranteed relay storage:** Relays may drop events
+2. **Escrow off-protocol:** Lightning escrow handled via external service (LNBits)
+3. **Dispute resolution out of scope:** Future NIP for Kind 30409
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-04-10 | Initial draft for community review |
+
+---
+
+## Authors
+
+**Deniz Yilmaz** – Founder, Colabonate  
+Contact: [dezooyi@gmail.com](mailto:dezooyi@gmail.com)  
+Nostr: `npub1jcqnaxvmrqteazz9y323gj6r3v0q0rslhng69e7jdslcjadsxa4scpp2sv`  
+Project: [colabonate.com](https://colabonate.com)
+
+---
+
+## Discussion
+
+Open an issue at [github.com/nostr-protocol/nips](https://github.com/nostr-protocol/nips) or reply to this PR.


### PR DESCRIPTION
> **This is a request for design feedback, not a merge request.**
> I would rather get the model right than get it merged fast.

## What this is

Two things are missing from the NIP-99 / market-spec stack:

**1. A checkout flow that lives on-graph.**
When the post-"buy now" state (order created, payment made, delivery confirmed) lives outside Nostr, different clients cannot read it. That creates checkout silos — the same problem NIP-99 solved for listings. The checkout layer needs to be public, addressable Nostr events so any client can read the history, build WoT signals on it, and compute reputation from it.

**2. Escrow and dispute resolution** for the subset of transactions where WoT alone is not enough: high-value items, first-time counterparties, anonymous markets, physical delivery with a time gap.

This PR proposes both. A minimal on-graph checkout state event and an optional escrow + dispute extension on top. WoT + p2p settlement handles most commerce and is completely unaffected. Escrow only activates when both parties opt in.

I originally framed this as just an "escrow extension." Conversations with the Gamma collective made it clear that the broader checkout layer is the actual missing piece. Escrow is the optional layer within it.

## The events

**Escrow State** tracks held funds: `HELD` / `RELEASED` / `REFUNDED` / `DISPUTED`.
**Dispute** is a public, neutral claim against an order: `OPEN` / `IN_REVIEW` / `RESOLVED`.

Both reference an existing order via its `order` id. The spec defines only these four states. How funds get into HELD — Lightning hold invoice, Cashu mint, onchain, EVM contract — is left to the escrow provider and out of scope for the spec.

(Full schemas in the file diff — or rendered: https://github.com/Colabonate/nips/blob/colabonate-freedom-protocol/115.md)

## Payment-agnostic design

A key constraint raised in community discussion: different implementations use different payment mechanisms (Lightning hold invoices, Cashu, onchain, Liquid, EVM contracts). The spec should not hardcode any of them.

Proposed payment proof tag:
```
["payment", "<type>", "<proof>", "<amount>", "<unit>"]
```
Where `type` determines how `proof` is interpreted. A new payment mechanism = a new `type` value. No schema change needed.

Examples:
- `["payment", "lightning", "<preimage>", "21000", "sat"]`
- `["payment", "cashu", "<token>", "21000", "sat"]`
- `["payment", "onchain", "<txid>", "21000", "sat"]`

## One honest architectural note up front

market-spec orders are NIP-17 encrypted DMs. The checkout, escrow, and dispute events defined here are **public** addressable events, deliberately. A third-party arbitrator, an escrow provider, and any reputation system all require a record that is not private to buyer and seller only. This is vocabulary-compatible with market-spec, not wire-compatible. I want feedback on whether that asymmetry is acceptable or a dealbreaker.

## Design questions I would genuinely like input on

1. **Checkout state as a new kind vs. an extra `type` on market-spec `kind:16`?** The Gamma collective may prefer this to extend the existing order kind rather than define a new one.

2. **Public checkout vs. encrypted orders** — is the visibility asymmetry workable, or should checkout records be reachable some other way?

3. **Who signs the escrow event** — the escrow provider, or either party?

4. **Payment-agnostic tag shape** — does `["payment", "<type>", "<proof>", "<amount>", "<unit>"]` cover all mechanisms, or is there a better shape?

5. **Escrow provider as a Nostr actor** — should the spec define how escrow providers publish their identity and reputation on-graph, or is that out of scope?

6. **Dispute neutrality** — does a generic marketplace dispute belong in this NIP, in a separate resolver-agnostic NIP, or is it client-defined?

## Reference implementation

Running in production (currently Lightning-specific, being generalised):
https://github.com/Colabonate/Colabonate-App

- Escrow state machine: `apps/server/routes/escrow.ts`
- Nostr events: `apps/server/services/nostr-relay.ts`

The production implementation uses 3-phase Lightning hold invoices (25/50/25 split). That is a product decision, not a spec requirement. The spec should only care about HELD/RELEASED/REFUNDED/DISPUTED.

## Author

Deniz Yilmaz · npub12sr83yw7psyjt9j96sdh8qq4w3qjls0phhazhs3vgcs6wwtf2lysgwgdku