### PR TITLE
NIP-10: kind 1 replies SHOULD be kind 1111

### DIFF
--- a/10.md
+++ b/10.md
@@ -12,7 +12,22 @@ This NIP defines `kind:1` as a simple plaintext note.
 
 The `.content` property contains some human-readable text. 
 
-`e` tags can be used to define note thread roots and replies. They SHOULD be sorted by the reply stack from root to the direct parent.
+Markup languages such as markdown and HTML SHOULD NOT be used. 
+
+```yaml
+{
+  "kind": 1,
+  "content": "just setting up my nstr"
+}
+```
+
+## Replies
+
+Replies to a `kind:1` note SHOULD be [NIP-22](22.md) `kind:1111` comments, so clients don't have to filter replies out of `kind:1` feeds.
+
+`kind:1` MUST NOT be used to reply to other kinds.
+
+## Quotes
 
 `q` tags MAY be used when citing events in the `.content` with [NIP-21](21.md).
 
@@ -20,13 +35,25 @@ The `.content` property contains some human-readable text.
 ["q", "<event-id> or <event-address>", "<relay-url>", "<pubkey-if-a-regular-event>"]
 ```
 
-Authors of the `e` and `q` tags SHOULD be added as `p` tags to notify of a new reply or quote.
+Authors of `q` tags SHOULD be added as `p` tags to notify of a quote.
 
-Markup languages such as markdown and HTML SHOULD NOT be used. 
+## The "p" tag
+Used in a text event contains a list of pubkeys used to record who is involved in a reply thread.
 
-## Marked "e" tags (PREFERRED)
+When replying to a text event E the reply event's "p" tags should contain all of E's "p" tags as well as the `"pubkey"` of the event being replied to.
 
-Kind 1 events with `e` tags are replies to other kind 1 events. Kind 1 replies MUST NOT be used to reply to other kinds, use [NIP-22](22.md) instead. 
+Example:  Given a text event authored by `a1` with "p" tags [`p1`, `p2`, `p3`] then the "p" tags of the reply should be [`a1`, `p1`, `p2`, `p3`]
+in no particular order.
+
+## Deprecated Kind 1 Replies
+
+`kind:1` used to be used to reply to `kind:1` before [NIP-22](NIP-22) introduced a generic way to reply to all kinds.
+
+Modern clients should not produce kind 1 replies. However, legacy clients may still produce them, so modern clients may wish to query and display them. Legacy clients should be updated to stop producing kind 1 replies.
+
+### Deprecated Marked "e" tags
+
+Kind 1 events with `e` tags are replies to other kind 1 events. 
 
 `["e", <event-id>, <relay-url>, <marker>, <pubkey>]`
 
@@ -45,15 +72,7 @@ A direct reply to the root of a thread should have a single marked "e" tag of ty
 
 `<pubkey>` SHOULD be the pubkey of the author of the `e` tagged event, this is used in the outbox model to search for that event from the authors write relays where relay hints did not resolve the event.
 
-## The "p" tag
-Used in a text event contains a list of pubkeys used to record who is involved in a reply thread.
-
-When replying to a text event E the reply event's "p" tags should contain all of E's "p" tags as well as the `"pubkey"` of the event being replied to.
-
-Example:  Given a text event authored by `a1` with "p" tags [`p1`, `p2`, `p3`] then the "p" tags of the reply should be [`a1`, `p1`, `p2`, `p3`]
-in no particular order.
-
-## Deprecated Positional "e" tags
+### Deprecated Positional "e" tags
 
 This scheme is not in common use anymore and is here just to keep backward compatibility with older events on the network. 
 


### PR DESCRIPTION
Follow up to https://github.com/nostr-protocol/nips/pull/2358

Fixes https://github.com/nostr-protocol/nips/issues/523

This is a spooky controversial one that we should all switch to kind 1111 for replies to kind 1, treating kind 1 just like any other kind.

Most modern clients already display it. Now Amethyst, Ditto, and the Mostr Bridge produce only kind 1111 replies.