### PR TITLE
NIP-G6: OpenWyrd Capability-URL Inline Rendering

### DIFF
--- a/G6.md
+++ b/G6.md
@@ -50,9 +50,28 @@ The structural privacy property of OpenWyrd MOP — that the host cannot decrypt
 
 ## 3. Specification
 
-### 3.1 URL pattern detection
+This section is self-contained: a client implementer can build to it without consulting MOP-001. MOP-001 remains the canonical source for the full envelope, publish path, and TTL semantics; pointers are noted inline for readers wanting fuller context.
 
-A client implementing this NIP scans the `content` field of `kind:1` text notes (and the inner sealed event of NIP-17 gift-wraps) for URLs matching the OpenWyrd MOP **fragment-form** as defined in MOP-001 §5.1:
+All binary values on the wire are base64url-encoded per RFC 4648 §5 with no padding (`=` characters MUST be omitted). Multi-byte integers in cryptographic constructions are big-endian.
+
+### 3.1 Constants
+
+| Name | Value | Purpose |
+|---|---|---|
+| `ENVELOPE_VERSION` | `0x01` | First byte of every envelope and AAD. |
+| `HANDLE_BYTES` | `12` | Raw handle byte length. |
+| `HANDLE_CHARS` | `16` | Base64url(no-pad) length of an encoded handle. |
+| `K_READ_BYTES` | `32` | AES-256-GCM key length. |
+| `K_READ_CHARS` | `43` | Base64url(no-pad) length of an encoded `K_read`. |
+| `K_ORIGIN_PUB_BYTES` | `33` | SEC1 compressed secp256k1 pubkey. |
+| `IV_BYTES` | `12` | AES-GCM nonce length. |
+| `TAG_BYTES` | `16` | AES-GCM authentication tag length. |
+| `ENVELOPE_BYTE_CEILING` | `1500` | Maximum envelope size. |
+| `PERMANENT_EXPIRES_AT_MS` | `253_370_764_800_000` | Year-9999 sentinel for permanent wyrds. |
+
+### 3.2 URL pattern detection
+
+A client implementing this NIP scans the `content` field of `kind:1` text notes (and the inner sealed event of NIP-17 gift-wraps) for URLs matching the **fragment-form**:
 
 ```
 https://<host>/w/<handle>#<K_read_b64u>
@@ -60,18 +79,16 @@ https://<host>/w/<handle>#<K_read_b64u>
 
 Where:
 - `<host>` is any DNS hostname.
-- `<handle>` matches the regex `[A-Za-z0-9_-]{16}` (16 base64url characters, no padding).
-- `<K_read_b64u>` matches `[A-Za-z0-9_-]{43}` (43 base64url characters, no padding — 32 bytes).
+- `<handle>` matches `^[A-Za-z0-9_-]{16}$` (16 base64url characters, no padding).
+- `<K_read_b64u>` matches `^[A-Za-z0-9_-]{43}$` (43 base64url characters, no padding — 32 bytes).
 
 The 16+43 character lengths are highly distinctive; false-positives on random URLs are negligible.
 
-A client MAY additionally recognize the **path-form** `https://<host>/w/<handle>/k/<K_read_b64u>` (MOP-001 §5.2), normalizing to fragment-form before any further processing. Composers MUST NOT emit path-form per MOP-001; this is for parser leniency only.
+A client MAY additionally recognize the legacy **path-form** `https://<host>/w/<handle>/k/<K_read_b64u>`, normalizing to fragment-form before any further processing.
 
-The URI scheme form `sendwyrd://w/<handle>#<K_read_b64u>` (MOP-001 §5.3) is out of scope for this NIP.
+### 3.3 Envelope fetch
 
-### 3.2 Envelope fetch
-
-For each detected URL, the client fetches the envelope:
+For each detected URL, the client issues:
 
 ```
 GET https://<host>/api/v1/wyrds/<handle>
@@ -79,39 +96,132 @@ MOP-Protocol-Version: 1
 Accept: application/json
 ```
 
-The response shape is defined in MOP-001 §4.5. Status semantics:
+**200 OK** response body:
 
-- `200` — envelope present; proceed to §3.3.
-- `410` — tombstone (burned or expired); render a tombstone indicator (see §3.4).
-- `404` — no such wyrd; fall back to standard OpenGraph rendering.
-- network error / non-MOP host — fall back to standard OpenGraph rendering.
+```json
+{
+  "handle": "<16-char-b64u>",
+  "envelope": "<b64u envelope bytes>",
+  "k_origin_pub": "<b64u 33-byte SEC1 compressed pubkey>",
+  "published_at": 1717000000000,
+  "expires_at": 1724776000000,
+  "replies_enabled": false
+}
+```
 
