### PR TITLE
Add relay roles event

### DIFF
--- a/43.md
+++ b/43.md
@@ -8,6 +8,40 @@ Relay Access Metadata and Requests
 
 This NIP defines a way for relays to advertise membership lists, and for clients to request admission to relays on behalf of users.
 
+## Role Definitions
+
+Relays MAY publish a `kind 33534` event which defines a role which may be assigned to members. This event MUST be signed by the pubkey specified in the `self` field of the relay's [NIP 11](./11.md) document.
+
+The following tags are required:
+
+- A [NIP 70](./70.md) `-` tag
+- The event's `d` tag defines the role id.
+
+The following tags are optional:
+
+- `label` - a label for the role.
+- `description` - a description of the role.
+- `color` - a `hue` value from `0` to `255` for the role.
+- `order` - a `order` integer for the role (for client display only).
+
+```yaml
+{
+  "kind": 33534,
+  "pubkey": "<nip11.self>",
+  "tags": [
+    ["-"],
+    ["d", "28b7e50f"],
+    ["label", "king"],
+    ["description", "ruler of the relay"],
+    ["color", "37"],
+    ["order", "1"],
+  ],
+  // ...other fields
+}
+```
+
+Relays MAY treat members with a given role differently in terms of relay access policies, but no mechanism for introspection is defined at this time.
+
 ## Membership Lists
 
 Relays MAY publish a `kind 13534` event which indicates pubkeys that have access to a given relay. This event MUST be signed by the pubkey specified in the `self` field of the relay's [NIP 11](./11.md) document.
@@ -15,7 +49,7 @@ Relays MAY publish a `kind 13534` event which indicates pubkeys that have access
 The following tags are required:
 
 - A [NIP 70](./70.md) `-` tag
-- A `member` tag containing a hex pubkey should be included for each member
+- A `member` tag containing a hex pubkey should be included for each member. Assigned roles may be included as subsequent arguments.
 
 This list should not be considered exhaustive or authoritative. To determine membership, both a `kind 13534` event by the relay, and a `kind 10010` event by the member should be consulted.
 
@@ -28,7 +62,7 @@ Example:
   "tags": [
     ["-"],
     ["member", "c308e1f882c1f1dff2a43d4294239ddeec04e575f2d1aad1fa21ea7684e61fb5"],
-    ["member", "ee1d336e13779e4d4c527b988429d96de16088f958cbf6c074676ac9cfd9c958"]
+    ["member", "ee1d336e13779e4d4c527b988429d96de16088f958cbf6c074676ac9cfd9c958", "28b7e50f"]
   ],
   // ...other fields
 }

--- a/43.md
+++ b/43.md
@@ -21,7 +21,7 @@ The following tags are optional:
 
 - `label` - a label for the role.
 - `description` - a description of the role.
-- `color` - a `hue` value from `0` to `255` for the role.
+- `color` - a `hue` value from `0` to `360` for the role.
 - `order` - a `order` integer for the role (for client display only).
 
 ```yaml

--- a/86.md
+++ b/86.md
@@ -49,6 +49,21 @@ This is the list of **methods** that may be supported:
 * `listallowedpubkeys`:
   - params: `[]`
   - result: `[{"pubkey": "<32-byte-hex>", "reason": "<optional-reason>"}, ...]`, an array of objects
+* `createrole`:
+  - params: `[id, label, description, color, order]`
+  - result: `true` (boolean true)
+* `editrole`:
+  - params: `[id, label, description, color, order]`
+  - result: `true` (boolean true)
+* `deleterole`:
+  - params: `[id]`
+  - result: `true` (boolean true)
+* `assignrole`:
+  - params: `["<32-byte-hex-public-key>", "<role-id>"]`
+  - result: `true` (a boolean always set to `true`)
+* `unassignrole`:
+  - params: `["<32-byte-hex-public-key>", "<role-id>"]`
+  - result: `true` (a boolean always set to `true`)
 * `listeventsneedingmoderation`:
   - params: `[]`
   - result: `[{"id": "<32-byte-hex>", "reason": "<optional-reason>"}]`, an array of objects


### PR DESCRIPTION
Allows relays to define roles and for admins to manage/assign/unassign members to those roles.