### PR TITLE
Add i tags to highlights, clarify that r is whatever

### DIFF
--- a/84.md
+++ b/84.md
@@ -14,11 +14,11 @@ The `.content` of these events is the highlighted portion of the text.
 `.content` might be empty for highlights of non-text based media (e.g. NIP-94 audio/video).
 
 ### References
-Events SHOULD tag the source of the highlight, whether nostr-native or not.
-`a` or `e` tags should be used for nostr events and `r` tags for URLs.
+Events SHOULD tag the source of the highlight, whether nostr-native or not. The following tags may be used to indicate different types of content:
 
-When tagging a URL, clients generating these events SHOULD do a best effort of cleaning the URL from trackers
-or obvious non-useful information from the query string.
+- `a` and/or `e` tags for nostr events
+- `i` tags for structured sources per [NIP 73](./73.md)
+- `r` tags for anything else (may contain a URL or text)
 
 ### Attribution
 Clients MAY include one or more `p` tags, tagging the original authors of the material being highlighted; this is particularly
@@ -42,9 +42,9 @@ Clients MAY include a `context` tag, useful when the highlight is a subset of a 
 surrounding content might be beneficial to give context to the highlight.
 
 ## Quote Highlights
-A `comment` tag may be added to create a quote highlight. This MUST be rendered like a quote repost with the highlight as the quoted note.
+A `comment` tag may be added to create a quote highlight. This SHOULD be rendered like a quote repost with the highlight as the quoted note.
 
-This is to prevent the creation and multiple notes (highlight + kind 1) for a single highlight action, which looks bad in micro-blogging clients where these notes may appear in succession.
+This is to prevent the creation of multiple notes (highlight + kind 1) for a single highlight action, which looks bad in micro-blogging clients where these notes may appear in succession.
 
 p-tag mentions MUST have a `mention` attribute to distinguish it from authors and editors.
 


### PR DESCRIPTION
I've been publishing highlights for a long time with a non-url source which amethyst and jumble fail to interpret because they assume it's a valid url. The sources I'm highlighting don't have a URL, so I can't follow the spec. This PR is a little gross, but is the best compromise between backwards compatibility, emergent protocol behavior (i.e., my broken implementation/usage), and an unambiguous way forward (`i` tags).