### PR TITLE
NIP-34: optional multi-maintainer support

### DIFF
--- a/34.md
+++ b/34.md
@@ -37,6 +37,16 @@ The `r` tag annotated with the `"euc"` marker should be the commit ID of the ear
 
 Except `d`, all tags are optional.
 
+### Multiple Maintainers
+
+Clients SHOULD recursively fetch repository announcements with the same `d` tag from pubkeys listed in the `maintainers` tag, starting from a 'selected maintainer'. A pubkey that doesn't mutually list back at every link in the chain SHOULD be treated as 'requested' to prevent reputation-harvesting attacks.
+
+When merging announcements and state across maintainers, standard addressable event rules apply (greatest created_at, lowest event id as tie-break); except for `relays` and `clone` tags which SHOULD be unioned across all maintainers, as each maintainer provides their own infrastructure.
+
+When tagging a repository, clients SHOULD include all known co-maintainers repository annoucements so that during ownership transitions, in-flight PRs/Issues likely already tag the new owner.
+
+If one maintainer is the lead, co-maintainers MAY only list them so the lead can remove co-maintainers unilaterally.
+
 ### Nostr Clone URL format
 
 A `nostr://` URL can be used to reference a repository announcement in a way that is compatible with `git clone` when a [git-remote-nostr](https://git-scm.com/docs/gitremote-helpers) helper is installed:

--- a/34.md
+++ b/34.md
@@ -39,7 +39,7 @@ Except `d`, all tags are optional.
 
 ### Multiple Maintainers
 
-Clients SHOULD recursively fetch repository announcements with the same `d` tag from pubkeys listed in the `maintainers` tag, starting from a 'selected maintainer'. A pubkey that doesn't mutually list back at every link in the chain SHOULD be treated as 'requested' to prevent reputation-harvesting attacks.
+Clients SHOULD recursively fetch repository announcements with the same `d` tag from pubkeys listed in the `maintainers` tag, starting from a 'selected maintainer'. A pubkey that doesn't mutually list back at every link in the chain SHOULD be treated as 'invited' to prevent reputation-harvesting attacks.
 
 When merging announcements and state across maintainers, standard addressable event rules apply (greatest created_at, lowest event id as tie-break); except for `relays` and `clone` tags which SHOULD be unioned across all maintainers, as each maintainer provides their own infrastructure.
 

--- a/34.md
+++ b/34.md
@@ -50,7 +50,7 @@ The `maintainers` tag is deprecated. If an announcement contains `M`, `m`, or `o
 
 Publishing clients MAY continue to include `maintainers` alongside role tags to enable graceful degradation for older clients. When present, it MUST contain only current, accepted `M` and `m` members.
 
-When `M` is used, `m` and `o` authors SHOULD list only themselves and the lead; other combinations SHOULD be avoided unless the author is `M`. This allows the lead to change or remove co-maintainers and moderators unilaterally.
+When `M` is used, a non-lead member SHOULD keep active only their own role and an `M` naming the lead. They SHOULD retain known third-party role history, using `defer` as the final end value so they make no current assignment through the record. Other active third-party assignments SHOULD be avoided. This allows the lead to coordinate the roster without discarding replicated history.
 
 An `o` role can only be assigned by an `M` or `m` member; the moderator's matching self-tag acknowledges rather than assigns it.
 
@@ -60,6 +60,8 @@ A role is currently held while any member's announcement assigns it as active.
 
 Role tags MAY record their history; a valid tag is currently active when it contains fewer than four elements or an odd number of elements:
 
+The literal `defer` MAY appear only as the final end value. Clients MUST treat a tag ending in `defer` as making no current assignment and MUST NOT parse `defer` as a timestamp.
+
 Conflicting records of a pubkey's past roles MUST be resolved using the selected maintainer's record of that pubkey, if any; otherwise the record from the member at the shortest recursion distance, with ties settled by lowest author pubkey value.
 
 ```yaml
@@ -68,6 +70,7 @@ Conflicting records of a pubkey's past roles MUST be resolved using the selected
 ["m", "<former-co-maintainer>", "<start-unix-timestamp>", "<end-unix-timestamp>"] // added, then removed
 ["m", "<returning-co-maintainer>", "<start-unix-timestamp>", "<end-unix-timestamp>", "<second-start-unix-timestamp>"] // added, removed, then added again
 ["o", "<former-moderator>", "<start-unix-timestamp>", "<end-unix-timestamp>", "<second-start-unix-timestamp>", "<second-end-unix-timestamp>"] // added, removed, added again, then removed again
+["m", "<co-maintainer>", "<start-unix-timestamp>", "defer"] // retained history, not a current assignment
 ```
 
 When merging announcements and state across members, standard addressable event rules apply (greatest `created_at`, lowest event id as tie-break), except `relays` and `clone` tags SHOULD be unioned across current members, as each provides their own infrastructure.

--- a/34.md
+++ b/34.md
@@ -24,28 +24,55 @@ Git repositories are hosted in Git-enabled servers, but their existence can be a
     ["clone", "<url for git-cloning>", ...], // a url to be given to `git clone` so anyone can clone it
     ["relays", "<relay-url>", ...], // relays that this repository will monitor for patches and issues
     ["r", "<earliest-unique-commit-id>", "euc"],
-    ["maintainers", "<other-recognized-maintainer>", ...],
     ["u","30617:<pubkey>:<identifer>|<git-url-https-prefered>","<relay-hint>","<author-pubkey>"], // optionally indicate repository is a subordinate fork
     ["t", "<arbitrary string>"], // hashtags labelling the repository
+    ["M", "<lead-maintainer>"], // lead from the beginning, still active
+    ["m", "<co-maintainer>"], // co-maintainer from the beginning, still active
+    ["o", "<moderator>"], // moderator from the beginning, still active
+    ["maintainers", "<other-recognized-maintainer>", ...], // deprecated fallback for clients without role support
   ]
 }
 ```
 
-The tags `web`, `clone`, `relays`, `maintainers` can have multiple values.
+The tags `web`, `clone`, `relays`, and the deprecated `maintainers` can have multiple values.
 
 The `r` tag annotated with the `"euc"` marker should be the commit ID of the earliest unique commit of this repo, made to identify it among forks and group it with other repositories hosted elsewhere that may represent essentially the same project. In most cases it will be the root commit of a repository. In case of a permanent fork between two projects, then the first commit after the fork should be used.
 
 Except `d`, all tags are optional.
 
-### Multiple Maintainers
+### Maintainers
 
-Clients SHOULD recursively fetch repository announcements with the same `d` tag from pubkeys listed in the `maintainers` tag, starting from a 'selected maintainer'. A pubkey that doesn't mutually list back at every link in the chain is invited. Invited pubkeys' events MUST NOT be treated as authoritative until they publish a repository announcement that makes the relationship reciprocal.
+A repository's members form a recursive, reciprocal set of announcements sharing the same `d` tag. Starting from a selected maintainer, clients SHOULD recursively fetch announcements from each pubkey assigned a role. A pubkey is invited until their own announcement acknowledges that role and assigns a role to an existing member. A member MAY leave by ending their self-role; this takes precedence over assignments in other announcements. Only members' events are authoritative.
 
-When merging announcements and state across maintainers, standard addressable event rules apply (greatest created_at, lowest event id as tie-break); except for `relays` and `clone` tags which SHOULD be unioned across all maintainers, as each maintainer provides their own infrastructure.
+During their listed periods, maintainers can publish authoritative state announcements and all members can perform other maintainer actions. An author without a self-role is implicitly a maintainer for the repository's entire history. A pubkey MAY appear in one `M`, one `m`, and one `o` tag to record transitions between roles.
 
-When tagging a repository, clients SHOULD include all known co-maintainers repository annoucements so that during ownership transitions, in-flight PRs/Issues likely already tag the new owner.
+The `maintainers` tag is deprecated. If an announcement contains `M`, `m`, or `o`, clients MUST ignore `maintainers`; otherwise it assigns the co-maintainer role. Without `M`, `m`, `o`, or `maintainers`, the author is the sole maintainer for the repository's entire history.
 
-If one maintainer is the lead, co-maintainers MAY only list them so the lead can remove co-maintainers unilaterally.
+Publishing clients MAY continue to include `maintainers` alongside role tags to enable graceful degradation for older clients. When present, it MUST contain only current, accepted `M` and `m` members.
+
+When `M` is used, `m` and `o` authors SHOULD list only themselves and the lead; other combinations SHOULD be avoided unless the author is `M`. This allows the lead to change or remove co-maintainers and moderators unilaterally.
+
+An `o` role can only be assigned by an `M` or `m` member; the moderator's matching self-tag acknowledges rather than assigns it.
+
+A role is currently held while any member's announcement assigns it as active.
+
+#### Role History
+
+Role tags MAY record their history; a valid tag is currently active when it contains fewer than four elements or an odd number of elements:
+
+Conflicting records of a pubkey's past roles MUST be resolved using the selected maintainer's record of that pubkey, if any; otherwise the record from the member at the shortest recursion distance, with ties settled by lowest author pubkey value.
+
+```yaml
+["m", "<current-co-maintainer>"] // active from the beginning, still active
+["m", "<founding-co-maintainer>", "0", "<end-unix-timestamp>"] // active from the beginning, then removed
+["m", "<former-co-maintainer>", "<start-unix-timestamp>", "<end-unix-timestamp>"] // added, then removed
+["m", "<returning-co-maintainer>", "<start-unix-timestamp>", "<end-unix-timestamp>", "<second-start-unix-timestamp>"] // added, removed, then added again
+["o", "<former-moderator>", "<start-unix-timestamp>", "<end-unix-timestamp>", "<second-start-unix-timestamp>", "<second-end-unix-timestamp>"] // added, removed, added again, then removed again
+```
+
+When merging announcements and state across members, standard addressable event rules apply (greatest `created_at`, lowest event id as tie-break), except `relays` and `clone` tags SHOULD be unioned across current members, as each provides their own infrastructure.
+
+When tagging a repository, clients SHOULD include all current members' repository announcements so that, during transitions, in-flight PRs and issues likely already tag the new owner.
 
 ### Nostr Clone URL format
 
@@ -242,7 +269,7 @@ Root Patches, PRs and Issues have a Status that defaults to 'Open' and can be se
 }
 ```
 
-The most recent Status event (by `created_at` date) from either the issue/patch author or a maintainer is considered valid.
+The most recent Status event (by `created_at` date) from either the issue/patch author or an authorized repository member is considered valid.
 
 The Status of a patch-revision is to either that of the root-patch, or `1632` (_Closed_) if the root-patch's Status is `1631` (_Applied/Merged_) and the patch-revision isn't tagged in the `1631` (_Applied/Merged_) event.
 

--- a/34.md
+++ b/34.md
@@ -39,7 +39,7 @@ Except `d`, all tags are optional.
 
 ### Multiple Maintainers
 
-Clients SHOULD recursively fetch repository announcements with the same `d` tag from pubkeys listed in the `maintainers` tag, starting from a 'selected maintainer'. A pubkey that doesn't mutually list back at every link in the chain SHOULD be treated as 'invited' to prevent reputation-harvesting attacks.
+Clients SHOULD recursively fetch repository announcements with the same `d` tag from pubkeys listed in the `maintainers` tag, starting from a 'selected maintainer'. A pubkey that doesn't mutually list back at every link in the chain is invited. Invited pubkeys' events MUST NOT be treated as authoritative until they publish a repository announcement that makes the relationship reciprocal.
 
 When merging announcements and state across maintainers, standard addressable event rules apply (greatest created_at, lowest event id as tie-break); except for `relays` and `clone` tags which SHOULD be unioned across all maintainers, as each maintainer provides their own infrastructure.
 

--- a/34.md
+++ b/34.md
@@ -42,13 +42,13 @@ Except `d`, all tags are optional.
 
 ### Maintainers
 
-A repository's members form a recursive, reciprocal set of announcements sharing the same `d` tag. Starting from a selected maintainer, clients SHOULD recursively fetch announcements from each pubkey assigned a role. A pubkey is invited until their own announcement acknowledges that role and assigns a role to an existing member. A member MAY leave by ending their self-role; this takes precedence over assignments in other announcements. Only members' events are authoritative.
+A repository's members form a recursive, reciprocal set of announcements sharing the same `d` tag. Starting from a selected maintainer, clients SHOULD recursively fetch announcements from each pubkey assigned a role. A pubkey in an active `M`/`m` entry, or a legacy `maintainers` tag, is invited until its announcement acknowledges the role and assigns a role to an existing member. A member MAY leave by ending their self-role; this takes precedence over assignments in other announcements. Only members' events are authoritative.
 
 During their listed periods, maintainers can publish authoritative state announcements and all members can perform other maintainer actions. An author without a self-role is implicitly a maintainer for the repository's entire history. A pubkey MAY appear in one `M`, one `m`, and one `o` tag to record transitions between roles.
 
 The `maintainers` tag is deprecated. If an announcement contains `M`, `m`, or `o`, clients MUST ignore `maintainers`; otherwise it assigns the co-maintainer role. Without `M`, `m`, `o`, or `maintainers`, the author is the sole maintainer for the repository's entire history.
 
-Publishing clients MAY continue to include `maintainers` alongside role tags to enable graceful degradation for older clients. When present, it MUST contain only current, accepted `M` and `m` members.
+Publishing clients MAY continue to include `maintainers` alongside role tags to enable graceful degradation for older clients. When present, it MUST contain exactly the pubkeys in active `M` and `m` entries, including both invited and confirmed maintainers.
 
 When `M` is used, a non-lead member SHOULD keep active only their own role and an `M` naming the lead. They SHOULD retain known third-party role history, using `defer` as the final end value so they make no current assignment through the record. Other active third-party assignments SHOULD be avoided. This allows the lead to coordinate the roster without discarding replicated history.
 


### PR DESCRIPTION
Implemented in ngit-cli, gitworkshop.dev, ngit-relay, ngit-grasp, etc. and referenced as 'recursive maintainer set' in the grasp protocol.

budabit also supports multi-maintainers. does this align with your implementation @chebizarro and @Pleb5?

I also think n34-relay support multi-maintainers @TheAwiteb? does this match your implementation?