### PR TITLE
NIP-46: add optional client metadata to connect request

### DIFF
--- a/46.md
+++ b/46.md
@@ -45,7 +45,7 @@ _remote-signer_ provides connection token in the form:
 bunker://<remote-signer-pubkey>?relay=<wss://relay-to-connect-on>&relay=<wss://another-relay-to-connect-on>&secret=<optional-secret-value>
 ```
 
-_user_ passes this token to _client_, which then sends `connect` request to _remote-signer_ via the specified relays. Optional secret can be used for single successfully established connection only, _remote-signer_ SHOULD ignore new attempts to establish connection with old secret.
+_user_ passes this token to _client_, which then sends `connect` request to _remote-signer_ via the specified relays. When connecting this way _client_ SHOULD include `optional_client_metadata` in the `connect` request (see [Client metadata](#client-metadata)), since unlike `nostrconnect://` this token carries no information identifying _client_. Optional secret can be used for single successfully established connection only, _remote-signer_ SHOULD ignore new attempts to establish connection with old secret.
 
 ### Direct connection initiated by the _client_
 
@@ -97,7 +97,7 @@ Each of the following are methods that the _client_ sends to the _remote-signer_
 
 | Command                  | Params                                                                        | Result                                                                 |
 | ------------------------ | -------------------------------------------------                             | ---------------------------------------------------------------------- |
-| `connect`                | `[<remote-signer-pubkey>, <optional_secret>, <optional_requested_perms>]`     | `"ack"` OR `<required-secret-value>`                                   |
+| `connect`                | `[<remote-signer-pubkey>, <optional_secret>, <optional_requested_perms>, <optional_client_metadata>]` | `"ack"` OR `<required-secret-value>`                                   |
 | `sign_event`             | `[<{kind, content, tags, created_at}>]`                                       | `json_stringified(<signed_event>)`                                     |
 | `ping`                   | `[]`                                                                          | `"pong"`                                                               |
 | `get_public_key`         | `[]`                                                                          | `<user-pubkey>`                                                        |
@@ -110,6 +110,16 @@ Each of the following are methods that the _client_ sends to the _remote-signer_
 ### Requested permissions
 
 The `connect` method may be provided with `optional_requested_perms` for user convenience. The permissions are a comma-separated list of `method[:params]`, i.e. `nip44_encrypt,sign_event:4` meaning permissions to call `nip44_encrypt` and to call `sign_event` with `kind:4`. Optional parameter for `sign_event` is the kind number, parameters for other methods are to be defined later. Same permission format may be used for `perms` field of `metadata` in `nostrconnect://` string.
+
+### Client metadata
+
+The `connect` method may be provided with `optional_client_metadata` so that _remote-signer_ can identify and label the connection. It is a JSON-stringified object whose fields mirror the `nostrconnect://` query parameters, all optional:
+
+- `name` - the name of the _client_ application
+- `url` - the canonical url of the _client_ application
+- `image` - a small image representing the _client_ application
+
+This is most useful for a connection initiated by _remote-signer_ (the `bunker://` flow), where — unlike `nostrconnect://` — _remote-signer_ has no other source for this information. To send metadata without requesting permissions, an empty string MUST be passed for `optional_requested_perms` so that the metadata occupies the fourth position. The metadata is _client_-supplied and unauthenticated; _remote-signer_ SHOULD treat it as a display hint only and MUST NOT use it for authorization decisions.
 
 ### Switching relays
 


### PR DESCRIPTION
`nostrconnect://` already lets a client advertise `name`/`url`/`image` in its URI, but the `bunker://` flow gives the remote-signer no equivalent — so bunker-paired connections show up unidentified in the signer UI. This adds an optional 4th `connect` param, `optional_client_metadata`, a JSON-stringified object carrying the same three fields.

- **Backward compatible** — optional positional param; existing clients send 3 params unchanged, signers that don't recognize the 4th ignore it.
- **No extra round-trip** — rides on the existing `connect` request, adds nothing to the handshake.
- **Symmetric** with the `nostrconnect://` metadata fields (same keys, reused descriptions).
- Spec'd as a display hint only / not for authorization, since the client pubkey in a bunker pairing is unauthenticated.
