### PR TITLE
NIP-78: require AUTH for kind 30078

### DIFF
--- a/78.md
+++ b/78.md
@@ -4,17 +4,23 @@ NIP-78
 Arbitrary custom app data
 -------------------------
 
-`draft` `optional`
+`draft` `optional` `relay`
 
 The goal of this NIP is to enable [remoteStorage](https://remotestorage.io/)-like capabilities for custom applications that do not care about interoperability.
 
 Even though interoperability is great, some apps do not want or do not need interoperability, and it wouldn't make sense for them. Yet Nostr can still serve as a generalized data storage for these apps in a "bring your own database" way, for example: a user would open an app and somehow input their preferred relay for storage, which would then enable these apps to store application-specific data there.
+
+These kinds are not meant to be used as a generic interchange format for data that should be public or exchanged between different applications. Applications that need such interoperability should use dedicated kinds instead.
 
 ## Nostr event
 
 This NIP specifies the use of event kinds `30078` (an _addressable_ event) with a `d` tag containing some reference to the app name and context -- or any other arbitrary string. `content` and other `tags` can be anything or in any format.
 
 It also defines the kind `78` (a _normal_ event) for when the app needs to store and query multiple events of the same type. Apps should use some unique tag (even a `d` tag) for grouping these events together.
+
+## AUTH
+
+Because this data is private to the user, relays SHOULD require clients to perform the [NIP-42](42.md) `AUTH` flow before accepting or serving `kind 30078` events, and SHOULD only serve these events to the authenticated owner, i.e. the client must authenticate with the same pubkey as the event author.
 
 ## Some use cases
 

--- a/78.md
+++ b/78.md
@@ -20,7 +20,7 @@ It also defines the kind `78` (a _normal_ event) for when the app needs to store
 
 ## AUTH
 
-Because this data is private to the user, relays SHOULD require clients to perform the [NIP-42](42.md) `AUTH` flow before accepting or serving `kind 30078` events, and SHOULD only serve these events to the authenticated owner, i.e. the client must authenticate with the same pubkey as the event author.
+Because this data is private to the user, relays SHOULD require clients to perform the [NIP-42](42.md) `AUTH` flow before accepting or serving `kind 78` and `kind 30078` events, and SHOULD only serve these events to the authenticated owner, i.e. the client must authenticate with the same pubkey as the event author.
 
 ## Some use cases
 


### PR DESCRIPTION
Closes #2452

Updates [NIP-78](78.md) to:

- Add a paragraph discouraging the use of kinds `78`/`30078` as a generic interchange format; applications needing interoperability should use dedicated kinds.
- Add an `AUTH` section stating that relays SHOULD require the [NIP-42](42.md) `AUTH` flow before accepting or serving `kind 30078` events, and SHOULD only serve them to the authenticated owner (same pubkey as the event author).
- Add the `relay` keyword to the NIP header, since it now specifies relay behavior.