### PR TITLE
Update nip 17 to indicate that wraps should be signed with the conversation key

### DIFF
--- a/59.md
+++ b/59.md
@@ -123,7 +123,7 @@ When adding expiration tags to both `seal` and `gift wrap` layers, implementatio
 
 Relays SHOULD delete `kind:1059` events whose p-tag matches the signer of [NIP-09](09.md) deletions or [NIP-62](62.md) vanish requests so that recipients can delete their messages. [legacy]
 
-In the past, signing keys were random, forcing users to download and encrypt all wraps in every situation. Until conversation keys are in wide use, recipients MUST NOT assume the signing key is the same as the conversation key.
+In the past, signing keys were random, forcing users to download and encrypt all wraps in every situation. Until signing keys are in wide use, recipients MUST NOT assume the signing key is non-random.
 
 ## An Example
 
@@ -131,7 +131,7 @@ Let's send a wrapped `kind 1` message between two parties asking "Are you going 
 
 - Author private key: `0beebd062ec8735f4243466049d7747ef5d6594ee838de147f8aab842b15e273`
 - Recipient private key: `e108399bd8424357a710b606ae0c13166d853d327e47a6e5e038197346bdbf45`
-- Ephemeral wrapper key: `4f02eac59266002db5801adc5270700ca69d5b8f761d8732fab2fbf233c90cbd`
+- Conversation signing key (derived in step 2): `2785604c24b7dd2fd83ff224f4d16b2dce384f3ce5a95c13f6ee2fe1fd170d41`
 
 Note that this messaging protocol should not be used in practice, this is just an example. Refer to other
 NIPs for concrete messaging protocols that depend on gift wraps.
