### PR TITLE
[NIP-51, NIP-37] fix: clarification private relays 

### DIFF
--- a/51.md
+++ b/51.md
@@ -34,7 +34,7 @@ For example, _mute list_ can contain the public keys of spammers and bad actors 
 | Profile badges    | 10008 | [NIP-58](58.md) badges a user has accepted and chosen to display | `"a"` (kind:30009 badge definitions) and `"e"` (kind:8 badge awards), and `"a"` (kind:30008 badge set) |
 | Simple groups     | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group id + relay URL + optional group name), `"r"` for each relay in use |
 | Relay feeds       | 10012 | user favorite browsable relays (and relay sets)             | `"relay"` (relay URLs) and `"a"` (kind:30002 relay set)                                             |
-| Draft relays      | 10013 | (nip44-encrypted) [NIP-37](37.md) draft relays              | `"relay"` (relay URL)                                                                               |
+| Private relays      | 10013 | (nip44-encrypted) [NIP-37](37.md) private relays (drafts)            | `"relay"` (relay URL)                                                                               |
 | Interests         | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a"` (kind:30015 interest set)                                                |
 | Media follows     | 10020 | multimedia (photos, short video) follow list                | `"p"` (pubkeys -- with optional relay hint and petname)                                             |
 | Emojis            | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                                    |


### PR DESCRIPTION
In `NIP-37` kind 10013 is named `Relay List for Private Content` in `NIP-51` `Draft relays` this PR changes `NIP-51` for consistency.