### PR TITLE
NIP-07: let clients pin the user key

### DIFF
--- a/07.md
+++ b/07.md
@@ -12,16 +12,18 @@ That object must define the following methods:
 
 ```
 async window.nostr.getPublicKey(): string // returns a public key as hex
-async window.nostr.signEvent(event: { created_at: number, kind: number, tags: string[][], content: string }): Event // takes an event object, adds `id`, `pubkey` and `sig` and returns it
+async window.nostr.signEvent(event: { pubkey?: string, created_at: number, kind: number, tags: string[][], content: string }): Event // takes an event object, adds `id`, `pubkey` and `sig` and returns it
 ```
 
 Aside from these two basic above, the following functions can also be implemented optionally:
 ```
-async window.nostr.nip04.encrypt(pubkey, plaintext): string // returns ciphertext and iv as specified in nip-04 (deprecated)
-async window.nostr.nip04.decrypt(pubkey, ciphertext): string // takes ciphertext and iv as specified in nip-04 (deprecated)
-async window.nostr.nip44.encrypt(pubkey, plaintext): string // returns ciphertext as specified in nip-44
-async window.nostr.nip44.decrypt(pubkey, ciphertext): string // takes ciphertext as specified in nip-44
+async window.nostr.nip04.encrypt(pubkey, plaintext, current_user?): string // returns ciphertext and iv as specified in nip-04 (deprecated)
+async window.nostr.nip04.decrypt(pubkey, ciphertext, current_user?): string // takes ciphertext and iv as specified in nip-04 (deprecated)
+async window.nostr.nip44.encrypt(pubkey, plaintext, current_user?): string // returns ciphertext as specified in nip-44
+async window.nostr.nip44.decrypt(pubkey, ciphertext, current_user?): string // takes ciphertext as specified in nip-44
 ```
+
+`pubkey` on the event object and `current_user` on the encryption functions both name the user key to act with. When set, the signer must use that key or reject the request. Signers that predate this may ignore it silently, so clients should check the `pubkey` of the event returned by `signEvent`.
 
 ### Recommendation to Extension Authors
 To make sure that the `window.nostr` is available to nostr clients on page load, the authors who create Chromium and Firefox extensions should load their scripts by specifying `"run_at": "document_end"` in the extension's manifest.


### PR DESCRIPTION
The key behind `window.nostr` can change at any time without the page knowing:
the user switches account in the signer, or logs out and logs back in with a
different key. A client that called `getPublicKey()` at login has no way to
require that later calls still use that key, so it can keep acting under an
identity the user has left.

This adds an optional `pubkey` on the `signEvent` event object, and an optional
`current_user` on the `nip04` and `nip44` functions. When set, the signer MUST
use that key or reject the request. Signers that ignore them behave as today.