### PR TITLE
Use hsl for role colors

### DIFF
--- a/43.md
+++ b/43.md
@@ -21,7 +21,7 @@ The following tags are optional:
 
 - `label` - a label for the role.
 - `description` - a description of the role.
-- `color` - a `hue` value from `0` to `360` for the role.
+- `color` - a tuple of `hue` (0 to 360), `saturation` (0 to 1), and `lightness` (0 to 1). Empty strings may be provided for any values, allowing clients to supply their own defaults for a coherent palette. Unless a specific color (like silver) is desired, providing only `hue` is recommended.
 - `order` - a `order` integer for the role (for client display only).
 
 ```yaml

--- a/86.md
+++ b/86.md
@@ -50,10 +50,10 @@ This is the list of **methods** that may be supported:
   - params: `[]`
   - result: `[{"pubkey": "<32-byte-hex>", "reason": "<optional-reason>"}, ...]`, an array of objects
 * `createrole`:
-  - params: `[id, label, description, color, order]`
+  - params: `[id, label, description, [h, s, l], order]`
   - result: `true` (boolean true)
 * `editrole`:
-  - params: `[id, label, description, color, order]`
+  - params: `[id, label, description, [h, s, l], order]`
   - result: `true` (boolean true)
 * `deleterole`:
   - params: `[id]`


### PR DESCRIPTION
This is named oklch, but I switched to hsl because it's just more intuitive and predictable when picking colors.