### PR TITLE
NIP-29: invite code suffix for group identifiers

### DIFF
--- a/29.md
+++ b/29.md
@@ -22,6 +22,14 @@ Relays are supposed to generate the events that describe group metadata and grou
 
 A group may be identified by a `naddr1...` code to its `kind:39000` metadata event, with the public key set to the relay `self` public key, the `d` identifier set to the group id, the kind set to `39000` and a relay hint to the relay that is hosting the group.
 
+An invite code may be appended to the group identifier:
+
+```
+naddr1...?invite=<code>
+```
+
+Clients should use this code in the `code` tag of the `kind:9021` join request. Since the bech32 charset doesn't include `?`, everything before the `?` is still a valid identifier on its own, so clients that don't understand the suffix can just ignore it.
+
 ## The `h` tag
 
 Events sent by users to groups (chat messages, text notes, moderation events etc) MUST have an `h` tag with the value set to the group _id_.


### PR DESCRIPTION
NIP-29 already has `kind:9009` `create-invite` and the `code` tag on `kind:9021`, but there is no way to share a group identifier together with an invite code. This adds an optional suffix:

`naddr1...?invite=<code>`

The bech32 charset doesn't include `?`, so everything before it is still a valid naddr on its own. Clients that understand the suffix use the code to fill the `code` tag of the `kind:9021` join request; clients that don't can ignore it.