### PR TITLE
Add NIP-A1: Key Set Declaration (kind 10045)

### DIFF
--- a/A1.md
+++ b/A1.md
@@ -1,0 +1,56 @@
+NIP-A1
+======
+
+Key Set Declaration
+-------------------
+
+`draft` `optional`
+
+A user can hold many keys. This event says: these keys are all me.
+
+`kind:10045` is a replaceable event. Each `p` tag names another key that is also the author.
+
+```jsonc
+{
+  "kind": 10045,
+  "pubkey": "<my-key>",
+  "tags": [
+    ["p", "<other-key>", "<relay-hint>"],
+    ["p", "<other-key>", "<relay-hint>"]
+  ],
+  "content": "",
+  // ...other fields
+}
+```
+
+The `p` tag has the pubkey in hex and an optional relay hint. There is no direction. The `content` is empty.
+
+## Verifying a link
+
+One event is not proof. Anyone can list any key. A link counts only when both keys list each other:
+
+- `A`'s event has `["p", B, ...]`, and
+- `B`'s event has `["p", A, ...]`.
+
+Both events are signed by their own key. So the pair proves one party holds both keys.
+
+Clients MUST require this mutual link before merging two keys. A one-sided claim is unverified.
+
+## Using the set
+
+Verified links form a set. Clients MAY treat the set as one identity and merge follows, mutes, profile, and reactions across it.
+
+Do not assume the link is transitive. `A ↔ B` and `B ↔ C` does not make `A` and `C` the same. They must list each other too.
+
+## Updates and removal
+
+The event is replaceable. Publish a new one to change it.
+
+To drop a key, republish without its `p` tag. Once either side drops the other, the link is unverified. You do not need the other key to cooperate.
+
+## Security
+
+- A verified link proves one party could sign with both keys. It does not prove a key was never shared or later stolen.
+- If one key is stolen, the thief keeps its side, but cannot forge the other side. Drop the link from the safe key.
+- This links keys in public. Do not declare keys you keep separate on purpose.
+- The relay hint is untrusted.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ NIPs listed here are not a protocol checklist. Nothing forces any software to im
 - [NIP-98: HTTP Auth](98.md)
 - [NIP-99: Classified Listings](99.md)
 - [NIP-A0: Voice Messages](A0.md)
+- [NIP-A1: Key Set Declaration](A1.md)
 - [NIP-A4: Public Messages](A4.md)
 - [NIP-B0: Web Bookmarks](B0.md)
 - [NIP-B7: Blossom](B7.md)
@@ -216,6 +217,7 @@ This table is not exhaustive. For a machine-readable registry of all known event
 | `10019`       | Nutzap Mint Recommendation      | [61](61.md)                            |
 | `10020`       | Media follows                   | [51](51.md)                            |
 | `10030`       | User emoji list                 | [51](51.md)                            |
+| `10045`       | Key Set Declaration             | [A1](A1.md)                            |
 | `10050`       | Relay list to receive DMs       | [51](51.md), [17](17.md)               |
 | `10051`       | KeyPackage Relays List          | [Marmot][marmot]                       |
 | `10054`       | Favorite podcasts list          | [51](51.md)                            |


### PR DESCRIPTION
A replaceable kind:10045 event where a key declares the other keys that are also the same person. A link is verified only when both keys list each other, which prevents unilateral impersonation. Verified links form an identity set clients may merge.