### PR TITLE
Add audio tracks and releases NIP

### DIFF
--- a/0a.md
+++ b/0a.md
@@ -11,12 +11,11 @@ This NIP succeeds an earlier draft ([nips PR #1043](https://github.com/nostr-pro
 The following kinds are defined by this NIP:
 
 - `31337` represents a music track
-- `31338` represents a podcast episode
-- `31339` represents a release: an album, EP, single, or compilation
+- `31341` represents a release: an album, EP, single, or compilation
 
-All three are addressable events: the `d` tag is the stable identity, and republishing with the same `d` replaces.
+Both are addressable events: the `d` tag is the stable identity, and republishing with the same `d` replaces.
 
-## Tracks and episodes (`31337`, `31338`)
+## Tracks (`31337`)
 
 The following tags are required:
 
@@ -30,14 +29,21 @@ The following tags are optional:
 - `image` is an artwork url.
 - `published_at` is a timestamp of the original publish date.
 - `t` (one or more) are topics.
-- `i` is an external GUID (e.g. a podcast GUID).
+- `i` is an external GUID.
 - `lyrics` is the full lyric text.
 - `explicit` is `"true"` when the track carries an explicit-content advisory.
-- `a` MAY reference the `31339` release the track belongs to, as `31339:<pubkey>:<d>`.
+- `alt` is a NIP-31 human-readable description, e.g. `"Music track: <title> by <artist>"`.
+- `artist` is the display name of the performing artist. The pubkey's kind `0` profile remains canonical; this tag lets clients render a name without a profile lookup.
+- `released` is the release date, ISO 8601 (`YYYY-MM-DD`; reduced precision like `YYYY` is acceptable).
+- `bitrate` is the audio bitrate, e.g. `"320kbps"`.
+- `format` is the file format, lowercase, e.g. `"flac"`.
+- `a` MAY reference the `31341` release the track belongs to, as `31341:<pubkey>:<d>`.
 - `zap` (one or more) declare revenue splits between contributors, as defined in [NIP-57 Appendix G](./57.md).
 - `lightning_node_id` is a Lightning node pubkey that accepts keysend payments for this track. Zaps cover discrete payments; this tag exists for continuous streaming payments, which need a node to keysend to.
 
 `content` SHOULD be a summary or description of the audio content.
+
+The `alt`, `artist`, `released`, `bitrate`, and `format` tag names and value conventions match the most consistent audio vocabulary observed in the wild (kind `36787`), so events under this NIP parse in existing music clients. This NIP aligns tag names only; it does not define or adopt kind `36787`.
 
 ## Categories and contributors
 
@@ -56,7 +62,7 @@ Any contributor category (`artist`, `featured`, `producer`, `composer`, `credit`
 
 This makes contributor graphs traversable: a track credits people, people are keys, and keys have profiles.
 
-## Releases (`31339`)
+## Releases (`31341`)
 
 A release groups tracks in order. The following tags are required:
 
@@ -111,7 +117,12 @@ Purchasable versions of a track or release (lossless downloads, stems) SHOULD be
     ["imeta", "url https://media.example.com/9f2c...", "x 9f2c...", "m audio/flac", "size 48213377"],
     ["duration", "241"],
     ["image", "https://media.example.com/1a8b..."],
-    ["a", "31339:8d5070...:first-transmission"],
+    ["a", "31341:8d5070...:first-transmission"],
+    ["alt", "Music track: Atlas Node by 0GGM3NT3D"],
+    ["artist", "0GGM3NT3D"],
+    ["released", "2026-08-31"],
+    ["bitrate", "987kbps"],
+    ["format", "flac"],
     ["c", "Electronic", "genre"],
     ["c", "0GGM3NT3D", "artist"],
     ["p", "8d5070...", "wss://relay.lightning.fm", "0GGM3NT3D"],

--- a/0a.md
+++ b/0a.md
@@ -1,0 +1,124 @@
+NIP-0a
+======
+
+Audio Tracks and Releases
+-------------------------
+
+`draft` `optional`
+
+This NIP succeeds an earlier draft ([nips PR #1043](https://github.com/nostr-protocol/nips/pull/1043)) and keeps its core. It is written from a shipping implementation: every required element below is published and parsed in production, and the reference publisher and consumer are open source.
+
+The following kinds are defined by this NIP:
+
+- `31337` represents a music track
+- `31338` represents a podcast episode
+- `31339` represents a release: an album, EP, single, or compilation
+
+All three are addressable events: the `d` tag is the stable identity, and republishing with the same `d` replaces.
+
+## Tracks and episodes (`31337`, `31338`)
+
+The following tags are required:
+
+- `d` is a unique identifier for the track, chosen by the client (a random id or a slug).
+- `title` is the title of the audio track.
+- `imeta` is as described in [NIP-92](./92.md) and MUST include at least `url`, `x` (sha256 of the file), and `m` (mime type). Multiple `imeta` tags MAY be included for different renditions (e.g. streaming vs lossless download).
+
+The following tags are optional:
+
+- `duration` is the duration in seconds.
+- `image` is an artwork url.
+- `published_at` is a timestamp of the original publish date.
+- `t` (one or more) are topics.
+- `i` is an external GUID (e.g. a podcast GUID).
+- `lyrics` is the full lyric text.
+- `explicit` is `"true"` when the track carries an explicit-content advisory.
+- `a` MAY reference the `31339` release the track belongs to, as `31339:<pubkey>:<d>`.
+- `zap` (one or more) declare revenue splits between contributors, as defined in [NIP-57 Appendix G](./57.md).
+- `lightning_node_id` is a Lightning node pubkey that accepts keysend payments for this track. Zaps cover discrete payments; this tag exists for continuous streaming payments, which need a node to keysend to.
+
+`content` SHOULD be a summary or description of the audio content.
+
+## Categories and contributors
+
+Structured metadata beyond the tags above uses `c` tags: `["c", "<value>", "<category>"]`. Expected categories include (but are not limited to):
+
+- `genre`, `subgenre` (SHOULD be based on [this list](https://github.com/wavlake/genre-list))
+- `artist`, `featured`, `producer`, `composer`, `credit`
+- `album`, `track_number`, `record_label`, `year`, `isrc`, `bpm`
+
+Any contributor category (`artist`, `featured`, `producer`, `composer`, `credit`, `member`) SHOULD be accompanied by a conventional `p` tag when the contributor has a known pubkey, and the `p` tag's petname MUST equal the `c` tag's value, so consumers can join the human-readable credit to the key:
+
+```json
+["c", "0GGM3NT3D", "artist"],
+["p", "8d507066...", "wss://relay.lightning.fm", "0GGM3NT3D"]
+```
+
+This makes contributor graphs traversable: a track credits people, people are keys, and keys have profiles.
+
+## Releases (`31339`)
+
+A release groups tracks in order. The following tags are required:
+
+- `d` is the release's stable identifier.
+- `title` is the release title.
+- `a` (one or more, in track order) reference the release's tracks as `31337:<pubkey>:<d>`. Order of the `a` tags is the track order.
+
+The following tags are optional:
+
+- `image` is the cover artwork url.
+- `published_at` is the release date.
+- `c` categories as above; `["c", "album", "release_type"]` (or `ep`, `single`, `compilation`) declares what kind of release this is.
+- Contributor `c` + `p` pairs as above, for release-level credits.
+
+A release MAY include tracks by pubkeys other than its author (compilations, splits). Consumers SHOULD fetch referenced tracks by address and tolerate missing ones.
+
+## Artists, bands, and members
+
+Artists are ordinary kind `0` profiles; nothing custom is needed for a solo act. A band, group, or collective is also a kind `0` profile, and it MAY declare its members with contributor pairs in its kind `0` tags. For example, the band "0GGM3NT3D & Friends" declares the solo artist 0GGM3NT3D as a member:
+
+```json
+["c", "0GGM3NT3D", "member"],
+["p", "8d507066...", "wss://relay.lightning.fm", "0GGM3NT3D"]
+```
+
+Members are profiles too, so the graph composes: a member's own releases, a band's releases, and guest credits on other artists' tracks are all reachable by following `p` tags.
+
+## Compatibility
+
+Earlier dialects of `31337` used discrete tags instead of (or alongside) `imeta`. Publishers MAY include them for compatibility and consumers SHOULD accept them when `imeta` is absent:
+
+- `url` / `media` is the url of the media.
+- `subject` is the title of the audio track.
+- `x` is the sha256 hash of the audio file.
+- `m` is the mime type of the audio file.
+- `size` is the size of the audio file in bytes.
+- `type` is `"audio"`.
+
+## Sales
+
+Purchasable versions of a track or release (lossless downloads, stems) SHOULD be listed as [NIP-99](./99.md) classified listings that reference the track or release with an `a` tag, rather than extending the kinds in this NIP.
+
+## Example
+
+```json
+{
+  "kind": 31337,
+  "content": "Recorded live to tape in one take.",
+  "tags": [
+    ["d", "atlas-node"],
+    ["title", "Atlas Node"],
+    ["imeta", "url https://media.example.com/9f2c...", "x 9f2c...", "m audio/flac", "size 48213377"],
+    ["duration", "241"],
+    ["image", "https://media.example.com/1a8b..."],
+    ["a", "31339:8d5070...:first-transmission"],
+    ["c", "Electronic", "genre"],
+    ["c", "0GGM3NT3D", "artist"],
+    ["p", "8d5070...", "wss://relay.lightning.fm", "0GGM3NT3D"],
+    ["c", "2026", "year"],
+    ["c", "3", "track_number"],
+    ["zap", "8d5070...", "wss://relay.lightning.fm", "9"],
+    ["zap", "e1b3f0...", "wss://relay.lightning.fm", "1"]
+  ]
+}
+```


### PR DESCRIPTION
Successor to #1043, which was closed with an invitation for an implementer to propose a format they actually ship. We ship this one: lightning.fm publishes kind 31337 in production, and the publisher ([desktop app](https://github.com/maml/lightning-fm-desktop)) and a self-hosted seller daemon ([artist nodes](https://github.com/maml/lightning-fm-artist-nodes)) are open source under MIT. The wire contract is documented at https://lightning.fm/interop and this text is written from it.

The draft keeps the core of #1043's final text (required d/title/imeta, the c-category system, the c+p contributor pairing) and extends it with the relations the format needs to grow: kind 31339 releases (albums/EPs/singles/compilations with ordered track references), bands as kind 0 profiles that declare members, per-track contributors, NIP-57 zap splits, and a compatibility section for the legacy discrete-tag dialect. Sales stay in NIP-99. lightning_node_id is kept optional with its honest rationale: continuous keysend streaming payments, which zaps don't cover.

Happy to adjust the NIP identifier, and to share anything useful from production usage.