### PR TITLE
NIP-34: remove unused refs tag extension

### DIFF
--- a/34.md
+++ b/34.md
@@ -78,16 +78,6 @@ The `refs` tag may appear multiple times, or none.
 
 If no `refs` tags are present, the author is no longer tracking repository state using this event. This approach enables the author to restart tracking state at a later time unlike [NIP-09](09.md) deletion requests.
 
-The `refs` tag can be optionally extended to enable clients to identify how many commits ahead a ref is:
-
-```jsonc
-{
-  "tags": [
-    ["refs/<heads|tags>/<branch-or-tag-name>", "<commit-id>", "<shorthand-parent-commit-id>", "<shorthand-grandparent>", ...],
-  ]
-}
-```
-
 ## Patches and Pull Requests (PRs)
 
 Patches and PRs can be sent by anyone to any repository. Patches and PRs to a specific repository SHOULD be sent to the relays specified in that repository's announcement event's `"relays"` tag. Patch and PR events SHOULD include an `a` tag pointing to that repository's announcement address.


### PR DESCRIPTION
No clients are known to be using this.