### PR TITLE
NIP-44: update test vectors checksum for the extended length prefix

### DIFF
--- a/44.md
+++ b/44.md
@@ -298,9 +298,9 @@ and [auditor's website](https://cure53.de/audit-report_nip44-implementations.pdf
 
 A collection of implementations in different languages is available at https://github.com/paulmillr/nip44.
 
-We publish extensive test vectors. Instead of having it in the document directly, a sha256 checksum of vectors is provided:
+We publish extensive test vectors in [`nip44.vectors.json`](https://github.com/paulmillr/nip44/blob/main/nip44.vectors.json). Instead of having it in the document directly, a sha256 checksum of vectors is provided:
 
-    269ed0f69e4c192512cc779e78c555090cebc7c785b609e338a62afc3ce25040  nip44.vectors.json
+    8fa53d784df75abe02c90282d1559e122f528a73ab88a477571d52484410c06d  nip44.vectors.json
 
 Example of a test vector from the file:
 
@@ -322,7 +322,7 @@ The file also contains intermediate values. A quick guidance with regards to its
 - `valid.calc_padded_len`: take unpadded length (first value), calculate padded length (second value)
 - `valid.encrypt_decrypt`: emulate real conversation. Calculate pub2 from sec2, verify conversation_key from (sec1, pub2), encrypt, verify payload, then calculate pub1 from sec1, verify conversation_key from (sec2, pub1), decrypt, verify plaintext.
 - `valid.encrypt_decrypt_long_msg`: same as previous step, but instead of a full plaintext and payload, their checksum is provided.
-- `invalid.encrypt_msg_lengths`
+- `invalid.encrypt_msg_lengths`: encrypting a plaintext of this byte length must throw an error
 - `invalid.get_conversation_key`: calculating conversation_key must throw an error
 - `invalid.decrypt`: decrypting message content must throw an error
 
@@ -331,6 +331,7 @@ The file also contains intermediate values. A quick guidance with regards to its
 The following test vectors exercise the boundary between the 2-byte u16 prefix and the 6-byte
 extended prefix. Since the payloads are too large to include inline, SHA-256 checksums of the
 plaintext and base64-encoded payload are provided (following the `encrypt_decrypt_long_msg` pattern).
+The same vectors are included in `nip44.vectors.json` as `valid.encrypt_decrypt_long_msg` entries.
 
 All vectors use the same `conversation_key` and `nonce` as above. Plaintext is the byte `0x61`
 (`'a'`) repeated to the specified length.

--- a/44.md
+++ b/44.md
@@ -300,7 +300,7 @@ A collection of implementations in different languages is available at https://g
 
 We publish extensive test vectors in [`nip44.vectors.json`](https://github.com/paulmillr/nip44/blob/main/nip44.vectors.json). Instead of having it in the document directly, a sha256 checksum of vectors is provided:
 
-    8fa53d784df75abe02c90282d1559e122f528a73ab88a477571d52484410c06d  nip44.vectors.json
+    2631ae433a47fb9cdd4e957a441abe5af3d7bd480862d951a69ef397d5b2f7f0  nip44.vectors.json
 
 Example of a test vector from the file:
 


### PR DESCRIPTION
Fixes #2455.

`nip44.vectors.json` is published in paulmillr/nip44, and the revision pinned by the checksum in 44.md predates #1907: it lists 65536, 100000 and 10000000 as invalid encrypt lengths, so an implementation that follows the current prose fails the published vectors.

paulmillr/nip44#27 regenerates the file: the three lengths leave `invalid.encrypt_msg_lengths`, the inline extended-prefix table from this document is folded into `valid.encrypt_decrypt_long_msg` next to two larger cases, `valid.calc_padded_len` gains entries above the threshold, and `invalid.decrypt` gains a payload that uses the 6-byte prefix for a short message.

This PR:

- updates the checksum to the regenerated file,
- links the file directly, and
- notes next to the inline table that the same vectors are in the JSON.

Merge after paulmillr/nip44#27. If that file changes during review, the checksum here will be updated to match.
