### PR TITLE
Clarify NIP-24 base profile fields

### DIFF
--- a/24.md
+++ b/24.md
@@ -10,7 +10,7 @@ This NIP keeps track of extra optional fields that can added to events which are
 
 ### kind 0
 
-These are extra fields not specified in NIP-01 that may be present in the stringified JSON of metadata events:
+These are extra fields not specified in [NIP-01](01.md) that may be present in the stringified JSON of metadata events. [NIP-01](01.md) defines the base `name`, `about` and `picture` fields.
 
   - `display_name`: an alternative, bigger name with richer characters than `name`. `name` should always be set regardless of the presence of `display_name` in the metadata.
   - `website`: a web URL related in any way to the event author.


### PR DESCRIPTION
## Summary
- Link NIP-24 kind 0 metadata back to NIP-01
- Explicitly note that NIP-01 defines the base `name`, `about`, and `picture` fields

Closes #820.

## Verification
- `npx --yes markdown-link-check --quiet 24.md`
- `git diff --check`

## Notes
This follows the maintainer suggestion in #820 without reintroducing the rejected #828 wording that made `display_name` preferred.
