### PR TITLE
Clarify NIP-51 item privacy

### DIFF
--- a/51.md
+++ b/51.md
@@ -10,6 +10,8 @@ This NIP defines lists of things that users can create. Lists can contain refere
 
 Public items in a list are specified in the event `tags` array, while private items are specified in a JSON array that mimics the structure of the event `tags` array, but stringified and encrypted using the same scheme from [NIP-44](44.md) (the shared key is computed using the author's public and private key) and stored in the `.content`. An earlier version of this specification used [NIP-04](04.md) for encryptions. Those are now deprecated. For backward compatibility, Clients can automatically discover if the encryption is NIP-04 or NIP-44 by searching for "iv" in the ciphertext and decrypting accordingly.
 
+List privacy is item-level. A single list event may contain both public items in `tags` and private items in `.content`; clients SHOULD preserve both parts when editing a list. This NIP does not define a list-level public/private flag.
+
 When new items are added to an existing list, clients SHOULD append them to the end of the list, so they are stored in chronological order.
 
 ## Types of lists


### PR DESCRIPTION
## Summary
- Clarify that NIP-51 privacy is item-level, not list-level
- Tell clients to preserve both public `tags` and encrypted `.content` when editing mixed lists
- Explicitly state that NIP-51 does not define a list-level public/private flag

Closes #2186.

## Verification
- `npx --yes markdown-link-check --quiet 51.md`
- `git diff --check`

## Notes
This codifies the issue discussion: clients may use local UI defaults for public/private additions, but interoperable NIP-51 lists can contain both public and private items.
