### PR TITLE
NIP-79: Stories

### DIFF
--- a/79.md
+++ b/79.md
@@ -1,0 +1,324 @@
+NIP-79
+======
+
+Stories
+-------
+
+`draft` `optional`
+
+This NIP defines **Stories** — ephemeral, full-screen photo or video slides that expire after 24 hours, inspired by the Stories format popularized by Instagram, Snapchat, and WhatsApp. Stories are a first-class content type on Nostr with support for multi-slide sequences, viewer receipts, emoji reactions, private replies, highlights (pinned stories), and close-friends-only visibility.
+
+---
+
+## Story Slide Event
+
+A single story slide is a **regular event** of `kind:19`.
+
+The `.content` field contains an optional text caption.
+
+### Tags
+
+| Tag | Required | Description |
+|-----|----------|-------------|
+| `imeta` | yes* | Media metadata (image or video) via [NIP-92](92.md). Required unless `text` tag is present |
+| `text` | yes* | For text-only slides — the slide body text. Required unless `imeta` is present |
+| `expiration` | yes | Unix timestamp for expiry — MUST be within 86400 seconds (24h) of `created_at` per [NIP-40](40.md) |
+| `d` | no | Unique identifier (required for addressable story sequences) |
+| `bg` | no | Background color hex (e.g. `#FF5733`) for text slides |
+| `font` | no | Font style hint for text slides: `serif`, `sans`, `mono`, `bold`, `italic` |
+| `duration` | no | For video slides — length in seconds |
+| `alt` | no | Accessibility description |
+| `t` | no | Hashtag |
+| `p` | no | Tagged person (pubkey) |
+| `content-warning` | no | Sensitive content label |
+
+### Example — Photo Story
+
+```json
+{
+  "kind": 19,
+  "content": "Good morning! ☀️",
+  "tags": [
+    ["imeta",
+      "url https://cdn.example.com/story-photo.jpg",
+      "m image/jpeg",
+      "dim 1080x1920",
+      "blurhash eVF$^OI:${M{%LRjWBoLoLaeR*",
+      "x 3093509d1e0bc604ff60cb9286f4cd7c781553bc8991937befaacfdc28ec5cdc"
+    ],
+    ["expiration", "1700000000"],
+    ["alt", "A sunrise photo with caption: Good morning!"]
+  ]
+}
+```
+
+### Example — Text Story
+
+```json
+{
+  "kind": 19,
+  "content": "What's your favourite programming language?",
+  "tags": [
+    ["text", "What's your favourite programming language?"],
+    ["bg", "#6C63FF"],
+    ["font", "bold"],
+    ["expiration", "1700000000"]
+  ]
+}
+```
+
+### Example — Video Story
+
+```json
+{
+  "kind": 19,
+  "content": "Check this out!",
+  "tags": [
+    ["imeta",
+      "url https://cdn.example.com/story-video.mp4",
+      "m video/mp4",
+      "dim 1080x1920",
+      "image https://cdn.example.com/story-thumb.jpg",
+      "duration 12.5"
+    ],
+    ["expiration", "1700000000"],
+    ["alt", "A short video clip"]
+  ]
+}
+```
+
+---
+
+## Story Sequence (Multi-slide)
+
+A **story sequence** groups multiple `kind:19` slides into an ordered album using an addressable event `kind:34237`.
+
+```json
+{
+  "kind": 34237,
+  "content": "My trip to Tokyo",
+  "tags": [
+    ["d", "tokyo-trip-2024"],
+    ["title", "Tokyo Trip"],
+    ["e", "<slide-1-event-id>", "<relay-url>", "0"],
+    ["e", "<slide-2-event-id>", "<relay-url>", "1"],
+    ["e", "<slide-3-event-id>", "<relay-url>", "2"],
+    ["expiration", "1700000000"],
+    ["t", "travel"],
+    ["t", "tokyo"]
+  ]
+}
+```
+
+The third value of each `e` tag is a zero-based **slide index** so clients render slides in the correct order. Clients SHOULD display slides sequentially with auto-advance (default 5 seconds per photo slide, full duration for video slides).
+
+---
+
+## Viewer Ring UI
+
+Clients implementing Stories MUST display an unviewed story indicator (commonly a colored ring) around the author's avatar when:
+
+1. A `kind:19` or `kind:34237` event exists from a followed pubkey
+2. The current time is before the `expiration` timestamp
+3. The local client has not yet recorded a view for that event
+
+The ring SHOULD visually distinguish:
+- **Unviewed** — colored ring (e.g. gradient)
+- **Viewed** — muted/grey ring
+- **Expired** — no ring (event hidden from main feed)
+
+Clients track view state **locally** — no server-side view state is required. Clients MAY additionally use view receipts (below) to show the author how many people have seen a story.
+
+---
+
+## Seen-by / View Receipt
+
+When a user views a story, their client MAY publish a **view receipt** as `kind:15750` to signal the view to the story author.
+
+```json
+{
+  "kind": 15750,
+  "content": "",
+  "tags": [
+    ["e", "<story-event-id>", "<relay-url>"],
+    ["p", "<story-author-pubkey>"]
+  ]
+}
+```
+
+### Privacy considerations
+
+- View receipts are **public events by default** — clients SHOULD warn users before enabling them
+- Authors can count view receipts by querying `kind:15750` events with `#e` filter matching their story IDs
+- Clients MAY use [NIP-59](59.md) Gift Wrap to send view receipts privately to the author only
+- Clients SHOULD make view receipt publishing **opt-in** for the viewer
+
+### Querying view count
+
+```json
+{
+  "kinds": [15750],
+  "#e": ["<story-event-id>"]
+}
+```
+
+---
+
+## Story Reactions (Emoji Tap)
+
+A viewer may react to a story with a quick emoji tap using `kind:15751`.
+
+```json
+{
+  "kind": 15751,
+  "content": "🔥",
+  "tags": [
+    ["e", "<story-event-id>", "<relay-url>"],
+    ["p", "<story-author-pubkey>"]
+  ]
+}
+```
+
+- The `.content` MUST be a single emoji character or Unicode sequence
+- Only the story author's client typically displays these reactions
+- Clients SHOULD aggregate reactions by emoji and show counts to the author
+- Standard [NIP-25](25.md) reactions on `kind:1` still apply for public reactions; `kind:15751` is specifically for the private story-reaction UX
+
+---
+
+## Story Reply (Private)
+
+A viewer may reply to a story with a private message. Story replies use [NIP-17](17.md) private direct messages with an `e` tag referencing the story event.
+
+```json
+{
+  "kind": 14,
+  "content": "This is amazing!",
+  "tags": [
+    ["p", "<story-author-pubkey>"],
+    ["e", "<story-event-id>", "<relay-url>", "reply"]
+  ]
+}
+```
+
+This event is wrapped in a NIP-59 Gift Wrap (`kind:1059`) before publishing, as per NIP-17. The story author's client SHOULD surface these replies alongside the view receipt count when the author reviews who saw their story.
+
+---
+
+## Story Highlights (Pinned Stories)
+
+A user may pin expired or active stories into a named **highlight collection** using `kind:30079` (parameterized replaceable event). This keeps stories accessible past their 24h expiry on the author's profile.
+
+```json
+{
+  "kind": 30079,
+  "content": "My best travel moments",
+  "tags": [
+    ["d", "travel-highlights"],
+    ["title", "Travel"],
+    ["image", "https://cdn.example.com/highlight-cover.jpg"],
+    ["e", "<story-event-id-1>", "<relay-url>"],
+    ["e", "<story-event-id-2>", "<relay-url>"],
+    ["a", "34237:<pubkey>:<d-tag>", "<relay-url>"],
+    ["t", "travel"]
+  ]
+}
+```
+
+| Tag | Description |
+|-----|-------------|
+| `d` | Unique highlight collection identifier |
+| `title` | Display name shown under the highlight circle |
+| `image` | Cover image URL for the highlight icon |
+| `e` | Reference to a `kind:19` story slide |
+| `a` | Reference to a `kind:34237` story sequence |
+
+Clients SHOULD display highlight collections on the user's profile page as persistent circles, independent of story expiration. The underlying story content remains accessible as long as the author's relay stores the event — the highlight is a pointer, not a copy.
+
+---
+
+## Close Friends Only Stories
+
+An author may restrict a story to a trusted list of followers using `kind:10079` — a replaceable event defining the author's **close friends list**.
+
+### Close Friends List
+
+```json
+{
+  "kind": 10079,
+  "content": "",
+  "tags": [
+    ["p", "<pubkey-1>"],
+    ["p", "<pubkey-2>"],
+    ["p", "<pubkey-3>"]
+  ]
+}
+```
+
+### Restricted Story
+
+A story intended only for close friends includes a `friends-only` tag:
+
+```json
+{
+  "kind": 19,
+  "content": "Just for you guys 🤫",
+  "tags": [
+    ["imeta",
+      "url https://cdn.example.com/private-story.jpg",
+      "m image/jpeg",
+      "dim 1080x1920"
+    ],
+    ["expiration", "1700000000"],
+    ["friends-only", ""],
+    ["p", "<close-friend-pubkey-1>"],
+    ["p", "<close-friend-pubkey-2>"]
+  ]
+}
+```
+
+### Enforcement
+
+- The `friends-only` tag signals **intent** — clients MUST NOT surface this story to users not listed in the `p` tags
+- For relay-level enforcement, authors SHOULD publish to a relay that supports [NIP-42](42.md) authentication and [NIP-70](70.md) protected events
+- Clients displaying a user's stories SHOULD check for `friends-only` tag and verify the viewer's pubkey is in the `p` tag list before rendering
+
+---
+
+## Summary of Event Kinds
+
+| Kind | Description |
+|------|-------------|
+| `19` | Story slide (photo, video, or text) |
+| `34237` | Addressable story sequence (multi-slide album) |
+| `15750` | Story view receipt |
+| `15751` | Story emoji reaction |
+| `30079` | Story highlights collection |
+| `10079` | Close friends list |
+
+---
+
+## Summary of New Tags
+
+| Tag | Event | Description |
+|-----|-------|-------------|
+| `text` | `kind:19` | Body text for text-only slides |
+| `bg` | `kind:19` | Background color hex for text slides |
+| `font` | `kind:19` | Font style hint for text slides |
+| `friends-only` | `kind:19` | Marks story as restricted to listed `p` pubkeys |
+| `image` | `kind:30079` | Cover image for a highlights collection |
+
+---
+
+## Relation to Other NIPs
+
+| NIP | Relation |
+|-----|----------|
+| [NIP-40](40.md) | `expiration` tag used for 24h story expiry |
+| [NIP-92](92.md) | `imeta` tag used for photo/video metadata |
+| [NIP-17](17.md) | Private DMs used for story replies |
+| [NIP-59](59.md) | Gift Wrap used to seal story replies and optionally view receipts |
+| [NIP-42](42.md) | Auth used for relay-level close-friends enforcement |
+| [NIP-70](70.md) | Protected events used for close-friends stories |
+| [NIP-25](25.md) | Public reactions still apply; `kind:15751` is for story-specific emoji taps |
+| [NIP-51](51.md) | Highlights (`kind:30079`) follows the lists pattern |

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ NIPs listed here are not a protocol checklist. Nothing forces any software to im
 - [NIP-75: Zap Goals](75.md)
 - [NIP-77: Negentropy Syncing](77.md)
 - [NIP-78: Application-specific data](78.md)