@@ -152,41 +152,47 @@ Do not sign the event.
 }
 ```
 
-### 2. Generate a conversation key
+### 2. Generate conversation keys
 
-The conversation key is `conv(a, B)` as described in [NIP 44](44.md). This is used for encrypting the rumor and seal, as well for signing the wrap.
+Compute `shared_x`, the unhashed 32-byte x-coordinate of the ECDH shared point `a · B`, as described in [NIP 44](44.md).
+
+The conversation's encryption key is `HKDF-extract(IKM=shared_x, salt=utf8_encode('nip44-v2'))`. This is used for encrypting the rumor and seal.
+
+The conversation's signing key is `HKDF-extract(IKM=shared_x, salt=utf8_encode('nip59-signing-key'))`. This is used for signing the wrap.
+
+To obtain a valid secp256k1 private key, interpret the 32-byte HKDF output as a big-endian integer and reduce it modulo the group order `n`. Because `n` is within ~2¹²⁸ of 2²⁵⁶, the reduction's bias is negligible, as is the chance the result is `0` (an invalid key).
 
 ### 3. Seal the rumor
 
-Encrypt the JSON-encoded `rumor` with the conversation key derived in the previous step. Place the result in the `content` field of a `kind 13` `seal` event. Sign it with the author's key.
+Encrypt the JSON-encoded `rumor` with the encryption key derived in the previous step. Place the result in the `content` field of a `kind 13` `seal` event. Sign it with the author's key.
 
 ```json
 {
-  "content": "AqBCdwoS7/tPK+QGkPCadJTn8FxGkd24iApo3BR9/M0uw6n4RFAFSPAKKMgkzVMoRyR3ZS/aqATDFvoZJOkE9cPG/TAzmyZvr/WUIS8kLmuI1dCA+itFF6+ULZqbkWS0YcVU0j6UDvMBvVlGTzHz+UHzWYJLUq2LnlynJtFap5k8560+tBGtxi9Gx2NIycKgbOUv0gEqhfVzAwvg1IhTltfSwOeZXvDvd40rozONRxwq8hjKy+4DbfrO0iRtlT7G/eVEO9aJJnqagomFSkqCscttf/o6VeT2+A9JhcSxLmjcKFG3FEK3Try/WkarJa1jM3lMRQqVOZrzHAaLFW/5sXano6DqqC5ERD6CcVVsrny0tYN4iHHB8BHJ9zvjff0NjLGG/v5Wsy31+BwZA8cUlfAZ0f5EYRo9/vKSd8TV0wRb9DQ=",
+  "content": "ArefS7v5eeEuw3O5OVwcLPud6CHN12+GcXdF3uvvz6ft8x4mzn+r/pAXezZRlIrUdlfQsnfbVTgrxeGXD2cCXtlzGew1CtF1coQZgxestY6sU87coUDUcgtLuSu8+aH1wTLQrIP3N9Pj2n+BM5Un2Wk6MU9n5/8oiFJFs85NJlLRpI2JomQHo0lM1L5Hx+OzFjdfnPCzhInaZsrNj9UmY16i7OAxw/HsNsKcaCs9YGgX/Iit+L7Z2y3xbAMH6vQMNITP70vkfvnzLK2sbWPV/JZdqEcZahQnMGwdfISmtevoyu+Nh9l8VS1rgC0SinmU7XfvAW+fGNMtctgcXN3rEZEYwI7ur98+PoYtTutUcDgJMCpbNcLtq3T1mbNBidQATzCWiLN9//k6yHiKvpnpQrziIYUVsnhm8+sY0lA+6lBWcC4=",
   "kind": 13,
   "created_at": 1703015180,
   "pubkey": "611df01bfcf85c26ae65453b772d8f1dfd25c264621c0277e1fc1518686faef9",
   "tags": [],
-  "id": "28a87d7c074d94a58e9e89bb3e9e4e813e2189f285d797b1c56069d36f59eaa7",
-  "sig": "02fc3facf6621196c32912b1ef53bac8f8bfe9db51c0e7102c073103586b0d29c3f39bdaa1e62856c20e90b6c7cc5dc34ca8bb6a528872cf6e65e6284519ad73"
+  "id": "226a7f47bc8eae64da723031c23db10b818bff91ddcb82cc33c67020ac4e15bf",
+  "sig": "beac0285e6610c9efa89f0670f3e0ed6cc25b0cdd0dc3dc01bd7b8f459cace2ce2653277a04f40c8f35dae8721dc178277fa6f3f427b4be397a829719e70b482"
 }
 ```
 
 ### 4. Wrap the seal
 
-Encrypt the JSON-encoded `kind 13` event the conversation key generated in step 2. Place the result
+Encrypt the JSON-encoded `kind 13` event with the encryption key generated in step 2. Place the result
 in the `content` field of a `kind 1059`. Add a single `p` tag containing the recipient's public key.
-Sign the `gift wrap` using the same conversation key.
+Sign the `gift wrap` using the conversation's signing key.
 
 ```json
 {
-  "content": "AhC3Qj/QsKJFWuf6xroiYip+2yK95qPwJjVvFujhzSguJWb/6TlPpBW0CGFwfufCs2Zyb0JeuLmZhNlnqecAAalC4ZCugB+I9ViA5pxLyFfQjs1lcE6KdX3euCHBLAnE9GL/+IzdV9vZnfJH6atVjvBkNPNzxU+OLCHO/DAPmzmMVx0SR63frRTCz6Cuth40D+VzluKu1/Fg2Q1LSst65DE7o2efTtZ4Z9j15rQAOZfE9jwMCQZt27rBBK3yVwqVEriFpg2mHXc1DDwHhDADO8eiyOTWF1ghDds/DxhMcjkIi/o+FS3gG1dG7gJHu3KkGK5UXpmgyFKt+421m5o++RMD/BylS3iazS1S93IzTLeGfMCk+7IKxuSCO06k1+DaasJJe8RE4/rmismUvwrHu/HDutZWkvOAhd4z4khZo7bJLtiCzZCZ74lZcjOB4CYtuAX2ZGpc4I1iOKkvwTuQy9BWYpkzGg3ZoSWRD6ty7U+KN+fTTmIS4CelhBTT15QVqD02JxfLF7nA6sg3UlYgtiGw61oH68lSbx16P3vwSeQQpEB5JbhofW7t9TLZIbIW/ODnI4hpwj8didtk7IMBI3Ra3uUP7ya6vptkd9TwQkd/7cOFaSJmU+BIsLpOXbirJACMn+URoDXhuEtiO6xirNtrPN8jYqpwvMUm5lMMVzGT3kMMVNBqgbj8Ln8VmqouK0DR+gRyNb8fHT0BFPwsHxDskFk5yhe5c/2VUUoKCGe0kfCcX/EsHbJLUUtlHXmTqaOJpmQnW1tZ/siPwKRl6oEsIJWTUYxPQmrM2fUpYZCuAo/29lTLHiHMlTbarFOd6J/ybIbICy2gRRH/LFSryty3Cnf6aae+A9uizFBUdCwTwffc3vCBae802+R92OL78bbqHKPbSZOXNC+6ybqziezwG+OPWHx1Qk39RYaF0aFsM4uZWrFic97WwVrH5i+/Nsf/OtwWiuH0gV/SqvN1hnkxCTF/+XNn/laWKmS3e7wFzBsG8+qwqwmO9aVbDVMhOmeUXRMkxcj4QreQkHxLkCx97euZpC7xhvYnCHarHTDeD6nVK+xzbPNtzeGzNpYoiMqxZ9bBJwMaHnEoI944Vxoodf51cMIIwpTmmRvAzI1QgrfnOLOUS7uUjQ/IZ1Qa3lY08Nqm9MAGxZ2Ou6R0/Z5z30ha/Q71q6meAs3uHQcpSuRaQeV29IASmye2A2Nif+lmbhV7w8hjFYoaLCRsdchiVyNjOEM4VmxUhX4VEvw6KoCAZ/XvO2eBF/SyNU3Of4SO",
+  "content": "ApxZebuqKMRdKJwxLp32U9oyaqYa1XIQNPk/LX37z/Qsm3lR2yZ7APNi14aWXpfwbrm+wDO/nXxnK3TTTaqCWYAc4XOb9jwfOXZa8tTIl2ClT8YfoTzE2uhqL1HhFTbn6uJ9eN4z9zfjyCat3eOxya0lohQ2xMCWcfdNKyTlyzcnoy+JNd82W93e20i1ueeAmv4r/fUzBJ4Taubv+XX32+NRSEN3wwPG7AbMCvPsMKqpOgvk0ihgZpWaJBHKzDW/KA5DrRJLN0ONIGu9WvtL+RjGvLbI/3Z4f+9anVN+zpiGO6T1rx+Bj/fmPuCzPj/sFbOgrX55W/A2VVP2cn2Fv5L518yMFYRSO6NUMwzBFZVjBE1LkHEhMeoLGB08nel1gMcaKJibmuC8otgcSeKUanqOyjtFGY8YfMEKOGXgqPUZDS0+xShNh/sioDY5T09Cm8z72weL8DdsaKc0hkOdZyH0iTuDRI5fYiwcX8K8zqD6Vsqz6cowSHQ/lgckdhzqHYFIF/hCqacwp7ibHvUK05AlRaAgbLf0ShGq6U2ypmnAMKRxzaAdIqYf36NS4MTbCIx7ZjxZRRCtO4NEgYoAJfjnp5tOjpfVQJr4EZ3x3zvpF6EvvSneuydo1qhYNJSzG0mFOi3iE9omWuJ0k/NzkOGATAP/V4hkKHc8144VfNPHGHHJtaiOs0BgrWRUGni2h0EMawbtJyvXqo6up/mStPYP0QtG9BOy3RzWB2Q77YGRV5CmFCOQM/XtWiPJCLby1umUp/REYj+4kwLhhgYrJINTB6CGqTiYdAet5bVG8nmnJhz2cpoKY4wNYoddYyebre8IpiaSWERvODr5OMGrvqH1JcR5Y+HzZ+xdlRiGZo5LQh6z4+S5CDO9BqaT6WXsIBE5/Q501cDdruj9lBVfsFDdFh7+M+UEY2Vu3O3R5lpDPiHI959S+4CZl5umvTZuVQWzbScGLfObuGXFbm4205/DzEGi1ifuTuwDyAeXNLCdym3K9z+pqv0GQ34bcXYlH/bPz3VJJvf6HZNDT9Yk/f7gDrdrJG/GWkJVfeT6m924pzQiKqcZgX936C09QvVxSsotOckPmYVcYbpywI67FO8QNUnW+0Qne8ewWyyf9xKVY+J9hjA3Gx6L1WnF/zZw56zxMj26+vkPr47LX51mEp9uAiFXsgZWg5f4LfERi3lFOwmY8ANQsLmALbMup10xVmO9mydoJFwTMzG3XdXHc7PvXro9RAgbPYr9NJCoO31R/y/FRCZJ6aFj+F8FlK6qd66m",
   "kind": 1059,
   "created_at": 1703021488,
-  "pubkey": "18b1a75918f1f2c90c23da616bce317d36e348bcf5f7ba55e75949319210c87c",
-  "id": "5c005f3ccf01950aa8d131203248544fb1e41a0d698e846bd419cec3890903ac",
-  "sig": "35fabdae4634eb630880a1896a886e40fd6ea8a60958e30b89b33a93e6235df750097b04f9e13053764251b8bc5dd7e8e0794a3426a90b6bcc7e5ff660f54259",
-  "tags": [["p", "166bf3765ebd1fc55decfe395beff2ea3b2a4e0a8946e7eb578512b555737c99"]],
+  "pubkey": "aefe6f6ff2ff2f2a12a90cfc79dca84abd6ba135d959d4247fa865853b1c281c",
+  "id": "8d786414e0269c586d301de546f10d5066c1cfaba55131db42a17d9f22eeb00a",
+  "sig": "ebea6ee30a6681247107d27496694f787f2a5d88c510bdb8c92d9c9cef9409188696fd5869d7184fe37cdcf245652a787fb24723f87c7c644bd6afa45906fd60",
+  "tags": [["p", "166bf3765ebd1fc55decfe395beff2ea3b2a4e0a8946e7eb578512b555737c99"]]
 }
 ```
 
@@ -199,25 +205,41 @@ Broadcast the `kind:1059` or `kind:21059` event to the recipient's relays only. 
 ### JavaScript
 
 ```javascript
