### PR TITLE
Add assign/unassign method to nip 86

### DIFF
--- a/86.md
+++ b/86.md
@@ -64,6 +64,12 @@ This is the list of **methods** that may be supported:
 * `unassignrole`:
   - params: `["<32-byte-hex-public-key>", "<role-id>"]`
   - result: `true` (a boolean always set to `true`)
+* `assignmethod`:
+  - params: `["<32-byte-hex-public-key>", "<nip86-method>"]`
+  - result: `[true|false, "<message>"]`
+* `unassignmethod`:
+  - params: `["<32-byte-hex-public-key>", "<nip86-method>"]`
+  - result: `[true|false, "<message>"]`
 * `listeventsneedingmoderation`:
   - params: `[]`
   - result: `[{"id": "<32-byte-hex>", "reason": "<optional-reason>"}]`, an array of objects


### PR DESCRIPTION
This allows relay admins to assign admin permissions to other users.