+- [NIP-79: Stories](79.md)
 - [NIP-7D: Forum Threads](7D.md)
 - [NIP-84: Highlights](84.md)
 - [NIP-85: Trusted Assertions](85.md)
@@ -140,6 +141,7 @@ This table is not exhaustive. For a machine-readable registry of all known event
 | `17`          | Reaction to a website           | [25](25.md)                            |
 | `20`          | Picture                         | [68](68.md)                            |
 | `21`          | Video Event                     | [71](71.md)                            |
+| `19`          | Story Slide                     | [79](79.md)                            |
 | `22`          | Short-form Portrait Video Event | [71](71.md)                            |
 | `24`          | Public Message                  | [A4](A4.md)                            |
 | `30`          | internal reference              | [NKBIP-03]                             |
@@ -199,6 +201,7 @@ This table is not exhaustive. For a machine-readable registry of all known event
 | `9734`        | Zap Request                     | [57](57.md)                            |
 | `9735`        | Zap                             | [57](57.md)                            |
 | `9802`        | Highlights                      | [84](84.md)                            |
+| `10079`       | Close Friends List              | [79](79.md)                            |
 | `10000`       | Mute list                       | [51](51.md)                            |
 | `10001`       | Pin list                        | [51](51.md)                            |
 | `10002`       | Relay List Metadata             | [65](65.md), [51](51.md)               |
