### PR TITLE
NIP-29: allow a tags in pin list

### DIFF
--- a/29.md
+++ b/29.md
@@ -139,7 +139,7 @@ Each moderation action uses a different kind and requires different arguments, w
 | 9007 | `create-group`  |                                        |
 | 9008 | `delete-group`  |                                        |
 | 9009 | `create-invite` | arbitrary `code`                       |
-| 9010 | `update-pin-list` | zero or more `e` with event id hex   |
+| 9010 | `update-pin-list` | zero or more `e` with event id hex or `a` with event address |
 
 It's expected that the group state (of who is an allowed member or not, who is an admin and with which permission or not, what are the group name and picture etc) can be fully reconstructed from the canonical sequence of these events.
 
@@ -263,7 +263,7 @@ The event MUST contain zero or more `participant` tags with the participant's pu
 
 - *group pinned events* (`kind:39005`) (optional)
 
-It's a list of events pinned in the group, in the order they should be displayed. The `kind:9010` moderation event carries the full list as `e` tags, so pinning, unpinning, reordering and clearing pins are all done by submitting a new list. Whenever one is accepted the relay regenerates this event to mirror it. The relay may choose to limit the number of pins.
+It's a list of events pinned in the group, in the order they should be displayed. The `kind:9010` moderation event carries the full list as `e` tags (regular events) and `a` tags (addressable events), so pinning, unpinning, reordering and clearing pins are all done by submitting a new list. Whenever one is accepted the relay regenerates this event to mirror it. The relay may choose to limit the number of pins.
 
 Clients may display these events at the top of the group view.
 
@@ -274,8 +274,9 @@ Clients may display these events at the top of the group view.
   "tags": [
     ["d", "<group-id>"],
     ["e", "<event-id1-as-hex>"],
+    ["a", "<kind>:<pubkey>:<d-identifier>"],
     ["e", "<event-id2-as-hex>"],
-    // other event ids...
+    // other event references...
   ],
   // other fields...
 }


### PR DESCRIPTION
Allows `a` tags in `update-pin-list` (`kind:9010`) and `kind:39005`, so addressable events can be pinned by address. Using `e` tags for those can leave pins unfindable after the event is replaced.

As discussed in #2379.