### PR TITLE
forum threads as djot

### DIFF
--- a/7D.md
+++ b/7D.md
@@ -18,6 +18,12 @@ A thread is a `kind 11` event.  Threads SHOULD include a `title`.
 }
 ```
 
+## Formatting
+
+`kind:11` posts can be formatted like `kind:1` (with direct images, links and [NIP-27](27.md) references), but could also support [Djot](https://www.djot.net/).
+
+## Replies
+
 Replies to `kind 11` MUST use [NIP-22](./22.md) `kind 1111` comments. Replies should
 always be to the root `kind 11` to avoid arbitrarily nested reply hierarchies.
 


### PR DESCRIPTION
Because [Djot](https://www.djot.net/) is great and we don't want to fall into Markdown degeneracy (if this remains unspecified someone will probably implement Markdown at some point and we'll be dead).

I believe this is already supported in https://github.com/dtonon/squalk.