### PR TITLE
Add rbac to nip 29

### DIFF
--- a/29.md
+++ b/29.md
@@ -16,7 +16,7 @@ Normally a group will originally belong to one specific relay, but the community
 
 ## Relay-generated events
 
-Relays are supposed to generate the events that describe group metadata and group admins. These are _addressable_ events signed by the relay keypair directly, with the group _id_ as the `d` tag.
+Relays are supposed to generate the events that describe group metadata, members, and roles. These are _addressable_ events signed by the relay keypair directly, with the group _id_ as the `d` tag.
 
 ## Group identifier
 
@@ -38,11 +38,7 @@ Relays should prevent late publication (messages published now with a timestamp 
 
 ## Group management
 
-Groups can have any number of users with elevated access. These users are identified by role labels which are arbitrarily defined by the relays (see also the description of `kind:39003`). What each role is capable of not defined in this NIP either, it's a relay policy that can vary. Roles can be assigned by other users (as long as they have the capability to add roles) by publishing a `kind:9000` event with that user's pubkey in a `p` tag and the roles afterwards (even if the user is already a group member a `kind:9000` can be issued and the user roles must just be updated).
-
-The roles supported by the group as to having some special privilege assigned to them should be accessible on the event `kind:39003`, but the relay may also accept other role names, arbitrarily defined by clients, and just not do anything with them.
-
-Users with any roles that have any privilege can be considered _admins_ in a broad sense and be returned in the `kind:39001` event for a group.
+Groups can have any number of users with elevated access. These users are identified by role ids defined in `kind:39003`, and assigned via `kind:9000` events. Each role specifies which event kinds and moderation actions members assigned to that role are permitted to perform. If a member is assigned multiple roles, they have the superset of permissions across all their roles.
 
 ## Live audio/video (AV) spaces
 
@@ -103,7 +99,7 @@ Any user can send one of these events to the relay in order to be automatically 
 
 ### Group state -- or moderation
 
-These are events expected to be sent by the relay master key or by group admins -- and relays should reject them if they don't come from an authorized admin. They also require the `h` tag.
+These are events expected to be sent by the relay master key or by members with the required permissions -- and relays should reject them if they don't come from an authorized member. They also require the `h` tag.
 
 - *moderation events* (`kinds:9000-9020`) (optional)
 
@@ -122,17 +118,17 @@ Clients can send these events to a relay in order to accomplish a moderation act
 
 Each moderation action uses a different kind and requires different arguments, which are given as tags. These are defined in the following table:
 
-| kind | name            | tags                                   |
-| ---  | ---             | ---                                    |
-| 9000 | `put-user`      | `p` with pubkey hex and optional roles |
-| 9001 | `remove-user`   | `p` with pubkey hex                    |
-| 9002 | `edit-metadata` | all the fields of *group-metadata*     |
-| 9005 | `delete-event`  | `e` with event id hex                  |
-| 9007 | `create-group`  |                                        |
-| 9008 | `delete-group`  |                                        |
-| 9009 | `create-invite` | arbitrary `code`                       |
+| kind | name            | tags                                                  |
+| ---  | ---             | ---                                                   |
+| 9000 | `put-user`      | `p` with pubkey hex and optional roles                |
+| 9001 | `remove-user`   | `p` with pubkey hex                                   |
+| 9002 | `edit-metadata` | fields to be modified matching tags from `kind:39000` |
+| 9005 | `delete-event`  | `e` with event id hex                                 |
+| 9007 | `create-group`  |                                                       |
+| 9008 | `delete-group`  |                                                       |
+| 9009 | `create-invite` | arbitrary `code`                                      |
 
-It's expected that the group state (of who is an allowed member or not, who is an admin and with which permission or not, what are the group name and picture etc) can be fully reconstructed from the canonical sequence of these events.
+It's expected that the group state (of who is an allowed member or not, what roles and permissions they have, what the group name and picture are, etc) can be fully reconstructed from the canonical sequence of these events.
 
 ### Group metadata events
 
@@ -144,6 +140,27 @@ This event defines the metadata for the group -- basically how clients should di
 
 If the group is forked and hosted in multiple relays, there will be multiple versions of this event in each different relay and so on.
 
+Several tags are defined:
+
+Tags `name`, `picture` and `about` are basic metadata for the group for display purposes.
+
+The `hidden` tag indicates that non-members should not be able to read, write, or see group metadata.
+
+The `join` tag indicates relay policy for becoming a group member. Join may be:
+
+- `never` - join requests are ignored
+- `always` - join requests are automatically approved
+- `invite` - join requests must have a valid invite code
+- `review` - join requests are manually reviewed
+
+Multiple non-contradictory policies can be specified by adding multiple `join` tags (e.g., `invite` and `review` means join requests without a valid code are manually reviewed).
+
+The `kinds` tag defines a comma-separated list of zero or more event kinds that can be sent to the group by members. If omitted, members may publish any kind to the group. If specified but no kinds are included, the group is read-only.
+
+The `perms` tag defines a comma-separate list of moderation actions (e.g. `put-user`) that can be sent to the group by any member.
+
+The `public-read` tag indicates that non-members can read this group's contents. The `public-write` tag indicates that non-members can publish events to this group as if they were members (with the same `kinds` restrictions).
+
 ```jsonc
 {
   "kind": 39000,
@@ -153,45 +170,21 @@ If the group is forked and hosted in multiple relays, there will be multiple ver
     ["name", "Pizza Lovers"],
     ["picture", "https://pizza.com/pizza.png"],
     ["about", "a group for people who love pizza"],
-    ["private"],
-    ["closed"],
-    ["supported_kinds", "9", "11"]
+    ["hidden"],
+    ["join", "always"],
+    ["kinds", "1,9734"], // notes and zaps only
+    ["perms", "create-invite"], // any member can create an invite
+    ["public-read"] // non-members can read the group's contents
   ]
-  // other fields...
-}
-```
-
-- `name`, `picture` and `about` are basic metadata for the group for display purposes.
-- `private` indicates that only members can _read_ group messages. Omitting this tag indicates that anyone can read group messages.
-- `restricted` indicates that only members can _write_ messages to the group. Omitting this tag indicates that anyone can send messages to the group.
-- `hidden` indicates that relays should hide group metadata from non-members. Omitting this tag indicates that anyone can request group metadata events.
-- `closed` indicates that join requests are ignored. Omitting this tag indicates that users can expect join requests to be honored.
-- `livekit` indicates that a group supports LiveKit-powered media rooms (live audio/video).
-- `supported_kinds` is a list of stringified kinds numbers the group supports. When not specified all kinds are assumed to be supported. It can contain no items, in which case no kinds are supported (this is the case for AV-only groups, for example).
-
-- *group admins* (`kind:39001`) (optional)
-
-Each admin is listed along with one or more roles. These roles SHOULD have a correspondence with the roles supported by the relay, as advertised by the `kind:39003` event.
-
-```jsonc
-{
-  "kind": 39001,
-  "content": "list of admins for the pizza lovers group",
-  "tags": [
-    ["d", "<group-id>"],
-    ["p", "<pubkey1-as-hex>", "ceo"],
-    ["p", "<pubkey2-as-hex>", "secretary", "gardener"],
-    // other pubkeys...
-  ],
   // other fields...
 }
 ```
 
 - *group members* (`kind:39002`) (optional)
 
-It's a list of pubkeys that are members of the group. Relays might choose to not to publish this information, to restrict what pubkeys can fetch it or to only display a subset of the members in it.
+A list of pubkeys that are members of the group followed by one or more role ids. Members automatically have the ability to see group metadata and read group content. See below for how to grant additional permissions via roles.
 
-Clients should not assume this will always be present or that it will contain a full list of members.
+Relays might choose to not to publish this information, to restrict what pubkeys can fetch it or to only display a subset of the members in it. Clients should not assume this will always be present or that it will contain a full list of members.
 
 ```jsonc
 {
@@ -199,9 +192,9 @@ Clients should not assume this will always be present or that it will contain a 
   "content": "list of members for the pizza lovers group",
   "tags": [
     ["d", "<group-id>"],
-    ["p", "<admin1>"],
-    ["p", "<member-pubkey1>"],
-    ["p", "<member-pubkey2>"],
+    ["p", "<admin1>", "a4f"],
+    ["p", "<member-pubkey1>", "2b9"],
+    ["p", "<member-pubkey2>", "2b9"],
     // other pubkeys...
   ],
   // other fields...
@@ -210,11 +203,21 @@ Clients should not assume this will always be present or that it will contain a 
 
 - *group roles* (`kind:39003`) (optional)
 
-This is an event that MAY be published by the relay informing users and clients about what are the roles supported by this relay according to its internal logic.
+This is an event that MAY be published by the relay which describes additional permissions granted to members assigned to this role.
 
-For example, a relay may choose to support the roles `"admin"` and `"moderator"`, in which the `"admin"` will be allowed to edit the group metadata, delete messages and remove users from the group, while the `"moderator"` can only delete messages (or the relay may choose to call these roles `"ceo"` and `"secretary"` instead, the exact role name is not relevant).
+Tags defined for this event include:
 
-The process through which the relay decides what roles to support and how to handle moderation events internally based on them is specific to each relay and not specified here.
+- `role` - defines a role identifier.
+- `label` - defines a label for the role.
+- `description` - describes the role.
+- `color` - defines a `hue` value from `0` to `255` for the role.
+- `order` - defines a `order` integer for the role (for client display only).
+- `kinds` - expands the allowed `kinds` that can be published by this role.
+- `perms` - expands the allowed moderation actions that can be published by this role.
+
+All tags are optional. If a member is assigned to multiple roles, they have the superset of role permissions. If a member is assigned no roles, they have no additional permissions beyond what the group metadata event defines.
+
+Example:
 
 ```jsonc
 {
@@ -222,9 +225,22 @@ The process through which the relay decides what roles to support and how to han
   "content": "list of roles supported by this group",
   "tags": [
     ["d", "<group-id>"],
-    ["role", "<role-name>", "<optional-description>"],
-    ["role", "<role-name>", "<optional-description>"],
-    // other roles...
+
+    ["role", "a4f"],
+    ["label", "a4f", "Aristocracy"],
+    ["description", "a4f", "Looks down upon the plebian scum"],
+    ["color", "a4f", "128"], // Azure
+    ["order", "a4f", "1"], // Top of the pile
+    ["perms", "a4f", "add-user", "remove-user"], // Can add/remove users
+    // No kinds tag, members can publish any kind to the group
+
+    ["role", "2b9"],
+    ["label", "2b9", "Scum"],
+    ["description", "2b9", "Plebian scum"],
+    ["color", "2b9", "210"], // Brown
+    ["order", "2b9", "2"], // Bottom of the pile
+    ["kinds", "2b9", "7,9734"], // Can send reactions and zaps to the group
+    // No perms tag, members can't do any moderation actions
   ],
   // other fields...
 }
@@ -259,7 +275,7 @@ The latest of either `kind:9000` or `kind:9001` events present in a group should
 
 ### Adding yourself to a group
 
-Anyone can send a `kind:9021` join request to a group. The relay may then generate a `kind:9000` event immediately, or defer that decision to an administrator. If a group is `closed`, join requests are not honored unless they include an invite code.
+Anyone can send a `kind:9021` join request to a group. The relay may then generate a `kind:9000` event immediately, or defer that decision to an authorized member. Behavior depends on the group's `join` policy: `never` ignores requests, `always` approves automatically, `invite` requires a valid code, and `review` defers to manual approval.
 
 ### Storing your list of groups
 


### PR DESCRIPTION
This change is not backwards compatible, but it is much more coherent, and far more flexible.