### PR TITLE
editing chat messages

### DIFF
--- a/C7.md
+++ b/C7.md
@@ -6,6 +6,12 @@ Chats
 
 `draft` `optional`
 
+This NIP describes simple chat messages.
+
+These messages behave like `kind:1` notes syntactically, but are intended to be used in the compĺetely different circumstance of sequential and localized group chats in which ordered consistency is expected, such as, for example, [NIP-29](29.md) rooms, in which a shared relay acts as the (temporary) single source of truth for all the chat messages.
+
+## Definition
+
 A chat message is a `kind 9` event.
 
 ```json
@@ -15,6 +21,8 @@ A chat message is a `kind 9` event.
   "tags": []
 }
 ```
+
+## Reply
 
 A reply to a `kind 9` is an additional `kind 9` which quotes the parent using a `q` tag.
 
@@ -27,3 +35,40 @@ A reply to a `kind 9` is an additional `kind 9` which quotes the parent using a 
   ]
 }
 ```
+
+## Edit
+
+Because these messages are always received in order, an edit can just be another message in the stream that refers to a previous message.
+
+The only difference between an edit and a normal message is that it will have a special `"edit"` tag (and an `EDIT` label prefixing the `content`) that allows clients to optionally parse it as a special edit action and have its changes applied to a previous message in the chat state. For that it uses a simple human-readable text-diff syntax in order to encode a "patch".
+
+Simpler clients that do not want to support this can be just fine with just displaying the edits as normal text messages.
+
+```json
+{
+  "kind": 9,
+  "content": "EDIT\n<patch-content>",
+  "tags": [
+    ["e", <event-id-being-edited>],
+    ["edit"]
+  ]
+}
+```
+
+In which `<patch-content>` is formed by one or more lines of
+
+```
+<index> -<number-of-characters-deleted> +<number-of-characters-inserted> <actual-characters-inserted>
+```
+
+For example, if the original text was `Their should hire more internets to help them` and was edited to `They should hire more interns to help` the patch will be:
+
+```
+0 -5 +4 They
+23 -9 +7 interns
+40 -5 +0
+```
+
+The indexes and amounts refer to unicode characters, not bytes.
+
+When generating these diffs clients should prefer to do it over full words instead of over characters, for readability.


### PR DESCRIPTION
I may be crazy, but I think this will work fine in NIP-29 groups.

Maybe this same approach also works in NIP-17 and other places.

The goal is to make it backwards-compatible such that it can still be read by people in clients that don't know about this change.

Because chat messages are delivered consistently by a single-source of truth this should work fine as a new message that performs a "state update" on the existing messages.