### PR TITLE
Clarify gift wrap metadata tags

### DIFF
--- a/59.md
+++ b/59.md
@@ -59,6 +59,8 @@ Tags MUST always be empty in a `kind:13`. The inner event MUST always be unsigne
 
 A `gift wrap` event is a `kind:1059` event that wraps any other event. `tags` SHOULD include any information
 needed to route the event to its intended recipient, including the recipient's `p` tag or [NIP-13](13.md) proof of work.
+Applications MAY include other tags, such as `k` tags for the wrapped event kind, when leaking that metadata is acceptable
+for the application's privacy model.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Clarify that gift wraps may include metadata tags beyond routing tags
- Call out `k` tags as allowed when leaking the wrapped event kind is acceptable for the application privacy model

Closes #2288.

## Verification
- `npx --yes markdown-link-check --quiet 59.md`
- `git diff --check`

## Notes
This keeps `k` tags optional rather than mandatory, matching the issue discussion that some applications can trade kind leakage for filtering while privacy-sensitive applications can continue to avoid extra metadata.
