### PR TITLE
NIP-34: allow PRs to target non-default branches

### DIFF
--- a/34.md
+++ b/34.md
@@ -138,6 +138,7 @@ A pull request is an event that points to proposed changes in a git repository.
     ["c", "<current-commit-id>"], // tip of the PR branch
     ["clone", "<clone-url>", ...], // at least one git clone url where commit can be downloaded
     ["branch-name", "<branch-name>"], // optional recommended branch name
+    ["b", "<target-branch-name>"], // optional: target a branch other than the repository's default branch
 
     ["e", "<root-patch-event-id>"], // optionally indicate PR is a revision of an existing patch, which should be closed
     ["merge-base", "<commit-id>"], // optional: the most recent common ancestor with the target branch


### PR DESCRIPTION
Adds an optional `b` tag to the NIP-34 PR event shape, allowing PRs to target non-default branches as now implemented in [ngit](https://gitworkshop.dev/danconwaydev.com/ngit/commit/df9d146df8d84473906445172d723a4d44b61f60) and [gitworkshop](https://gitworkshop.dev/danconwaydev.com/gitworkshop/commit/b29f27cc5e862349c37db65f59cfae30d1a9ebd0).