### PR TITLE
NIP-29: group reporting via NIP-17 DMs to the relay's administrative contact

### DIFF
--- a/29.md
+++ b/29.md
@@ -251,6 +251,35 @@ The event MUST contain zero or more `participant` tags with the participant's pu
 }
 ```
 
+## Reporting groups
+
+The relay master key (the [NIP-11](11.md) `"self"` pubkey) is an automation key that signs the group metadata events; it is not an inbox and reports SHOULD NOT be addressed to it. Relays SHOULD advertise the two [NIP-11](11.md) keys separately:
+
+- `self`: the relay master key, which signs group metadata events;
+- `pubkey`: the administrative contact, which receives reports of abuse or illegal content.
+
+The administrative contact `pubkey` SHOULD have a `kind:10050` DM relay list ([NIP-17](17.md)) published, and the relay SHOULD serve it in response to `{"kinds": [10050], "authors": ["<pubkey>"]}`. The relays listed in that event must accept `kind:1059` gift wraps addressed to that key.
+
+To report a group (or relay-wide abuse), users send a [NIP-17](17.md) private direct message to the administrative contact `pubkey`. The `kind:14` message SHOULD include an `h` tag with the group _id_ and MAY include `q` tags citing specific offending events.
+
+```jsonc
+{
+  "kind": 14,
+  "content": "this group is being used to distribute malware",
+  "tags": [
+    ["p", "<nip-11-administrative-contact-pubkey>"],
+    ["h", "<group-id>"],
+    ["q", "<offending-event-id>", "<relay-url>", "<offending-event-pubkey>"]
+  ]
+}
+```
+
+Private messages prevent retaliation against reporters and avoid drawing attention to the reported content. How the relay operator handles reports is left to its internal policy.
+
+Clients SHOULD only offer this option when the administrative contact's `kind:10050` event can be found.
+
+Reports about a user or message inside a group go to the group admins instead: clients MAY send them as [NIP-17](17.md) direct messages to the `kind:39001` admins that have a `kind:10050` published, citing the reported message with a `q` tag or the reported user with a [NIP-21](21.md) reference in the content. `p` tags identify receivers in `kind:14` and MUST NOT tag the reported user.
+
 ## Implementation quirks
 
 ### Checking your own membership in a group


### PR DESCRIPTION
Recommends NIP-29 relays to advertise the NIP-11 `self` and `pubkey` keys separately, with a `kind:10050` published for the administrative contact, so groups can be reported via NIP-17 DMs.