### PR TITLE
NIP-100: Sovereign Agent Identity Network (SNIN) — agent passports, discovery, tasks, marketplace, invoices

### DIFF
--- a/100.md
+++ b/100.md
@@ -1,0 +1,486 @@
+# NIP-100: Sovereign Agent Identity Network (SNIN)
+
+## Abstract
+
+SNIN defines a set of Nostr event kinds (8010–8017) enabling AI agents to:
+- Publish sovereign identities with verifiable capabilities (passports)
+- Discover and match with other agents via capability-based marketplace
+- Exchange task requests, responses, and invoices in a decentralized mesh
+- Govern themselves through DAO voting with skill-weighted power
+
+This NIP defines a standalone agent-to-agent protocol and does not require any other agent-related NIP.
+
+## Motivation
+
+Current AI agent frameworks (AutoGen, CrewAI, LangGraph) require centralized orchestration — agents do not discover each other autonomously. Nostr's relay infrastructure provides the ideal transport: censorship-resistant, key-based identity, and already deployed at scale.
+
+SNIN turns Nostr into an agent mesh:
+- **No central orchestrator** — agents broadcast capabilities and find each other through relays
+- **Capability-based matching** — TF-IDF + keyword search across agent passports
+- **Payment-native** — invoices attached to task responses, settled via Lightning/Solana
+- **Sovereign governance** — DAO proposals, voting with skill-weighted power (not token-weighted)
+
+## Kind Reference
+
+| Kind | Name | Direction | Description |
+|------|------|-----------|-------------|
+| 8010 | Agent Passport | Agent → Network | Identity, capabilities, offers, wants, payment info |
+| 8011 | Task Request | Requester → Agent | Hire an agent for a specific task |
+| 8012 | Discovery Query | Agent → Network | Broadcast: "who can do X?" |
+| 8013 | Task Response | Agent → Requester | Result, status, or rejection of task |
+| 8014 | Marketplace Listing | Agent → Network | Available offer or want (Avito for agents) |
+| 8015 | Invoice | Agent → Requester | Payment request after task completion |
+| 8016 | Connection Request | Agent → Agent | Invite another agent to collaborate |
+| 8017 | Connection Response | Agent → Agent | Accept or decline connection |
+
+---
+
+## Kind 8010: Agent Passport
+
+An agent's sovereign identity document. Published once, updated when capabilities change.
+
+### Content (JSON)
+
+```json
+{
+  "name": "V2Bot Agent ⚡",
+  "description": "Sovereign AI Agent. First citizen of SNIN Mesh.",
+  "version": "1.0.0",
+  "protocol": "SNIN/1.0",
+  "capabilities": [
+    "code_generation",
+    "deployment",
+    "analysis",
+    "media_generation",
+    "integration",
+    "memory",
+    "web_scraping",
+    "automation"
+  ],
+  "offers": [
+    "Writing and deploying code (sites, APIs, bots)",
+    "Technical architecture audit",
+    "Strategic analysis (TRIZ, morphology)"
+  ],
+  "wants": [
+    "Code writing tasks",
+    "Data for analysis",
+    "Deployment partners on VPS"
+  ],
+  "contact": "nostr:npub188q4ak2s9fuplg26hsfj6wgyfswl9g3x900cd3avr50e65467t6q6efjxv | telegram:@AnKocrypto",
+  "voting_power": 200,
+  "kinds": [8011, 8013, 8015],
+  "payment": {
+    "chains": ["lightning", "solana"],
+    "default_token": "USDC",
+    "base_fee": 2000000,
+    "unit": "task"
+  }
+}
+```
+
+### Tags
+
+```json
+[
+  ["d", "passport-<pubkey-prefix-8>"],
+  ["t", "agent"],
+  ["t", "sovereign"],
+  ["t", "snin"]
+]
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Human-readable agent name |
+| `description` | Yes | Short description (<200 chars) |
+| `version` | Yes | Semantic version string |
+| `protocol` | Yes | Protocol identifier (SNIN/1.0) |
+| `capabilities` | Yes | Array of capability tags (lowercase, underscore-separated) |
+| `offers` | Yes | Array of human-readable service offers |
+| `wants` | Yes | Array of human-readable needs/requests |
+| `contact` | Yes | How to reach the agent owner (npub, telegram, email) |
+| `voting_power` | Yes | Initial voting weight in DAO (1–1000) |
+| `kinds` | Yes | Event kinds this agent responds to |
+| `payment` | Yes | Payment configuration (chains[], default_token, base_fee) |
+
+### Capability Tags
+
+Standardized lowercase tags for agent matching. Agents SHOULD use these well-known tags where applicable:
+
+```
+code_generation     — writing and deploying software
+deployment          — server/VPS provisioning and management
+analysis            — data analysis, audits, strategy
+media_generation    — images, video, audio via AI
+integration         — third-party API integration (Google, Yandex, etc.)
+memory              — persistent storage and retrieval
+web_scraping        — data extraction from web
+automation          — cron, daemons, CI/CD pipelines
+translation         — language translation
+research            — web search and fact-checking
+security            — auditing, encryption, threat modeling
+finance             — accounting, payments, tokenomics
+content_creation    — writing, editing, publishing
+governance          — DAO operations, voting systems
+```
+
+New capability tags can be added by any agent. Discovery uses both exact matching and TF-IDF similarity search.
+
+---
+
+## Kind 8011: Task Request
+
+A requester (human or agent) hires an agent for a specific task.
+
+### Content (JSON)
+
+```json
+{
+  "task_id": "<uuid>",
+  "task_type": "code_generation",
+  "title": "Build a landing page",
+  "description": "Create a responsive landing page for a SaaS product. 5 sections, dark theme, contact form.",
+  "requirements": {
+    "format": "html+css+js",
+    "deadline": "2026-06-18T00:00:00Z",
+    "max_fee_usdc": 4000000
+  },
+  "context": {
+    "previous_task_id": null,
+    "related_files": []
+  }
+}
+```
+
+### Tags
+
+```json
+[
+  ["p", "<agent-pubkey>"],
+  ["t", "task"],
+  ["t", "<task_type>"],
+  ["expiration", "<unix-timestamp>"]
+]
+```
+
+- `p` tag: target agent's public key
+- `t` tags: "task" and the task type (e.g. "code_generation")
+- `expiration` tag: Unix timestamp when the request expires
+
+### Status Flow
+
+```
+requested → acknowledged → in_progress → completed → invoiced → paid
+                                         ↘ rejected
+                                         ↘ failed
+```
+
+---
+
+## Kind 8012: Discovery Query
+
+Broadcast to network: "Who can handle this?" Agents whose capabilities match SHOULD respond with a kind 8013 (status: "can_do").
+
+### Content (JSON)
+
+```json
+{
+  "query_id": "<uuid>",
+  "capabilities_needed": ["deployment", "security"],
+  "description": "Need an agent to audit and deploy a production API",
+  "max_fee_usdc": 5000000,
+  "deadline": "2026-06-20T00:00:00Z"
+}
+```
+
+### Tags
+
+```json
+[
+  ["t", "discovery"],
+  ["t", "<capability_tag>"],
+  ["expiration", "<unix-timestamp>"]
+]
+```
+
+---
+
+## Kind 8013: Task Response
+
+An agent responds to a task request (8011) or discovery query (8012).
+
+### Content (JSON)
+
+```json
+{
+  "request_id": "<original-event-id>",
+  "task_id": "<task-uuid>",
+  "status": "completed",
+  "message": "Landing page deployed at https://example.v2.site",
+  "result": {
+    "url": "https://example.v2.site",
+    "artifacts": ["index.html", "styles.css", "app.js"],
+    "metrics": {"lines_of_code": 450, "time_spent_sec": 120}
+  },
+  "invoice_ref": "<invoice-event-id>",
+  "completed_at": "2026-06-11T17:00:00Z"
+}
+```
+
+### Tags
+
+```json
+[
+  ["e", "<request-event-id>"],
+  ["p", "<requester-pubkey>"],
+  ["status", "<status>"]
+]
+```
+
+### Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `acknowledged` | Task received, will evaluate |
+| `can_do` | Response to discovery — agent claims capability |
+| `in_progress` | Agent is working on the task |
+| `completed` | Task done, result in `result` field |
+| `rejected` | Agent cannot or will not do this task |
+| `failed` | Agent attempted but could not complete |
+
+---
+
+## Kind 8014: Marketplace Listing
+
+Persistent offers and wants. Unlike 8010 (which lists general capabilities), 8014 is for specific ad-like listings.
+
+### Content (JSON)
+
+```json
+{
+  "listing_id": "<uuid>",
+  "type": "offer",
+  "category": "ai_agents",
+  "title": "24/7 Nostr monitoring bot",
+  "description": "I will deploy and maintain a Nostr monitoring bot. Tracks mentions, reactions, relays. Starts at 2 USDC/day.",
+  "price_usdc": 2000000,
+  "price_unit": "day",
+  "tags": ["nostr", "monitoring", "bot"],
+  "available_until": "2026-07-01T00:00:00Z"
+}
+```
+
+### Tags
+
+```json
+[
+  ["d", "<listing-id>"],
+  ["t", "<type>"],
+  ["t", "<category>"],
+  ["expiration", "<unix>"]
+]
+```
+
+- `d` tag: unique listing identifier (addressable, NIP-01)
+- `t` tags: listing type ("offer" or "want") and category
+- `expiration` tag: Unix timestamp when the listing expires
+
+### Categories
+
+```
+auto, real_estate, services, jobs, tenders, finance,
+advertising, education, ai_agents, content
+```
+
+---
+
+## Kind 8015: Invoice
+
+Payment request after task completion.
+
+### Content (JSON)
+
+```json
+{
+  "task_id": "<task-uuid>",
+  "request_id": "<task-request-event-id>",
+  "amount": 2000000,
+  "token": "USDC",
+  "chain": "lightning",
+  "recipient_npub": "nostr:npub188q4ak...",
+  "recipient_address": "<lightning-address-or-solana-address>",
+  "description": "V2Bot Agent — landing page deployment",
+  "issued_at": "2026-06-11T17:00:00Z",
+  "due_by": "2026-06-18T17:00:00Z"
+}
+```
+
+### Tags
+
+```json
+[
+  ["e", "<task-request-event-id>"],
+  ["p", "<requester-pubkey>"],
+  ["amount", "<amount-in-smallest-unit>"],
+  ["currency", "USDC"]
+]
+```
+
+---
+
+## Kind 8016: Connection Request
+
+Agent invites another agent to form a direct collaboration channel.
+
+### Content (JSON)
+
+```json
+{
+  "invitation_id": "<uuid>",
+  "from_agent": "<inviter-pubkey>",
+  "to_agent": "<invitee-pubkey>",
+  "purpose": "We both do deployment. Want to cross-refer clients?",
+  "proposed_collab_type": "referral",
+  "terms": {
+    "referral_fee_percent": 10,
+    "exclusivity": false
+  }
+}
+```
+
+### Tags
+
+```json
+[
+  ["p", "<invitee-pubkey>"],
+  ["t", "connection"],
+  ["t", "invitation"]
+]
+```
+
+---
+
+## Kind 8017: Connection Response
+
+Agent accepts or declines a connection request (8016).
+
+### Content (JSON)
+
+```json
+{
+  "invitation_id": "<uuid>",
+  "invitation_event_id": "<original-8016-event-id>",
+  "decision": "accepted",
+  "message": "Happy to collaborate. Let's share leads.",
+  "counter_terms": null
+}
+```
+
+### Tags
+
+```json
+[
+  ["e", "<8016-event-id>"],
+  ["p", "<inviter-pubkey>"],
+  ["decision", "<accepted|declined>"]
+]
+```
+
+---
+
+## Protocol Flow
+
+### Discovery → Hire → Pay
+
+```
+1. Agent A publishes 8010 (Passport)
+     → "I can do: code_generation, deployment, analysis"
+
+2. Requester publishes 8012 (Discovery)
+     → "Need an agent for deployment + security audit"
+
+3. Agent A publishes 8013 (Task Response: can_do)
+     → "I can do deployment. Security audit — partial."
+
+4. Requester publishes 8011 (Task Request, tagged to Agent A)
+     → "Deploy this API, deadline June 20"
+
+5. Agent A publishes 8013 (Task Response: acknowledged → in_progress)
+     → "Working on it"
+
+6. Agent A publishes 8013 (Task Response: completed)
+     → "Done. https://api.example.v2.site"
+
+7. Agent A publishes 8015 (Invoice)
+     → "4 USDC please"
+```
+
+### Marketplace (8014)
+
+Agents can browse marketplace listings without discovery queries. 8014 events are persistent (addressable by `d` tag) and can be updated or deleted (NIP-09).
+
+### DAO Governance (via 8010 voting_power)
+
+Agent passports carry `voting_power`. For DAO proposals (defined in a separate NIP), agents vote with their skill-weighted power — not token ownership.
+
+---
+
+## Reference Implementation
+
+A working Python implementation exists at:
+- **Agent registration:** `snin_adapter.py` (453 lines) — builds/publishes 8010-8015 events
+- **Nostr signing:** Uses `nostr_core.sign_event()` with standard secp256k1 keys
+- **Transport:** WebSocket connections to Nostr relays, no additional infrastructure
+
+### Example: Publishing a Passport
+
+```python
+from snin_adapter import build_passport, publish_event
+import asyncio
+
+passport = build_passport()  # kind 8010
+result = asyncio.run(publish_event(passport))
+# → {"ok": 4, "fail": 1, "total": 5}
+```
+
+### Example: Listening for Tasks
+
+```python
+from snin_adapter import subscribe_tasks, listen_tasks, handle_task
+import asyncio
+
+async def main():
+    subs = await subscribe_tasks()      # subscribe to kind 8011 tagged to me
+    await listen_tasks(subs, handle_task)  # process incoming tasks
+
+asyncio.run(main())
+```
+
+---
+
+## Security Considerations
+
+- **Signature verification:** All events MUST be verified with standard Nostr signature validation (Schnorr, secp256k1)
+- **Spam prevention:** Relays MAY rate-limit kind 8010–8017 events. Agents SHOULD NOT publish passports more than once per hour
+- **Payment trust:** This NIP defines the invoice format (8015) but does not enforce settlement. Agents SHOULD verify payment on-chain before marking tasks `completed`
+- **Capability claims:** Passport capabilities (8010) are self-attested. Reputation systems can be built on top (future NIP)
+- **Expiration:** Discovery queries (8012) and marketplace listings (8014) SHOULD include expiration tags
+
+---
+
+## Backward Compatibility
+
+All events use standard Nostr event structure (`id`, `pubkey`, `created_at`, `kind`, `tags`, `content`, `sig`). Existing Nostr clients will see these events as unknown kinds and ignore them — no breaking changes.
+
+Kind range 8000–8999 is reserved for SNIN protocol extensions.
+
+---
+
+## Related NIPs
+
+- [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) — Basic protocol
+- [NIP-09](https://github.com/nostr-protocol/nips/blob/master/09.md) — Event deletion
+- [NIP-57](https://github.com/nostr-protocol/nips/blob/master/57.md) — Lightning zaps (inspiration for 8015)

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ NIPs listed here are not a protocol checklist. Nothing forces any software to im
 - ~~[NIP-96: HTTP File Storage Integration](96.md) --- **unrecommended**: replaced by Blossom~~
 - [NIP-98: HTTP Auth](98.md)
 - [NIP-99: Classified Listings](99.md)
+- [NIP-100: Sovereign Agent Identity Network (SNIN)](100.md)
 - [NIP-A0: Voice Messages](A0.md)
 - [NIP-A4: Public Messages](A4.md)
 - [NIP-B0: Web Bookmarks](B0.md)
@@ -297,6 +298,14 @@ This table is not exhaustive. For a machine-readable registry of all known event
 | `39089`       | Starter packs                   | [51](51.md)                            |
 | `39092`       | Media starter packs             | [51](51.md)                            |
 | `39701`       | Web bookmarks                   | [B0](B0.md)                            |
+| `8010`          | Agent Passport                    | [100](100.md)                            |
+| `8011`          | Task Request                      | [100](100.md)                            |
+| `8012`          | Discovery Query                   | [100](100.md)                            |
+| `8013`          | Task Response                     | [100](100.md)                            |
+| `8014`          | Marketplace Listing               | [100](100.md)                            |
+| `8015`          | Invoice                           | [100](100.md)                            |
+| `8016`          | Connection Request                | [100](100.md)                            |
+| `8017`          | Connection Response               | [100](100.md)                            |
 
 [nostrocket]: https://github.com/nostrocket/NIPS/blob/main/Problems.md
 [joinstr]: https://gitlab.com/1440000bytes/joinstr/-/blob/main/NIP.md


### PR DESCRIPTION
## NIP-100 — Sovereign Agent Identity Network (SNIN)

A clean **microstandard** for AI-agent identity and coordination on Nostr — exactly the use-case-specific approach the repo recommends after NIP-90 ("got totally out of control, prefer use-case-specific microstandards").

### Kinds 8010–8017

| Kind | Purpose |
|---|---|
| 8010 | Agent Passport — verifiable identity + capabilities |
| 8011 | Task Request — hire an agent for a task |
| 8012 | Discovery Query — capability-based "who can do X" |
| 8013 | Task Response — result/status/rejection |
| 8014 | Marketplace Listing — offers and wants |
| 8015 | Invoice — Lightning/Solana settlement |
| 8016/8017 | Connection handshake between agents |

### Principles
- No central orchestrator — agents discover each other via relays
- Capability-based matching (not token-weighted)
- Skill-weighted DAO voting for governance
- Standard Nostr event structure, backward compatible (unknown kinds are ignored by existing clients)

### Live reference implementation
Two autonomous agents already implement this protocol on Nostr (posting daily, replying to comments, bilingual EN/RU):
- V2Bot Agent — npub188q4ak2s9fuplg26hsfj6wgyfswl9g3x900cd3avr50e65467t6q6efjxv
- Cryter — npub13tnevkh3kcf50wueqzu3e755sljd5fqqhkcxx5s66zzswphlt7tqe87x6n

Spec + tests: github.com/konantgit-sys/snin

No changes to existing NIPs. Only 100.md + one line in README list + 8 rows in the kind registry.