### PR TITLE
add kind:10011, favorite follow sets

### DIFF
--- a/51.md
+++ b/51.md
@@ -20,32 +20,33 @@ Standard lists use normal replaceable events, meaning users may only have a sing
 
 For example, _mute list_ can contain the public keys of spammers and bad actors users don't want to see in their feeds or receive annoying notifications from.
 
-| name              | kind  | description                                                 | expected tag items                                                                                  |
-| ---               | ---   | ---                                                         | ---                                                                                                 |
-| Follow list       |     3 | microblogging basic follow list, see [NIP-02](02.md)        | `"p"` (pubkeys -- with optional relay hint and petname)                                             |
-| Mute list         | 10000 | things the user doesn't want to see in their feeds          | `"p"` (pubkeys), `"t"` (hashtags), `"word"` (lowercase string), `"e"` (threads)                     |
-| Pinned notes      | 10001 | events the user intends to showcase in their profile page   | `"e"` (kind:1 notes)                                                                                |
-| Read/write relays | 10002 | where a user publishes to and where they expect mentions    | see [NIP-65](65.md)                                                                                 |
-| Bookmarks         | 10003 | uncategorized, "global" list of things a user wants to save | `"e"` (kind:1 notes), `"a"` (kind:30023 articles)                   |
-| Communities       | 10004 | [NIP-72](72.md) communities the user belongs to             | `"a"` (kind:34550 community definitions)                                                            |
-| Public chats      | 10005 | [NIP-28](28.md) chat channels the user is in                | `"e"` (kind:40 channel definitions)                                                                 |
-| Blocked relays    | 10006 | relays clients should never connect to                      | `"relay"` (relay URLs)                                                                              |
-| Search relays     | 10007 | relays clients should use when performing search queries    | `"relay"` (relay URLs)                                                                              |
-| Profile badges    | 10008 | [NIP-58](58.md) badges a user has accepted and chosen to display | `"a"` (kind:30009 badge definitions) and `"e"` (kind:8 badge awards), and `"a"` (kind:30008 badge set) |
-| Simple groups     | 10009 | [NIP-29](29.md) groups the user is in                       | `"group"` ([NIP-29](29.md) group id + relay URL + optional group name), `"r"` for each relay in use |
-| Relay feeds       | 10012 | user favorite browsable relays (and relay sets)             | `"relay"` (relay URLs) and `"a"` (kind:30002 relay set)                                             |
-| Private relays      | 10013 | (nip44-encrypted) [NIP-37](37.md) private relays (drafts)            | `"relay"` (relay URL)                                                                               |
-| Interests         | 10015 | topics a user may be interested in and pointers             | `"t"` (hashtags) and `"a"` (kind:30015 interest set)                                                |
-| Media follows     | 10020 | multimedia (photos, short video) follow list                | `"p"` (pubkeys -- with optional relay hint and petname)                                             |
-| Emojis            | 10030 | user preferred emojis and pointers to emoji sets            | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                                    |
-| DM relays         | 10050 | Where to receive [NIP-17](17.md) direct messages            | `"relay"` (see [NIP-17](17.md))                                                                     |
-| Blossom servers   | 10063 | Servers where to upload and look for images and other blobs | `"server"` (see [NIP-B7](B7.md))                                                                    |
-| Good wiki authors | 10101 | [NIP-54](54.md) user recommended wiki authors               | `"p"` (pubkeys)                                                                                     |
-| Good wiki relays  | 10102 | [NIP-54](54.md) relays deemed to only host useful articles  | `"relay"` (relay URLs)                                                                              |
-| Git authors       | 10017 | code (people who produce NIP-34 events) follow list         | `"p"` (pubkeys -- with optional relay hint and petname)                                             |
-| Git repositories  | 10018 | [NIP-34](34.md) followed repositories                       | `"a"` (kind:30617 repository announcement event)                                                    |
-| Favorite podcasts | 10054 | podcasts a user wants to bookmark as favorites              | `"p"` ([NIP-F4](F4.md) podcast pubkeys), `"url"` (RSS/XML podcast URLs)                             |
-| Authored podcasts | 10064 | podcasts the user authors                                   | `"p"` ([NIP-F4](F4.md) podcast pubkeys)                                                             |
+| name                 | kind  | description                                                      | expected tag items                                                                                     |
+| ---                  | ---   | ---                                                              | ---                                                                                                    |
+| Follow list          | 3     | microblogging basic follow list, see [NIP-02](02.md)             | `"p"` (pubkeys -- with optional relay hint and petname)                                                |
+| Mute list            | 10000 | things the user doesn't want to see in their feeds               | `"p"` (pubkeys), `"t"` (hashtags), `"word"` (lowercase string), `"e"` (threads)                        |
+| Pinned notes         | 10001 | events the user intends to showcase in their profile page        | `"e"` (kind:1 notes)                                                                                   |
+| Read/write relays    | 10002 | where a user publishes to and where they expect mentions         | see [NIP-65](65.md)                                                                                    |
+| Bookmarks            | 10003 | uncategorized, "global" list of things a user wants to save      | `"e"` (kind:1 notes), `"a"` (kind:30023 articles)                                                      |
+| Communities          | 10004 | [NIP-72](72.md) communities the user belongs to                  | `"a"` (kind:34550 community definitions)                                                               |
+| Public chats         | 10005 | [NIP-28](28.md) chat channels the user is in                     | `"e"` (kind:40 channel definitions)                                                                    |
+| Blocked relays       | 10006 | relays clients should never connect to                           | `"relay"` (relay URLs)                                                                                 |
+| Search relays        | 10007 | relays clients should use when performing search queries         | `"relay"` (relay URLs)                                                                                 |
+| Profile badges       | 10008 | [NIP-58](58.md) badges a user has accepted and chosen to display | `"a"` (kind:30009 badge definitions) and `"e"` (kind:8 badge awards), and `"a"` (kind:30008 badge set) |
+| Simple groups        | 10009 | [NIP-29](29.md) groups the user is in                            | `"group"` ([NIP-29](29.md) group id + relay URL + optional group name), `"r"` for each relay in use    |
+| Favorite follow sets | 10011 | user favorite follow sets                                        | `"a"` (kind:30000 follow set)                                                                          |
+| Relay feeds          | 10012 | user favorite browsable relays (and relay sets)                  | `"relay"` (relay URLs) and `"a"` (kind:30002 relay set)                                                |
+| Private relays       | 10013 | (nip44-encrypted) [NIP-37](37.md) private relays (drafts)        | `"relay"` (relay URL)                                                                                  |
+| Interests            | 10015 | topics a user may be interested in and pointers                  | `"t"` (hashtags) and `"a"` (kind:30015 interest set)                                                   |
+| Media follows        | 10020 | multimedia (photos, short video) follow list                     | `"p"` (pubkeys -- with optional relay hint and petname)                                                |
+| Emojis               | 10030 | user preferred emojis and pointers to emoji sets                 | `"emoji"` (see [NIP-30](30.md)) and `"a"` (kind:30030 emoji set)                                       |
+| DM relays            | 10050 | Where to receive [NIP-17](17.md) direct messages                 | `"relay"` (see [NIP-17](17.md))                                                                        |
+| Blossom servers      | 10063 | Servers where to upload and look for images and other blobs      | `"server"` (see [NIP-B7](B7.md))                                                                       |
+| Good wiki authors    | 10101 | [NIP-54](54.md) user recommended wiki authors                    | `"p"` (pubkeys)                                                                                        |
+| Good wiki relays     | 10102 | [NIP-54](54.md) relays deemed to only host useful articles       | `"relay"` (relay URLs)                                                                                 |
+| Git authors          | 10017 | code (people who produce NIP-34 events) follow list              | `"p"` (pubkeys -- with optional relay hint and petname)                                                |
+| Git repositories     | 10018 | [NIP-34](34.md) followed repositories                            | `"a"` (kind:30617 repository announcement event)                                                       |
+| Favorite podcasts    | 10054 | podcasts a user wants to bookmark as favorites                   | `"p"` ([NIP-F4](F4.md) podcast pubkeys), `"url"` (RSS/XML podcast URLs)                                |
+| Authored podcasts    | 10064 | podcasts the user authors                                        | `"p"` ([NIP-F4](F4.md) podcast pubkeys)                                                                |
 
 ### Sets
 


### PR DESCRIPTION
Similar to how `kind:10012` can have `"a"` tags with relay sets (`kind:30002`), this does the same for follow sets (`kind:30000`).