### PR TITLE
NIP-46: add logout method to end remote signer sessions

### DIFF
--- a/46.md
+++ b/46.md
@@ -106,6 +106,7 @@ Each of the following are methods that the _client_ sends to the _remote-signer_
 | `nip44_encrypt`          | `[<third_party_pubkey>, <plaintext_to_encrypt>]`                              | `<nip44_ciphertext>`                                                   |
 | `nip44_decrypt`          | `[<third_party_pubkey>, <nip44_ciphertext_to_decrypt>]`                       | `<plaintext>`                                                          |
 | `switch_relays`          | `[]`                                                                          | `["<relay-url>", "<relay-url>", ...]` OR `null`                        |
+| `logout`                 | `[]`                                                                          | `"ack"`                                                                |
 
 ### Requested permissions
 
@@ -116,6 +117,12 @@ The `connect` method may be provided with `optional_requested_perms` for user co
 At all times, the _remote-signer_ should be in control of what relays are being used for the connection between it and the _client_. Therefore it should be possible for it to evolve its set of relays over time as old relays go out of operation and new ones appear. Even more importantly, in the case of the connection initiated by the _client_ the client may pick relays completely foreign to the _remote-signer_'s preferences, so it must be possible for it to switch those immediately.
 
 Therefore, compliant clients should send a `switch_relays` request immediately upon establishing a connection (always, or at reasonable intervals). Upon receiving such requests, the _remote-signer_ should reply with its updated list of relays, or `null` if there is nothing to be changed. Immediately upon receiving an updated relay list, the _client_ should update its local state and send further requests on the new relays. The `remote-signer` should then be free to disconnect from the previous relays if that is desired.
+
+### Ending a session
+
+When the _user_ logs out of the _client_, the _client_ MAY send a `logout` request to inform the _remote-signer_ that the session is no longer needed. Upon receiving such a request, the _remote-signer_ SHOULD remove the session associated with the requesting `client-pubkey` and reject any further requests from it (a new `connect` would be required to re-establish a session). The _remote-signer_ should reply with `"ack"` before removing the session.
+
+The `logout` request is a courtesy hint and is not a security boundary: the _remote-signer_ MUST NOT rely on it being sent, and the _client_ MUST still delete its locally stored `client-keypair` on logout regardless of whether the request was acknowledged.
 
 ## Response Events `kind:24133`
 


### PR DESCRIPTION
Adds a simple `logout` method that can be used by the client to signal that the session is ended and is no longer needed

## Implementations

 - [Clave](https://njump.to/nevent1qvzqqqqqqypzqvff2z0z85axzf0pg5d9jykmuqgfnc23wfkywe45fc0vhryydagxqy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qgwwaehxw309ahx7uewd3hkctcqyrzxewdsa8mnkhdvm8f2etgvk27de5u6tevaxza6yrgq624ywfjns7t67tn)
 - [applesauce](https://github.com/hzrd149/applesauce/blob/master/packages/signers/src/signers/nostr-connect-signer.ts#L439-L448)
 - [Nip46Lab](https://github.com/greenart7c3/Nip46Lab)
 - [Amber](https://github.com/greenart7c3/Amber/commit/db29ede72d30d782eb5827fd8c68be77b423a21a)
 - [nostur](https://njump.to/nevent1qvzqqqqqqypzpxlqhc8uq725sgejx9s5uns7lj0j3vxm8xqprmlweuzlu4cwthfnqy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qghwaehxw309aex2mrp0yh8qunfd4skctnwv46z7qpqwtv9nxpqxn4ztk2w4w8kfh86uq3dapn55kfykml0yvcqjsmy652qlddx9z)
 - [nostr-tools](https://github.com/nbd-wtf/nostr-tools)
 
## Pending Implementations
 - [nostrify PR](https://gitlab.com/soapbox-pub/nostrify/-/merge_requests/143)