### PR TITLE
NIP-34: remove incorrect claim about NIP-09 and state reset

### DIFF
--- a/34.md
+++ b/34.md
@@ -76,8 +76,6 @@ An optional source of truth for the state of branches and tags in a repository.
 
 The `refs` tag may appear multiple times, or none.
 
-If no `refs` tags are present, the author is no longer tracking repository state using this event. This approach enables the author to restart tracking state at a later time unlike [NIP-09](09.md) deletion requests.
-
 The `refs` tag can be optionally extended to enable clients to identify how many commits ahead a ref is:
 
 ```jsonc


### PR DESCRIPTION
The removed sentence claimed that using an empty refs list (rather than a NIP-09 deletion) was necessary to allow the author to restart tracking state later. This was incorrect even when written (May 2024): NIP-09 already supported 'a' tags on replaceable events, deleting only versions up to the deletion event's created_at timestamp, which means a new state event published afterward would be valid and unaffected.

@Pleb5. Can you confirm you havn't implemented this?