### PR TITLE
Add sticker pack kinds 10031 and 30031 to Event Kinds table

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ This table is not exhaustive. For a machine-readable registry of all known event
 | `10019`       | Nutzap Mint Recommendation      | [61](61.md)                            |
 | `10020`       | Media follows                   | [51](51.md)                            |
 | `10030`       | User emoji list                 | [51](51.md)                            |
+| `10031`       | User sticker pack list          | [sonar-stickers][sonar-stickers]       |
 | `10050`       | Relay list to receive DMs       | [51](51.md), [17](17.md)               |
 | `10051`       | KeyPackage Relays List          | [Marmot][marmot]                       |
 | `10054`       | Favorite podcasts list          | [51](51.md)                            |
@@ -256,6 +257,7 @@ This table is not exhaustive. For a machine-readable registry of all known event
 | `30023`       | Long-form Content               | [23](23.md)                            |
 | `30024`       | Draft Long-form Content         | [23](23.md)                            |
 | `30030`       | Emoji sets                      | [51](51.md)                            |
+| `30031`       | Sticker packs                   | [sonar-stickers][sonar-stickers]       |
 | `30040`       | Curated Publication Index       | [NKBIP-01]                             |
 | `30041`       | Curated Publication Content     | [NKBIP-01]                             |
 | `30063`       | Release artifact sets           | [51](51.md)                            |
@@ -304,6 +306,7 @@ This table is not exhaustive. For a machine-readable registry of all known event
 [NKBIP-02]: https://wikistr.com/nkbip-02*fd208ee8c8f283780a9552896e4823cc9dc6bfd442063889577106940fd927c1
 [NKBIP-03]: https://wikistr.com/nkbip-03*fd208ee8c8f283780a9552896e4823cc9dc6bfd442063889577106940fd927c1
 [marmot]: https://github.com/marmot-protocol/marmot
+[sonar-stickers]: https://sonarprivacy.xyz/docs/#SONAR-STICKERS
 
 
 ## Message types


### PR DESCRIPTION
## Summary

Registers two event kinds used by the open sticker-pack directory specified in [Sonar Stickers](https://sonarprivacy.xyz/docs/#SONAR-STICKERS):

| kind | description | range |
|------|-------------|-------|
| `30031` | Sticker packs | addressable (`30000`–`39999`) |
| `10031` | User sticker pack list | replaceable (`10000`–`19999`) |

These deliberately sit one slot above the NIP-51 / NIP-30 custom-emoji kinds `30030` (emoji set) and `10030` (user emoji list). Stickers reuse a similar event shape (`title` / `image` / `description` / `emoji` tags on the pack, `a`-tag pointers on the list) but **must not collide** with emoji kinds, or clients would parse sticker packs as emoji sets and installed-pack lists as emoji lists.

## Spec highlights

- Pack format marker: `sonar-sticker-pack-v1` (`pack_format` tag + recommended `t` discovery tag)
- Sticker image bytes live on HTTPS Blossom-compatible servers; events carry `sticker` tags with shortcode, URL, sha256, MIME, optional dim/alt/emoji
- Sent sticker references include the plaintext hash so edited addressable packs cannot silently change old messages
- Full format: https://sonarprivacy.xyz/docs/#SONAR-STICKERS (source: [SONAR-STICKERS.md](https://github.com/hedwig-corp/bitchat-to-sonar/blob/main/docs/SONAR-STICKERS.md))

## Related

- Companion PR to register the same kinds in the machine-readable schema: https://github.com/nostr-protocol/registry-of-kinds (opening alongside this)

## Notes

This only extends the **Event Kinds** index in the README (with an external-spec reference, same pattern as Marmot / NKBIP / joinstr). A full NIP document can follow once multiple independent clients implement the format.