### PR TITLE
Decouple nip 29 roles and permissions

### DIFF
--- a/29.md
+++ b/29.md
@@ -78,11 +78,11 @@ Relays should prevent late publication (messages published now with a timestamp 
 
 ## Group management
 
-Groups can have any number of users with elevated access. These users are identified by role labels which are arbitrarily defined by the relays (see also the description of `kind:39003`). What each role is capable of not defined in this NIP either, it's a relay policy that can vary. Roles can be assigned by other users (as long as they have the capability to add roles) by publishing a `kind:9000` event with that user's pubkey in a `p` tag and the roles afterwards (even if the user is already a group member a `kind:9000` can be issued and the user roles must just be updated).
+Groups can have any number of users with elevated access. Permissions are articulated in terms of kinds (for example, `9000`), and are assigned directly to users, not via roles. However, roles may be used by relay implementations or automations to auto-assign arbitrary permissions.
 
-The roles supported by the group as to having some special privilege assigned to them should be accessible on the event `kind:39003`, but the relay may also accept other role names, arbitrarily defined by clients, and just not do anything with them.
+Permissions are advertised on `kind:39001` admins lists; roles are advertised on `kind:39002` member lists.
 
-Users with any roles that have any privilege can be considered _admins_ in a broad sense and be returned in the `kind:39001` event for a group.
+Authorized users can assign roles by publishing a `kind:9000` event with that user's pubkey in a `p` tag and the roles afterwards. Authorized users can assign permissions by publishing a `kind:9011` (and unassign using a `kind:9012`) with that user's pubkey in a `p` tag and the list of permitted kinds afterwards.
 
 ## Live audio/video (AV) spaces
 
@@ -147,7 +147,7 @@ These are events expected to be sent by the relay master key or by group admins 
 
 - *moderation events* (`kinds:9000-9020`) (optional)
 
-Clients can send these events to a relay in order to accomplish a moderation action. Relays must check if the pubkey sending the event is capable of performing the given action based on its role and the relay's internal policy (see also the description of `kind:39003`).
+Clients can send these events to a relay in order to accomplish a moderation action. Relays must check if the pubkey sending the event is capable of performing the given action based assigned permissions (optionally surfaced via `kind:39001`).
 
 ```yaml
 {
@@ -172,6 +172,8 @@ Each moderation action uses a different kind and requires different arguments, w
 | 9008 | `delete-group`  |                                        |
 | 9009 | `create-invite` | arbitrary `code`                       |
 | 9010 | `update-pin-list` | zero or more `e` with event id hex or `a` with event address |
+| 9011 | `assign-permission` | `p` with pubkey hex and a list of kinds |
+| 9012 | `unassign-permission` | `p` with pubkey hex and a list of kinds |
 
 It's expected that the group state (of who is an allowed member or not, who is an admin and with which permission or not, what are the group name and picture etc) can be fully reconstructed from the canonical sequence of these events.
 
@@ -213,7 +215,7 @@ If the group is forked and hosted in multiple relays, there will be multiple ver
 
 - *group admins* (`kind:39001`) (optional)
 
-Each admin is listed along with one or more roles. These roles SHOULD have a correspondence with the roles supported by the relay, as advertised by the `kind:39003` event.
+Each admin is listed along with one or more privileged management event kinds they are permitted to publish to the group.
 
 ```yaml
 {
@@ -221,8 +223,8 @@ Each admin is listed along with one or more roles. These roles SHOULD have a cor
   "content": "list of admins for the pizza lovers group",
   "tags": [
     ["d", "<group-id>"],
-    ["p", "<pubkey1-as-hex>", "ceo"],
-    ["p", "<pubkey2-as-hex>", "secretary", "gardener"],
+    ["p", "<pubkey1-as-hex>", "9000"],
+    ["p", "<pubkey2-as-hex>", "9000", "9001"],
     // other pubkeys...
   ],
   // other fields...
@@ -231,7 +233,7 @@ Each admin is listed along with one or more roles. These roles SHOULD have a cor
 
 - *group members* (`kind:39002`) (optional)
 
-It's a list of pubkeys that are members of the group. Relays might choose to not to publish this information, to restrict what pubkeys can fetch it or to only display a subset of the members in it.
+A pubkeys that are members of the group with a list of optional roles. Relays might choose to not to publish this information, to restrict what pubkeys can fetch it or to only display a subset of the members in it.
 
 Clients should not assume this will always be present or that it will contain a full list of members.
 
@@ -241,9 +243,8 @@ Clients should not assume this will always be present or that it will contain a 
   "content": "list of members for the pizza lovers group",
   "tags": [
     ["d", "<group-id>"],
-    ["p", "<admin1>"],
-    ["p", "<member-pubkey1>"],
-    ["p", "<member-pubkey2>"],
+    ["p", "<member-pubkey1>", "ceo"],
+    ["p", "<member-pubkey2>", "gardener", "undertaker"],
     // other pubkeys...
   ],
   // other fields...
@@ -252,11 +253,7 @@ Clients should not assume this will always be present or that it will contain a 
 
 - *group roles* (`kind:39003`) (optional)
 
-This is an event that MAY be published by the relay informing users and clients about what are the roles supported by this relay according to its internal logic.
-
-For example, a relay may choose to support the roles `"admin"` and `"moderator"`, in which the `"admin"` will be allowed to edit the group metadata, delete messages and remove users from the group, while the `"moderator"` can only delete messages (or the relay may choose to call these roles `"ceo"` and `"secretary"` instead, the exact role name is not relevant).
-
-The process through which the relay decides what roles to support and how to handle moderation events internally based on them is specific to each relay and not specified here.
+This is an event that MAY be published by the relay informing users and clients about what are the roles supported by this relay according to its internal logic. Roles do not imply permissions, but relay implementations or automations may auto-assign permissions based on role assignments.
 
 ```yaml
 {


### PR DESCRIPTION
Supersedes https://github.com/nostr-protocol/nips/pull/2316

This design is mostly backwards compatible (the only breaking change is it swaps out meaningless role strings with meaningful kind strings in the members event). It follows how NIP 43's roles work by decoupling permissions from roles. This way, roles can be cosmetic or meaningful depending on the relay's policy, and any member can be assigned a role. Roles have nothing to do with permissions, which are directly assigned to users (although relays may choose to assign permissions in response to a role assignment). Permissions are group management kind numbers, advertised on the group admins list.