### PR TITLE
NIP-F6: Sticker Packs

### DIFF
--- a/F6.md
+++ b/F6.md
@@ -19,8 +19,8 @@ A sticker pack is an **addressable** event of kind `30031`. The `.content` MUST 
 | `d` | one | yes | Pack identifier; 1–80 chars of `[A-Za-z0-9._-]`. |
 | `title` | one | yes | Human-readable pack title. |
 | `pack_format` | one | yes | Format marker. This NIP defines `sonar-sticker-pack-v1`. |
-| `sticker` | many | at least one | A single sticker (see below). |
-| `image` | one | no | Cover image: `["image", <url>, <sha256?>, <WIDTHxHEIGHT?>]`. |
+| `sticker` | many | at least one valid | A single sticker (see below). |
+| `image` | one | no | Cover image: `["image", <url>, <sha256>, <mime>, <dimensions?>]`. |
 | `description` | one | no | Free-text pack description. |
 | `license` | one | no | License of the pack artwork. |
 | `emoji` | many | no | A [NIP-30](30.md)-compatible `["emoji", <shortcode>, <url>]` alias for a sticker, so emoji-capable clients can reuse the same art. |
@@ -29,17 +29,34 @@ A sticker pack is an **addressable** event of kind `30031`. The `.content` MUST 
 ### The `sticker` tag
 
 ```
-["sticker", <shortcode>, <url>, <sha256>, <mime>, <dimensions?>, <alt?>]
+["sticker", <shortcode>, <keyed-field>...]
 ```
 
-- **shortcode** — 1–64 chars of `[A-Za-z0-9_]`; unique within the pack.
-- **url** — HTTPS URL of the image. Non-HTTPS URLs MUST be rejected by clients.
-- **sha256** — 64 lowercase hex characters; the SHA-256 of the image bytes found at `url`.
-- **mime** — one of `image/webp`, `image/png`, `image/apng`, `image/gif`.
-- **dimensions** (optional) — `WIDTHxHEIGHT`, each value ≤ 4096.
-- **alt** (optional) — accessibility text for the sticker.
+`<shortcode>` is positional. Every later element is a space-delimited key/value pair in the style of [NIP-92](92.md) `imeta`: split on the **first** space; the left token is the key, the remainder is the value (and MAY contain spaces).
 
-A pack SHOULD contain no more than 200 stickers.
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `url` | yes | HTTPS URL of the image. Non-HTTPS URLs MUST be rejected. |
+| `x` | yes | 64 lowercase hex characters; SHA-256 of the image bytes at `url`. |
+| `m` | yes | One of `image/webp`, `image/png`, `image/apng`, `image/gif`. |
+| `dim` | no | `WIDTHxHEIGHT`, each value an integer ≤ 4096. |
+| `alt` | no | Accessibility text for the sticker. |
+
+- **shortcode** — 1–64 chars of `[A-Za-z0-9_]`. Shortcodes MUST be unique within the pack. If a later `sticker` tag repeats a shortcode, clients MUST keep the first valid entry and ignore the rest.
+- **`x` MAY repeat.** Two shortcodes MAY point at the same image bytes.
+- Keyed-field order is insignificant.
+- Unknown keys MUST be ignored.
+- Duplicate keys in one tag: the first value wins.
+- A field with no space, an empty key, or an empty required value makes that sticker invalid. Invalid stickers MUST be ignored. If no valid sticker remains, the pack MUST be rejected.
+- A pack SHOULD contain no more than 200 stickers.
+
+### The `image` cover tag
+
+```
+["image", <url>, <sha256>, <mime>, <dimensions?>]
+```
+
+Cover `url`, `sha256`, and `mime` are required when the tag is present. They use the same HTTPS, hash, MIME-allowlist, and 4096×4096 rules as sticker images. Clients MUST NOT cache or render a cover whose hash is missing or does not match the downloaded bytes, or whose MIME is outside the allowlist. `dimensions`, if present, is `WIDTHxHEIGHT` with each value ≤ 4096.
 
 ### Example
 
@@ -53,23 +70,35 @@ A pack SHOULD contain no more than 200 stickers.
     ["pack_format", "sonar-sticker-pack-v1"],
     ["description", "A small starter pack."],
     ["t", "sonar-sticker-pack-v1"],
