### PR TITLE
nip23: use Djot

### DIFF
--- a/23.md
+++ b/23.md
@@ -14,11 +14,7 @@ Deprecated: `kind:30024` was used for long-form drafts (self-encrypted nip04, sa
 
 ### Format
 
-The `.content` of these events should be a string text in Markdown syntax. To maximize compatibility and readability between different clients and devices, any client that is creating long form notes:
-
-- MUST NOT hard line-break paragraphs of text, such as arbitrary line breaks at 80 column boundaries.
-
-- MUST NOT support adding HTML to Markdown.
+The `.content` of these events should be a string of text in [Djot](https://djot.net/) for the same reasons as in [NIP-54](https://github.com/nostr-protocol/nips/blob/master/54.md#why-djot).
 
 ### Metadata
 
@@ -65,4 +61,4 @@ References to other Nostr notes, articles or profiles must be made according to 
 
 ### Replies & Comments
 
-Replies to `kind 30023` MUST use [NIP-22](./22.md) `kind 1111` comments. 
+Replies to `kind 30023` MUST use [NIP-22](./22.md) `kind 1111` comments.


### PR DESCRIPTION
I believe this will make client devs happy. Clients currently show non-identical stuff; some devs keep [reinventing](https://github.com/cesardeazevedo/nosotros/issues/190#issuecomment-4149138284) parsers. And these parsers are possibly vulnerable to [DoS attacks](https://bgslabs.org/blog/why-are-we-using-markdown/#exhibit-a-bold-italic-bold-italic) as well.