### PR TITLE
NIP-59: relays should reject kind 13 seal events

### DIFF
--- a/59.md
+++ b/59.md
@@ -55,6 +55,8 @@ without the receiver's or the sender's private key. The only public information 
 
 Tags MUST always be empty in a `kind:13`. The inner event MUST always be unsigned.
 
+A `seal` is never meant to be published on its own; it is always wrapped inside a `gift wrap`. Relays SHOULD reject `kind:13` events.
+
 ### 3. Gift Wrap Event Kind
 
 A `gift wrap` event is a `kind:1059` event that wraps any other event. `tags` SHOULD include any information


### PR DESCRIPTION
Since seal events are only ever supposed to be used inside of giftwraps, relay should reject them.