-    ["sticker", "wave", "https://blob.example/stickers/wave.webp",
-      "8f4a2b9c7d1e6053a24bf0c1e8d9a7f3b6c2e4d8f0a1b2c3d4e5f6a7b8c9d0e1", "image/webp", "256x256", "a waving hand"],
-    ["sticker", "sats", "https://blob.example/stickers/sats.webp",
-      "1c0ffee54bd1290b1f8a7c3d2e4b5a6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2", "image/webp"]
+    ["image", "https://blob.example/stickers/cover.webp",
+      "9a1b2c3d4e5f60718293a4b5c6d7e8f90123456789abcdef0123456789abcdef", "image/webp", "512x512"],
+    ["sticker", "wave",
+      "url https://blob.example/stickers/wave.webp",
+      "x 8f4a2b9c7d1e6053a24bf0c1e8d9a7f3b6c2e4d8f0a1b2c3d4e5f6a7b8c9d0e1",
+      "m image/webp",
+      "dim 256x256",
+      "alt a waving hand"],
+    ["sticker", "sats",
+      "url https://blob.example/stickers/sats.webp",
+      "x 1c0ffee54bd1290b1f8a7c3d2e4b5a6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2",
+      "m image/webp"]
   ]
 }
 ```
 
 ## Installed sticker packs (kind 10031)
 
-A user's installed packs are advertised in a **replaceable** event of kind `10031`. The `.content` MUST be empty. Each installed pack is one `a` tag pointing at its kind `30031` coordinate:
+Kind `10031` is an **optional** [NIP-51](51.md)-style standard list. It is the sticker analogue of kind `10030` (preferred emojis). A client that can send and receive stickers without publishing `10031` is still F6-compatible. Clients MAY keep the install set local-only.
+
+When published, it is a **replaceable** event. The `.content` MUST be empty. Each installed pack is one `a` tag pointing at its kind `30031` coordinate:
 
 ```
 ["a", "30031:<pubkey>:<identifier>"]
 ```
 
-The `a` tags MUST be deduplicated and SHOULD preserve first-seen order. Clients SHOULD merge versions seen across relays, keeping the newest event.
+The `a` tags MUST be deduplicated (first occurrence wins) and SHOULD preserve the order they appear in the surviving event. Clients SHOULD merge versions seen across relays by [NIP-01](01.md) replaceable-event rules: keep the newest `created_at`, and on a timestamp tie keep the event with the lowest `id`.
+
+A published `10031` is public. It tells anyone who asks which packs the user has installed. Do not put private or unannounced packs in it.
 
 ## Pack format `sonar-sticker-pack-v1`
 
@@ -77,26 +106,198 @@ The format marker `sonar-sticker-pack-v1` declares the tag layout specified abov
 
 ## Image storage
 
-Sticker bytes live on [NIP-B7](B7.md) (Blossom) servers, or any HTTPS host — **never** in the event. Clients:
+Sticker and cover bytes live on [NIP-B7](B7.md) (Blossom) servers, or any HTTPS host — **never** in the event. Clients:
 
 1. Fetch the image over **HTTPS only**.
-2. Verify that the downloaded bytes hash (SHA-256) to the value carried in the `sticker` tag before caching or rendering.
+2. Verify that the downloaded bytes hash (SHA-256) to the value carried on the tag (`x` for a sticker, `sha256` for a cover) before caching or rendering.
 3. Enforce the MIME allowlist (`image/webp`, `image/png`, `image/apng`, `image/gif`) and the 4096×4096 dimension bound.
 
 ## Referencing stickers
 
-To send a sticker, a client emits a reference to `(pack-coordinate, shortcode, sha256)` inside the content of whatever message type it already uses — a kind `1` note, a [NIP-17](17.md) direct message, or any application-specific message. **No new event kind is introduced for sending stickers.** A receiver resolves the reference by fetching the pack event and matching the shortcode, and it SHOULD confirm that the referenced hash matches the pack entry.
+To send a sticker, a client adds **one or more** `sticker` tags to the event that already carries the message. **No new event kind is introduced for sending stickers.** The canonical tag is:
+
+```
+["sticker", "30031:<pubkey>:<identifier>", "<shortcode>", "<sha256>"]
+```
+
+An optional fifth value MAY be the pack event `id` (32-byte lowercase hex) if the sender wants to pin a specific version.
+
+| Field | Rule |
+|-------|------|
+| coordinate | `30031:<32-byte lowercase hex pubkey>:<d-tag>`. Any other shape is malformed. |
+| shortcode | Same charset as in the pack. Empty or illegal shortcodes are malformed. |
+| sha256 | 64 lowercase hex characters. Any other shape is malformed. |
+| event id | Optional. If present and not 64 lowercase hex, the tag is malformed. |
+
+Further rules:
+
+- The tag MUST be placed on the event the receiver reads as the message: a kind `1` note, the [NIP-17](17.md) **rumor**, or the application-specific message event. It MUST NOT be placed only on a NIP-17 wrap; that would leak the sticker to the wrap's relays.
+- `.content` MAY be empty. Clients MAY put a human fallback (for example `:wave:`) in `.content` for clients that do not implement this NIP.
+- Malformed `sticker` tags MUST be ignored. Parsers MUST NOT crash.
+- Identical duplicate tags MUST be treated as one.
+- Distinct valid tags on the same event are independent stickers. A client that can only render one SHOULD render the first valid tag and ignore the rest.
+- A receiver resolves a tag by fetching the current kind `30031` at that coordinate (or a cached copy) and matching `shortcode`. It MUST confirm that the referenced hash equals the pack entry's `x` before fetching or rendering the image.
 
 Because the reference carries the expected hash, a receiver can reject a substituted image without trusting either the pack author or the blob host.
 
+### Historical resolution
+
+The coordinate `30031:<pubkey>:<d>` names the **current** pack. Kind `30031` is addressable: relays keep only the latest event per `(kind, pubkey, d)` ([NIP-01](01.md)). A hash match stops byte substitution. It does not recover a URL that a later pack version dropped.
+
+Intended model:
+
+1. Clients SHOULD cache every `(coordinate, shortcode, sha256, url, mime)` tuple they have fetched and hash-verified.
+2. A send MAY pin a pack event `id` as the fifth tag value. Receivers that still have that event MAY use it; others fall through to (1) or (3).
+3. If neither the cache nor the currently resolved pack contains that `(shortcode, sha256)` pair, render an "unknown sticker" placeholder. Do **not** render whatever image the current pack holds under that shortcode.
+
+Failure to resolve an old version is an accepted limitation.
+
 ## Discovery
 
-Clients discover packs by querying relays for kind `30031` events — optionally filtered by `#t`, by author, or by the `d` identifier. A user's installed packs are discovered from that user's kind `10031` event.
+Clients discover packs by querying relays for kind `30031` events — optionally filtered by `#t`, by author, or by the `d` identifier. A user's published install list, if any, is that user's kind `10031` event.
 
 ## Security and privacy considerations
 
