### PR TITLE
docs: Standardize BCP-47 "lang" label namespace in NIP-32 and migrate language tags

### DIFF
--- a/32.md
+++ b/32.md
@@ -94,7 +94,7 @@ Example events
 
 A suggestion that multiple pubkeys be associated with the `permies` topic.
 
-```yaml
+```json
 {
   "kind": 1985,
   "tags": [
@@ -109,7 +109,7 @@ A suggestion that multiple pubkeys be associated with the `permies` topic.
 
 A report flagging violence toward a human being as defined by ontology.example.com.
 
-```yaml
+```json
 {
   "kind": 1985,
   "tags": [
@@ -124,7 +124,7 @@ A report flagging violence toward a human being as defined by ontology.example.c
 
 A moderation suggestion for a chat event.
 
-```yaml
+```json
 {
   "kind": 1985,
   "tags": [
@@ -138,7 +138,7 @@ A moderation suggestion for a chat event.
 
 Assignment of a license to an event.
 
-```yaml
+```json
 {
   "kind": 1985,
   "tags": [
@@ -153,7 +153,7 @@ Assignment of a license to an event.
 Publishers can self-label by adding `l` tags to their own non-1985 events. In this case, the kind 1 event's author
 is labeling their note as being related to Milan, Italy using ISO 3166-2.
 
-```yaml
+```json
 {
   "kind": 1,
   "tags": [
@@ -167,7 +167,7 @@ is labeling their note as being related to Milan, Italy using ISO 3166-2.
 
 Author is labeling their note language as English using ISO-639-1.
 
-```yaml
+```json
 {
   "kind": 1,
   "tags": [

--- a/32.md
+++ b/32.md
@@ -57,7 +57,7 @@ Language Labels
 
 The `lang` namespace MAY be used to label the language of an event's text content. This is useful
 for text events such as kind 1 notes, [NIP-22](22.md) comments, [NIP-23](23.md) long-form content,
-[NIP-42](42.md) channel messages, and [NIP-84](84.md) highlights.
+[NIP-28](28.md) channel messages, and [NIP-84](84.md) highlights.
 
 An `l` tag with mark `lang` MUST have a value that is a valid [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
 language tag, such as `ja`, `en`, `en-US`, `zh-Hant`, or `es-AR`. The special code `und` indicates

--- a/32.md
+++ b/32.md
@@ -77,7 +77,7 @@ because BCP-47 additionally allows region and script subtags.
 
 Example of a kind 1 event whose content is in Portuguese:
 
-```yaml
+```json
 {
   "kind": 1,
   "tags": [

--- a/32.md
+++ b/32.md
@@ -52,6 +52,43 @@ Self-Reporting
 `l` and `L` tags MAY be added to other event kinds to support self-reporting. For events
 with a kind other than 1985, labels refer to the event itself.
 
+Language Labels
+---------------
+
+The `lang` namespace MAY be used to label the language of an event's text content. This is useful
+for text events such as kind 1 notes, [NIP-22](22.md) comments, [NIP-23](23.md) long-form content,
+[NIP-42](42.md) channel messages, and [NIP-84](84.md) highlights.
+
+An `l` tag with mark `lang` MUST have a value that is a valid [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
+language tag, such as `ja`, `en`, `en-US`, `zh-Hant`, or `es-AR`. The special code `und` indicates
+an undetermined language. Events whose content is in multiple languages MAY include one `l` tag per
+language.
+
+A `lang` label is an author-asserted hint and is NOT authoritative. Relays MUST NOT reject events
+that lack a `lang` label or that contain unrecognized codes. Clients MAY run their own language
+detection and MAY let users override the label. An absent `lang` label means the language is
+unspecified.
+
+Because `lang` labels use the indexable single-letter `l` tag, relays implementing this NIP can
+serve language-filtered queries such as `{"#l": ["pt"]}` without any further changes.
+
+The `ISO-639-1` example below remains valid, but publishers SHOULD prefer the `lang` namespace
+because BCP-47 additionally allows region and script subtags.
+
+Example of a kind 1 event whose content is in Portuguese:
+
+```yaml
+{
+  "kind": 1,
+  "tags": [
+    ["L", "lang"],
+    ["l", "pt", "lang"]
+  ],
+  "content": "Olá, mundo!",
+  // other fields...
+}
+```
+
 Example events
 --------------
 
@@ -173,4 +210,5 @@ Appendix: Known Ontologies
 
 Below is a non-exhaustive list of ontologies currently in widespread use.
 
+- `lang` — language labels using [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags
 - [social ontology categories](https://github.com/CLARIAH/awesome-humanities-ontologies)

--- a/66.md
+++ b/66.md
@@ -51,7 +51,7 @@ Example:
     ["R", "!payment"],
     ["R", "auth"],
     ["g", "ww8p1r4t8"],
-    ["l", "en", "ISO-639-1"],
+    ["l", "en", "lang"],
     ["t", "nsfw" ],
     ["rtt-open", "234" ]
   ]

--- a/68.md
+++ b/68.md
@@ -74,8 +74,8 @@ They may contain multiple images to be displayed as a single post.
     ["g", "<geohash>"],
 
     // When text is written in the image, add the tag to represent the language
-    ["L", "ISO-639-1"],
-    ["l", "en", "ISO-639-1"]
+    ["L", "lang"],
+    ["l", "en", "lang"]
   ]
 }
 ```

--- a/71.md
+++ b/71.md
@@ -95,7 +95,7 @@ Example:
     "x b2e0a7a82ac9f3f3a71f1d9a78c381d5be9d1cf19dce258765c17c8a76287c93",
     "m audio/mp3",
     "waveform 0 7 35 8 100 100 49 8 4 16 8 10 7 2 20 10 100 100 100 100 100 100 15 100 100 100 25 60 5 4 3 1 0 100 100 15 100 29 88 0 33 11 39 100 100 19 4 100 42 35 5 0 1 5 0 0 11 38 100 94 17 11 44 58 5 100 100 100 55 14 72 100 100 57 6 1 14 2 16 100 100 40 16 100 100 6 32 14 13 41 36 16 14 6 3 0 1 2 1 6 0",
-    "l en ISO-639-1 ov",
+    "l en lang ov",
     "fallback https://myotherserver.com/audio/en/12345.mp3",
     "fallback https://andanotherserver.com/audio/en/12345.mp3",
     "service nip96",
@@ -201,7 +201,7 @@ Additionally `service nip96` may be included to allow clients to search the auth
       "url https://example.com/audio.mp3",
       "x b2e0a7a82ac9f3f3a71f1d9a78c381d5be9d1cf19dce258765c17c8a76287c93",
       "m audio/mp3",
-      "l en ISO-639-1 ov"
+      "l en lang ov"
     ],
 
     ["duration", <duration in seconds>],


### PR DESCRIPTION
## Summary

Standardize a `lang` label namespace for NIP-32 so authors can declare the language of their text events using the indexable single-letter `l` tag, enabling language-filtered feeds such as `{"#l": ["ja"]}` on any relay that already implements NIP-12/NIP-32, without any relay changes.

## Motivation

- Language-filtered feeds are impossible today: auto-detection runs client-side after the fact, and relays can only filter on indexable (single-letter) tags.
- Detection is unreliable for typical Nostr content (short posts mixed with URLs, hashtags, and bech32 strings).
- NIP-32 already supports author self-labeling; this change only standardizes the namespace and code format to remove the adoption barrier.

## Changes

- NIP-32: add "Language Labels" section defining `["l", "<BCP-47>", "lang"]`, the `und` code, multi-language handling, and non-authoritative semantics.
- NIP-32: add `lang` to the Known Ontologies appendix.
- NIP-66: migrate relay monitor report language label from `ISO-639-1` to `lang`.
- NIP-68: migrate image text language label from `ISO-639-1` to `lang`.
- NIP-71: migrate audio track language label from `ISO-639-1` to `lang`.

## Notes

- `l` tags are already indexable per NIP-12/NIP-32, so this change has no relay impact.
- The legacy ISO-639-1 example in NIP-32 is kept but `lang` is marked as preferred.

## References

- Issue: https://github.com/nostr-protocol/nips/issues/2450
- NIP-32: https://github.com/nostr-protocol/nips/blob/master/32.md
- NIP-37 (Language Tag, closed): https://github.com/nostr-protocol/nips/pull/632
- NIP-24 (kind 0 languages field): https://github.com/nostr-protocol/nips/pull/2159