### PR TITLE
NIP-34: replace `personal-fork` with `u` and GRASP-06

### DIFF
--- a/34.md
+++ b/34.md
@@ -10,7 +10,7 @@ This NIP defines all the ways code collaboration using and adjacent to [`git`](h
 
 ## Repository announcements
 
-Git repositories are hosted in Git-enabled servers, but their existence can be announced using Nostr events. By doing so the author asserts themselves as a maintainer and expresses a willingness to receive patches, bug reports and comments in general, unless `t` tag `personal-fork` is included.
+Git repositories are hosted in Git-enabled servers, but their existence can be announced using Nostr events. By doing so the author asserts themselves as a maintainer of the primary project, unless a `u` tag is included.
 
 ```yaml
 {
@@ -25,7 +25,7 @@ Git repositories are hosted in Git-enabled servers, but their existence can be a
     ["relays", "<relay-url>", ...], // relays that this repository will monitor for patches and issues
     ["r", "<earliest-unique-commit-id>", "euc"],
     ["maintainers", "<other-recognized-maintainer>", ...],
-    ["t","personal-fork"], // optionally indicate author isn't a maintainer
+    ["u","30617:<pubkey>:<identifer>|<git-url-https-prefered>","<relay-hint>","<author-pubkey>"], // optionally indicate repository is a subordinate fork
     ["t", "<arbitrary string>"], // hashtags labelling the repository
   ]
 }
@@ -123,7 +123,7 @@ The PR or PR update tip SHOULD be successfully pushed to `refs/nostr/<[PR|PR-Upd
 
 An attempt SHOULD be made to push this ref to all repositories listed in the repository's announcement event's `"clone"` tag, for which their is reason to believe the user might have write access. This includes each [grasp server](https://njump.me/naddr1qvzqqqrhnypzpgqgmmc409hm4xsdd74sf68a2uyf9pwel4g9mfdg8l5244t6x4jdqy28wumn8ghj7un9d3shjtnwva5hgtnyv4mqqpt8wfshxuqlnvh8x) which can be identified using this method: `clone` tag includes `[http|https]://<grasp-path>/<valid-npub>/<string>.git` and `relays` tag includes `[ws/wss]://<grasp-path>`.
 
-Clients MAY fallback to creating a 'personal-fork' `repository announcement` listing other grasp servers, e.g. from the `User grasp list`, for the purpose of serving the specified commit(s).
+Clients MAY fallback to using [GRASP-06](https://njump.me/naddr1qvzqqqrhnypzpgqgmmc409hm4xsdd74sf68a2uyf9pwel4g9mfdg8l5244t6x4jdqy28wumn8ghj7un9d3shjtnwva5hgtnyv4mqqpt8wfshxuqlnvh8x), e.g. from the `User grasp list`, for the purpose of serving the specified commit(s). Clients SHOULD not create `30617` event for the purpose of hosting a PR.
 
 ```yaml
 {


### PR DESCRIPTION
creating a fork (ie. a fresh repo announcement with `personal-fork`) for a PR is an anti-pattern. This replaces that fallback flow with the new GRASP-06 flow to enable PRs to be created when the maintainer's listed grasp servers are unavailable.

For the other use of `personal-fork`, `u` has been introduced, which now links to the primary project.

celerbrate / blame @hzrd149 for the `u` idea.

I'm unsure whether we should change `u` from optional to a SHOULD with `["u", "root"]` alternative. That way we could filter root repos only.