### PR TITLE
NIP-29: add message pinning (update-pin-list and kind:39005)

### DIFF
--- a/29.md
+++ b/29.md
@@ -131,6 +131,7 @@ Each moderation action uses a different kind and requires different arguments, w
 | 9007 | `create-group`  |                                        |
 | 9008 | `delete-group`  |                                        |
 | 9009 | `create-invite` | arbitrary `code`                       |
+| 9010 | `update-pin-list` | zero or more `e` with event id hex   |
 
 It's expected that the group state (of who is an allowed member or not, who is an admin and with which permission or not, what are the group name and picture etc) can be fully reconstructed from the canonical sequence of these events.
 
@@ -246,6 +247,26 @@ The event MUST contain zero or more `participant` tags with the participant's pu
     ["d", "<group-id>"],
     ["participant", "<pubkey>"],
     // other participants...
+  ],
+  // other fields...
+}
+```
+
+- *group pinned events* (`kind:39005`) (optional)
+
+It's a list of events pinned in the group, in the order they should be displayed. The `kind:9010` moderation event carries the full list as `e` tags, so pinning, unpinning, reordering and clearing pins are all done by submitting a new list. Whenever one is accepted the relay regenerates this event to mirror it. The relay may choose to limit the number of pins.
+
+Clients may display these events at the top of the group view.
+
+```jsonc
+{
+  "kind": 39005,
+  "content": "",
+  "tags": [
+    ["d", "<group-id>"],
+    ["e", "<event-id1-as-hex>"],
+    ["e", "<event-id2-as-hex>"],
+    // other event ids...
   ],
   // other fields...
 }


### PR DESCRIPTION
Adds message pinning to NIP-29 groups.

- `kind:9010` `update-pin-list`: moderation event carrying the full pinned list as `e` tags in display order. A new list pins, unpins, reorders or clears in a single action.
- `kind:39005` *group pinned events*: relay-generated event mirroring the latest accepted list.

Same design as #1163 after the feedback there (a single `update-pin-list` instead of add/remove pairs). That PR used `9009` and `39003`, which have since become `create-invite` and *group roles*; this uses the first free kinds and is written against the current text.