-- **Verify before caching.** Never cache or render image bytes whose hash does not match the `sticker` tag.
+- **Verify before caching.** Never cache or render image bytes whose hash does not match the sticker `x` or the cover `sha256`.
 - **Untrusted-state rendering.** If the currently resolved pack does not contain the `(shortcode, hash)` pair from a reference, render an "unknown sticker" placeholder — not whatever image the pack currently holds under that shortcode.
 - **HTTPS only.** Reject non-HTTPS image URLs regardless of what a pack event claims.
 - **Robust parsing.** Every field in a pack event or sticker reference is attacker-controlled; parsers MUST NOT crash on malformed input.
 - **Fetch consent.** Automatically resolving a pack referenced by an inbound message can act as a read beacon: the fetch reveals to the pack's host (and to relays) that a particular message was opened. Resolving packs the user has *not* installed SHOULD require explicit user action, and failed lookups SHOULD be negative-cached to avoid a repeated beacon on every render.
+- **Install list is public.** Publishing kind `10031` advertises which packs the user uses. Prefer a local-only install set when that is a problem.
+
+## Normative examples
+
+Hashes below are illustrative 64-char lowercase hex. They are not hashes of real files.
+
+The pubkey used in send examples is
+`f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca`.
+
+### Minimal valid pack
+
+Optional cover, description, license, emoji, `dim`, and `alt` are omitted.
+
+```json
+{
+  "kind": 30031,
+  "content": "",
+  "tags": [
+    ["d", "tiny"],
+    ["title", "Tiny"],
+    ["pack_format", "sonar-sticker-pack-v1"],
+    ["sticker", "ok",
+      "url https://blob.example/ok.webp",
+      "x 0000000000000000000000000000000000000000000000000000000000000001",
+      "m image/webp"]
+  ]
+}
+```
+
+### Pack with `alt` but no `dim`
+
+```json
+{
+  "kind": 30031,
+  "content": "",
+  "tags": [
+    ["d", "tiny"],
+    ["title", "Tiny"],
+    ["pack_format", "sonar-sticker-pack-v1"],
+    ["sticker", "ok",
+      "url https://blob.example/ok.webp",
+      "x 0000000000000000000000000000000000000000000000000000000000000001",
+      "m image/webp",
+      "alt thumbs up"]
+  ]
+}
+```
+
+This is valid. Under the old positional layout it was not.
+
+### Two shortcodes, one hash
+
+```json
+{
+  "kind": 30031,
+  "content": "",
+  "tags": [
+    ["d", "tiny"],
+    ["title", "Tiny"],
+    ["pack_format", "sonar-sticker-pack-v1"],
+    ["sticker", "wave",
+      "url https://blob.example/hand.webp",
+      "x 0000000000000000000000000000000000000000000000000000000000000002",
+      "m image/webp"],
+    ["sticker", "hello",
+      "url https://blob.example/hand.webp",
+      "x 0000000000000000000000000000000000000000000000000000000000000002",
+      "m image/webp"]
+  ]
+}
+```
+
+Both entries are valid. A later `["sticker", "wave", ...]` in the same pack is ignored.
+
+### Canonical sent-sticker reference
+
+Kind `1`, empty content, one sticker:
+
+```json
+{
+  "kind": 1,
+  "content": "",
+  "tags": [
+    ["sticker", "30031:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:tiny", "ok", "0000000000000000000000000000000000000000000000000000000000000001"]
+  ]
+}
+```
+
+The same tag on a NIP-17 rumor is the canonical private-message form. Putting it only on the wrap is invalid.
+
+### Malformed and duplicate sent-sticker references
+
+Receivers MUST accept the event and apply these outcomes:
+
+```json
+{
+  "kind": 1,
+  "content": ":ok:",
+  "tags": [
+    ["sticker", "30031:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:tiny", "ok", "0000000000000000000000000000000000000000000000000000000000000001"],
+    ["sticker", "30031:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:tiny", "ok", "0000000000000000000000000000000000000000000000000000000000000001"],
+    ["sticker", "not-a-coordinate", "ok", "0000000000000000000000000000000000000000000000000000000000000001"],
+    ["sticker", "30031:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:tiny", "ok"],
+    ["sticker", "30031:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:tiny", "ok", "ZZ"],
+    ["sticker", "30031:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:tiny", "hello", "0000000000000000000000000000000000000000000000000000000000000002"]
+  ]
+}
+```
+
+| Tag | Outcome |
+|-----|---------|
+| first `ok` | valid; render it |
+| second `ok` (identical) | duplicate; treat as the first |
+| `not-a-coordinate` | malformed; ignore |
+| missing hash | malformed; ignore |
+| hash `ZZ` | malformed; ignore |
+| `hello` | valid and distinct; a one-sticker client ignores it, a multi-sticker client renders it too |
+
+### Installed-list dedup and replaceable tie-break
+
+Event A (`created_at=100`, `id=bbb...`):
+
+```json
+{
+  "kind": 10031,
+  "created_at": 100,
+  "content": "",
+  "tags": [
+    ["a", "30031:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:tiny"],
+    ["a", "30031:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:tiny"],
+    ["a", "30031:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:other"]
+  ]
+}
+```
+
+Dedup keeps the first `tiny` and then `other`.
+
+Event B (`created_at=100`, `id=aaa...`): same tags as A but a lower `id`. Relays and clients keep B and discard A ([NIP-01](01.md)). Event C (`created_at=101`) replaces both, regardless of `id`.