-The client SHOULD include a User-Agent identifying itself and the NIP version for telemetry on the host's side; this is not a privacy issue (the host already serves the envelope to anyone).
+`published_at` and `expires_at` are Unix epoch milliseconds. For permanent wyrds, `expires_at` MUST equal `PERMANENT_EXPIRES_AT_MS` (`253_370_764_800_000`); the client MUST use this exact value when reconstructing the AAD (see §3.5).
 
-### 3.3 Decryption and rendering
+**410 Gone** response body (tombstone):
 
-The client decrypts the envelope body per MOP-001 §6.3 (AES-256-GCM with the AAD construction in MOP-001 §4.3), using the `K_read` from the URL fragment.
+```json
+{
+  "status": "gone",
+  "reason": "expired",
+  "gone_at": "2026-04-28T12:00:00.000Z"
+}
+```
 
-The decrypted body is plaintext UTF-8 (or the canonical signed-message form per MOP-001 §6.4 for authored wyrds). Clients MUST verify any embedded signature per MOP-001 §6.4 before treating the content as authored; unverified or unsigned content should be rendered with a "no authorship attestation" indicator.
+`reason` is one of `"expired"`, `"burned"`, `"key_mismatch"`. Render a tombstone indicator; do not attempt decryption.
 
-Rendering: the client SHOULD replace the standard OpenGraph link card with a decrypted-content card containing:
+**Status handling summary:**
+- `200` → proceed to §3.4.
+- `410` → tombstone card per §3.7.
+- `404` → no such wyrd; fall back to standard OpenGraph rendering.
+- network error / non-MOP host → fall back to standard OpenGraph rendering.
+
+### 3.4 Envelope byte layout
+
+Decode the `envelope` field from base64url to raw bytes. The envelope is the concatenation:
+
+```
+ver(1) || iv(12) || ciphertext(N) || tag(16)
+```
+
+- `ver` MUST equal `ENVELOPE_VERSION` (`0x01`); reject if not.
+- `iv` is the 12-byte AES-GCM nonce.
+- `ciphertext` is the AES-256-GCM ciphertext of the UTF-8 body.
+- `tag` is the 16-byte GCM authentication tag (appended; matches the Web Crypto API output convention).
+
+Total envelope length MUST satisfy `1 + 12 + 16 ≤ len ≤ 1500`.
+
+### 3.5 AAD construction
+
+The Additional Authenticated Data passed to AES-256-GCM is the concatenation:
+
+```
+ver(1) || handle(12) || expires_at_ms_be(8) || replies_enabled(1)
+```
+
+— total 22 bytes. Field semantics:
+
+| Field | Bytes | Encoding |
+|---|---|---|
+| `ver` | 1 | `0x01` (`ENVELOPE_VERSION`). |
+| `handle` | 12 | The handle's **raw bytes** (base64url-decoded from the response's `handle` field). |
+| `expires_at_ms` | 8 | Big-endian uint64. The `expires_at` value from the response, exactly as returned (use `PERMANENT_EXPIRES_AT_MS` for permanent wyrds). |
+| `replies_enabled` | 1 | `0x01` if true, `0x00` if false. |
+
+Tampering with any AAD byte causes AES-GCM tag verification to fail, binding the ciphertext to the handle, expiry, and replies-policy.
+
+### 3.6 Body decryption
+
+```
+require envelope[0] == 0x01
+iv          = envelope[1..13]
+ct_and_tag  = envelope[13..]              // ciphertext concatenated with 16-byte tag
+K_read      = base64url_decode(URL_fragment)   // 32 bytes
+aad         = build_aad(handle_raw, expires_at_ms, replies_enabled)   // §3.5
+plaintext   = AES-256-GCM-Decrypt(K_read, iv, ct_and_tag, aad)
+body        = utf8_decode(plaintext, fatal=true)
+```
+
+Decryption MUST fail closed: any tag mismatch, length error, version mismatch, or non-strict UTF-8 surfaces as decrypt failure with no further attempt. On failure, fall back to the standard OpenGraph card and SHOULD surface a small "decryption failed" indicator.
+
+### 3.7 Authorship attestation verification
+
+A wyrd whose decrypted body is exactly three lines (LF-separated):
+
+```
+sendwyrd-attestation/v1
+target=<16-char-handle-b64u>
+sig=<86-char-sig-b64u>
+```
+
+is an *authorship attestation* for the target wyrd. To verify:
+
+1. Compute the attestation message hash (`m`):
+
+   ```
+   m = SHA-256(
+     "mop:v1:authorship_attestation"   // 29 ASCII bytes
+     || target_handle_raw              // 12 raw bytes (base64url-decoded `target`)
+   )
+   ```
+
+2. Decode `sig` to 64 raw bytes (BIP-340 Schnorr signature).
+3. Derive the X-only pubkey (32 bytes) by dropping the leading parity byte from the attestation's `k_origin_pub` (from §3.3).
+4. Verify the BIP-340 Schnorr signature over `m`. If valid, the attestation binds the target wyrd's authorship to the X-only pubkey.
+
+Rendering MAY surface a verification banner. Unverified or absent attestations MUST NOT be rendered as authored.
+
+> The literal `sendwyrd-attestation/v1` is required for v1 conformance; a future MOP revision may generalize to `mop-attestation/v1`.
+
+### 3.8 Rendering
+
+The client SHOULD replace the standard OpenGraph link card with a decrypted-content card containing:
 
 - The decrypted plaintext (or a sensible truncation).
 - A small "OpenWyrd MOP" badge or icon indicating the source protocol.