-import {bytesToHex} from "@noble/hashes/utils"
+import {hexToBytes} from "@noble/hashes/utils"
+import {extract as hkdfExtract} from "@noble/hashes/hkdf"
+import {sha256} from "@noble/hashes/sha2"
+import {secp256k1} from "@noble/curves/secp256k1"
+import {bytesToNumberBE, numberToBytesBE} from "@noble/curves/utils"
 import type {EventTemplate, UnsignedEvent, Event} from "nostr-tools"
-import {getPublicKey, getEventHash, nip19, nip44, finalizeEvent, generateSecretKey} from "nostr-tools"
+import {getPublicKey, getEventHash, nip19, nip44, finalizeEvent} from "nostr-tools"
 
 type Rumor = UnsignedEvent & {id: string}
 
 const TWO_DAYS = 2 * 24 * 60 * 60
 
+// secp256k1 group order
+const SECP256K1_N = BigInt("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141")
+
 const now = () => Math.round(Date.now() / 1000)
 const randomNow = () => Math.round(now() - (Math.random() * TWO_DAYS))
 
-const nip44ConversationKey = (privateKey: Uint8Array, publicKey: string) =>
-  nip44.v2.utils.getConversationKey(bytesToHex(privateKey), publicKey)
+// The NIP-44 conversation key, used to encrypt the rumor, seal, and wrap.
+const getEncryptionKey = (privateKey: Uint8Array, publicKey: string) =>
+  nip44.v2.utils.getConversationKey(privateKey, publicKey)
 
