### PR TITLE
Add claim management to nip 86

### DIFF
--- a/43.md
+++ b/43.md
@@ -143,23 +143,7 @@ Some examples:
 ["OK", <event-id>, true, "info: welcome to wss://relay.bunk.skunk!"]
 ```
 
-## Invite Request
-
-Users may request a claim string from a relay by making a request for `kind 28935` events. This event MUST be signed by the pubkey specified in the `self` field of the relay's [NIP 11](./11.md) document.
-
-```yaml
-{
-  "kind": 28935,
-  "pubkey": "<nip11.self>",
-  "tags": [
-    ["-"],
-    ["claim", "<invite code>"],
-  ],
-  // ...other fields
-}
-```
-
-Note that these events are in the `ephemeral` range, which means relays must explicitly opt-in to this behavior by generating claims on the fly when requested. This allows relays to improve security by issuing a different claim for each request, only issuing claims to certain users, or expiring claims.
+Users can request a `claim` using the [NIP 86](./86.md) `createclaim` method.
 
 ## Leave Request
 

--- a/86.md
+++ b/86.md
@@ -64,6 +64,15 @@ This is the list of **methods** that may be supported:
 * `unassignrole`:
   - params: `["<32-byte-hex-public-key>", "<role-id>"]`
   - result: `true` (a boolean always set to `true`)
+* `listclaims`:
+  - params: `[]`
+  - result: `[claim, ...]`, an array of NIP 43 invite codes
+* `createclaim`:
+  - params: `[claim]`
+  - result: `true` (boolean true)
+* `deleteclaim`:
+  - params: `[claim]`
+  - result: `true` (boolean true)
 * `listeventsneedingmoderation`:
   - params: `[]`
   - result: `[{"id": "<32-byte-hex>", "reason": "<optional-reason>"}]`, an array of objects


### PR DESCRIPTION
This is so admins can manage NIP 43 invite codes. The use case I have which requires this is collecting payment for a community relay before the user's identity has even been created. This allows me to create an invite code associated with a role, collect payment, give the user the invite code and redirect to flotilla. They then use the invite code, meanwhile my bot listens to the kind 28935 sent to the relay, then assigns a role to the user automatically granting them access to a specific room.

Labyrithine, but pretty cool that I can compose this stuff to support increasingly arbitrary flows.