### PR TITLE
Avoid nip46 silent timeouts

### DIFF
--- a/46.md
+++ b/46.md
@@ -143,6 +143,7 @@ The `content` field is a JSON-RPC-like message that is [NIP-44](44.md) encrypted
 - `id` is the request ID that this response is for.
 - `results` is a string of the result of the call (this can be either a string or a JSON stringified object)
 - `error`, _optionally_, it is an error in string form, if any. Its presence indicates an error with the request.
+
 Requests made with unknown or unsupported methods MUST be replied with an error.
 
 ## Example flow for signing an event

--- a/46.md
+++ b/46.md
@@ -143,6 +143,7 @@ The `content` field is a JSON-RPC-like message that is [NIP-44](44.md) encrypted
 - `id` is the request ID that this response is for.
 - `results` is a string of the result of the call (this can be either a string or a JSON stringified object)
 - `error`, _optionally_, it is an error in string form, if any. Its presence indicates an error with the request.
+Requests made with unknown or unsupported methods MUST be replied with an error.
 
 ## Example flow for signing an event
 


### PR DESCRIPTION
I'm experimenting with some custom nip46 methods that I'm not sure if current bunker implementations will ever implement, though some may. There's also for example @Semisol 's nip44 v3 methods that I think just Amber supports for now.

I'd like to be able to receive an error reply instead of no response when a bunker doesn't support a method. An absent reply results in a client timeout.

Goal is to speed things up cause timeouts can be from 5 to 30s of waiting depending on client implementation.

Pinging some people that I know have working bunker implementations: @greenart7c3 @fiatjaf @alexgleason 