-const nip44Encrypt = (data: EventTemplate, privateKey: Uint8Array, publicKey: string) =>
-  nip44.v2.encrypt(JSON.stringify(data), nip44ConversationKey(privateKey, publicKey))
+// The wrap signing key: HKDF-extract over the same ECDH secret with a distinct salt, reduced to a
+// valid secp256k1 scalar. Both parties derive the same key, so its pubkey indexes the conversation.
+const getSigningKey = (privateKey: Uint8Array, publicKey: string) => {
+  const sharedX = secp256k1.getSharedSecret(privateKey, hexToBytes("02" + publicKey)).subarray(1, 33)
+  const prk = hkdfExtract(sha256, sharedX, new TextEncoder().encode("nip59-signing-key"))
+  return numberToBytesBE(bytesToNumberBE(prk) % SECP256K1_N, 32)
+}
 
-const nip44Decrypt = (data: Event, privateKey: Uint8Array) =>
-  JSON.parse(nip44.v2.decrypt(data.content, nip44ConversationKey(privateKey, data.pubkey)))
+const encrypt = (data: EventTemplate, conversationKey: Uint8Array) =>
+  nip44.v2.encrypt(JSON.stringify(data), conversationKey)
+
+const decrypt = (ciphertext: string, conversationKey: Uint8Array) =>
+  JSON.parse(nip44.v2.decrypt(ciphertext, conversationKey))
 
 const createRumor = (event: Partial<UnsignedEvent>, privateKey: Uint8Array) => {
   const rumor = {
@@ -233,49 +255,42 @@ const createRumor = (event: Partial<UnsignedEvent>, privateKey: Uint8Array) => {
   return rumor as Rumor
 }
 
-const createSeal = (rumor: Rumor, privateKey: Uint8Array, recipientPublicKey: string) => {
-  return finalizeEvent(
+const createSeal = (rumor: Rumor, privateKey: Uint8Array, recipientPublicKey: string) =>
+  finalizeEvent(
     {
       kind: 13,
-      content: nip44Encrypt(rumor, privateKey, recipientPublicKey),
+      content: encrypt(rumor, getEncryptionKey(privateKey, recipientPublicKey)),
       created_at: randomNow(),
       tags: [],
     },
     privateKey
   ) as Event
-}
 
-const createWrap = (event: Event, privateKey: Uint8Array, recipientPublicKey: string) => {
-  const conversationKey = nip44ConversationKey(privateKey, recipientPublicKey)
-
-  return finalizeEvent(
+const createWrap = (seal: Event, privateKey: Uint8Array, recipientPublicKey: string) =>
+  finalizeEvent(
     {
       kind: 1059,
-      content: nip44Encrypt(event, privateKey, recipientPublicKey),
+      content: encrypt(seal, getEncryptionKey(privateKey, recipientPublicKey)),
       created_at: randomNow(),
       tags: [["p", recipientPublicKey]],
     },
-    privateKey
+    getSigningKey(privateKey, recipientPublicKey)
   ) as Event
-}
 
-const createEphemeralWrap = (event: Event, privateKey: Uint8Array, recipientPublicKey: string) => {
-  const conversationKey = nip44ConversationKey(privateKey, recipientPublicKey)
-
-  return finalizeEvent(
+const createEphemeralWrap = (seal: Event, privateKey: Uint8Array, recipientPublicKey: string) =>
+  finalizeEvent(
     {
       kind: 21059,
-      content: nip44Encrypt(event, privateKey, recipientPublicKey),
+      content: encrypt(seal, getEncryptionKey(privateKey, recipientPublicKey)),
       created_at: randomNow(),
       tags: [["p", recipientPublicKey]],
     },
-    privateKey
+    getSigningKey(privateKey, recipientPublicKey)
   ) as Event
-}
 
-// Test case using the above example
 const senderPrivateKey = nip19.decode(`nsec1p0ht6p3wepe47sjrgesyn4m50m6avk2waqudu9rl324cg2c4ufesyp6rdg`).data
 const recipientPrivateKey = nip19.decode(`nsec1uyyrnx7cgfp40fcskcr2urqnzekc20fj0er6de0q8qvhx34ahazsvs9p36`).data
+const senderPublicKey = getPublicKey(senderPrivateKey)
 const recipientPublicKey = getPublicKey(recipientPrivateKey)
 
 const rumor = createRumor(
@@ -287,10 +302,10 @@ const rumor = createRumor(
 )
 
 const seal = createSeal(rumor, senderPrivateKey, recipientPublicKey)
-const wrap = createWrap(seal, recipientPublicKey)
+const wrap = createWrap(seal, senderPrivateKey, recipientPublicKey)
 
-// Recipient unwraps with their private key.
+const conversationKey = getEncryptionKey(recipientPrivateKey, senderPublicKey)
 
-const unwrappedSeal = nip44Decrypt(wrap, recipientPrivateKey)
-const unsealedRumor = nip44Decrypt(unwrappedSeal, recipientPrivateKey)
+const unwrappedSeal = decrypt(wrap.content, conversationKey)
+const unsealedRumor = decrypt(unwrappedSeal.content, conversationKey)
 ```

--- a/59.md
+++ b/59.md
@@ -160,7 +160,7 @@ The conversation's encryption key is `HKDF-extract(IKM=shared_x, salt=utf8_encod
 
 The conversation's signing key is `HKDF-extract(IKM=shared_x, salt=utf8_encode('nip59-signing-key'))`. This is used for signing the wrap.
 
-To obtain a valid secp256k1 private key, interpret the 32-byte HKDF output as a big-endian integer and reduce it modulo the group order `n`. Because `n` is within ~2¹²⁸ of 2²⁵⁶, the reduction's bias is negligible, as is the chance the result is `0` (an invalid key).
+To obtain a valid secp256k1 private key, interpret the 32-byte HKDF output as a big-endian integer and check that it falls in the range `[1, n-1]`, where `n` is the secp256k1 group order. In the unlikely event that it does not (the output is `0` or `>= n`), append an incrementing counter to the salt (`utf8_encode('nip59-signing-key1')`, then `utf8_encode('nip59-signing-key2')`, and so on) and re-derive until the output is in range. Both parties perform this deterministic search identically, so they still arrive at the same signing key.
 
 ### 3. Seal the rumor
 
@@ -209,7 +209,7 @@ import {hexToBytes} from "@noble/hashes/utils"
 import {extract as hkdfExtract} from "@noble/hashes/hkdf"
 import {sha256} from "@noble/hashes/sha2"
 import {secp256k1} from "@noble/curves/secp256k1"
-import {bytesToNumberBE, numberToBytesBE} from "@noble/curves/utils"
+import {bytesToNumberBE} from "@noble/curves/utils"
 import type {EventTemplate, UnsignedEvent, Event} from "nostr-tools"
 import {getPublicKey, getEventHash, nip19, nip44, finalizeEvent} from "nostr-tools"
 
@@ -227,12 +227,22 @@ const randomNow = () => Math.round(now() - (Math.random() * TWO_DAYS))
 const getEncryptionKey = (privateKey: Uint8Array, publicKey: string) =>
   nip44.v2.utils.getConversationKey(privateKey, publicKey)
 
-// The wrap signing key: HKDF-extract over the same ECDH secret with a distinct salt, reduced to a
+// The wrap signing key: HKDF-extract over the same ECDH secret with a distinct salt, yielding a
 // valid secp256k1 scalar. Both parties derive the same key, so its pubkey indexes the conversation.
 const getSigningKey = (privateKey: Uint8Array, publicKey: string) => {
   const sharedX = secp256k1.getSharedSecret(privateKey, hexToBytes("02" + publicKey)).subarray(1, 33)
-  const prk = hkdfExtract(sha256, sharedX, new TextEncoder().encode("nip59-signing-key"))
-  return numberToBytesBE(bytesToNumberBE(prk) % SECP256K1_N, 32)
+
+  // Interpret the HKDF output as a big-endian scalar. In the astronomically unlikely event it falls
+  // outside [1, n-1] (an invalid key), append an incrementing counter to the salt and re-derive.
+  // Both parties run the same deterministic search, so they agree on the key.
+  for (let counter = 0; ; counter++) {
+    const salt = new TextEncoder().encode("nip59-signing-key" + (counter || ""))
+    const prk = hkdfExtract(sha256, sharedX, salt)
+    const scalar = bytesToNumberBE(prk)
+    if (scalar >= 1n && scalar < SECP256K1_N) {
+      return prk
+    }
+  }
 }
 
 const encrypt = (data: EventTemplate, conversationKey: Uint8Array) =>

--- a/59.md
+++ b/59.md
@@ -99,10 +99,6 @@ recipients, such as live chat or real-time gaming.
 Encryption is done following [NIP-44](44.md) on the JSON-encoded event. Place the encryption payload in the `.content`
 of the wrapper event (either a `seal` or a `gift wrap`).
 
-## Spam Protection
-
-Gift wrap events are signed by random one-time keys, so relays cannot rely on pubkey-based anti-spam or anti-sybil measures (e.g. reputation, trust scores, rate limits by key). To mitigate this, a relay may enforce a [NIP-42](42.md) `auth-required` policy and authenticate clients before accepting gift wraps. Therefore clients SHOULD support authenticating to such relays using the user's real identity. Because NIP-42 authentication is ephemeral (it is not recorded in the event signature), it does not fully undermine the privacy or deniability properties of gift wrapping.
-
 ## Other Considerations
 
 If a `rumor` is intended for more than one party, or if the author wants to retain an encrypted copy, a single
@@ -125,8 +121,9 @@ AUTH, and refuse to serve wrapped events to non-recipients.
 
 When adding expiration tags to both `seal` and `gift wrap` layers, implementations SHOULD use independent random timestamps for each layer. Using different `created_at` values increases timing variance and helps protect against metadata correlation attacks.
 
-Since signing keys are random, relays SHOULD delete `kind:1059` events whose p-tag matches the signer of
-[NIP-09](09.md) deletions or [NIP-62](62.md) vanish requests.
+Relays SHOULD delete `kind:1059` events whose p-tag matches the signer of [NIP-09](09.md) deletions or [NIP-62](62.md) vanish requests so that recipients can delete their messages. [legacy]
+
+In the past, signing keys were random, forcing users to download and encrypt all wraps in every situation. Until conversation keys are in wide use, recipients MUST NOT assume the signing key is the same as the conversation key.
 
 ## An Example
 
@@ -155,11 +152,13 @@ Do not sign the event.
 }
 ```
 
-### 2. Seal the rumor
+### 2. Generate a conversation key
 
-Encrypt the JSON-encoded `rumor` with a conversation key derived using the author's private key and
-the recipient's public key. Place the result in the `content` field of a `kind 13` `seal` event. Sign
-it with the author's key.
+The conversation key is `conv(a, B)` as described in [NIP 44](44.md). This is used for encrypting the rumor and seal, as well for signing the wrap.
+
+### 3. Seal the rumor
+
+Encrypt the JSON-encoded `rumor` with the conversation key derived in the previous step. Place the result in the `content` field of a `kind 13` `seal` event. Sign it with the author's key.
 
 ```json
 {
@@ -173,11 +172,11 @@ it with the author's key.
 }
 ```
 
-### 3. Wrap the seal
+### 4. Wrap the seal
 
-Encrypt the JSON-encoded `kind 13` event with your ephemeral, single-use random key. Place the result
+Encrypt the JSON-encoded `kind 13` event the conversation key generated in step 2. Place the result
 in the `content` field of a `kind 1059`. Add a single `p` tag containing the recipient's public key.
-Sign the `gift wrap` using the random key generated in the previous step.
+Sign the `gift wrap` using the same conversation key.
 
 ```json
 {
@@ -191,7 +190,7 @@ Sign the `gift wrap` using the random key generated in the previous step.
 }
 ```
 
-### 4. Broadcast Selectively
+### 5. Broadcast Selectively
 
 Broadcast the `kind:1059` or `kind:21059` event to the recipient's relays only. Delete all the other events.
 
@@ -246,31 +245,31 @@ const createSeal = (rumor: Rumor, privateKey: Uint8Array, recipientPublicKey: st
   ) as Event
 }
 
-const createWrap = (event: Event, recipientPublicKey: string) => {
-  const randomKey = generateSecretKey()
+const createWrap = (event: Event, privateKey: Uint8Array, recipientPublicKey: string) => {
+  const conversationKey = nip44ConversationKey(privateKey, recipientPublicKey)
 
   return finalizeEvent(
     {
       kind: 1059,
-      content: nip44Encrypt(event, randomKey, recipientPublicKey),
+      content: nip44Encrypt(event, privateKey, recipientPublicKey),
       created_at: randomNow(),
       tags: [["p", recipientPublicKey]],
     },
-    randomKey
+    privateKey
   ) as Event
 }
 
-const createEphemeralWrap = (event: Event, recipientPublicKey: string) => {
-  const randomKey = generateSecretKey()
+const createEphemeralWrap = (event: Event, privateKey: Uint8Array, recipientPublicKey: string) => {
+  const conversationKey = nip44ConversationKey(privateKey, recipientPublicKey)
 
   return finalizeEvent(
     {
       kind: 21059,
-      content: nip44Encrypt(event, randomKey, recipientPublicKey),
+      content: nip44Encrypt(event, privateKey, recipientPublicKey),
       created_at: randomNow(),
       tags: [["p", recipientPublicKey]],
     },
-    randomKey
+    privateKey
   ) as Event
 }
 


### PR DESCRIPTION
For discussion. This trades off some metadata hiding (watchers can now identify a single conversation over time) for spam prevention and the ability to target a conversation by counterparty.

In concrete terms, this allows the user to:

- Only download messages from people they follow or have otherwise whitelisted instead of unknown contact.
- Download all messages, and lazily decrypt them as they become relevant to user actions.
- Decrypt a single message per signer in order to identify counterparties without unwrapping all events.
- Download and encrypt messages from a single counterparty the user actually wants to talk to.

This is backwards compatible in the sense that old clients that don't assign any expectation to the pubkey will continue to work. However, in order to take advantage of the benefits of this change, clients will need to switch to using the conversation key to sign wraps, which will take some time.