### PR TITLE
Use kind 1111 replies to kind 1 notes (#2250)

### DIFF
--- a/22.md
+++ b/22.md
@@ -56,8 +56,6 @@ Their uppercase versions use the same type of values but relate to the root item
 
 `p` tags SHOULD be used when mentioning pubkeys in the `.content` with [NIP-21](21.md).
 
-Comments MUST NOT be used to reply to kind 1 notes. [NIP-10](10.md) should instead be followed.
-
 ## Examples
 
 A comment on a blog post looks like this:


### PR DESCRIPTION
Remove the line that discourages the use of kind 1111 replies to kind 1 notes (#2250)