### PR TITLE
Clarify zero limit behavior

### DIFF
--- a/01.md
+++ b/01.md
@@ -148,6 +148,8 @@ A `REQ` message may contain multiple filters. In this case, events that match an
 
 The `limit` property of a filter is only valid for the initial query and MUST be ignored afterwards. When `limit: n` is present it is assumed that the events returned in the initial query will be the last `n` events ordered by the `created_at`. Newer events should appear first, and in the case of ties the event with the lowest id (first in lexical order) should be first. Relays SHOULD use the `limit` value to guide how many events are returned in the initial response. Returning fewer events is acceptable, but returning (much) more should be avoided to prevent overwhelming clients.
 
+When `limit` is zero, the relay MUST NOT return stored events for that filter. After the initial queries for all filters are complete, the relay MUST send `EOSE` and MUST keep the subscription active for newly received matching events.
+
 ### From relay to client: sending events and notices
 
 Relays can send 5 types of messages, which must also be JSON arrays, according to the following patterns:


### PR DESCRIPTION
Clarify that `limit: 0` skips stored events, while the relay still sends `EOSE` and keeps the subscription active for future matching events.

This matches strfry, nostr-rs-relay, Khatru, Nostream, and rnostr, as well as all seven public relays whose behavior was conclusively tested.