### PR TITLE
Add Static Website curation sets to NIP-51

### DIFF
--- a/51.md
+++ b/51.md
@@ -56,23 +56,24 @@ For example, _relay sets_ can be displayed in a dropdown UI to give users the op
 
 Aside from their main identifier, the `"d"` tag, sets can optionally have a `"title"`, an `"image"` and a `"description"` tags that can be used to enhance their UI.
 
-| name                  | kind  | description                                                                                  | expected tag items                                                                  |
-| ---                   | ---   | ---                                                                                          | ---                                                                                 |
-| Follow sets           | 30000 | categorized groups of users a client may choose to check out in different circumstances      | `"p"` (pubkeys)                                                                     |
-| Relay sets            | 30002 | user-defined relay groups the user can easily pick and choose from during various operations | `"relay"` (relay URLs)                                                              |
-| Bookmark sets         | 30003 | user-defined bookmarks categories , for when bookmarks must be in labeled separate groups    | `"e"` (kind:1 notes), `"a"` (kind:30023 articles)                                   |
-| Curation sets         | 30004 | groups of articles picked by users as interesting and/or belonging to the same category      | `"a"` (kind:30023 articles), `"e"` (kind:1 notes)                                   |
-| Curation sets         | 30005 | groups of videos picked by users as interesting and/or belonging to the same category        | `"e"` (kind:21 videos)                                                              |
-| Curation sets         | 30006 | groups of pictures picked by users as interesting and/or belonging to the same category      | `"e"` (kind:20 pictures)                                                            |
-| Kind mute sets        | 30007 | mute pubkeys by kinds<br>`"d"` tag MUST be the kind string                                   | `"p"` (pubkeys)                                                                     |
-| Badge sets            | 30008 | [NIP-58](58.md) categorized groups of badges                                                 | `"a"` (kind:30009 badge definitions) and `"e"` (kind:8 badge awards)                |
-| Interest sets         | 30015 | interest topics represented by a bunch of "hashtags"                                         | `"t"` (hashtags)                                                                    |
-| Emoji sets            | 30030 | categorized emoji groups                                                                     | `"emoji"` (see [NIP-30](30.md))                                                     |
-| Release artifact sets | 30063 | group of artifacts of a software release                                                     | `"e"` (kind:1063 [file metadata](94.md) events), `"a"` (software application event) |
-| App curation sets     | 30267 | references to multiple software applications                                                 | `"a"` (software application event)                                                  |
-| Calendar              | 31924 | a set of events categorized in any way                                                       | `"a"` (calendar event event)                                                        |
-| Starter packs         | 39089 | a named set of profiles to be shared around with the goal of being followed together         | `"p"` (pubkeys)                                                                     |
-| Media starter packs   | 39092 | same as above, but specific to multimedia (photos, short video) clients                      | `"p"` (pubkeys)                                                                     |
+| name                         | kind  | description                                                                                  | expected tag items                                                                  |
+| ---                          | ---   | ---                                                                                          | ---                                                                                 |
+| Follow sets                  | 30000 | categorized groups of users a client may choose to check out in different circumstances      | `"p"` (pubkeys)                                                                     |
+| Relay sets                   | 30002 | user-defined relay groups the user can easily pick and choose from during various operations | `"relay"` (relay URLs)                                                              |
+| Bookmark sets                | 30003 | user-defined bookmarks categories , for when bookmarks must be in labeled separate groups    | `"e"` (kind:1 notes), `"a"` (kind:30023 articles)                                   |
+| Curation sets                | 30004 | groups of articles picked by users as interesting and/or belonging to the same category      | `"a"` (kind:30023 articles), `"e"` (kind:1 notes)                                   |
+| Curation sets                | 30005 | groups of videos picked by users as interesting and/or belonging to the same category        | `"e"` (kind:21 videos)                                                              |
+| Curation sets                | 30006 | groups of pictures picked by users as interesting and/or belonging to the same category      | `"e"` (kind:20 pictures)                                                            |
+| Kind mute sets               | 30007 | mute pubkeys by kinds<br>`"d"` tag MUST be the kind string                                   | `"p"` (pubkeys)                                                                     |
+| Badge sets                   | 30008 | [NIP-58](58.md) categorized groups of badges                                                 | `"a"` (kind:30009 badge definitions) and `"e"` (kind:8 badge awards)                |
+| Interest sets                | 30015 | interest topics represented by a bunch of "hashtags"                                         | `"t"` (hashtags)                                                                    |
+| Emoji sets                   | 30030 | categorized emoji groups                                                                     | `"emoji"` (see [NIP-30](30.md))                                                     |
+| Release artifact sets        | 30063 | group of artifacts of a software release                                                     | `"e"` (kind:1063 [file metadata](94.md) events), `"a"` (software application event) |
+| App curation sets            | 30267 | references to multiple software applications                                                 | `"a"` (software application event)                                                  |
+| Static Website curation sets | 30499 | references to multiple static websites                                                       | `"a"` (kind:35128 named site manifest); default list has `d` tag set to `"starred"` |
+| Calendar                     | 31924 | a set of events categorized in any way                                                       | `"a"` (calendar event event)                                                        |
+| Starter packs                | 39089 | a named set of profiles to be shared around with the goal of being followed together         | `"p"` (pubkeys)                                                                     |
+| Media starter packs          | 39092 | same as above, but specific to multimedia (photos, short video) clients                      | `"p"` (pubkeys)                                                                     |
 
 ### Deprecated standard lists
 


### PR DESCRIPTION
Single row addition to NIP-51. Had to widen the first column.

This is live at https://44billion.net/+apps/naddr1qvzqqqrhyvpzplrsshpc8wn3w3tsf0wpcmhu7latqxt4q809nrz7d3fh4s9n9fxtqyvhwumn8ghj7un9d3shjt35x33xjmrvd9hkutnwv46qzxthwden5te0wpuhyctdd9jzuenfv96x5ctx9e3k7mgqqaehgctjwfjkgcwvgsl