### PR TITLE
nip50: add autocomplete:true/false search extension

### DIFF
--- a/50.md
+++ b/50.md
@@ -53,3 +53,4 @@ Relay MAY support these extensions:
 - `language:<two letter ISO 639-1 language code>` - include only events of a specified language
 - `sentiment:<negative/neutral/positive>` - include only events of a specific sentiment
 - `nsfw:<true/false>` - include or exclude nsfw events (default: true)
+- `autocomplete:<true/false>` - match the query as a prefix against short, name-shaped fields (e.g. profile `name`/`display_name`/`nip05`, channel `name`, `title` tags) instead of full-text content, suitable for typeahead/autocomplete UIs


### PR DESCRIPTION
Adds `autocomplete:true/false` token token to NIP-50.

It enables this interaction:

```
➜  ~ nak req -k 0 --search "fiat autocomplete:true" -l 1 relay.ditto.pub
relay.ditto.pub... ok.
{"kind":0,"id":"37ed86ba48007dfdab46b3605e5644fceb09605088e83645949650fb588adf4b","pubkey":"3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d","created_at":1755901618,"tags":[],"content":"{\"name\":\"fiatjaf\",\"about\":\"~\",\"picture\":\"https://fiatjaf.com/static/favicon.jpg\",\"nip05\":\"_@fiatjaf.com\",\"lud16\":\"npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6@npub.cash\",\"website\":\"https://stuff.fiatjaf.com/\",\"banner\":\"https://cdn.satellite.earth/8f10244a702cbc2ca57b6c27a57b8cc02d5fdddccab0fc2e5988ce17e08f1732.jpg\"}","sig":"6f6d71ab2eb8bb21e66bcfee43a7d5ea4e0ae3a6f062cec462fa9405af67a60681134cf00ccc754984aa621a47ca73d1c7ec096e56c48b4a812b8330acd84ea7"}
```

Ditto Relay implements it for things like Follow Packs, Lists, and any events with a "title" tag.