### PR TITLE
NIP-90: add optional DVM heartbeat event (kind 11998)

### DIFF
--- a/90.md
+++ b/90.md
@@ -230,3 +230,26 @@ Service Providers MAY use NIP-89 announcements to advertise their support for jo
 ```
 
 Customers can use NIP-89 to see what service providers their follows use.
+
+## Appendix 3: DVM heartbeat
+Service Providers MAY periodically emit a heartbeat event to signal that they are currently online. Announcements (see [Appendix 2](#appendix-2-service-provider-discoverability)) tell customers what a service provider supports, but they say nothing about whether the machine is still running: a machine that went offline leaves its announcement behind.
+
+```yaml
+{
+  "kind": 11998,
+  "pubkey": "<dvm-pubkey>",
+  "content": "<empty-or-status-payload>",
+  "tags": [
+    ["expiration", "<unix-timestamp>"]
+  ],
+  // other fields...
+}
+```
+
+* Heartbeats SHOULD be emitted at a regular interval (e.g. every 5 minutes). The interval is up to the service provider.
+* The event is self-authenticating: the author pubkey MUST be the same pubkey that published the service provider's NIP-89 announcement.
+* `content`: MAY be empty or carry arbitrary status information (e.g. current load, supported job kinds).
+* Customers MAY use the most recent heartbeat of a service provider to determine whether it is currently online, to filter out stale announcements, or to order announcements by liveness. Announcements without a recent heartbeat SHOULD be treated as possibly-stale.
+* Heartbeats SHOULD include an `expiration` tag (a unix timestamp after which the event is considered invalid, per NIP-01 event treatment). Since heartbeats are emitted continuously, expiring them allows relays to garbage-collect old ones instead of storing an unbounded stream - this keeps the heartbeat from becoming a relay-spam vector.
+* Customers only need the most recent heartbeat; relays MAY discard expired or superseded heartbeats without breaking the flow.
+* This kind is defined outside the `5000-7000` range reserved above, so it cannot be confused with job requests, results or feedback.


### PR DESCRIPTION
Problem                                                                                                                                                 
                                                                                                                                                         
 NIP-89 announcements tell customers what a Data Vending Machine supports, but they say nothing about                                                    
 whether the machine is still running. A DVM that went offline leaves its announcement behind, and customers                                             
 have no protocol-level way to distinguish live machines from dead ones. This matters in practice: discovery                                             
 feeds and DVM clients end up surfacing stale machines, or have to guess based on heuristics.                             

- Customers MAY use the most recent heartbeat to determine whether a DVM is online, filter stale announcements, or order announcements by liveness; announcements without a recent heartbeat SHOULD be treated as possibly-stale.

{
  "kind": 11998,
  "pubkey": "<dvm-pubkey>",
  "content": "<empty-or-status-payload>",
  "tags": [
    ["expiration", "<unix-timestamp>"]
  ]
}

Design notes
- Kind choice: 11998 sits outside the 5000-7000 range this NIP reserves, so it cannot collide with job requests, results or feedback.
- Ephemeral in practice: only the most recent heartbeat matters; expired or superseded heartbeats can be discarded freely.
- Strictly optional: DVMs that don't emit heartbeats keep working exactly as before — no existing flow changes.                                      
                                                                                                                                                             
 Working implementation                                                                                                                                  
                                                                                                                                                         
 This is implemented and running in production in believethehype/nostrdvm (https://github.com/believethehype/                                            
 nostrdvm), a DVM framework where several content-discovery DVMs (kind 5000-5999) emit heartbeats on a 5-                                                
 minute interval across multiple relays, and clients use them for liveness filtering of NIP-89 announcements.                                                                                                                                                       
                            