@@ -259,7 +262,10 @@ This table is not exhaustive. For a machine-readable registry of all known event
 | `30040`       | Curated Publication Index       | [NKBIP-01]                             |
 | `30041`       | Curated Publication Content     | [NKBIP-01]                             |
 | `30063`       | Release artifact sets           | [51](51.md)                            |
+| `15750`       | Story View Receipt              | [79](79.md)                            |
+| `15751`       | Story Emoji Reaction            | [79](79.md)                            |
 | `30078`       | Application-specific Data       | [78](78.md)                            |
+| `30079`       | Story Highlights Collection     | [79](79.md)                            |
 | `30166`       | Relay Discovery                 | [66](66.md)                            |
 | `30267`       | App curation sets               | [51](51.md)                            |
 | `30311`       | Live Event                      | [53](53.md)                            |
@@ -285,6 +291,7 @@ This table is not exhaustive. For a machine-readable registry of all known event
 | `32267`       | Software Application            |                                        |
 | `34235`       | Addressable Video Event         | [71](71.md)                            |
 | `34236`       | Addressable Short Video Event   | [71](71.md)                            |
+| `34237`       | Addressable Story Sequence      | [79](79.md)                            |
 | `34550`       | Community Definition            | [72](72.md)                            |
 | `34128`       | Legacy nsite manifest           | [5A](5A.md) (deprecated)               |
 | `35128`       | Named nsite manifest            | [5A](5A.md)                            |


