### PR TITLE
Add signevent to nip86

### DIFF
--- a/86.md
+++ b/86.md
@@ -52,6 +52,9 @@ This is the list of **methods** that may be supported:
 * `listeventsneedingmoderation`:
   - params: `[]`
   - result: `[{"id": "<32-byte-hex>", "reason": "<optional-reason>"}]`, an array of objects
+* `signevent`:
+  - params: `[{kind, content, tags, created_at}]`
+  - result: `[{kind, content, tags, created_at, id, sig, pubkey}]` (the event signed by the relay's `self` pubkey)
 * `allowevent`:
   - params: `["<32-byte-hex-event-id>", "<optional-reason>"]`
   - result: `true` (a boolean always set to `true`)


### PR DESCRIPTION
This allows relay admins to manage nip 43 events on behalf of the relay. This will come in handy with an upcoming PR which introduces relay-level roles.