-- An expiry indicator derived from envelope `expires_at` (e.g. "expires in 12 days", "permanent", or "expired").
-- Authorship indicator: pubkey or "anonymous" per the verified signature.
+- An expiry indicator derived from `expires_at` (e.g. "expires in 12 days", "permanent", or "expired").
+- Authorship indicator: pubkey or "anonymous" per the verified signature (§3.7).
 
 Clients MAY offer a user setting to suppress inline decryption (render the standard OG card instead), for users who prefer tap-to-reveal.
 
-### 3.4 Tombstone rendering
+### 3.9 Backward compatibility
 
-If the host returns `410` (tombstone), the client SHOULD render a card indicating the wyrd is no longer available, with a reason if provided per MOP-001 §4.6. Do NOT attempt to render decrypted content (there is none).
+This NIP is purely additive. Clients that do not implement it render OpenWyrd MOP capability URLs exactly as today: as clickable links with the standard OpenGraph credential card. No event structure changes; no tags; no signer changes; no wire-format additions.
 
-### 3.5 Backward compatibility
-
-This NIP is purely additive. Clients that do not implement it render OpenWyrd MOP capability URLs exactly as they do today: as clickable links with a standard OpenGraph credential card (rendered from `og:image` served by the relay). No event structure changes; no tags; no signer changes; no wire-format additions.
-
-Implementing clients SHOULD NOT hide events whose URL pattern they fail to decrypt for any reason; fall back to the OG-card behavior gracefully.
+Implementing clients SHOULD NOT hide events whose URL pattern they fail to decrypt; fall back to the OG-card behavior gracefully.
 
 ## 4. Anticipated Counter-Arguments
 

