### PR TITLE
Clarify NIP-39 proof text

### DIFF
--- a/39.md
+++ b/39.md
@@ -31,32 +31,36 @@ Clients SHOULD process any `i` tags with more than 2 values for future extensibi
 Identity provider names SHOULD only include `a-z`, `0-9` and the characters `._-/` and MUST NOT include `:`.
 Identity names SHOULD be normalized if possible by replacing uppercase letters with lowercase letters, and if there are multiple aliases for an entity the primary one should be used.
 
+## Proof text
+
+Verifiers SHOULD accept a proof resource that contains the claimed public key as `nostr:<npub encoded public key>` so the surrounding text can be localized. Verifiers MAY also accept the legacy English text defined in the claim types below. A bare `npub` without the `nostr:` prefix SHOULD NOT be considered sufficient proof.
+
 ## Claim types
 
 ### `github`
 
 Identity: A GitHub username.
 
-Proof: A GitHub Gist ID. This Gist should be created by `<identity>` with a single file that has the text `Verifying that I control the following Nostr public key: <npub encoded public key>`.
+Proof: A GitHub Gist ID. This Gist should be created by `<identity>` with a single file whose content follows [Proof text](#proof-text). Legacy clients may expect the text `Verifying that I control the following Nostr public key: <npub encoded public key>`.
 This can be located at `https://gist.github.com/<identity>/<proof>`.
 
 ### `twitter`
 
 Identity: A Twitter username.
 
-Proof: A Tweet ID. The tweet should be posted by `<identity>` and have the text `Verifying my account on nostr My Public Key: "<npub encoded public key>"`.
+Proof: A Tweet ID. The tweet should be posted by `<identity>` and follow [Proof text](#proof-text). Legacy clients may expect the text `Verifying my account on nostr My Public Key: "<npub encoded public key>"`.
 This can be located at `https://twitter.com/<identity>/status/<proof>`.
 
 ### `mastodon`
 
 Identity: A Mastodon instance and username in the format `<instance>/@<username>`.
 
-Proof: A Mastodon post ID. This post should be published by `<username>@<instance>` and have the text `Verifying that I control the following Nostr public key: "<npub encoded public key>"`.
+Proof: A Mastodon post ID. This post should be published by `<username>@<instance>` and follow [Proof text](#proof-text). Legacy clients may expect the text `Verifying that I control the following Nostr public key: "<npub encoded public key>"`.
 This can be located at `https://<identity>/<proof>`.
 
 ### `telegram`
 
 Identity: A Telegram user ID.
 
-Proof: A string in the format `<ref>/<id>` which points to a message published in the public channel or group with name `<ref>` and message ID `<id>`. This message should be sent by user ID `<identity>` and have the text `Verifying that I control the following Nostr public key: "<npub encoded public key>"`.
+Proof: A string in the format `<ref>/<id>` which points to a message published in the public channel or group with name `<ref>` and message ID `<id>`. This message should be sent by user ID `<identity>` and follow [Proof text](#proof-text). Legacy clients may expect the text `Verifying that I control the following Nostr public key: "<npub encoded public key>"`.
 This can be located at `https://t.me/<proof>`.


### PR DESCRIPTION
Closes #837.

## Summary
- allows language-neutral NIP-39 proofs using `nostr:<npub>`
- keeps legacy English proof strings valid for compatibility
- says bare `npub` mentions are not sufficient proof

## Tests
- `npx --yes markdown-link-check --quiet 39.md`
- `git diff --check`