### PR TITLE
nip34: drop GRASP hosting instructions from pull request description

### DIFF
--- a/34.md
+++ b/34.md
@@ -119,11 +119,7 @@ The first patch in a series MAY be a cover letter in the format produced by `git
 
 ### Pull Requests
 
-The PR or PR update tip SHOULD be successfully pushed to `refs/nostr/<[PR|PR-Update]-event-id>` in all repositories listed in its `clone` tag before the event is signed.
-
-An attempt SHOULD be made to push this ref to all repositories listed in the repository's announcement event's `"clone"` tag, for which their is reason to believe the user might have write access. This includes each [grasp server](https://njump.me/naddr1qvzqqqrhnypzpgqgmmc409hm4xsdd74sf68a2uyf9pwel4g9mfdg8l5244t6x4jdqy28wumn8ghj7un9d3shjtnwva5hgtnyv4mqqpt8wfshxuqlnvh8x) which can be identified using this method: `clone` tag includes `[http|https]://<grasp-path>/<valid-npub>/<string>.git` and `relays` tag includes `[ws/wss]://<grasp-path>`.
-
-Clients MAY fallback to using [GRASP-06](https://njump.me/naddr1qvzqqqrhnypzpgqgmmc409hm4xsdd74sf68a2uyf9pwel4g9mfdg8l5244t6x4jdqy28wumn8ghj7un9d3shjtnwva5hgtnyv4mqqpt8wfshxuqlnvh8x), e.g. from the `User grasp list`, for the purpose of serving the specified commit(s). Clients SHOULD not create `30617` event for the purpose of hosting a PR.
+A pull request is an event that points to proposed changes in a git repository.
 
 ```yaml
 {


### PR DESCRIPTION
The GRASP-related hosting guidance (pushing to grasp servers, fallback to GRASP-06, etc.) belongs in the GRASP protocol, not inside the NIP-34 specification. Not every client that handles pull requests is a GRASP client, and including those details unnecessarily complicates the NIP-34. Replace that section with a description of pull request events, keeping the spec focused on its own scope.

cc: @DanConwayDev @fiatjaf 