--- a/G6.md
+++ b/G6.md
@@ -8,29 +8,17 @@ OpenWyrd Capability-URL Inline Rendering
 
 > Successor in spirit to the withdrawn NIP-C6 ([#2327](https://github.com/nostr-protocol/nips/pull/2327), withdrawn 2026-04-28). Inherits both review objections from that round: zero sender burden, URL self-identifies.
 
-## 1. Problem
+## 1. Motivation
 
-A user pastes an OpenWyrd MOP capability URL into a Nostr note:
+[OpenWyrd MOP](https://openwyrd.org/spec/MOP-001) capability URLs have the shape `https://<host>/w/<handle>#<K_read>`, where the URL fragment is the read key. By RFC 3986 §3.5 the fragment is processed client-side and never sent to the host, so the host is read-blind: it serves ciphertext to anyone who asks for the handle but cannot decrypt. The URL alone, in possession of a reader, is the read grant.
 
-```
-https://sendwyrd.com/w/Ix3kP9oW0bC2mLxV#7ZQv...K0n
-```
+When such a URL is pasted into a Nostr `kind:1` note, link-card rendering today shows only the host's OpenGraph credential card — a content-free "tap to decrypt" tile, identical for every wyrd. The recipient has to tap, leave the client, and decrypt in a browser tab to read the message. A Nostr client that pattern-matches the URL, fetches the envelope, and decrypts client-side using the URL fragment can render the plaintext inline in feed instead.
 
-Today, every Nostr client that does link-card rendering (Damus, Amethyst, Iris, Snort, Primal) shows the same austere "tap to decrypt" OpenGraph card the user would see on X, iMessage, or Slack — a content-free credential card. The recipient can't read the wyrd in feed; they have to tap, leave the client, and decrypt in a browser tab.
+This NIP is scoped to Nostr because Nostr is the ecosystem where the rendering pattern is realistically implementable: clients run JavaScript on third-party content, extend their own rendering, and integrate sovereign protocols. Closed platforms (X, iMessage, WhatsApp, Telegram, Facebook Messenger) have neither the technical surface nor the disposition to ship protocol-specific decryption codepaths and will continue to render the OG card. Graceful degradation is built into the design — the protocol itself is platform-agnostic; only the high-fidelity rendering is Nostr-shaped.
 
-OpenWyrd MOP itself is platform-agnostic — capability URLs render the same austere card on any OG-rendering surface today. But client-side decrypt-and-render in feed is a *rendering pattern* that's only viable on Nostr. Closed platforms (X, iMessage, WhatsApp, Telegram, Facebook Messenger) don't run JavaScript on third-party content, and their dev cultures wouldn't ship protocol-specific decryption codepaths on principle. Nostr is the one ecosystem with both the technical surface (clients render rich content, run JS, ship fast) and the cultural disposition (decentralized, sovereign, willing to integrate open protocols) to make this implementable in practice.
+The proposal supersedes the withdrawn NIP-C6 ([#2327](https://github.com/nostr-protocol/nips/pull/2327)). C6 proposed a per-event tag schema; review feedback landed on two points — sender burden, and tag redundancy when the URL self-identifies. This NIP inherits both: senders paste URLs exactly as today (no tags, no signer changes, no wire-format additions), and clients pattern-match on URL shape (the NIP supplies the protocol-specific decryption knowledge that pattern-matching alone can't). The entire delta is on the rendering client.
 
-This NIP defines the rendering contract for that case.
-
-### Demonstrating the gap
-
-Reviewers can reproduce with three lines:
-
-1. Open Damus (or any OG-rendering Nostr client).
-2. Open a thread containing the URL above (or any `https://sendwyrd.com/w/{handle}#{key}`).
-3. Observe: a content-free encrypted-credential card. Tap to read.
-
-After this NIP is implemented in a client, step 3 becomes: the client renders the decrypted plaintext inline. No tap, no context switch.
+To reproduce the gap: paste any `https://sendwyrd.com/w/{handle}#{key}` URL into Damus (or any OG-rendering Nostr client) and observe the content-free credential card. After implementation, the same URL renders the decrypted plaintext inline.
 
 ## 2. Threat Model
 
@@ -223,51 +211,13 @@ This NIP is purely additive. Clients that do not implement it render OpenWyrd MO
 
 Implementing clients SHOULD NOT hide events whose URL pattern they fail to decrypt; fall back to the OG-card behavior gracefully.
 
-## 4. Anticipated Counter-Arguments
-
-### 4.1 "This is asking too much from the sender."
-
-It asks zero from the sender. Senders paste the URL into `kind:1` content exactly as they do today. No tags, no signer changes, no schema. The entire delta is on the rendering client. (NIP-C6's withdrawal turned on this point; this NIP inherits the lesson.)
-
-### 4.2 "Why not just rely on URL self-identification, no NIP needed?"
-
-Pattern-matching alone is what a client without this NIP already does — it identifies the URL as a URL and renders it via standard OG. To go further (fetch the envelope, decrypt, render plaintext) requires the client to know that this URL shape maps to a specific protocol with a specific decryption procedure. This NIP supplies that knowledge: a small, narrowly-scoped contract pointing clients at MOP-001. Without it, every client would have to independently rediscover the URL shape and protocol.
-
-### 4.3 "Why scope to OpenWyrd MOP rather than capability URLs in general?"
-
-A generic "any URL with a high-entropy fragment is a capability URL" pattern is fragile (false positives on legitimate URL fragments) and underspecified (each capability protocol has a different cipher and envelope format). Scoping to a specific protocol with a published spec keeps the NIP narrow, reviewable, and implementable. Future capability protocols can publish successor NIPs citing the same pattern; this NIP does not preclude them.
-
-### 4.4 "Decryption codepath is a real engineering ask."
-
-Yes. A reference implementation exists at [`@openwyrd/mop`](https://www.npmjs.com/package/@openwyrd/mop) on npm (Apache-2.0). Most Nostr clients are TypeScript / JavaScript; integration is an `npm install` plus invoking the documented decrypt API. Native clients have crypto primitives available; the envelope format is small (see MOP-001 §4.2) and the cipher is standard AES-256-GCM.
-
-### 4.5 "What about Nostr clients that don't run on the open web?"
-
-This NIP is opt-in per client. Nothing breaks for clients that don't implement it. The fallback is the OG card — the same content-free encrypted-credential card the user already sees today on X, iMessage, etc.
-
-### 4.6 "Auto-decrypting in feed surfaces sensitive content unnecessarily."
-
-The sender chose to post the URL in a public event. Anyone who reads the post can decrypt by visiting the URL anyway. Inline rendering does not expand the audience. For senders who want true privacy, NIP-17 gift-wrap is the right tool (and this NIP applies to the inner sealed event there too — to the recipient who's already authorized to read). Clients MAY offer a per-user "blur until tapped" setting; that is a UX policy, not a protocol requirement.
-
-## 5. Ecosystem Positioning
-
-This NIP is scoped to Nostr clients not because the protocol is Nostr-specific (OpenWyrd MOP is platform-agnostic and ships everywhere a URL ships), but because Nostr is the only ecosystem where this *rendering pattern* is realistically implementable. Closed platforms have neither the technical surface (no JS execution on third-party content, no extensibility for client developers) nor the cultural disposition (no incentive to integrate sovereign-protocol decryption) to ship it. The asymmetry is the practical reality: **OpenWyrd MOP renders fully on Nostr; degrades gracefully elsewhere** to the existing content-free OG card. The protocol stays open; only the high-fidelity rendering is Nostr-shaped.
-
-## 6. Reference Implementation
+## 4. Reference Implementation
 
 - [`@openwyrd/mop`](https://www.npmjs.com/package/@openwyrd/mop) — TypeScript / JavaScript reference (Apache-2.0). Exports `decryptWyrd(envelope, K_read) → plaintext` and `verifySignedBody(plaintext) → { author, body }`.
 - Envelope fetch: `GET /api/v1/wyrds/{handle}` with `MOP-Protocol-Version: 1`.
 - Live test target: any URL of the form `https://sendwyrd.com/w/<handle>#<key>`.
 
-## 7. Open Questions
-
-The following are intentionally left to client implementers; this NIP does not normatively constrain them.
-
-1. **Inline rendering vs. OG-card augmentation.** Replace the OG card entirely, or render the decrypted body alongside it? Probably the former for cleanliness; clients MAY differ.
-2. **Decryption-failure UX.** What does a client show when the envelope is fetched but decryption fails (corrupted body, wrong key, version mismatch)? Suggested: render the OG card and a small "decryption failed" indicator.
-3. **Fragment-redaction in feed.** Should clients redact the `#K_read` portion of the URL when displaying the URL text alongside the rendered content (since the URL fragment is now visually surfaced as plaintext)? UX-only; not protocol-relevant.
-
-## 8. References
+## 5. References
 
 - MOP-001: Capability-URL Message Envelope — `https://openwyrd.org/spec/MOP-001`
 - RFC 3986 §3.5 — Fragment Identifiers

--- a/G6.md
+++ b/G6.md
@@ -1,0 +1,165 @@
+NIP-G6
+======
+
+OpenWyrd Capability-URL Inline Rendering
+----------------------------------------
+
+`draft` `optional`
+
+> Successor in spirit to the withdrawn NIP-C6 ([#2327](https://github.com/nostr-protocol/nips/pull/2327), withdrawn 2026-04-28). Inherits both review objections from that round: zero sender burden, URL self-identifies.
+
+## 1. Problem
+
+A user pastes an OpenWyrd MOP capability URL into a Nostr note:
+
+```
+https://sendwyrd.com/w/Ix3kP9oW0bC2mLxV#7ZQv...K0n
+```
+
+Today, every Nostr client that does link-card rendering (Damus, Amethyst, Iris, Snort, Primal) shows the same austere "tap to decrypt" OpenGraph card the user would see on X, iMessage, or Slack — a content-free credential card. The recipient can't read the wyrd in feed; they have to tap, leave the client, and decrypt in a browser tab.
+
+OpenWyrd MOP itself is platform-agnostic — capability URLs render the same austere card on any OG-rendering surface today. But client-side decrypt-and-render in feed is a *rendering pattern* that's only viable on Nostr. Closed platforms (X, iMessage, WhatsApp, Telegram, Facebook Messenger) don't run JavaScript on third-party content, and their dev cultures wouldn't ship protocol-specific decryption codepaths on principle. Nostr is the one ecosystem with both the technical surface (clients render rich content, run JS, ship fast) and the cultural disposition (decentralized, sovereign, willing to integrate open protocols) to make this implementable in practice.
+
+This NIP defines the rendering contract for that case.
+
+### Demonstrating the gap
+
+Reviewers can reproduce with three lines:
+
+1. Open Damus (or any OG-rendering Nostr client).
+2. Open a thread containing the URL above (or any `https://sendwyrd.com/w/{handle}#{key}`).
+3. Observe: a content-free encrypted-credential card. Tap to read.
+
+After this NIP is implemented in a client, step 3 becomes: the client renders the decrypted plaintext inline. No tap, no context switch.
+
+## 2. Threat Model
+
+The capability URL is a bearer secret. Possession of `{handle}#{key}` is exactly the right to read the wyrd. By posting the URL into a public Nostr event, the sender has already granted read access to every reader of the event. **This NIP does not change who can decrypt.** It only changes whether the recipient's client renders the plaintext inline or makes the recipient tap-and-leave to read it.
+
+What this NIP changes:
+- Rendering location: from a separate browser tab to inside the Nostr client's feed.
+- Decryption agent: from the user's browser at the relay host to the user's Nostr client.
+
+What this NIP does NOT change:
+- Who can decrypt (anyone who possesses the URL — unchanged).
+- Where K_read travels (URL fragment, never to the host — unchanged).
+- The host's read-blindness (relays serve ciphertext only — unchanged).
+- The wyrd's TTL, replay, or burn semantics (envelope-level — unchanged).
+
+The structural privacy property of OpenWyrd MOP — that the host cannot decrypt — is independent of this NIP. Clients implementing this NIP MUST NOT transmit `K_read` to any third party, including the relay, telemetry endpoints, or preview-proxy services.
+
+## 3. Specification
+
+### 3.1 URL pattern detection
+
+A client implementing this NIP scans the `content` field of `kind:1` text notes (and the inner sealed event of NIP-17 gift-wraps) for URLs matching the OpenWyrd MOP **fragment-form** as defined in MOP-001 §5.1:
+
+```
+https://<host>/w/<handle>#<K_read_b64u>
+```
+
+Where:
+- `<host>` is any DNS hostname.
+- `<handle>` matches the regex `[A-Za-z0-9_-]{16}` (16 base64url characters, no padding).
+- `<K_read_b64u>` matches `[A-Za-z0-9_-]{43}` (43 base64url characters, no padding — 32 bytes).
+
+The 16+43 character lengths are highly distinctive; false-positives on random URLs are negligible.
+
+A client MAY additionally recognize the **path-form** `https://<host>/w/<handle>/k/<K_read_b64u>` (MOP-001 §5.2), normalizing to fragment-form before any further processing. Composers MUST NOT emit path-form per MOP-001; this is for parser leniency only.
+
+The URI scheme form `sendwyrd://w/<handle>#<K_read_b64u>` (MOP-001 §5.3) is out of scope for this NIP.
+
+### 3.2 Envelope fetch
+
+For each detected URL, the client fetches the envelope:
+
+```
+GET https://<host>/api/v1/wyrds/<handle>
+MOP-Protocol-Version: 1
+Accept: application/json
+```
+
+The response shape is defined in MOP-001 §4.5. Status semantics:
+
+- `200` — envelope present; proceed to §3.3.
+- `410` — tombstone (burned or expired); render a tombstone indicator (see §3.4).
+- `404` — no such wyrd; fall back to standard OpenGraph rendering.
+- network error / non-MOP host — fall back to standard OpenGraph rendering.
+
+The client SHOULD include a User-Agent identifying itself and the NIP version for telemetry on the host's side; this is not a privacy issue (the host already serves the envelope to anyone).
+
+### 3.3 Decryption and rendering
+
+The client decrypts the envelope body per MOP-001 §6.3 (AES-256-GCM with the AAD construction in MOP-001 §4.3), using the `K_read` from the URL fragment.
+
+The decrypted body is plaintext UTF-8 (or the canonical signed-message form per MOP-001 §6.4 for authored wyrds). Clients MUST verify any embedded signature per MOP-001 §6.4 before treating the content as authored; unverified or unsigned content should be rendered with a "no authorship attestation" indicator.
+
+Rendering: the client SHOULD replace the standard OpenGraph link card with a decrypted-content card containing:
+
+- The decrypted plaintext (or a sensible truncation).
+- A small "OpenWyrd MOP" badge or icon indicating the source protocol.
+- An expiry indicator derived from envelope `expires_at` (e.g. "expires in 12 days", "permanent", or "expired").
+- Authorship indicator: pubkey or "anonymous" per the verified signature.
+
+Clients MAY offer a user setting to suppress inline decryption (render the standard OG card instead), for users who prefer tap-to-reveal.
+
+### 3.4 Tombstone rendering
+
+If the host returns `410` (tombstone), the client SHOULD render a card indicating the wyrd is no longer available, with a reason if provided per MOP-001 §4.6. Do NOT attempt to render decrypted content (there is none).
+
+### 3.5 Backward compatibility
+
+This NIP is purely additive. Clients that do not implement it render OpenWyrd MOP capability URLs exactly as they do today: as clickable links with a standard OpenGraph credential card (rendered from `og:image` served by the relay). No event structure changes; no tags; no signer changes; no wire-format additions.
+
+Implementing clients SHOULD NOT hide events whose URL pattern they fail to decrypt for any reason; fall back to the OG-card behavior gracefully.
+
+## 4. Anticipated Counter-Arguments
+
+### 4.1 "This is asking too much from the sender."
+
+It asks zero from the sender. Senders paste the URL into `kind:1` content exactly as they do today. No tags, no signer changes, no schema. The entire delta is on the rendering client. (NIP-C6's withdrawal turned on this point; this NIP inherits the lesson.)
+
+### 4.2 "Why not just rely on URL self-identification, no NIP needed?"
+
+Pattern-matching alone is what a client without this NIP already does — it identifies the URL as a URL and renders it via standard OG. To go further (fetch the envelope, decrypt, render plaintext) requires the client to know that this URL shape maps to a specific protocol with a specific decryption procedure. This NIP supplies that knowledge: a small, narrowly-scoped contract pointing clients at MOP-001. Without it, every client would have to independently rediscover the URL shape and protocol.
+
+### 4.3 "Why scope to OpenWyrd MOP rather than capability URLs in general?"
+
+A generic "any URL with a high-entropy fragment is a capability URL" pattern is fragile (false positives on legitimate URL fragments) and underspecified (each capability protocol has a different cipher and envelope format). Scoping to a specific protocol with a published spec keeps the NIP narrow, reviewable, and implementable. Future capability protocols can publish successor NIPs citing the same pattern; this NIP does not preclude them.
+
+### 4.4 "Decryption codepath is a real engineering ask."
+
+Yes. A reference implementation exists at [`@openwyrd/mop`](https://www.npmjs.com/package/@openwyrd/mop) on npm (Apache-2.0). Most Nostr clients are TypeScript / JavaScript; integration is an `npm install` plus invoking the documented decrypt API. Native clients have crypto primitives available; the envelope format is small (see MOP-001 §4.2) and the cipher is standard AES-256-GCM.
+
+### 4.5 "What about Nostr clients that don't run on the open web?"
+
+This NIP is opt-in per client. Nothing breaks for clients that don't implement it. The fallback is the OG card — the same content-free encrypted-credential card the user already sees today on X, iMessage, etc.
+
+### 4.6 "Auto-decrypting in feed surfaces sensitive content unnecessarily."
+
+The sender chose to post the URL in a public event. Anyone who reads the post can decrypt by visiting the URL anyway. Inline rendering does not expand the audience. For senders who want true privacy, NIP-17 gift-wrap is the right tool (and this NIP applies to the inner sealed event there too — to the recipient who's already authorized to read). Clients MAY offer a per-user "blur until tapped" setting; that is a UX policy, not a protocol requirement.
+
+## 5. Ecosystem Positioning
+
+This NIP is scoped to Nostr clients not because the protocol is Nostr-specific (OpenWyrd MOP is platform-agnostic and ships everywhere a URL ships), but because Nostr is the only ecosystem where this *rendering pattern* is realistically implementable. Closed platforms have neither the technical surface (no JS execution on third-party content, no extensibility for client developers) nor the cultural disposition (no incentive to integrate sovereign-protocol decryption) to ship it. The asymmetry is the practical reality: **OpenWyrd MOP renders fully on Nostr; degrades gracefully elsewhere** to the existing content-free OG card. The protocol stays open; only the high-fidelity rendering is Nostr-shaped.
+
+## 6. Reference Implementation
+
+- [`@openwyrd/mop`](https://www.npmjs.com/package/@openwyrd/mop) — TypeScript / JavaScript reference (Apache-2.0). Exports `decryptWyrd(envelope, K_read) → plaintext` and `verifySignedBody(plaintext) → { author, body }`.
+- Envelope fetch: `GET /api/v1/wyrds/{handle}` with `MOP-Protocol-Version: 1`.
+- Live test target: any URL of the form `https://sendwyrd.com/w/<handle>#<key>`.
+
+## 7. Open Questions
+
+The following are intentionally left to client implementers; this NIP does not normatively constrain them.
+
+1. **Inline rendering vs. OG-card augmentation.** Replace the OG card entirely, or render the decrypted body alongside it? Probably the former for cleanliness; clients MAY differ.
+2. **Decryption-failure UX.** What does a client show when the envelope is fetched but decryption fails (corrupted body, wrong key, version mismatch)? Suggested: render the OG card and a small "decryption failed" indicator.
+3. **Fragment-redaction in feed.** Should clients redact the `#K_read` portion of the URL when displaying the URL text alongside the rendered content (since the URL fragment is now visually surfaced as plaintext)? UX-only; not protocol-relevant.
+
+## 8. References
+
+- MOP-001: Capability-URL Message Envelope — `https://openwyrd.org/spec/MOP-001`
+- RFC 3986 §3.5 — Fragment Identifiers
+- NIP-17 — Private Direct Messages
+- NIP-C6 (withdrawn) — [#2327](https://github.com/nostr-protocol/nips/pull/2327) — predecessor

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ They exist to document what may be implemented by [Nostr](https://github.com/nos
 - [NIP-C0: Code Snippets](C0.md)
 - [NIP-C7: Chats](C7.md)
 - [NIP-EE: E2EE Messaging using MLS Protocol](EE.md) --- **unrecommended**: superseded by the [Marmot Protocol](https://github.com/marmot-protocol/marmot)
+- [NIP-G6: OpenWyrd Capability-URL Inline Rendering](G6.md)
 
 ## Event Kinds
 | kind          | description                     | NIP                                    |


### PR DESCRIPTION
## TL;DR

Defines a rendering contract for Nostr clients to recognize OpenWyrd MOP capability URLs in `kind:1` content (or NIP-17 inner sealed events), fetch the envelope, decrypt client-side using the URL fragment, and render plaintext inline in feed in lieu of the standard OpenGraph card.

Zero sender burden — no tags, no signer changes, no wire-format additions. Senders paste URLs exactly as today; the entire delta is on the rendering client.

## Successor to withdrawn NIP-C6

Both review objections from [#2327](https://github.com/nostr-protocol/nips/pull/2327) are baked in:

1. **Sender burden → zero.** Entire delta on the rendering client.
2. **URL self-identification → preserved.** Clients pattern-match on URL shape (16-char handle + 43-char base64url key — distinctive enough to skip false-positives). The NIP supplies the protocol-specific decryption knowledge that pattern-matching alone can't.

## What the client does

```
1. Detect URL: https://<host>/w/<handle>#<K_read>
   handle: ^[A-Za-z0-9_-]{16}$    K_read: ^[A-Za-z0-9_-]{43}$ (32 bytes)

2. Fetch:    GET https://<host>/api/v1/wyrds/<handle>
             MOP-Protocol-Version: 1
   Returns:  { handle, envelope, k_origin_pub, published_at, expires_at, replies_enabled }

3. Decrypt:  envelope = 0x01 || iv(12) || ct(N) || tag(16)
             aad      = 0x01 || handle_raw(12) || be8(expires_at_ms) || replies_enabled(1)
             plaintext = AES-256-GCM-Decrypt(K_read, iv, ct||tag, aad)

4. Render:   plaintext + "OpenWyrd MOP" badge + expiry indicator,
             replacing the standard OG card.
```

Full constants, response shapes, tombstone handling, and BIP-340 attestation verification inlined in [G6.md](G6.md) §3 — self-contained, no external links required to implement.

## Threat model (no privacy delta)

The capability URL is a bearer secret — posting it publicly already grants read access to every reader. **This NIP does not change who can decrypt**, only whether the recipient sees plaintext in-feed or has to tap-and-leave. Host read-blindness (K_read never travels HTTP, RFC 3986 §3.5) is unchanged. Clients implementing this NIP MUST NOT transmit K_read to any third party.

## Reference implementation

[`@openwyrd/mop`](https://www.npmjs.com/package/@openwyrd/mop) on npm (Apache-2.0). Live test: any `https://sendwyrd.com/w/<handle>#<key>` URL.

## Number

`G6` picked after scanning merged NIPs and ~200 open/closed PRs — no conflict. `G` is outside the hex convention used by merged NIPs to date; **happy to renumber per editor preference**.