### PR TITLE
NIP-44: note that the pinned vectors predate the extended length prefix

### DIFF
--- a/44.md
+++ b/44.md
@@ -302,6 +302,14 @@ We publish extensive test vectors. Instead of having it in the document directly
 
     269ed0f69e4c192512cc779e78c555090cebc7c785b609e338a62afc3ce25040  nip44.vectors.json
 
+The file behind that checksum predates the extended length prefix, and its
+`invalid.encrypt_msg_lengths` still lists 65536, 100000 and 10000000. All three
+are valid encrypt lengths under `max_plaintext_size`, so an implementation that
+follows this document fails those vectors. Until the file is regenerated, take
+the boundary coverage from the [extended length prefix test
+vectors](#extended-length-prefix-test-vectors) below instead, and read that
+entry as asserting only that 0 is invalid.
+
 Example of a test vector from the file:
 
 ```json


### PR DESCRIPTION
Closes the reported half of nostr-protocol/nips#2455 that lives in this repo. @staab — you asked for a PR; this is the piece that is mergeable on its own.

## Why this is two PRs

`nip44.vectors.json` is not in this repo. It lives at `paulmillr/nip44`, and `44.md:303` pins only its sha256. So the fix splits:

- **paulmillr/nip44#28** regenerates the file.
- **this PR** documents the conflict for anyone hitting it before that lands, and it needs no coordination to merge.

## The conflict

This document defines the extended length prefix — 2-byte `u16` below 65536, 6 bytes at or above — and `max_plaintext_size` 4294967295. The vectors file it pins still lists 65536, 100000 and 10000000 under `invalid.encrypt_msg_lengths`. All three are valid encrypt lengths under the prose above them.

I verified the artifact rather than assuming drift: the file at `paulmillr/nip44@main` hashes to exactly the published `269ed0f6…5040` and still contains that list. So nothing has been tampered with and re-vendoring reproduces the same conflict — the vectors simply were not regenerated when the extended prefix landed. That repo was last pushed 2024-12-04.

The practical cost is that a conformance suite driven by the vectors rejects what this document requires, with no refreshed file to pull. I hit exactly that implementing the decrypt side.

## What this changes

Eight lines after the checksum: name the discrepancy, point implementers at the inline [extended length prefix test vectors](#extended-length-prefix-test-vectors) this document already carries, and say the entry should be read as asserting only that 0 is invalid.

Nothing normative changes. If you would rather wait and land the checksum bump in one go once #28 merges, say so and I will close this — but the note is useful while that repo is dormant.

## On the inline table

Worth recording that it is correct: I reproduced all three published `payload_sha256` values byte-for-byte, plus the 65535 u16 case as a control, and each round-trips back through `decrypt`. #28 adds those same three cases to the vectors file so the two agree.