### PR DESCRIPTION
## Summary

This PR proposes **NIP-79**, defining **Stories** — ephemeral full-screen photo, video, and text slide events that expire after 24 hours, with a complete social interaction layer.

## What's included

| Feature | Implementation |
|---------|---------------|
| Story slide | `kind:19` — photo, video, or text with `expiration` (NIP-40) |
| Multi-slide sequence | `kind:34237` addressable event with ordered `e` tags |
| Viewer ring UI | Client-side: colored ring for unviewed, grey for viewed, hidden when expired |
| Seen-by / view receipt | `kind:15750` — optional, privacy-preserving, opt-in for viewers |
| Story emoji reaction | `kind:15751` — single emoji tap, visible only to author |
| Story reply | NIP-17 private DM with `e` tag referencing the story |
| Highlights | `kind:30079` — named collections that pin stories past expiry |
| Close friends only | `kind:10079` close friends list + `friends-only` tag on story |

## Motivation

Stories are one of the most-used features across Instagram, WhatsApp, and Snapchat. No existing Nostr NIP defines a first-class story format. NIP-71 mentions "stories" in passing but provides no spec. NIP-40 only handles expiry. This NIP fills the gap with a complete, composable standard that builds on existing NIPs rather than reinventing them.

## New event kinds

| Kind | Description |
|------|-------------|
| `19` | Story slide (photo, video, or text) |
| `34237` | Addressable story sequence |
| `15750` | Story view receipt |
| `15751` | Story emoji reaction |
| `30079` | Story highlights collection |
| `10079` | Close friends list |

## Relation to existing NIPs

- **NIP-40** — `expiration` tag for 24h story expiry
- **NIP-92** — `imeta` tag for photo/video metadata
- **NIP-17** — private DMs for story replies
- **NIP-59** — Gift Wrap for sealed story replies and optional private view receipts
- **NIP-42 + NIP-70** — relay-level enforcement for close-friends stories
- **NIP-51** — highlights (`kind:30079`) follows the lists pattern

## Open questions for reviewers

- Should `kind:15750` / `kind:15751` use a different numbering scheme (ephemeral range 20000–29999)?
- Should view receipts default to Gift Wrap (private) rather than public?
- Should the close friends list reuse `kind:30000` follow sets (NIP-51) with a `d` tag instead of a new `kind:10079`?