### PR TITLE
NIP-52E/52R: private calendar events, busy lists and recurring event support

### DIFF
--- a/52E.md
+++ b/52E.md
@@ -8,9 +8,8 @@ This NIP extends [NIP-52](https://github.com/nostr-protocol/nips/blob/master/52.
 
 - **Private time-based events** visible only to invited participants (kind `32678`)
 - **Private day events** visible only to invited participants (kind `32681`)
-- **Calendar event gift wraps** that deliver decryption keys to participants (kind `1052`)
+- **Calendar event gift wraps** that deliver decryption keys to participants (kind `1059`)
 - **Private calendar lists** — self-encrypted personal collections of event references (kind `32123`)
-- **Participant removal** events to opt out of a private event (kind `84`)
 - **Public busy lists** for declaring unavailability without leaking event details (kind `31926`)
 
 ---
@@ -29,10 +28,9 @@ NIP-52E uses a **view key** pattern: event content is encrypted with a randomly 
 |-------|------|------|
 | 32678 | Private Time-Based Calendar Event | Parameterized replaceable |
 | 32681 | Private Day Event | Parameterized replaceable |
-| 1052  | Calendar Event Gift Wrap | Regular (NIP-59) |
-| 52    | Calendar Event Rumor | Unsigned (inside gift wrap) |
+| 1059  | Calendar Event Gift Wrap | Regular (NIP-59) |
+| 1052  | Calendar Invitation Rumor | Unsigned (inside gift wrap) |
 | 32123 | Private Calendar List | Parameterized replaceable |
-| 84    | Participant Removal | Regular |
 | 31926 | Public Busy List | Parameterized replaceable |
 
 ---
@@ -220,7 +218,7 @@ Decrypted inner tags (after applying the view key):
 
 ---
 
-## 3. Calendar Event Gift Wrap (kind `1052`)
+## 3. Calendar Event Gift Wrap (kind `1059`)
 
 When a private event is created, the author sends a [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md) gift wrap to each participant (including themselves). The gift wrap carries the `viewKey` so participants can decrypt the event.
 
@@ -249,16 +247,18 @@ The `a` tag uses the standard NIP-01 parameterized address format: `kind:pubkey:
 **Layer 2 — Seal** (kind `13`, signed by sender):
 - `content`: `nip44Encrypt(recipientPubkey, JSON.stringify(rumor))`
 
-**Layer 3 — Gift Wrap** (kind `1052`, signed by a random ephemeral key):
+**Layer 3 — Gift Wrap** (kind `1059`, signed by a random ephemeral key):
 - `content`: `nip44Encrypt(ephemeralKey, recipientPubkey, JSON.stringify(seal))`
-- `tags`: `[["p", "<recipient hex pubkey>"]]`
+- `tags`: `[["p", "<recipient hex pubkey>"], ["k", "1052"]]`
+
+The outer `k` tag signals the rumor kind (`1052`) without decryption, allowing relay-side filtering to distinguish calendar invitations from other gift-wrapped content such as DMs.
 
 ### Fetching Gift Wraps
 
 Clients subscribe with:
 
 ```
-{ "kinds": [1052], "#p": ["<user hex pubkey>"] }
+{ "kinds": [1059], "#p": ["<user hex pubkey>"], "#k": ["1052"] }
 ```
 
 Unwrap: gift wrap → seal → rumor → extract the `a` tag coordinate and `viewKey`.
@@ -271,7 +271,6 @@ When the user accepts an invitation:
 2. Add the reference to the user's chosen calendar list (kind `32123`)
 3. Re-publish the updated calendar list
 
-When the user dismisses an invitation, it is hidden locally and not added to any calendar.
 
 ### Deduplication
 
@@ -503,25 +502,27 @@ Note: this filter will not return the recurring event, so always fetch it separa
 
 ---
 
-## 6. Participant Removal (kind `84`)
+## 6. Invitation Dismissal
 
-Published by a participant who opts out of a private event. This notifies the event author and other participants that this person is no longer attending.
+To dismiss an invitation of a private event, a participant publishes a [NIP-09](https://github.com/nostr-protocol/nips/blob/master/09.md) kind `5` deletion event referencing the event coordinate:
 
 ```json
 {
-  "kind": 84,
+  "kind": 5,
   "pubkey": "<departing participant hex pubkey>",
   "created_at": <unix timestamp>,
   "tags": [
     ["a", "<32678|32681>:<author-pubkey>:<event-d-tag>"],
+    ["k", "1059"],
     ["e", "<private event id>"],
-    ["k", "<32678|32681>"]
   ],
   "content": "<optional reason>",
   "id": "<event id>",
   "sig": "<signature>"
 }
 ```
+
+NIP-59 supports NIP-09 deletion, so this pattern extends naturally to dismissing gift-wrapped invitations.
 
 ---
 
@@ -582,14 +583,14 @@ Use kind `32678` for time-based events (`start`/`end` as Unix timestamps) and ki
              ["viewKey", "{nsec(viewSecretKey)}"]]
       content: ""
    b. Seal (kind 13): encrypt rumor for recipient using sender's key
-   c. Gift Wrap (kind 1052): encrypt seal using ephemeral key, tag with recipient pubkey
+   c. Gift Wrap (kind 1059): encrypt seal using ephemeral key, tag with recipient pubkey and ["k", "1052"]
    d. Fetch recipient's NIP-65 inbox relays → publish gift wrap there
 ```
 
 ### Receiving and Accepting an Invitation
 
 ```
-1. Subscribe: { kinds: [1052], "#p": [myPubkey] }
+1. Subscribe: { kinds: [1059], "#p": [myPubkey], "#k": ["1052"] }
 2. For each gift wrap received:
    a. Unwrap: gift wrap → seal → rumor
    b. Extract event coordinate, relayHint, and viewKey from rumor tags
@@ -601,7 +602,7 @@ Use kind `32678` for time-based events (`start`/`end` as Unix timestamps) and ki
    a. Build event ref: [coordinate, relayHint, nsecViewKey]
       (relayHint comes from the rumor's a tag — the author's chosen fetch relay)
    b. Add to chosen calendar list (kind 32123), re-publish
-4. User dismisses: hide locally, do not add to calendar
+4. User dismisses: publish a kind `5` deletion event referencing the event coordinate (see §6), then hide locally
 ```
 
 ### Loading Calendar Events at Startup
@@ -626,10 +627,10 @@ Use kind `32678` for time-based events (`start`/`end` as Unix timestamps) and ki
 
 ## Security Considerations
 
-- **Relay metadata**: Even with encrypted content, relay operators can observe that a user publishes kind `32123` events and receives kind `1052` gift wraps. Event frequency and timing are not hidden.
+- **Relay metadata**: Even with encrypted content, relay operators can observe that a user publishes kind `32123` events and receives kind `1059` gift wraps. Event frequency and timing are not hidden.
 - **View key distribution**: Once a `viewKey` is shared via gift wrap, the recipient can share it further. There is no technical enforcement of access control beyond key distribution.
 - **Calendar list privacy**: Self-encryption (encrypted to own pubkey) means no one else can read the list — but it also means losing the private key means losing all calendar data.
 - **Gift wrap sender privacy**: NIP-59 gift wraps use ephemeral keys for the outer wrap, obscuring the sender's identity from relay operators. The seal layer uses the sender's actual key to authenticate to the recipient.
 - **No forward secrecy**: If a `viewKey` is compromised, all past and future versions of the event (same `d-tag`) are readable. Rotating the key requires publishing a new event with a new `viewKey` and re-sharing it.
 - **Busy list granularity**: Monthly busy lists reveal *when* a user is unavailable but not the reason. Publishing very short or very precise blocks may allow inference about the nature of events. Clients MAY round block boundaries to reduce this risk.
-- **Removing Participants**: Removing a participant from the event simply will not remove the participant's access from that event. To fully remove a participant, the key with which the event was encrypted should be rotated and sent to the other participants. This NIP does not define the protocol for key rotation, but the clients should keep this in mind while designing the feature
+- **Removing Participants**: Removing a participant from the event does not revoke their access — they retain the `viewKey` from their original invitation. To fully revoke access, the view key must be rotated and new gift wraps sent to the remaining participants. This NIP does not define the protocol for key rotation, but clients should keep this in mind while designing the feature.

--- a/52E.md
+++ b/52E.md
@@ -1,0 +1,635 @@
+# NIP-52E
+
+## Private Calendar Events and Private Calendar Lists
+
+`draft` `optional`
+
+This NIP extends [NIP-52](https://github.com/nostr-protocol/nips/blob/master/52.md) with a privacy layer, adding:
+
+- **Private time-based events** visible only to invited participants (kind `32678`)
+- **Private day events** visible only to invited participants (kind `32681`)
+- **Calendar event gift wraps** that deliver decryption keys to participants (kind `1052`)
+- **Private calendar lists** — self-encrypted personal collections of event references (kind `32123`)
+- **Participant removal** events to opt out of a private event (kind `84`)
+- **Public busy lists** for declaring unavailability without leaking event details (kind `31926`)
+
+---
+
+## Motivation
+
+NIP-52 defines public calendar events visible to everyone. Many real-world scheduling needs — personal appointments, private meetings, sensitive bookings — require events that are invisible to relay operators and the general public.
+
+NIP-52E uses a **view key** pattern: event content is encrypted with a randomly generated keypair. The secret key ("view key") is distributed to each intended participant. This separates content encryption from identity and makes it easy to edit events without re-keying recipients.
+
+---
+
+## Event Kinds
+
+| Kind  | Name | Type |
+|-------|------|------|
+| 32678 | Private Time-Based Calendar Event | Parameterized replaceable |
+| 32681 | Private Day Event | Parameterized replaceable |
+| 1052  | Calendar Event Gift Wrap | Regular (NIP-59) |
+| 52    | Calendar Event Rumor | Unsigned (inside gift wrap) |
+| 32123 | Private Calendar List | Parameterized replaceable |
+| 84    | Participant Removal | Regular |
+| 31926 | Public Busy List | Parameterized replaceable |
+
+---
+
+## View Key Pattern
+
+Each private event is encrypted with an independent, randomly generated NIP-44 keypair:
+
+1. Generate a random secret key: `viewSecretKey = generateSecretKey()`
+2. Derive its public key: `viewPublicKey = getPublicKey(viewSecretKey)`
+3. Compute a NIP-44 conversation key: `ck = nip44.getConversationKey(viewSecretKey, viewPublicKey)`
+4. Encrypt content: `nip44.encrypt(JSON.stringify(innerTags), ck)`
+
+This is a **self-encryption** pattern: the view key encrypts data to its own corresponding public key. Anyone who has `viewSecretKey` can derive `viewPublicKey` and decrypt.
+
+The `viewSecretKey` is encoded as an `nsec` bech32 string (NIP-19) for storage and transfer.
+
+Decryption:
+
+```
+viewSecretKey = nip19.decode(nsecViewKey).data
+viewPublicKey = getPublicKey(viewSecretKey)
+ck = nip44.getConversationKey(viewSecretKey, viewPublicKey)
+innerTags = JSON.parse(nip44.decrypt(event.content, ck))
+```
+
+---
+
+## 1. Private Time-Based Calendar Event (kind `32678`)
+
+A private time-based calendar event. The equivalent of NIP-52 kind `31923`, but fully encrypted.
+
+### Event Structure
+
+```json
+{
+  "kind": 32678,
+  "pubkey": "<author hex pubkey>",
+  "created_at": <unix timestamp>,
+  "tags": [["d", "<event d-tag>"]],
+  "content": "<NIP-44 encrypted blob>",
+  "id": "<event id>",
+  "sig": "<signature>"
+}
+```
+
+Only the `d` tag is public. All event data lives in the encrypted `content`.
+
+### Encrypted Content
+
+The plaintext is a JSON array of tags, serialized and then encrypted:
+
+```json
+[
+  ["title", "<event title>"],
+  ["description", "<event description>"],
+  ["start", <unix timestamp in seconds>],
+  ["end", <unix timestamp in seconds>],
+  ["image", "<optional image URL>"],
+  ["d", "<event d-tag>"],
+  ["location", "<optional location>"],
+  ["p", "<author hex pubkey>"],
+  ["p", "<participant hex pubkey>"],
+  ["L", "rrule"],
+  ["l", "<RRULE string, e.g. FREQ=WEEKLY;BYDAY=MO>"],
+  ["notification", "<enabled|disabled>"]
+]
+```
+
+Required inner tags: `title`, `start`, `d`.
+Optional inner tags: `description`, `end`, `image`, `location`, `p` (participants), `L`/`l` (RRULE for recurring events), `notification`.
+
+Both regular and recurring events use kind `32678`. Recurring events are identified by the presence of `L`/`l` (RRULE) tags in the decrypted payload.
+
+### Example
+
+Published event (only `d` tag visible):
+
+```json
+{
+  "kind": 32678,
+  "pubkey": "ab12cd34ef56...",
+  "created_at": 1700000000,
+  "tags": [["d", "7f3a2b1c0e"]],
+  "content": "BpGtXz3...<NIP-44 ciphertext>...Qm9lR",
+  "id": "...",
+  "sig": "..."
+}
+```
+
+Decrypted inner tags (after applying the view key):
+
+```json
+[
+  ["title", "Team Sync"],
+  ["description", "Weekly alignment meeting"],
+  ["start", 1700002800],
+  ["end", 1700006400],
+  ["image", ""],
+  ["d", "7f3a2b1c0e"],
+  ["location", "https://meet.example.com/abc"],
+  ["p", "ab12cd34ef56..."],
+  ["p", "12ab34cd56ef..."]
+]
+```
+
+---
+
+## 2. Private Day Event (kind `32681`)
+
+A private date-based calendar event spanning one or more whole days. The equivalent of NIP-52 kind `31922`, but fully encrypted using the same view-key pattern as kind `32678`.
+
+### Event Structure
+
+```json
+{
+  "kind": 32681,
+  "pubkey": "<author hex pubkey>",
+  "created_at": <unix timestamp>,
+  "tags": [["d", "<event d-tag>"]],
+  "content": "<NIP-44 encrypted blob>",
+  "id": "<event id>",
+  "sig": "<signature>"
+}
+```
+
+Only the `d` tag is public. All event data lives in the encrypted `content`.
+
+### Encrypted Content
+
+The plaintext is a JSON array of tags, serialized and then encrypted. Dates use the `YYYY-MM-DD` format from NIP-52 — not Unix timestamps:
+
+```json
+[
+  ["title", "<event title>"],
+  ["description", "<event description>"],
+  ["start", "<YYYY-MM-DD>"],
+  ["end", "<YYYY-MM-DD>"],
+  ["image", "<optional image URL>"],
+  ["d", "<event d-tag>"],
+  ["location", "<optional location>"],
+  ["p", "<author hex pubkey>"],
+  ["p", "<participant hex pubkey>"],
+  ["L", "rrule"],
+  ["l", "<RRULE string, e.g. FREQ=YEARLY>"],
+  ["notification", "<enabled|disabled>"]
+]
+```
+
+Required inner tags: `title`, `start`, `d`.
+Optional inner tags: `description`, `end` (exclusive end date; if absent the event spans only `start`), `image`, `location`, `p` (participants), `L`/`l` (RRULE for recurring events), `notification`.
+
+The `end` date is **exclusive** (following NIP-52 convention): an event with `start: 2024-12-24` and `end: 2024-12-26` spans December 24–25.
+
+### Example
+
+Published event (only `d` tag visible):
+
+```json
+{
+  "kind": 32681,
+  "pubkey": "ab12cd34ef56...",
+  "created_at": 1700000000,
+  "tags": [["d", "4a1b2c3d0f"]],
+  "content": "CqHzYw8...<NIP-44 ciphertext>...Rn2kS",
+  "id": "...",
+  "sig": "..."
+}
+```
+
+Decrypted inner tags (after applying the view key):
+
+```json
+[
+  ["title", "Company Offsite"],
+  ["description", "Annual team offsite"],
+  ["start", "2024-12-09"],
+  ["end", "2024-12-13"],
+  ["d", "4a1b2c3d0f"],
+  ["location", "Lisbon, Portugal"],
+  ["p", "ab12cd34ef56..."],
+  ["p", "12ab34cd56ef..."]
+]
+```
+
+---
+
+## 3. Calendar Event Gift Wrap (kind `1052`)
+
+When a private event is created, the author sends a [NIP-59](https://github.com/nostr-protocol/nips/blob/master/59.md) gift wrap to each participant (including themselves). The gift wrap carries the `viewKey` so participants can decrypt the event.
+
+Recipients see incoming gift wraps as **invitations** — they must explicitly accept them to add the event to one of their calendars.
+
+### Three-Layer NIP-59 Structure
+
+**Layer 1 — Rumor** (kind `52`, unsigned, not broadcast):
+
+```json
+{
+  "kind": 52,
+  "pubkey": "<sender hex pubkey>",
+  "created_at": <unix timestamp>,
+  "tags": [
+    ["a", "<32678|32681>:<author hex pubkey>:<event d-tag>", "<relay hint URL>"],
+    ["viewKey", "<nsec-encoded view secret key>"]
+  ],
+  "content": "",
+  "id": "<rumor id>"
+}
+```
+
+The `a` tag uses the standard NIP-01 parameterized address format: `kind:pubkey:d-tag`. Use `32678` for time-based events and `32681` for day events. The relay hint is the URL of a relay that accepted the private event, so the recipient can fetch it.
+
+**Layer 2 — Seal** (kind `13`, signed by sender):
+- `content`: `nip44Encrypt(recipientPubkey, JSON.stringify(rumor))`
+
+**Layer 3 — Gift Wrap** (kind `1052`, signed by a random ephemeral key):
+- `content`: `nip44Encrypt(ephemeralKey, recipientPubkey, JSON.stringify(seal))`
+- `tags`: `[["p", "<recipient hex pubkey>"]]`
+
+### Fetching Gift Wraps
+
+Clients subscribe with:
+
+```
+{ "kinds": [1052], "#p": ["<user hex pubkey>"] }
+```
+
+Unwrap: gift wrap → seal → rumor → extract the `a` tag coordinate and `viewKey`.
+
+### Invitation Acceptance
+
+When the user accepts an invitation:
+
+1. Build an event reference: `["{32678|32681}:{authorPubkey}:{dTag}", "{relayHint}", "{nsecViewKey}"]`
+2. Add the reference to the user's chosen calendar list (kind `32123`)
+3. Re-publish the updated calendar list
+
+When the user dismisses an invitation, it is hidden locally and not added to any calendar.
+
+### Deduplication
+
+Before displaying an invitation, check if the event's `d-tag` already exists in any of the user's calendar lists. If it does, skip the gift wrap silently (the user already has the event).
+
+---
+
+## 4. Private Calendar List (kind `32123`)
+
+A private calendar list is a **self-encrypted**, parameterized replaceable event that organizes a user's private events into a named, colored collection. A user can have multiple calendar lists (e.g. "Work", "Personal", "Travel").
+
+**Self-encryption**: The content is encrypted using NIP-44 with the user's own public key (via the signer). Only the user's private key can decrypt it. This keeps calendar lists private even on public relays.
+
+### Event Structure
+
+```json
+{
+  "kind": 32123,
+  "pubkey": "<user hex pubkey>",
+  "created_at": <unix timestamp>,
+  "tags": [["d", "<calendar d-tag>"]],
+  "content": "<NIP-44 self-encrypted blob>",
+  "id": "<event id>",
+  "sig": "<signature>"
+}
+```
+
+### d-tag Derivation
+
+The `d` tag can be the first 16 hex characters (8 bytes) of the SHA-256 hash of `"<title>:<created_at>"`:
+
+```
+d = SHA-256("<title>:<created_at>").slice(0, 16)
+```
+
+Because parameterized replaceable events are scoped to `kind:pubkey:d`, the `d` tag only needs to be unique per author — a short, deterministic hash is sufficient. Using the title and creation time (rather than a random UUID) makes the identifier stable and reproducible from the same inputs.
+
+Example: title `"Work"`, `created_at` `1700000000` → `d = SHA-256("Work:1700000000").slice(0, 16)`
+
+### Encryption and Decryption
+
+```
+// Encrypt
+encryptedContent = signer.nip44Encrypt(userPubkey, JSON.stringify(innerTags))
+
+// Decrypt
+plaintext = signer.nip44Decrypt(event.pubkey, event.content)
+// event.pubkey == userPubkey, completing the self-encryption round-trip
+```
+
+### Encrypted Inner Tags
+
+```json
+[
+  ["title", "<calendar name>"],
+  ["content", "<optional calendar description>"],
+  ["color", "<hex color code, e.g. #4285f4>"],
+  ["notifications", "disabled"],
+  ["a", "32678:<authorPubkey>:<eventDTag>", "<relayUrl>", "<nsecViewKey>"],
+  ["a", "32681:<authorPubkey>:<eventDTag>", "<relayUrl>", "<nsecViewKey>"]
+]
+```
+
+**Inner tag reference:**
+
+| Tag | Required | Description |
+|-----|----------|-------------|
+| `title` | Yes | Display name of the calendar |
+| `content` | No | Calendar description (use empty string if omitted) |
+| `color` | No | Hex color code for UI theming |
+| `notifications` | No | `"disabled"` to mute all notifications for this calendar; omit to enable |
+| `a` | Repeated | Event reference (see below) |
+
+### Event Reference Format
+
+Each `a` tag in the decrypted inner tags is an event reference with this structure:
+
+```
+["a", "{kind}:{authorPubkey}:{eventDTag}", "{relayUrl}", "{nsecViewKey}"]
+```
+
+| Position | Content |
+|----------|---------|
+| `[0]` | `"a"` |
+| `[1]` | NIP-01 parameterized address: `kind:hex-pubkey:d-tag` |
+| `[2]` | Relay hint URL (empty string if none) |
+| `[3]` | `nsec`-encoded view secret key for decrypting the referenced event |
+
+### Full Example
+
+Raw event on relay (only `d` tag visible to anyone):
+
+```json
+{
+  "kind": 32123,
+  "pubkey": "ab12cd34...",
+  "created_at": 1700000000,
+  "tags": [["d", "a3f8c21b4d7e9012"]],
+  "content": "Bx7Tz2...<NIP-44 ciphertext>...kR3mP",
+  "id": "...",
+  "sig": "..."
+}
+```
+
+Decrypted inner tags:
+
+```json
+[
+  ["title", "Work"],
+  ["content", "Work meetings and deadlines"],
+  ["color", "#1a73e8"],
+  ["a", "32678:ab12cd34...:7f3a2b1c0e", "wss://relay.damus.io/", "nsec1xyz..."],
+  ["a", "32678:ab12cd34...:9d8e7f6a5b", "wss://relay.damus.io/", "nsec1abc..."]
+]
+```
+
+### Deletion
+
+Calendar lists are deleted with a NIP-09 kind `5` event that references both:
+- The calendar list's event ID (`e` tag)
+- The parameterized address `32123:<pubkey>:<d-tag>` (`a` tag)
+
+### Visibility Toggle
+
+Whether a calendar list is shown or hidden in the UI is **client-side only** and not stored in the Nostr event. Clients should persist visibility state locally.
+
+---
+
+## 5. Public Busy List (kind `31926`)
+
+A public busy list declares when a user is unavailable — without revealing why or with whom. It is a parameterized replaceable event with an empty `content` field so no private details are ever leaked.
+
+Any calendar client that knows a user's pubkey can fetch their busy list and render unavailable blocks. This enables free/busy visibility across clients without sharing event content.
+
+There are two forms: **monthly** (one event per calendar month, updated whenever a new event is added or removed) and **recurring** (a single event holding repeating busy blocks expressed as RRULE strings, useful for standing commitments like weekly meetings or working hours). This is done to keep the event size reasonable.
+
+### Monthly Busy List
+
+One event per author per month. The `d` tag is the month in `YYYY-MM` format.
+
+```json
+{
+  "kind": 31926,
+  "pubkey": "<user hex pubkey>",
+  "created_at": 1700000000,
+  "tags": [
+    ["d", "2024-12"],
+    ["t", "2024-12"],
+    ["t", "busy"],
+    ["block", "1733230800", "1733232600"],
+    ["block", "1733320800", "1733323200"]
+  ],
+  "content": ""
+}
+```
+
+| Tag | Values | Required | Description |
+|-----|--------|----------|-------------|
+| `d` | `YYYY-MM` | Yes | Replacement key; one event per author per month |
+| `t` | `YYYY-MM` | Yes | Queryable month hashtag for relay-side filtering |
+| `t` | `"busy"` | Yes | Secondary tag for discovery |
+| `block` | `<start-unix-sec>`, `<end-unix-sec>` | Repeated | Unavailable time range. All values in Unix seconds. Repeat for multiple blocks within the month |
+
+`content` MUST be the empty string. No titles, descriptions, or participant information may appear anywhere in the event.
+
+Since this is parameterized replaceable, publishing a new version replaces the old one. Clients MUST include all blocks for the month in each published version — partial updates are not supported.
+
+### Recurring Busy List
+
+A single event holds standing commitments that repeat indefinitely. The `d` tag is the literal string `"recurring"`, distinguishing it from month-keyed events.
+
+```json
+{
+  "kind": 31926,
+  "pubkey": "<user hex pubkey>",
+  "created_at": 1700000000,
+  "tags": [
+    ["d", "recurring"],
+    ["t", "busy"],
+    ["block", "1733230800", "1733232600", "FREQ=WEEKLY;BYDAY=MO,WE,FR"],
+    ["block", "1733284800", "1733288400", "FREQ=DAILY"]
+  ],
+  "content": ""
+}
+```
+
+| Tag | Values | Required | Description |
+|-----|--------|----------|-------------|
+| `d` | `"recurring"` | Yes | Identifies this as the recurring busy list |
+| `t` | `"busy"` | Yes | Secondary tag for discovery |
+| `block` | `<start-unix-sec>`, `<end-unix-sec>`, `<rrule>` | Repeated | A recurring unavailable range. `start` and `end` define the **first occurrence**. `rrule` is a bare RFC 5545 RRULE value (no `RRULE:` prefix). The duration of each occurrence equals `end − start` seconds |
+
+The `rrule` value follows [RFC 5545 §3.8.5.3](https://www.rfc-editor.org/rfc/rfc5545#section-3.8.5.3). The `start` timestamp of the `block` tag serves as `DTSTART`; clients MUST NOT include `DTSTART` inside the RRULE string itself.
+
+#### Example expansion
+
+```
+["block", "1733230800", "1733232600", "FREQ=WEEKLY;BYDAY=MO"]
+```
+
+`end − start = 1800 s` (30 minutes). Starting from Unix timestamp `1733230800` (a Monday), this block recurs every Monday for 30 minutes. Clients expand all occurrences within the date range they are querying and treat each as an unavailable block.
+
+### Querying Busy Lists
+
+Fetch both monthly and recurring busy lists for a user in one subscription:
+
+```json
+{ "kinds": [31926], "authors": ["<user-pubkey>"] }
+```
+
+Filter client-side: events whose `d` tag matches `YYYY-MM` are monthly; the event with `d = "recurring"` contains RRULE-based blocks.
+
+To fetch only specific months (e.g. December 2024):
+
+```json
+{ "kinds": [31926], "authors": ["<user-pubkey>"], "#t": ["2024-12", "busy"] }
+```
+
+Note: this filter will not return the recurring event, so always fetch it separately or use the unfiltered query when checking availability.
+
+### Client Directives
+
+- Clients MUST NOT include any private details (titles, participants, locations) in busy list events. `content` MUST always be the empty string.
+- Clients SHOULD update the relevant monthly busy list whenever a private event that occupies a time block is created, edited, or deleted.
+- Clients SHOULD publish or update the recurring busy list whenever the user creates or removes a recurring private event.
+- For the above 2 cases, clients SHOULD ideally ask the user if they want a calendar event added to their public busy list.
+- When evaluating whether a time slot is free, clients MUST expand all recurring `block` entries for the date range under consideration and union them with the relevant monthly blocks.
+- Clients SHOULD fetch the recurring busy list alongside monthly busy lists whenever computing availability for any date range.
+
+---
+
+## 6. Participant Removal (kind `84`)
+
+Published by a participant who opts out of a private event. This notifies the event author and other participants that this person is no longer attending.
+
+```json
+{
+  "kind": 84,
+  "pubkey": "<departing participant hex pubkey>",
+  "created_at": <unix timestamp>,
+  "tags": [
+    ["a", "<32678|32681>:<author-pubkey>:<event-d-tag>"],
+    ["e", "<private event id>"],
+    ["k", "<32678|32681>"]
+  ],
+  "content": "<optional reason>",
+  "id": "<event id>",
+  "sig": "<signature>"
+}
+```
+
+---
+
+## Relay Hints
+
+Private events, gift wraps, and calendar lists span multiple parties and relays. Correct relay selection is critical: a stale or missing hint means participants cannot fetch the event.
+
+### Publishing Private Events
+
+When publishing a private event (kind `32678` or `32681`), the author MUST choose relays that all participants can read. The recommended strategy is:
+
+1. Fetch each participant's NIP-65 relay list (kind `10002`).
+2. Collect their **inbox** (read) relays.
+3. Publish the event to the union of the author's own write relays and all participants' inbox relays.
+
+The **relay hint** stored in the gift wrap rumor and in the calendar list MUST be one of the relays that accepted the event. Prefer a relay that all participants are likely to have read access to.
+
+### Sending Gift Wraps
+
+Each gift wrap (kind `1052`) is addressed to a single recipient and MUST be published to that recipient's inbox relays (from their NIP-65 kind `10002` relay list). Do not publish gift wraps to the author's own relays — the recipient may never see them.
+
+The rumor inside the gift wrap carries a relay hint in its `a` tag. This hint MUST point to a relay that currently hosts the private event, so the recipient can fetch it immediately after unwrapping.
+
+### Relay Hints in Calendar Lists
+
+The relay hint stored in each `a` tag inside a kind `32123` calendar list must remain accurate over time:
+
+- **At creation**: store the relay hint returned from the event publish step above.
+- **After editing**: if the event is re-published (e.g., to additional relays), update the calendar list's relay hint to a relay that has the latest version.
+- **At acceptance**: when a recipient accepts an invitation, they MUST extract the relay hint from the gift wrap's rumor `a` tag and store it verbatim in their calendar list entry. This is the relay the author chose as the canonical fetch point.
+- **Stale hints**: if a fetch against the stored hint fails, clients SHOULD retry against their known relay set before treating the event as missing. Clients SHOULD then update the stored hint to a relay that responded successfully.
+
+---
+
+## Complete Protocol Flows
+
+### Creating a Private Event
+
+Use kind `32678` for time-based events (`start`/`end` as Unix timestamps) and kind `32681` for day events (`start`/`end` as `YYYY-MM-DD` dates).
+
+```
+1. Generate viewSecretKey (random)
+2. Build inner tags array: [["title", ...], ["start", ...], ...]
+   (use Unix timestamps for 32678; use YYYY-MM-DD strings for 32681)
+3. content = nip44.encrypt(JSON.stringify(innerTags),
+             nip44.getConversationKey(viewSecretKey, getPublicKey(viewSecretKey)))
+4. Determine target relays:
+   - Fetch NIP-65 relay lists (kind 10002) for all participants
+   - targetRelays = union(author write relays, all participant inbox relays)
+5. Publish { kind: 32678|32681, tags: [["d", dTag]], content } to targetRelays
+   - relayHint = one relay from targetRelays that accepted the event
+6. Build event ref: ["32678|32681:{authorPubkey}:{dTag}", "{relayHint}", "{nsec(viewSecretKey)}"]
+7. Add event ref to creator's calendar list (kind 32123), re-encrypt, re-publish
+8. Update the relevant month's busy list (kind 31926) with the event's time block
+9. For each participant (including creator):
+   a. Create rumor (kind 52):
+      tags: [["a", "32678|32681:{authorPubkey}:{dTag}", "{relayHint}"],
+             ["viewKey", "{nsec(viewSecretKey)}"]]
+      content: ""
+   b. Seal (kind 13): encrypt rumor for recipient using sender's key
+   c. Gift Wrap (kind 1052): encrypt seal using ephemeral key, tag with recipient pubkey
+   d. Fetch recipient's NIP-65 inbox relays → publish gift wrap there
+```
+
+### Receiving and Accepting an Invitation
+
+```
+1. Subscribe: { kinds: [1052], "#p": [myPubkey] }
+2. For each gift wrap received:
+   a. Unwrap: gift wrap → seal → rumor
+   b. Extract event coordinate, relayHint, and viewKey from rumor tags
+   c. Check if event d-tag already exists in any calendar list → skip if so
+   d. Fetch from relayHint first, then fall back to known relays:
+      { kinds: [32678, 32681], "#d": [eventDTag], authors: [authorPubkey] }
+   e. Decrypt with viewKey → display as pending invitation
+3. User accepts:
+   a. Build event ref: [coordinate, relayHint, nsecViewKey]
+      (relayHint comes from the rumor's a tag — the author's chosen fetch relay)
+   b. Add to chosen calendar list (kind 32123), re-publish
+4. User dismisses: hide locally, do not add to calendar
+```
+
+### Loading Calendar Events at Startup
+
+```
+1. Fetch own calendar lists: { kinds: [32123], authors: [myPubkey] }
+2. Self-decrypt each list → extract event refs
+3. Parse each ref to get: kind, authorPubkey, eventDTag, relayUrl, viewKey
+4. Fetch events, prioritising the stored relay hint per event:
+   { kinds: [32678, 32681], "#d": [dTags], authors: [authorPubkeys] }
+   (send each request to its relay hint first; merge fallback relays for any misses)
+5. Decrypt each event: viewPrivateKey = decode(nsecViewKey),
+   innerTags = JSON.parse(nip44.decrypt(event.content,
+                          getConversationKey(viewPrivateKey, getPublicKey(viewPrivateKey))))
+6. Associate each event with its calendar (for color theming, visibility)
+7. Deduplicate by event d-tag, keeping the higher created_at version
+8. For any event that was fetched from a relay other than its stored hint,
+   update the calendar list entry with the new relay hint and re-publish
+```
+
+---
+
+## Security Considerations
+
+- **Relay metadata**: Even with encrypted content, relay operators can observe that a user publishes kind `32123` events and receives kind `1052` gift wraps. Event frequency and timing are not hidden.
+- **View key distribution**: Once a `viewKey` is shared via gift wrap, the recipient can share it further. There is no technical enforcement of access control beyond key distribution.
+- **Calendar list privacy**: Self-encryption (encrypted to own pubkey) means no one else can read the list — but it also means losing the private key means losing all calendar data.
+- **Gift wrap sender privacy**: NIP-59 gift wraps use ephemeral keys for the outer wrap, obscuring the sender's identity from relay operators. The seal layer uses the sender's actual key to authenticate to the recipient.
+- **No forward secrecy**: If a `viewKey` is compromised, all past and future versions of the event (same `d-tag`) are readable. Rotating the key requires publishing a new event with a new `viewKey` and re-sharing it.
+- **Busy list granularity**: Monthly busy lists reveal *when* a user is unavailable but not the reason. Publishing very short or very precise blocks may allow inference about the nature of events. Clients MAY round block boundaries to reduce this risk.
+- **Removing Participants**: Removing a participant from the event simply will not remove the participant's access from that event. To fully remove a participant, the key with which the event was encrypted should be rotated and sent to the other participants. This NIP does not define the protocol for key rotation, but the clients should keep this in mind while designing the feature

--- a/52R.md
+++ b/52R.md
@@ -1,0 +1,261 @@
+# NIP-52R
+
+## Recurring Calendar Events (Addendum to NIP-52)
+
+`draft` `optional`
+
+This NIP proposes extending [NIP-52](https://github.com/nostr-protocol/nips/blob/master/52.md) to support recurring (repeating) calendar events via [iCalendar RRULE](https://www.rfc-editor.org/rfc/rfc5545#section-3.8.5.3) strings attached using the [NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md) label convention.
+
+NIP-52 explicitly deferred recurring events as a future concern. This document proposes a minimal, backward-compatible mechanism that allows clients to express recurrence without inventing a new tag vocabulary.
+
+---
+
+## Motivation
+
+Recurring events — weekly standups, monthly reviews, annual birthdays, daily journaling reminders — are a fundamental part of how people use calendars. The iCalendar RRULE format (RFC 5545) is a widely understood, well-tested standard for expressing recurrence. Rather than designing a bespoke Nostr recurrence grammar, this NIP reuses RRULE directly.
+
+---
+
+## Approach: RRULE via NIP-32 Labels
+
+Recurrence is expressed by adding two tags to an existing kind `31923` (time-based) or kind `31922` (date-based) calendar event:
+
+```
+["L", "rrule"]
+["l", "<RRULE string>"]
+```
+
+- `["L", "rrule"]` declares the `rrule` label namespace (per NIP-32)
+- `["l", "<RRULE string>"]` carries the RRULE value as the label
+
+This is purely additive. Clients that do not understand these tags treat the event as a single non-recurring occurrence starting at `start`. Clients that understand RRULE expand the event into its occurrence set.
+
+---
+
+## Tag Specification
+
+### New optional tags (for kind `31922` and kind `31923`)
+
+| Tag | Value | Description |
+|-----|-------|-------------|
+| `L` | `"rrule"` | Declares the RRULE label namespace |
+| `l` | `"<RRULE string>"` | The recurrence rule; must follow RFC 5545 RRULE syntax |
+
+Both tags MUST appear together. An `L` tag with value `"rrule"` without a following `l` tag is invalid.
+
+### RRULE Syntax
+
+The value of the `l` tag is a bare RRULE property value per RFC 5545, **without** the `RRULE:` prefix and **without** a `DTSTART` component (the event's `start` tag serves as DTSTART).
+
+Examples of valid values:
+
+| Value | Meaning |
+|-------|---------|
+| `FREQ=DAILY` | Every day |
+| `FREQ=WEEKLY` | Every week on the same weekday as `start` |
+| `FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR` | Every weekday (Mon–Fri) |
+| `FREQ=MONTHLY` | Same day of the month, every month |
+| `FREQ=MONTHLY;INTERVAL=3` | Every 3 months (quarterly) |
+| `FREQ=YEARLY` | Same date each year |
+| `FREQ=WEEKLY;COUNT=10` | Every week, 10 times total |
+| `FREQ=DAILY;UNTIL=20260101T000000Z` | Every day until 1 Jan 2026 |
+
+Supported RRULE properties: `FREQ`, `INTERVAL`, `BYDAY`, `COUNT`, `UNTIL`.
+
+Clients SHOULD ignore (not fail on) unsupported RRULE properties for forward compatibility.
+
+### DTSTART
+
+The DTSTART used for RRULE expansion is the event's `start` tag value:
+- For kind `31923`: `start` is a Unix timestamp in seconds; convert to a UTC datetime for RRULE computation
+- For kind `31922`: `start` is an ISO 8601 date (YYYY-MM-DD); treat as a date-only DTSTART
+
+### Event Duration
+
+Duration is derived from `end - start`. Each occurrence has the same duration as the original event. If `end` is absent, duration is zero (instantaneous occurrence).
+
+---
+
+## Changes to the `D` Tag for Recurring Events
+
+The existing NIP-52 spec requires a `D` (day index) tag for kind `31923`:
+
+> `D` (required) the day-granularity unix timestamp on which the event takes place, calculated as `floor(unix_seconds() / seconds_in_one_day)`. Multiple tags SHOULD be included to cover the event's timeframe.
+
+For recurring events, enumerating every future occurrence as `D` tags is impractical (an infinite series has infinitely many). This NIP proposes the following revision:
+
+**For recurring events (`L`/`l` tags present):**
+
+- `D` tags are **optional** but SHOULD cover the next N upcoming occurrences from the time of publication (recommended: 52 occurrences, or 2 years of occurrences — whichever is smaller)
+- Clients MUST NOT rely solely on `D` tag filtering to discover recurring events; they should fetch by `d` tag or author and evaluate RRULE client-side
+- Including a reasonable window of `D` tags allows relay-side filtering to surface events that are "active now" without requiring clients to fetch all events and compute occurrences locally
+
+**For non-recurring events (no `L`/`l` tags):**
+
+- `D` tag behavior is unchanged from NIP-52
+
+---
+
+## Full Example: Kind `31923` with Recurrence
+
+A weekly team sync recurring every Monday:
+
+```json
+{
+  "kind": 31923,
+  "pubkey": "ab12cd34ef56...",
+  "created_at": 1700000000,
+  "content": "Weekly team alignment meeting",
+  "tags": [
+    ["d", "team-sync-weekly"],
+    ["title", "Team Sync"],
+    ["start", "1700650800"],
+    ["end", "1700654400"],
+    ["start_tzid", "America/New_York"],
+    ["end_tzid", "America/New_York"],
+    ["L", "rrule"],
+    ["l", "FREQ=WEEKLY;BYDAY=MO"],
+    ["D", "19680"],
+    ["D", "19687"],
+    ["D", "19694"],
+    ["location", "https://meet.example.com/team-sync"],
+    ["p", "ab12cd34ef56...", "", "organizer"],
+    ["p", "12ab34cd56ef...", "", "attendee"]
+  ]
+}
+```
+
+(The `D` values cover the next several Monday occurrences from the publication date.)
+
+A yearly birthday reminder with no end:
+
+```json
+{
+  "kind": 31922,
+  "pubkey": "ab12cd34ef56...",
+  "created_at": 1700000000,
+  "content": "Alice's birthday",
+  "tags": [
+    ["d", "alice-birthday"],
+    ["title", "Alice's Birthday"],
+    ["start", "1990-04-15"],
+    ["L", "rrule"],
+    ["l", "FREQ=YEARLY"]
+  ]
+}
+```
+
+A daily standup limited to 10 occurrences:
+
+```json
+{
+  "kind": 31923,
+  "pubkey": "ab12cd34ef56...",
+  "created_at": 1700000000,
+  "content": "Morning standup",
+  "tags": [
+    ["d", "standup-sprint-42"],
+    ["title", "Sprint 42 Standup"],
+    ["start", "1700650800"],
+    ["end", "1700652600"],
+    ["L", "rrule"],
+    ["l", "FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR;COUNT=10"]
+  ]
+}
+```
+
+---
+
+## Client Rendering
+
+### Computing Occurrences
+
+1. Parse the `start` tag as DTSTART
+2. Read the RRULE from the `l` tag
+3. Use an RFC 5545 RRULE library (e.g. `rrule.js`) to expand occurrences
+4. Each occurrence shares the same duration as the original event (`end - start`)
+5. When rendering a calendar view, find occurrences that fall within the visible date range
+
+Pseudocode:
+
+```
+dtstart = parse(event.start)          // Unix seconds → Date
+rruleStr = event.tags["l"]            // bare RRULE string
+rule = RRule.fromString(
+  "DTSTART:" + formatISO(dtstart) + "\n" +
+  "RRULE:" + rruleStr
+)
+duration = event.end - event.start    // in seconds
+occurrences = rule.between(viewStart, viewEnd)
+render(occurrences.map(occ => { begin: occ, end: occ + duration }))
+```
+
+### Fetching Recurring Events
+
+Because recurring events may have started long before the current view window, clients MUST NOT filter recurring events by `start` time alone. Specifically:
+
+- A weekly event started 2 years ago will have `start` = 2 years ago, but its next occurrence may be tomorrow
+- Clients should fetch events by `author` + `d` tag and evaluate RRULE client-side, or maintain a local cache of known recurring events
+
+Recommended fetch strategy:
+
+1. Fetch all events for a user with a broad or no time-range filter
+2. Identify events with `L = "rrule"` tags
+3. Expand their occurrences into the current view window
+4. For known-recurring events already in cache, always re-evaluate against the current view window on load
+
+### Deduplication with RSVP
+
+RSVPs (kind `31925`) reference a specific revision of a calendar event via its `a` tag and optional `e` tag. For recurring events, a single RSVP SHOULD be interpreted as applying to all future occurrences unless the RSVP's `e` tag pins it to a specific event revision. Clients MAY choose to allow per-occurrence RSVP by creating a separate RSVP event per occurrence.
+
+---
+
+## Modifying or Deleting Individual Occurrences
+
+NIP-52R does not define a mechanism for modifying individual occurrences of a recurring series (iCalendar calls these "exception dates" via `EXDATE` and override events via `RECURRENCE-ID`). This complexity is left to a future NIP extension.
+
+For now, the recommended approach for clients that need to cancel a single occurrence is to publish a new non-recurring event at the specific time, note in its description that it replaces the occurrence, and optionally notify participants via DM or gift wrap.
+
+---
+
+## Backward Compatibility
+
+- Clients that do not support RRULE will render the event as a single occurrence at `start`/`end` — exactly as any other NIP-52 event
+- The `L`/`l` tags are invisible to non-NIP-32-aware clients
+- No new event kinds are required; existing kinds `31922` and `31923` are reused
+- No changes to the RSVP kind `31925` are required
+
+---
+
+## Summary of Changes to NIP-52
+
+| Section | Change |
+|---------|--------|
+| Common tags | Add `L` (label namespace, optional) and `l` (label value, optional) |
+| Time-based event (kind 31923) | `D` tag is optional when `L = "rrule"` is present |
+| Date-based event (kind 31922) | `L`/`l` tags may express recurrence for annual/monthly date-based events |
+| Intentionally Unsupported section | Remove "Recurring Calendar Events" from unsupported list |
+| New section: Recurring Calendar Events | Document RRULE via NIP-32 labels as described above |
+
+---
+
+## Relationship to NIP-32
+
+[NIP-32](https://github.com/nostr-protocol/nips/blob/master/32.md) defines a generic label mechanism using `L` (namespace) and `l` (label value) tags. This NIP registers `"rrule"` as a label namespace for calendar events. The convention is:
+
+- `["L", "rrule"]` — declares this event has an RRULE label
+- `["l", "<value>", "rrule"]` — NIP-32 full form (the third element is the namespace)
+
+Both forms are acceptable. The two-tag form (without the namespace repeated in `l`) is preferred for brevity in calendar events since the adjacent `L` tag makes the namespace unambiguous.
+
+---
+
+## Reference Implementation
+
+A working implementation exists at [formstr-hq/nostr-calendar](https://github.com/formstr-hq/nostr-calendar) (live at [calendar.formstr.app](https://calendar.formstr.app)).
+
+Relevant source files:
+- `src/utils/repeatingEventsHelper.ts` — RRULE parsing, occurrence expansion, `buildRecurrenceRule` / `parseRecurrenceRule`
+- `src/common/calendarEngine.ts` — per-day occurrence rendering via `getEventSegmentForDay`
+- `src/utils/parser.ts` — `nostrEventToCalendar` RRULE tag parsing (`L`/`l` case)
+- `src/common/nostr.ts` — `preparePrivateCalendarEvent` shows RRULE tag emission pattern


### PR DESCRIPTION
  Introduces two companion extensions to NIP-52:

---

  **NIP-52R - Recurring Events**

  Extends NIP-52 with RRULE-based recurrence using L/l label tags inside event payloads.

---

  **NIP-52E - Private Calendar Events**

  Adds a privacy layer on top of NIP-52 using a view key pattern (NIP-44 self-encryption):

  - 32678 - Private time-based calendar event (encrypted equivalent of 31923)
  - 32681 -  Private day event (encrypted equivalent of 31922)
  - 1052 - Calendar event gift wrap (NIP-59) for distributing view keys to participants
  - 32123 - Private calendar list (self-encrypted, owner-only)
  - 31926 - Public busy list (signals unavailability without leaking event details)

  Only the d tag is public; all event content lives in the encrypted content field. Participants receive the
  viewKey (nsec) via gift wrap and can decrypt independently of the author.

  Full protocol flows are specified for: creating a private event, receiving and accepting an invitation, and
  loading calendar events at startup.

---

Closing #2027 in favour of this