--- a/F6.md
+++ b/F6.md
@@ -1,0 +1,102 @@
+NIP-F6
+======
+
+Sticker Packs
+-------------
+
+`draft` `optional`
+
+This NIP defines two event kinds that allow users to publish and share **sticker packs** — named collections of image stickers addressed by content-addressed metadata. A sticker is referenced by its pack and a shortcode, never embedded as raw bytes, so the same pack is portable across clients and blob hosts.
+
+It follows the patterns of [NIP-30](30.md) (custom emoji) and the lists of [NIP-51](51.md), and it stores sticker image bytes on [NIP-B7](B7.md) (Blossom) servers.
+
+## Sticker pack (kind 30031)
+
+A sticker pack is an **addressable** event of kind `30031`. The `.content` MUST be empty; all pack metadata is carried in tags.
+
+| Tag | Multiplicity | Required | Meaning |
+|-----|--------------|----------|---------|
+| `d` | one | yes | Pack identifier; 1–80 chars of `[A-Za-z0-9._-]`. |
+| `title` | one | yes | Human-readable pack title. |
+| `pack_format` | one | yes | Format marker. This NIP defines `sonar-sticker-pack-v1`. |
+| `sticker` | many | at least one | A single sticker (see below). |
+| `image` | one | no | Cover image: `["image", <url>, <sha256?>, <WIDTHxHEIGHT?>]`. |
+| `description` | one | no | Free-text pack description. |
+| `license` | one | no | License of the pack artwork. |
+| `emoji` | many | no | A [NIP-30](30.md)-compatible `["emoji", <shortcode>, <url>]` alias for a sticker, so emoji-capable clients can reuse the same art. |
+| `t` | many | no | Recommended discovery hashtag. Clients SHOULD include `sonar-sticker-pack-v1`. |
+
+### The `sticker` tag
+
+```
+["sticker", <shortcode>, <url>, <sha256>, <mime>, <dimensions?>, <alt?>]
+```
+
+- **shortcode** — 1–64 chars of `[A-Za-z0-9_]`; unique within the pack.
+- **url** — HTTPS URL of the image. Non-HTTPS URLs MUST be rejected by clients.
+- **sha256** — 64 lowercase hex characters; the SHA-256 of the image bytes found at `url`.
+- **mime** — one of `image/webp`, `image/png`, `image/apng`, `image/gif`.
+- **dimensions** (optional) — `WIDTHxHEIGHT`, each value ≤ 4096.
+- **alt** (optional) — accessibility text for the sticker.
+
+A pack SHOULD contain no more than 200 stickers.
+
+### Example
+
+```json
+{
+  "kind": 30031,
+  "content": "",
+  "tags": [
+    ["d", "sonar-essentials"],
+    ["title", "Sonar Essentials"],
+    ["pack_format", "sonar-sticker-pack-v1"],
+    ["description", "A small starter pack."],
+    ["t", "sonar-sticker-pack-v1"],
+    ["sticker", "wave", "https://blob.example/stickers/wave.webp",
+      "8f4a2b9c7d1e6053a24bf0c1e8d9a7f3b6c2e4d8f0a1b2c3d4e5f6a7b8c9d0e1", "image/webp", "256x256", "a waving hand"],
+    ["sticker", "sats", "https://blob.example/stickers/sats.webp",
+      "1c0ffee54bd1290b1f8a7c3d2e4b5a6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2", "image/webp"]
+  ]
+}
+```
+
+## Installed sticker packs (kind 10031)
+
+A user's installed packs are advertised in a **replaceable** event of kind `10031`. The `.content` MUST be empty. Each installed pack is one `a` tag pointing at its kind `30031` coordinate:
+
+```
+["a", "30031:<pubkey>:<identifier>"]
+```
+
+The `a` tags MUST be deduplicated and SHOULD preserve first-seen order. Clients SHOULD merge versions seen across relays, keeping the newest event.
+
+## Pack format `sonar-sticker-pack-v1`
+
+The format marker `sonar-sticker-pack-v1` declares the tag layout specified above. Future, incompatible pack formats MUST use a distinct marker so a client never interprets one layout as another. A client that does not recognize a pack's `pack_format` SHOULD treat the pack as opaque and decline to render its stickers.
+
+## Image storage
+
+Sticker bytes live on [NIP-B7](B7.md) (Blossom) servers, or any HTTPS host — **never** in the event. Clients:
+
+1. Fetch the image over **HTTPS only**.
+2. Verify that the downloaded bytes hash (SHA-256) to the value carried in the `sticker` tag before caching or rendering.
+3. Enforce the MIME allowlist (`image/webp`, `image/png`, `image/apng`, `image/gif`) and the 4096×4096 dimension bound.
+
+## Referencing stickers
+
+To send a sticker, a client emits a reference to `(pack-coordinate, shortcode, sha256)` inside the content of whatever message type it already uses — a kind `1` note, a [NIP-17](17.md) direct message, or any application-specific message. **No new event kind is introduced for sending stickers.** A receiver resolves the reference by fetching the pack event and matching the shortcode, and it SHOULD confirm that the referenced hash matches the pack entry.
+
+Because the reference carries the expected hash, a receiver can reject a substituted image without trusting either the pack author or the blob host.
+
+## Discovery
+
+Clients discover packs by querying relays for kind `30031` events — optionally filtered by `#t`, by author, or by the `d` identifier. A user's installed packs are discovered from that user's kind `10031` event.
+
+## Security and privacy considerations
+
+- **Verify before caching.** Never cache or render image bytes whose hash does not match the `sticker` tag.
+- **Untrusted-state rendering.** If the currently resolved pack does not contain the `(shortcode, hash)` pair from a reference, render an "unknown sticker" placeholder — not whatever image the pack currently holds under that shortcode.
+- **HTTPS only.** Reject non-HTTPS image URLs regardless of what a pack event claims.
+- **Robust parsing.** Every field in a pack event or sticker reference is attacker-controlled; parsers MUST NOT crash on malformed input.
+- **Fetch consent.** Automatically resolving a pack referenced by an inbound message can act as a read beacon: the fetch reveals to the pack's host (and to relays) that a particular message was opened. Resolving packs the user has *not* installed SHOULD require explicit user action, and failed lookups SHOULD be negative-cached to avoid a repeated beacon on every render.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ NIPs listed here are not a protocol checklist. Nothing forces any software to im
 - [NIP-CC: Geocaching](CC.md)
 - ~~[NIP-EE: E2EE Messaging using MLS Protocol](EE.md) --- **unrecommended**: superseded by the [Marmot Protocol](https://github.com/marmot-protocol/marmot)~~
 - [NIP-F4: Podcasts](F4.md)
+- [NIP-F6: Sticker Packs](F6.md)
 
 ## Event Kinds
 


### PR DESCRIPTION
## Summary

Adds a full NIP specifying **sticker packs**: two event kinds for publishing, sharing, and installing named collections of image stickers.

- **kind `30031`** (addressable) — a sticker pack definition
- **kind `10031`** (replaceable) — a user's installed pack list

Stickers are addressed by content-addressed metadata (`shortcode` + SHA-256 + MIME); image bytes are stored on [NIP-B7](https://github.com/nostr-protocol/nips/blob/master/B7.md) (Blossom) servers, never in the event. The format marker `sonar-sticker-pack-v1` declares the tag layout.

## Relationship to other work

This is the **full specification** for the kinds registered in:
- registry-of-kinds: https://github.com/nostr-protocol/registry-of-kinds/pull/4
- the Event Kinds table entry: #2410

Those register the kind numbers; this NIP defines the protocol around them. It is a companion to the implementation docs at https://sonarprivacy.xyz/docs#SONAR-STICKERS.

## NIP number

`F6` is freely chosen — unused in the repo and not claimed by any open PR (checked the index and all 50 open PRs). It is provisional and trivially changed if a maintainer prefers a different number.

## Format

Follows the structure of NIP-30 (custom emoji) and the list patterns of NIP-51. Deliberately storage-agnostic (any HTTPS / Blossom host) and focused on the kinds, tags, and client/security behavior.
