### PR TITLE
Clarify subscription replacement behavior

### DIFF
--- a/01.md
+++ b/01.md
@@ -132,7 +132,11 @@ Clients can send 3 types of messages, which must be JSON arrays, according to th
 }
 ```
 
-Upon receiving a `REQ` message, the relay SHOULD return events that match the filter. Any new events it receives SHOULD be sent to that same websocket until the connection is closed, a `CLOSE` event is received with the same `<subscription_id>`, or a new `REQ` is sent using the same `<subscription_id>` (in which case a new subscription is created, replacing the old one).
+Upon receiving a `REQ` message, the relay SHOULD return events that match the filter. Any new events it receives SHOULD be sent to that same websocket until the connection is closed, a `CLOSE` message is received with the same `<subscription_id>`, or a new `REQ` is sent using the same `<subscription_id>` (in which case a new subscription is created, replacing the old one).
+
+Receiving a `CLOSE` message or a new `REQ` message with the same `<subscription_id>` ends the previous subscription immediately. After that point, the relay MUST NOT send `EVENT`, `EOSE` or `CLOSED` messages for the previous subscription. Relays MAY continue or complete internal work already started for the previous subscription, but MUST discard its outputs.
+
+Clients SHOULD avoid repeatedly replacing subscriptions when debouncing or combining filters would produce the same result, as relays may still pay the cost of in-flight work whose outputs are discarded.
 
 Filter attributes containing lists (`ids`, `authors`, `kinds` and tag filters like `#e`) are JSON arrays with one or more values. At least one of the arrays' values must match the relevant field in an event for the condition to be considered a match. For scalar event attributes such as `authors` and `kind`, the attribute from the event must be contained in the filter list. In the case of tag attributes such as `#e`, for which an event may have multiple values, the event and filter condition values must have at least one item in common.
 
@@ -171,7 +175,7 @@ This NIP defines no rules for how `NOTICE` messages should be sent or treated.
   * `["OK", "b1a649ebe8...", false, "restricted: not allowed to write."]`
   * `["OK", "b1a649ebe8...", false, "error: could not connect to the database"]`
   * `["OK", "b1a649ebe8...", false, "mute: no one was listening to your ephemeral event and it wasn't handled in any way, it was ignored"]`
-- `CLOSED` messages MUST be sent in response to a `REQ` when the relay refuses to fulfill it. It can also be sent when a relay decides to kill a subscription on its side before a client has disconnected or sent a `CLOSE`. This message uses the same pattern of `OK` messages with the machine-readable prefix and human-readable message. Some examples:
+- `CLOSED` messages MUST be sent in response to a `REQ` when the relay refuses to fulfill it. It can also be sent when a relay decides to kill an active subscription on its side before a client has disconnected or ended it with `CLOSE` or a replacement `REQ`. Relays MUST NOT send `CLOSED` merely to acknowledge a client `CLOSE` or replacement `REQ` for the ended subscription. This message uses the same pattern of `OK` messages with the machine-readable prefix and human-readable message. Some examples:
   * `["CLOSED", "sub1", "unsupported: filter contains unknown elements"]`
   * `["CLOSED", "sub1", "error: could not connect to the database"]`
   * `["CLOSED", "sub1", "error: shutting down idle subscription"]`


### PR DESCRIPTION
## Summary
- Clarify that `CLOSE` or same-id `REQ` ends the previous subscription immediately
- Forbid stale `EVENT`, `EOSE`, and `CLOSED` messages from ended subscriptions
- Clarify that `CLOSED` is not an acknowledgement for client-initiated `CLOSE` or replacement `REQ`
- Add client-side guidance to debounce or combine replacement subscriptions when practical

## Research addressed
- Fixes #2079: same-id `REQ` replacement left clients unable to tell which `EOSE` belonged to which filter set.
- Incorporates #1887 consensus: relays should not send `CLOSED` after client `CLOSE`; `CLOSED` is relay-initiated/refusal signaling.
- Handles relay implementation critique from #2079: relays may be unable to cancel synchronous in-flight work, so the spec permits internal work to finish while requiring discarded outputs.
- Handles client resource critique from #2079: clients should avoid rapid replacement when debouncing or combining filters gives the same result.

## Verification
- `npx --yes markdown-link-check --quiet 01.md`
