### PR TITLE
NIP-94: file encryption

### DIFF
--- a/94.md
+++ b/94.md
@@ -27,6 +27,11 @@ This NIP specifies the use of the `1063` event kind, having in `content` a descr
 * `alt` (optional) description for accessibility
 * `fallback` (optional) zero or more fallback file sources in case `url` fails
 * `service` (optional) service type which is serving the file (eg. [NIP-96](96.md))
+* `encryption-algorithm` (optional) the algorithm used to encrypt the file. Supported algorithms: `aes-gcm`
+* `decryption-key` (optional) the hexencoded key used to decrypt the file
+* `decryption-nonce` (optional) the hexencoded nonce used to decrypt the file
+
+When the file is encrypted, `m` is the MIME type of the file before encryption, `x` is the hash of the encrypted file, and `ox` is the hash of the file before encryption. Any `thumb`, `image` and `fallback` sources are encrypted with the same key and nonce.
 
 ```yaml
 {
@@ -44,7 +49,10 @@ This NIP specifies the use of the `1063` event kind, having in `content` a descr
     ["thumb", <string with thumbnail URI>, <Hash SHA-256>],
     ["image", <string with preview URI>, <Hash SHA-256>],
     ["summary", <excerpt>],
-    ["alt", <description>]
+    ["alt", <description>],
+    ["encryption-algorithm", <encryption algorithm>],
+    ["decryption-key", <hexencoded decryption key>],
+    ["decryption-nonce", <hexencoded decryption nonce>]
   ],
   "content": "<caption>",
   // other fields...


### PR DESCRIPTION
It would be nice to encrypt files uploaded to public Blossom servers. Then the server operator doesn't even know what they are.

This copies the NIP-17 encryption properties into NIP-94 so it can be used in imeta too.